### PR TITLE
[feat/#3] 글로벌 예외 처리 로직 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,9 @@ dependencies {
 	// springboot web
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 
+	// validation
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
+
 	// lombok
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/umc/cockple/demo/global/exception/GeneralException.java
+++ b/src/main/java/umc/cockple/demo/global/exception/GeneralException.java
@@ -9,10 +9,10 @@ import umc.cockple.demo.global.response.dto.ErrorReasonDTO;
 @AllArgsConstructor
 public class GeneralException extends RuntimeException {
 
-  private BaseErrorCode code;
+    private BaseErrorCode code;
 
-  public ErrorReasonDTO getErrorReason() {
-    return this.code.getReason();
-  }
+    public ErrorReasonDTO getErrorReason() {
+        return this.code.getReason();
+    }
 
 }

--- a/src/main/java/umc/cockple/demo/global/exception/GeneralException.java
+++ b/src/main/java/umc/cockple/demo/global/exception/GeneralException.java
@@ -1,0 +1,18 @@
+package umc.cockple.demo.global.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import umc.cockple.demo.global.response.code.BaseErrorCode;
+import umc.cockple.demo.global.response.dto.ErrorReasonDTO;
+
+@Getter
+@AllArgsConstructor
+public class GeneralException extends RuntimeException {
+
+  private BaseErrorCode code;
+
+  public ErrorReasonDTO getErrorReason() {
+    return this.code.getReason();
+  }
+
+}

--- a/src/main/java/umc/cockple/demo/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/umc/cockple/demo/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,69 @@
+package umc.cockple.demo.global.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+import umc.cockple.demo.global.response.BaseResponse;
+import umc.cockple.demo.global.response.code.status.CommonErrorCode;
+import umc.cockple.demo.global.response.dto.ErrorReasonDTO;
+
+import java.util.stream.Collectors;
+
+import static java.util.Arrays.stream;
+
+@Slf4j
+@RestControllerAdvice(annotations = {RestController.class})
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
+
+    /**
+     * 비즈니스 로직 예외
+     */
+    @ExceptionHandler(GeneralException.class)
+    public ResponseEntity<BaseResponse<Void>> handleGeneralException(
+            GeneralException ex, WebRequest request) {
+
+        ErrorReasonDTO errorReason = ex.getErrorReason();
+
+        log.warn("Business Exception: code={}, message={}, uri={}",
+                errorReason.getCode(), errorReason.getMessage(), getRequestURI(request));
+
+        BaseResponse<Void> response = BaseResponse.error(ex.getCode());
+
+        return ResponseEntity
+                .status(errorReason.getHttpStatus())
+                .body(response);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<BaseResponse<Void>> handleGlobalException(
+            Exception ex, WebRequest request){
+
+        String requestURI = getRequestURI(request);
+
+        log.error("Unexpected exception: uri={}, type={}, message={}, stackTrace={}",
+                requestURI, ex.getClass().getSimpleName(), ex.getMessage(), getStackTrace(ex));
+
+        BaseResponse<Void> response = BaseResponse.error(CommonErrorCode._INTERNAL_SERVER_ERROR);
+
+        return ResponseEntity
+                .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(response);
+    }
+
+    private static String getRequestURI(WebRequest request) {
+        return request.getDescription(false).replace("uri=", "");
+    }
+
+    private String getStackTrace(Exception ex) {
+        return stream(ex.getStackTrace())
+                .limit(5)  // 상위 5개만
+                .map(StackTraceElement::toString)
+                .collect(Collectors.joining(" | "));
+    }
+
+}

--- a/src/main/java/umc/cockple/demo/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/umc/cockple/demo/global/exception/GlobalExceptionHandler.java
@@ -1,17 +1,26 @@
 package umc.cockple.demo.global.exception;
 
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 import umc.cockple.demo.global.response.BaseResponse;
 import umc.cockple.demo.global.response.code.status.CommonErrorCode;
 import umc.cockple.demo.global.response.dto.ErrorReasonDTO;
 
+import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static java.util.Arrays.stream;
@@ -39,9 +48,154 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
                 .body(response);
     }
 
