### PR TITLE
[fix#6] GlobalExceptionHandler에서 @ExceptionHandler 충돌 문제 해결

### DIFF
--- a/src/main/java/umc/cockple/demo/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/umc/cockple/demo/global/exception/GlobalExceptionHandler.java
@@ -3,7 +3,9 @@ package umc.cockple.demo.global.exception;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.FieldError;
@@ -33,7 +35,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
      * 비즈니스 로직 예외
      */
     @ExceptionHandler(GeneralException.class)
-    public ResponseEntity<BaseResponse<Void>> handleGeneralException(
+    public ResponseEntity<Object> handleGeneralException(
             GeneralException ex, WebRequest request) {
 
         ErrorReasonDTO errorReason = ex.getErrorReason();
@@ -51,9 +53,9 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     /**
      * @Valid 어노테이션으로 binding error 발생 시 (@RequestBody)
      */
-    @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<BaseResponse<Void>> handleMethodArgumentNotValid(
-            MethodArgumentNotValidException ex, WebRequest request) {
+    @Override
+    protected ResponseEntity<Object> handleMethodArgumentNotValid(
+            MethodArgumentNotValidException ex, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
 
         String requestURI = getRequestURI(request);
         List<String> fieldErrors = extractFieldErrors(ex);
@@ -85,7 +87,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
      * @Validated 어노테이션으로 binding error 발생 시 (@PathVariable, @RequestParam)
      */
     @ExceptionHandler(ConstraintViolationException.class)
-    public ResponseEntity<BaseResponse<Void>> handleConstraintViolation(
+    public ResponseEntity<Object> handleConstraintViolation(
             ConstraintViolationException ex, WebRequest request) {
 
         String requestURI = getRequestURI(request);
@@ -122,7 +124,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
      * RequestParam 타입 변환 실패
      */
     @ExceptionHandler(MethodArgumentTypeMismatchException.class)
-    public ResponseEntity<BaseResponse<Void>> handleMethodArgumentTypeMismatch(
+    public ResponseEntity<Object> handleMethodArgumentTypeMismatch(
             MethodArgumentTypeMismatchException ex, WebRequest request) {
 
         String requestURI = getRequestURI(request);
@@ -153,9 +155,9 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     /**
      * 필수 RequestParam 누락
      */
-    @ExceptionHandler(MissingServletRequestParameterException.class)
-    public ResponseEntity<BaseResponse<Void>> handleMissingServletRequestParameter(
-            MissingServletRequestParameterException ex, WebRequest request) {
+    @Override
+    protected ResponseEntity<Object> handleMissingServletRequestParameter(
+            MissingServletRequestParameterException ex, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
 
         String requestURI = getRequestURI(request);
 
@@ -172,9 +174,9 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     /**
      * JSON 파싱 오류 (@RequestBody)
      */
-    @ExceptionHandler(HttpMessageNotReadableException.class)
-    public ResponseEntity<BaseResponse<Void>> handleHttpMessageNotReadable(
-            HttpMessageNotReadableException ex, WebRequest request) {
+    @Override
+    protected ResponseEntity<Object> handleHttpMessageNotReadable(
+            HttpMessageNotReadableException ex, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
 
         String requestURI = getRequestURI(request);
 
@@ -194,7 +196,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
      * 최종 예외
      */
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<BaseResponse<Void>> handleGlobalException(
+    public ResponseEntity<Object> handleGlobalException(
             Exception ex, WebRequest request) {
 
         String requestURI = getRequestURI(request);


### PR DESCRIPTION
## ❤️ 기능 설명
문제: Ambiguous @ExceptionHandler method mapped for [MissingServletRequestParameterException] 에러 해결

원인: Spring Boot 3.x에서 ResponseEntityExceptionHandler의 기본 핸들러와 커스텀 @ExceptionHandler가 충돌

해결 방법
주요 변경사항

1. @ExceptionHandler → @Override 패턴으로 변경
- handleMissingServletRequestParameter() - 필수 파라미터 누락
- handleMethodArgumentNotValid() - @Valid 검증 실패
- handleHttpMessageNotReadable() - JSON 파싱 오류
2. 반환 타입 통일: 모든 핸들러를 ResponseEntity<Object>로 표준화
3. 메서드 시그니처 업데이트: Spring Boot 3.x 호환

<br>

![image](https://github.com/user-attachments/assets/0267b57c-e65c-471d-81ea-3c043303ec81)

<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #6 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!
Spring Boot 3.x에서는 ResponseEntityExceptionHandler를 상속받은 클래스에서 Spring 기본 예외를 처리할 때 @Override 방식을 사용해야 한다고 하네요 ㅠㅠ

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
