### PR TITLE
[Feat/#5] 기본 응답 형식 설계 및 응답 통일 구현

### DIFF
--- a/src/main/java/umc/cockple/demo/global/response/BaseResponse.java
+++ b/src/main/java/umc/cockple/demo/global/response/BaseResponse.java
@@ -3,8 +3,11 @@ package umc.cockple.demo.global.response;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Builder;
 import lombok.Getter;
+import umc.cockple.demo.global.response.code.BaseCode;
 import umc.cockple.demo.global.response.code.BaseErrorCode;
+import umc.cockple.demo.global.response.code.status.CommonSuccessCode;
 import umc.cockple.demo.global.response.dto.ErrorReasonDTO;
+import umc.cockple.demo.global.response.dto.ReasonDTO;
 
 @Getter
 @Builder
@@ -17,6 +20,49 @@ public class BaseResponse<T> {
     private final T data;
     private final ErrorReasonDTO errorReason;
 
+    //성공 응답 생성: 결과 데이터 포함
+    public static <T> BaseResponse<T> success(BaseCode successCode, T data) {
+        ReasonDTO reason = successCode.getReason();
+        return BaseResponse.<T>builder()
+                .isSuccess(true)
+                .code(reason.getCode())
+                .message(reason.getMessage())
+                .data(data)
+                .build();
+    }
+
+    //성공 응답 생성: 결과 데이터 없음
+    public static <T> BaseResponse<T> success(BaseCode successCode) {
+        ReasonDTO reason = successCode.getReason();
+        return BaseResponse.<T>builder()
+                .isSuccess(true)
+                .code(reason.getCode())
+                .message(reason.getMessage())
+                .build();
+    }
+
+    //성공 응답 생성: 결과 데이터 포함, 커스텀 메시지 포함
+    public static <T> BaseResponse<T> success(BaseCode successCode, String customMessage, T data) {
+        ReasonDTO reason = successCode.getReason();
+        return BaseResponse.<T>builder()
+                .isSuccess(true)
+                .code(reason.getCode())
+                .message(customMessage)
+                .data(data)
+                .build();
+    }
+
+    //성공 응답 생성: 결과 데이터 없음, 커스텀 메시지 포함
+    public static <T> BaseResponse<T> success(BaseCode successCode, String customMessage) {
+        ReasonDTO reason = successCode.getReason();
+        return BaseResponse.<T>builder()
+                .isSuccess(true)
+                .code(reason.getCode())
+                .message(customMessage)
+                .build();
+    }
+
+    //실패 응답 생성
     public static <T> BaseResponse<T> error(BaseErrorCode errorCode) {
         ErrorReasonDTO errorReason = errorCode.getReason();
         return BaseResponse.<T>builder()
@@ -27,6 +73,7 @@ public class BaseResponse<T> {
                 .build();
     }
 
+    //실패 응답 생성: 커스텀 메시지 포함
     public static <T> BaseResponse<T> error(BaseErrorCode errorCode, String customMessage) {
         ErrorReasonDTO errorReason = errorCode.getReason();
         return BaseResponse.<T>builder()

--- a/src/main/java/umc/cockple/demo/global/response/code/BaseCode.java
+++ b/src/main/java/umc/cockple/demo/global/response/code/BaseCode.java
@@ -1,0 +1,7 @@
+package umc.cockple.demo.global.response.code;
+
+import umc.cockple.demo.global.response.dto.ReasonDTO;
+
+public interface BaseCode {
+    ReasonDTO getReason();
+}

--- a/src/main/java/umc/cockple/demo/global/response/code/status/CommonSuccessCode.java
+++ b/src/main/java/umc/cockple/demo/global/response/code/status/CommonSuccessCode.java
@@ -1,0 +1,26 @@
+package umc.cockple.demo.global.response.code.status;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import umc.cockple.demo.global.response.code.BaseCode;
+import umc.cockple.demo.global.response.dto.ReasonDTO;
+
+@Getter
+@RequiredArgsConstructor
+public enum CommonSuccessCode implements BaseCode {
+
+    OK(HttpStatus.OK, "COMMON200", "요청에 성공했습니다."),
+    CREATED(HttpStatus.CREATED, "COMMON201", "요청이 성공적으로 처리되어 리소스가 생성되었습니다."),
+    ACCEPTED(HttpStatus.ACCEPTED, "COMMON202", "요청이 접수되었습니다."),
+    NO_CONTENT(HttpStatus.NO_CONTENT, "COMMON204", "요청이 성공적으로 처리되었으나 반환할 데이터가 없습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    @Override
+    public ReasonDTO getReason(){
+        return ReasonDTO.of(code, message, httpStatus);
+    }
+}

--- a/src/main/java/umc/cockple/demo/global/response/dto/ReasonDTO.java
+++ b/src/main/java/umc/cockple/demo/global/response/dto/ReasonDTO.java
@@ -1,4 +1,21 @@
 package umc.cockple.demo.global.response.dto;
 
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@Builder
 public class ReasonDTO {
+    private final String code;
+    private final String message;
+    private final HttpStatus httpStatus;
+
+    public static ReasonDTO of(String code, String message, HttpStatus httpStatus) {
+        return ReasonDTO.builder()
+                .code(code)
+                .message(message)
+                .httpStatus(httpStatus)
+                .build();
+    }
 }

--- a/src/main/java/umc/cockple/demo/global/response/dto/ReasonDTO.java
+++ b/src/main/java/umc/cockple/demo/global/response/dto/ReasonDTO.java
@@ -1,0 +1,4 @@
+package umc.cockple.demo.global.response.dto;
+
+public class ReasonDTO {
+}


### PR DESCRIPTION
## ❤️ 기능 설명
API 응답 형식을 통일하여 구현했습니다.
- BaseCode 인터페이스 정의
- BaseResponse 클래스 성공 응답 메소드 추가 구현
- CommonSuccessCode Enum 구현 (자주 사용되는 OK, CREATED 등 추가)

<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #5
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- CommonSuccessCode의 성공 응답 코드에 LOGIN_SUCCESS(HttpStatus.OK, "AUTH200", "로그인에 성공했습니다.")와 같은 도메인 별 성공 응답도 추가하는 것은 어떤지 의견 부탁 드립니다.
- ReasonDTO과 ErrorReasonDTO는 동일한 코드인데 합치는 것이 좋을지, 의미 상 분할하는 것이 좋을지 의견 부탁 드립니다. 

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [ ] 이슈넘버를 적었는가?