+    /**
+     * @Valid 어노테이션으로 binding error 발생 시 (@RequestBody)
+     */
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<BaseResponse<Void>> handleMethodArgumentNotValid(
+            MethodArgumentNotValidException ex, WebRequest request) {
+
+        String requestURI = getRequestURI(request);
+        List<String> fieldErrors = extractFieldErrors(ex);
+
+        log.warn("Validation failed: uri={}, errors={}", requestURI, fieldErrors);
+
+        String errorMessage = buildErrorMessage(ex);
+        BaseResponse<Void> response = BaseResponse.error(CommonErrorCode.VALIDATION_FAILED, errorMessage);
+
+        return ResponseEntity
+                .status(CommonErrorCode.VALIDATION_FAILED.getHttpStatus())
+                .body(response);
+    }
+
+    private static List<String> extractFieldErrors(MethodArgumentNotValidException ex) {
+        return ex.getBindingResult().getFieldErrors().stream()
+                .map(error -> error.getField() + ": " + error.getDefaultMessage())
+                .toList();
+    }
+
+    private static String buildErrorMessage(MethodArgumentNotValidException ex) {
+        return ex.getBindingResult().getFieldErrors().stream()
+                .findFirst()
+                .map(FieldError::getDefaultMessage)
+                .orElse("입력값 검증에 실패했습니다.");
+    }
+
+    /**
+     * @Validated 어노테이션으로 binding error 발생 시 (@PathVariable, @RequestParam)
+     */
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<BaseResponse<Void>> handleConstraintViolation(
+            ConstraintViolationException ex, WebRequest request) {
+
+        String requestURI = getRequestURI(request);
+        List<String> violations = extractConstraintViolations(ex);
+
+        log.warn("Constraint violation: uri={}, message={}", requestURI, violations);
+
+        String errorMessage = buildErrorMessage(ex);
+        BaseResponse<Void> response = BaseResponse.error(CommonErrorCode.VALIDATION_FAILED, errorMessage);
+
+        return ResponseEntity
+                .status(CommonErrorCode.VALIDATION_FAILED.getHttpStatus())
+                .body(response);
+    }
+
+    private static List<String> extractConstraintViolations(ConstraintViolationException ex) {
+        return ex.getConstraintViolations().stream()
+                .map(violation -> {
+                    String propertyPath = violation.getPropertyPath().toString();
+                    String message = violation.getMessage();
+                    return propertyPath + ": " + message;
+                })
+                .toList();
+    }
+
+    private static String buildErrorMessage(ConstraintViolationException ex) {
+        return ex.getConstraintViolations().stream()
+                .findFirst()
+                .map(ConstraintViolation::getMessage)
+                .orElse("요청 파라미터가 올바르지 않습니다.");
+    }
+
+    /**
+     * RequestParam 타입 변환 실패
+     */
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<BaseResponse<Void>> handleMethodArgumentTypeMismatch(
+            MethodArgumentTypeMismatchException ex, WebRequest request) {
+
+        String requestURI = getRequestURI(request);
+        String expectedType = getExpectedType(ex);
+
+        log.warn("Type mismatch: uri={}, param={}, value={}, expectedType={}",
+                requestURI, ex.getName(), ex.getValue(), expectedType);
+
+        String errorMessage = buildErrorMessage(ex, expectedType);
+        BaseResponse<Void> response = BaseResponse.error(CommonErrorCode.INVALID_PARAMETER_TYPE, errorMessage);
+
+        return ResponseEntity
+                .status(CommonErrorCode.INVALID_PARAMETER_TYPE.getHttpStatus())
+                .body(response);
+    }
+
+    private static String buildErrorMessage(MethodArgumentTypeMismatchException ex, String expectedType) {
+        return String.format("파라미터 '%s'는 %s 타입이어야 합니다.",
+                ex.getName(), expectedType);
+    }
+
+    private static String getExpectedType(MethodArgumentTypeMismatchException ex) {
+        return Optional.ofNullable(ex.getRequiredType())
+                .map(Class::getSimpleName)
+                .orElse("unknown");
+    }
+
+    /**
+     * 필수 RequestParam 누락
+     */
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    public ResponseEntity<BaseResponse<Void>> handleMissingServletRequestParameter(
+            MissingServletRequestParameterException ex, WebRequest request) {
+
+        String requestURI = getRequestURI(request);
+
+        log.warn("Missing parameter: uri={}, param={}", requestURI, ex.getParameterName());
+
+        String errorMessage = String.format("필수 파라미터 '%s'가 누락되었습니다.", ex.getParameterName());
+        BaseResponse<Void> response = BaseResponse.error(CommonErrorCode.MISSING_REQUIRED_PARAMETER, errorMessage);
+
+        return ResponseEntity
+                .status(CommonErrorCode.MISSING_REQUIRED_PARAMETER.getHttpStatus())
+                .body(response);
+    }
+
+    /**
+     * JSON 파싱 오류 (@RequestBody)
+     */
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<BaseResponse<Void>> handleHttpMessageNotReadable(
+            HttpMessageNotReadableException ex, WebRequest request) {
+
+        String requestURI = getRequestURI(request);
+
+        log.warn("JSON parsing error: uri={}, message={}", requestURI, ex.getMessage());
+
+        BaseResponse<Void> response = BaseResponse.error(
+                CommonErrorCode.INVALID_REQUEST_FORMAT,
+                "요청 데이터 형식이 올바르지 않습니다."
+        );
+
+        return ResponseEntity
+                .status(CommonErrorCode.INVALID_REQUEST_FORMAT.getHttpStatus())
+                .body(response);
+    }
+
+    /**
+     * 최종 예외
+     */
     @ExceptionHandler(Exception.class)
     public ResponseEntity<BaseResponse<Void>> handleGlobalException(
-            Exception ex, WebRequest request){
+            Exception ex, WebRequest request) {
 
         String requestURI = getRequestURI(request);
 

--- a/src/main/java/umc/cockple/demo/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/umc/cockple/demo/global/exception/GlobalExceptionHandler.java
@@ -48,7 +48,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
         log.error("Unexpected exception: uri={}, type={}, message={}, stackTrace={}",
                 requestURI, ex.getClass().getSimpleName(), ex.getMessage(), getStackTrace(ex));
 
-        BaseResponse<Void> response = BaseResponse.error(CommonErrorCode._INTERNAL_SERVER_ERROR);
+        BaseResponse<Void> response = BaseResponse.error(CommonErrorCode.INTERNAL_SERVER_ERROR);
 
         return ResponseEntity
                 .status(HttpStatus.INTERNAL_SERVER_ERROR)

--- a/src/main/java/umc/cockple/demo/global/response/BaseResponse.java
+++ b/src/main/java/umc/cockple/demo/global/response/BaseResponse.java
@@ -1,0 +1,40 @@
+package umc.cockple.demo.global.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
+import lombok.Getter;
+import umc.cockple.demo.global.response.code.BaseErrorCode;
+import umc.cockple.demo.global.response.dto.ErrorReasonDTO;
+
+@Getter
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)  // null 값 제외
+public class BaseResponse<T> {
+
+    private final boolean isSuccess;
+    private final String code;
+    private final String message;
+    private final T data;
+    private final ErrorReasonDTO errorReason;
+
+    public static <T> BaseResponse<T> error(BaseErrorCode errorCode) {
+        ErrorReasonDTO errorReason = errorCode.getReason();
+        return BaseResponse.<T>builder()
+                .isSuccess(false)
+                .code(errorReason.getCode())
+                .message(errorReason.getMessage())
+                .errorReason(errorReason)
+                .build();
+    }
+
+    public static <T> BaseResponse<T> error(BaseErrorCode errorCode, String customMessage) {
+        ErrorReasonDTO errorReason = errorCode.getReason();
+        return BaseResponse.<T>builder()
+                .isSuccess(false)
+                .code(errorReason.getCode())
+                .message(customMessage)
+                .errorReason(errorReason)
+                .build();
+    }
+
+}

--- a/src/main/java/umc/cockple/demo/global/response/code/BaseErrorCode.java
+++ b/src/main/java/umc/cockple/demo/global/response/code/BaseErrorCode.java
@@ -6,5 +6,4 @@ public interface BaseErrorCode {
 
     ErrorReasonDTO getReason();
 
-    ErrorReasonDTO getReasonHttpStatus();
 }

--- a/src/main/java/umc/cockple/demo/global/response/code/BaseErrorCode.java
+++ b/src/main/java/umc/cockple/demo/global/response/code/BaseErrorCode.java
@@ -1,0 +1,8 @@
+package umc.cockple.demo.global.response.code;
+
+public interface BaseErrorCode {
+
+    ErrorReasonDTO getReason();
+
+    ErrorReasonDTO getReasonHttpStatus();
+}

--- a/src/main/java/umc/cockple/demo/global/response/code/BaseErrorCode.java
+++ b/src/main/java/umc/cockple/demo/global/response/code/BaseErrorCode.java
@@ -1,5 +1,7 @@
 package umc.cockple.demo.global.response.code;
 
+import umc.cockple.demo.global.response.dto.ErrorReasonDTO;
+
 public interface BaseErrorCode {
 
     ErrorReasonDTO getReason();

--- a/src/main/java/umc/cockple/demo/global/response/code/status/CommonErrorCode.java
+++ b/src/main/java/umc/cockple/demo/global/response/code/status/CommonErrorCode.java
@@ -1,0 +1,29 @@
+package umc.cockple.demo.global.response.code.status;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+import umc.cockple.demo.global.response.code.BaseErrorCode;
+import umc.cockple.demo.global.response.dto.ErrorReasonDTO;
+
+@Getter
+@AllArgsConstructor
+public enum CommonErrorCode implements BaseErrorCode {
+
+    _BAD_REQUEST(HttpStatus.BAD_REQUEST,"COMMON400","잘못된 요청입니다."),
+    _UNAUTHORIZED(HttpStatus.UNAUTHORIZED,"COMMON401","인증이 필요합니다."),
+    _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "접근 권한이 없는 요청입니다."),
+    _NOT_FOUND(HttpStatus.NOT_FOUND, "COMMON404", "요청 리소스를 찾을 수 없습니다"),
+
+    _INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON500", "서버 에러, 관리자에게 문의 바랍니다."),
+    _SERVICE_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "COMMON503", "서버가 일시적으로 사용중지 되었습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    @Override
+    public ErrorReasonDTO getReason() {
+        return ErrorReasonDTO.of(code, message, httpStatus);
+    }
+}

--- a/src/main/java/umc/cockple/demo/global/response/code/status/CommonErrorCode.java
+++ b/src/main/java/umc/cockple/demo/global/response/code/status/CommonErrorCode.java
@@ -16,7 +16,12 @@ public enum CommonErrorCode implements BaseErrorCode {
     NOT_FOUND(HttpStatus.NOT_FOUND, "COMMON404", "요청 리소스를 찾을 수 없습니다"),
 
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON500", "서버 에러, 관리자에게 문의 바랍니다."),
-    SERVICE_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "COMMON503", "서버가 일시적으로 사용중지 되었습니다.");
+    SERVICE_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "COMMON503", "서버가 일시적으로 사용중지 되었습니다."),
+
+    VALIDATION_FAILED(HttpStatus.BAD_REQUEST, "COMMON400_VALIDATION", "입력값 검증에 실패했습니다"),
+    INVALID_PARAMETER_TYPE(HttpStatus.BAD_REQUEST, "COMMON400_TYPE", "파라미터 타입이 올바르지 않습니다"),
+    INVALID_REQUEST_FORMAT(HttpStatus.BAD_REQUEST, "COMMON400_FORMAT", "요청 형식이 올바르지 않습니다"),
+    MISSING_REQUIRED_PARAMETER(HttpStatus.BAD_REQUEST, "COMMON400_PARAM", "필수 파라미터가 누락되었습니다");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/umc/cockple/demo/global/response/code/status/CommonErrorCode.java
+++ b/src/main/java/umc/cockple/demo/global/response/code/status/CommonErrorCode.java
@@ -10,13 +10,13 @@ import umc.cockple.demo.global.response.dto.ErrorReasonDTO;
 @AllArgsConstructor
 public enum CommonErrorCode implements BaseErrorCode {
 
-    _BAD_REQUEST(HttpStatus.BAD_REQUEST,"COMMON400","잘못된 요청입니다."),
-    _UNAUTHORIZED(HttpStatus.UNAUTHORIZED,"COMMON401","인증이 필요합니다."),
-    _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "접근 권한이 없는 요청입니다."),
-    _NOT_FOUND(HttpStatus.NOT_FOUND, "COMMON404", "요청 리소스를 찾을 수 없습니다"),
+    BAD_REQUEST(HttpStatus.BAD_REQUEST,"COMMON400","잘못된 요청입니다."),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED,"COMMON401","인증이 필요합니다."),
+    FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "접근 권한이 없는 요청입니다."),
+    NOT_FOUND(HttpStatus.NOT_FOUND, "COMMON404", "요청 리소스를 찾을 수 없습니다"),
 
-    _INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON500", "서버 에러, 관리자에게 문의 바랍니다."),
-    _SERVICE_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "COMMON503", "서버가 일시적으로 사용중지 되었습니다.");
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON500", "서버 에러, 관리자에게 문의 바랍니다."),
+    SERVICE_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "COMMON503", "서버가 일시적으로 사용중지 되었습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/umc/cockple/demo/global/response/dto/ErrorReasonDTO.java
+++ b/src/main/java/umc/cockple/demo/global/response/dto/ErrorReasonDTO.java
@@ -20,6 +20,4 @@ public class ErrorReasonDTO {
                 .build();
     }
 
-
-
 }

--- a/src/main/java/umc/cockple/demo/global/response/dto/ErrorReasonDTO.java
+++ b/src/main/java/umc/cockple/demo/global/response/dto/ErrorReasonDTO.java
@@ -1,0 +1,25 @@
+package umc.cockple.demo.global.response.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@Builder
+public class ErrorReasonDTO {
+
+    private final String code;
+    private final String message;
+    private final HttpStatus httpStatus;
+
+    public static ErrorReasonDTO of(String code, String message, HttpStatus httpStatus) {
+        return ErrorReasonDTO.builder()
+                .code(code)
+                .message(message)
+                .httpStatus(httpStatus)
+                .build();
+    }
+
+
+
+}


### PR DESCRIPTION
## ❤️ 기능 설명
전역적 예외 핸들러를 구현했습니다.

1. 비즈니스 로직 예외 (GeneralException)
2. @Valid 검증 실패 (MethodArgumentNotValidException) - @RequestBody
3. @Validated 검증 실패 (ConstraintViolationException) - @RequestParam, @PathVariable
4. URL의 타입 변환 실패 (MethodArgumentTypeMismatchException)
5. 필수 파라미터 누락 (MissingServletRequestParameterException)
6. JSON 파싱 오류 (HttpMessageNotReadableException)
7. 최종 예외 (Exception)

<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #3 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!
![image](https://github.com/user-attachments/assets/e5f99147-10a0-4b3e-b499-cd2eeb426516)

- 이거 에러 코드 추가적으로 만들었는데 의견 부탁드립니다!

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
