### PR TITLE
[feat/#19] 운동 신청 API 구현

### DIFF
--- a/src/main/java/umc/cockple/demo/domain/exercise/controller/ExerciseController.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/controller/ExerciseController.java
@@ -44,4 +44,24 @@ public class ExerciseController {
 
         return BaseResponse.success(CommonSuccessCode.CREATED, response);
     }
+
+    @PostMapping("/exercises/{exerciseId}/participants")
+    @Operation(summary = "운동 신청",
+            description = "모임에서 생성한 운동에 신청합니다. 외부 게스트 허용일 경우 모임 멤버가 아니어도 가능합니다.")
+    @ApiResponse(responseCode = "0", description = "운동 신청 성공")
+    @ApiResponse(responseCode = "400", description = "입력값 오류 또는 비즈니스 룰 위반")
+    @ApiResponse(responseCode = "403", description = "권한 없음")
+    public BaseResponse<ExerciseJoinResponseDTO> JoinExercise(
+            @PathVariable Long exerciseId,
+            Authentication authentication
+    ){
+
+        // TODO: JWT 인증 구현 후 교체 예정
+        Long memberId = 1L; // 임시값
+
+        ExerciseJoinResponseDTO response = exerciseCommandService.joinExercise(
+                exerciseId, memberId);
+
+        return BaseResponse.success(CommonSuccessCode.CREATED, response);
+    }
 }

--- a/src/main/java/umc/cockple/demo/domain/exercise/controller/ExerciseController.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/controller/ExerciseController.java
@@ -10,6 +10,7 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import umc.cockple.demo.domain.exercise.dto.ExerciseCreateRequestDTO;
 import umc.cockple.demo.domain.exercise.dto.ExerciseCreateResponseDTO;
+import umc.cockple.demo.domain.exercise.dto.ExerciseJoinResponseDTO;
 import umc.cockple.demo.domain.exercise.service.ExerciseCommandService;
 import umc.cockple.demo.global.response.BaseResponse;
 import umc.cockple.demo.global.response.code.status.CommonSuccessCode;

--- a/src/main/java/umc/cockple/demo/domain/exercise/converter/ExerciseConverter.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/converter/ExerciseConverter.java
@@ -3,10 +3,11 @@ package umc.cockple.demo.domain.exercise.converter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import umc.cockple.demo.domain.exercise.domain.Exercise;
-import umc.cockple.demo.domain.exercise.dto.ExerciseAddrCreateCommand;
-import umc.cockple.demo.domain.exercise.dto.ExerciseCreateCommand;
-import umc.cockple.demo.domain.exercise.dto.ExerciseCreateRequestDTO;
-import umc.cockple.demo.domain.exercise.dto.ExerciseCreateResponseDTO;
+import umc.cockple.demo.domain.exercise.dto.*;
+import umc.cockple.demo.domain.member.domain.Member;
+import umc.cockple.demo.domain.member.domain.MemberExercise;
+
+import java.time.LocalDateTime;
 
 @Component
 @RequiredArgsConstructor
@@ -37,6 +38,15 @@ public class ExerciseConverter {
         return ExerciseCreateResponseDTO.builder()
                 .exerciseId(exercise.getId())
                 .createdAt(exercise.getCreatedAt())
+                .build();
+    }
+
+    public ExerciseJoinResponseDTO toJoinResponseDTO(MemberExercise memberExercise, Exercise exercise) {
+        return ExerciseJoinResponseDTO.builder()
+                .participantId(memberExercise.getId())
+                .participantNumber(memberExercise.getParticipantNum())
+                .joinedAt(memberExercise.getJoinedAt())
+                .currentParticipants(exercise.getNowCapacity())
                 .build();
     }
 }

--- a/src/main/java/umc/cockple/demo/domain/exercise/domain/Exercise.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/domain/Exercise.java
@@ -3,11 +3,13 @@ package umc.cockple.demo.domain.exercise.domain;
 import jakarta.persistence.*;
 import lombok.*;
 import umc.cockple.demo.domain.exercise.dto.ExerciseCreateCommand;
+import umc.cockple.demo.domain.member.domain.Member;
 import umc.cockple.demo.domain.member.domain.MemberExercise;
 import umc.cockple.demo.domain.party.domain.Party;
 import umc.cockple.demo.global.common.BaseEntity;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -75,4 +77,23 @@ public class Exercise extends BaseEntity {
                 .build();
     }
 
+    public MemberExercise addParticipant(Member member) {
+
+        Integer participantNum = calculateNextParticipantNumber();
+
+        MemberExercise memberExercise = MemberExercise.createParticipation(this, member, participantNum);
+
+        addToParticipants(memberExercise);
+
+        return memberExercise;
+    }
+
+    private Integer calculateNextParticipantNumber() {
+        return this.nowCapacity + 1;
+    }
+
+    private void addToParticipants(MemberExercise memberExercise) {
+        this.memberExercises.add(memberExercise);
+        this.nowCapacity++;
+    }
 }

--- a/src/main/java/umc/cockple/demo/domain/exercise/dto/ExerciseJoinResponseDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/dto/ExerciseJoinResponseDTO.java
@@ -1,0 +1,10 @@
+package umc.cockple.demo.domain.exercise.dto;
+
+import java.time.LocalDateTime;
+
+public record ExerciseJoinResponseDTO(
+        Long participantId,
+        LocalDateTime joinedAt,
+        Integer currentParticipants
+) {
+}

--- a/src/main/java/umc/cockple/demo/domain/exercise/dto/ExerciseJoinResponseDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/dto/ExerciseJoinResponseDTO.java
@@ -1,9 +1,13 @@
 package umc.cockple.demo.domain.exercise.dto;
 
+import lombok.Builder;
+
 import java.time.LocalDateTime;
 
+@Builder
 public record ExerciseJoinResponseDTO(
         Long participantId,
+        Integer participantNumber,
         LocalDateTime joinedAt,
         Integer currentParticipants
 ) {

--- a/src/main/java/umc/cockple/demo/domain/exercise/exception/ExerciseErrorCode.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/exception/ExerciseErrorCode.java
@@ -17,8 +17,9 @@ public enum ExerciseErrorCode implements BaseErrorCode {
     PARTY_NOT_FOUND(HttpStatus.NOT_FOUND, "EXERCISE004", "존재하지 않는 파티입니다."),
     INSUFFICIENT_PERMISSION(HttpStatus.FORBIDDEN, "EXERCISE005", "운동을 생성할 권한이 없습니다."),
     INVALID_EXERCISE_TIME(HttpStatus.BAD_REQUEST, "EXERCISE006", "종료 시간은 시작 시간보다 늦어야 합니다."),
-    PAST_TIME_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "EXERCISE007", "운동 시간은 과거로 할 수 없습니다.");
-
+    PAST_TIME_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "EXERCISE007", "운동 시간은 과거로 할 수 없습니다."),
+    EXERCISE_NOT_FOUND(HttpStatus.NOT_FOUND, "EXERCISE008", "존재하지 않는 운동입니다."),
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "EXERCISE009", "존재하지 않는 멤버입니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/umc/cockple/demo/domain/exercise/exception/ExerciseErrorCode.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/exception/ExerciseErrorCode.java
@@ -19,7 +19,10 @@ public enum ExerciseErrorCode implements BaseErrorCode {
     INVALID_EXERCISE_TIME(HttpStatus.BAD_REQUEST, "EXERCISE006", "종료 시간은 시작 시간보다 늦어야 합니다."),
     PAST_TIME_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "EXERCISE007", "운동 시간은 과거로 할 수 없습니다."),
     EXERCISE_NOT_FOUND(HttpStatus.NOT_FOUND, "EXERCISE008", "존재하지 않는 운동입니다."),
-    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "EXERCISE009", "존재하지 않는 멤버입니다.");
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "EXERCISE009", "존재하지 않는 멤버입니다."),
+    EXERCISE_ALREADY_STARTED(HttpStatus.BAD_REQUEST, "EXERCISE010", "이미 시작된 운동에는 참여할 수 없습니다."),
+    ALREADY_JOINED_EXERCISE(HttpStatus.BAD_REQUEST, "EXERCISE011", "이미 참여 신청한 운동입니다."),
+    NOT_PARTY_MEMBER(HttpStatus.FORBIDDEN, "EXERCISE012", "파티 멤버만 참여할 수 있습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseCommandService.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseCommandService.java
@@ -102,6 +102,6 @@ public class ExerciseCommandService {
 
     private Member getMember(Long memberId) {
         return memberRepository.findById(memberId)
-                .orElseThrow(() -> new ExerciseException(ExerciseErrorCode.Member_NOT_FOUND));
+                .orElseThrow(() -> new ExerciseException(ExerciseErrorCode.MEMBER_NOT_FOUND));
     }
 }

--- a/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseCommandService.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseCommandService.java
@@ -13,7 +13,6 @@ import umc.cockple.demo.domain.exercise.dto.ExerciseCreateRequestDTO;
 import umc.cockple.demo.domain.exercise.dto.ExerciseCreateResponseDTO;
 import umc.cockple.demo.domain.exercise.exception.ExerciseErrorCode;
 import umc.cockple.demo.domain.exercise.exception.ExerciseException;
-import umc.cockple.demo.domain.exercise.repository.ExerciseAddrRepository;
 import umc.cockple.demo.domain.exercise.repository.ExerciseRepository;
 import umc.cockple.demo.domain.member.repository.MemberPartyRepository;
 import umc.cockple.demo.domain.party.domain.Party;
@@ -33,9 +32,7 @@ public class ExerciseCommandService {
     private final ExerciseRepository exerciseRepository;
     private final PartyRepository partyRepository;
     private final MemberPartyRepository memberPartyRepository;
-    private final ExerciseAddrRepository exerciseAddrRepository;
     private final ExerciseConverter exerciseConverter;
-
 
     public ExerciseCreateResponseDTO createExercise(Long partyId, Long memberId, ExerciseCreateRequestDTO request) {
 
@@ -72,7 +69,6 @@ public class ExerciseCommandService {
         if (!isOwner && !isManager)
             throw new ExerciseException(ExerciseErrorCode.INSUFFICIENT_PERMISSION);
     }
-
 
     private void validateExerciseTime(ExerciseCreateRequestDTO request) {
         LocalDate date = request.toParsedDate();

--- a/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseCommandService.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseCommandService.java
@@ -137,7 +137,7 @@ public class ExerciseCommandService {
             return;
         }
 
-        if(!exercise.getOutsideGuestAccept()) {
+        if(Boolean.FALSE.equals(exercise.getOutsideGuestAccept())) {
             throw new ExerciseException(ExerciseErrorCode.NOT_PARTY_MEMBER);
         }
     }

--- a/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseCommandService.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseCommandService.java
@@ -12,6 +12,7 @@ import umc.cockple.demo.domain.exercise.exception.ExerciseErrorCode;
 import umc.cockple.demo.domain.exercise.exception.ExerciseException;
 import umc.cockple.demo.domain.exercise.repository.ExerciseRepository;
 import umc.cockple.demo.domain.member.domain.Member;
+import umc.cockple.demo.domain.member.domain.MemberExercise;
 import umc.cockple.demo.domain.member.repository.MemberExerciseRepository;
 import umc.cockple.demo.domain.member.repository.MemberPartyRepository;
 import umc.cockple.demo.domain.member.repository.MemberRepository;
@@ -95,6 +96,9 @@ public class ExerciseCommandService {
         Member member = getMember(memberId);
         validateExerciseJoin(exercise, member);
 
+        MemberExercise memberExercise = exercise.addParticipant(member);
+
+        memberExerciseRepository.save(memberExercise);
     }
 
     private Exercise getExercise(Long exerciseId) {

--- a/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseCommandService.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseCommandService.java
@@ -13,6 +13,7 @@ import umc.cockple.demo.domain.exercise.exception.ExerciseException;
 import umc.cockple.demo.domain.exercise.repository.ExerciseRepository;
 import umc.cockple.demo.domain.member.domain.Member;
 import umc.cockple.demo.domain.member.repository.MemberPartyRepository;
+import umc.cockple.demo.domain.member.repository.MemberRepository;
 import umc.cockple.demo.domain.party.domain.Party;
 import umc.cockple.demo.domain.party.repository.PartyRepository;
 import umc.cockple.demo.global.enums.Role;
@@ -30,6 +31,7 @@ public class ExerciseCommandService {
     private final ExerciseRepository exerciseRepository;
     private final PartyRepository partyRepository;
     private final MemberPartyRepository memberPartyRepository;
+    private final MemberRepository memberRepository;
     private final ExerciseConverter exerciseConverter;
 
     public ExerciseCreateResponseDTO createExercise(Long partyId, Long memberId, ExerciseCreateRequestDTO request) {
@@ -99,7 +101,7 @@ public class ExerciseCommandService {
 
 
     private Member getMember(Long memberId) {
-        return memeberRepository.findById(memberId)
+        return memberRepository.findById(memberId)
                 .orElseThrow(() -> new ExerciseException(ExerciseErrorCode.Member_NOT_FOUND));
     }
 }

--- a/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseCommandService.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseCommandService.java
@@ -7,13 +7,11 @@ import org.springframework.transaction.annotation.Transactional;
 import umc.cockple.demo.domain.exercise.converter.ExerciseConverter;
 import umc.cockple.demo.domain.exercise.domain.Exercise;
 import umc.cockple.demo.domain.exercise.domain.ExerciseAddr;
-import umc.cockple.demo.domain.exercise.dto.ExerciseAddrCreateCommand;
-import umc.cockple.demo.domain.exercise.dto.ExerciseCreateCommand;
-import umc.cockple.demo.domain.exercise.dto.ExerciseCreateRequestDTO;
-import umc.cockple.demo.domain.exercise.dto.ExerciseCreateResponseDTO;
+import umc.cockple.demo.domain.exercise.dto.*;
 import umc.cockple.demo.domain.exercise.exception.ExerciseErrorCode;
 import umc.cockple.demo.domain.exercise.exception.ExerciseException;
 import umc.cockple.demo.domain.exercise.repository.ExerciseRepository;
+import umc.cockple.demo.domain.member.domain.Member;
 import umc.cockple.demo.domain.member.repository.MemberPartyRepository;
 import umc.cockple.demo.domain.party.domain.Party;
 import umc.cockple.demo.domain.party.repository.PartyRepository;
@@ -83,5 +81,25 @@ public class ExerciseCommandService {
         if (exerciseDateTime.isBefore(LocalDateTime.now())) {
             throw new ExerciseException(ExerciseErrorCode.PAST_TIME_NOT_ALLOWED);
         }
+    }
+
+    public ExerciseJoinResponseDTO joinExercise(Long exerciseId, Long memberId) {
+
+        log.info("운동 신청 시작 - exerciseId: {}, memberId: {}", exerciseId, memberId);
+
+        Exercise exercise = getExercise(exerciseId);
+        Member member = getMember(memberId);
+
+    }
+
+    private Exercise getExercise(Long exerciseId) {
+        return exerciseRepository.findById(exerciseId)
+                .orElseThrow(() -> new ExerciseException(ExerciseErrorCode.EXERCISE_NOT_FOUND));
+    }
+
+
+    private Member getMember(Long memberId) {
+        return memeberRepository.findById(memberId)
+                .orElseThrow(() -> new ExerciseException(ExerciseErrorCode.Member_NOT_FOUND));
     }
 }

--- a/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseCommandService.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseCommandService.java
@@ -100,6 +100,8 @@ public class ExerciseCommandService {
 
         memberExerciseRepository.save(memberExercise);
 
+        log.info("운동 신청 종료 - memberExerciseId: {}", memberExercise.getId());
+
         return exerciseConverter.toJoinResponseDTO(memberExercise, exercise);
     }
 

--- a/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseCommandService.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseCommandService.java
@@ -109,8 +109,8 @@ public class ExerciseCommandService {
 
     private void validateExerciseJoin(Exercise exercise, Member member) {
         validateExerciseNotStarted(exercise);
-        validateDuplicatedJoin(exercise, member);
-        validateAllowedJoin(exercise, member);
+        validateAlreadyJoined(exercise, member);
+        validateJoinPermission(exercise, member);
     }
 
     private void validateExerciseNotStarted(Exercise exercise) {
@@ -120,13 +120,13 @@ public class ExerciseCommandService {
         }
     }
 
-    private void validateDuplicatedJoin(Exercise exercise, Member member) {
+    private void validateAlreadyJoined(Exercise exercise, Member member) {
         if(memberExerciseRepository.existsByExerciseAndMember(exercise, member)) {
             throw new ExerciseException(ExerciseErrorCode.ALREADY_JOINED_EXERCISE);
         }
     }
 
-    private void validateAllowedJoin(Exercise exercise, Member member) {
+    private void validateJoinPermission(Exercise exercise, Member member) {
         if(isPartyMember(exercise, member)) {
             return;
         }

--- a/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseCommandService.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseCommandService.java
@@ -99,6 +99,8 @@ public class ExerciseCommandService {
         MemberExercise memberExercise = exercise.addParticipant(member);
 
         memberExerciseRepository.save(memberExercise);
+
+        return exerciseConverter.toJoinResponseDTO(memberExercise, exercise);
     }
 
     private Exercise getExercise(Long exerciseId) {

--- a/src/main/java/umc/cockple/demo/domain/member/domain/MemberExercise.java
+++ b/src/main/java/umc/cockple/demo/domain/member/domain/MemberExercise.java
@@ -33,10 +33,6 @@ public class MemberExercise extends BaseEntity {
     @Column(nullable = false)
     private Integer participantNum;
 
-    @Column(nullable = false)
-    @Enumerated(EnumType.STRING)
-    private ExerciseOrderType orderType;
-
     public static MemberExercise createParticipation(Exercise exercise, Member member, Integer participantNum) {
         return MemberExercise.builder()
                 .exercise(exercise)

--- a/src/main/java/umc/cockple/demo/domain/member/domain/MemberExercise.java
+++ b/src/main/java/umc/cockple/demo/domain/member/domain/MemberExercise.java
@@ -36,4 +36,13 @@ public class MemberExercise extends BaseEntity {
     @Column(nullable = false)
     @Enumerated(EnumType.STRING)
     private ExerciseOrderType orderType;
+
+    public static MemberExercise createParticipation(Exercise exercise, Member member, Integer participantNum) {
+        return MemberExercise.builder()
+                .exercise(exercise)
+                .member(member)
+                .joinedAt(LocalDateTime.now())
+                .participantNum(participantNum)
+                .build();
+    }
 }

--- a/src/main/java/umc/cockple/demo/domain/member/repository/MemberExerciseRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/member/repository/MemberExerciseRepository.java
@@ -1,0 +1,11 @@
+package umc.cockple.demo.domain.member.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import umc.cockple.demo.domain.exercise.domain.Exercise;
+import umc.cockple.demo.domain.member.domain.Member;
+import umc.cockple.demo.domain.member.domain.MemberExercise;
+
+public interface MemberExerciseRepository extends JpaRepository<MemberExercise, Long> {
+
+    boolean existsByExerciseAndMember(Exercise exercise, Member member);
+}

--- a/src/main/java/umc/cockple/demo/domain/member/repository/MemberPartyRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/member/repository/MemberPartyRepository.java
@@ -1,10 +1,14 @@
 package umc.cockple.demo.domain.member.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import umc.cockple.demo.domain.member.domain.Member;
 import umc.cockple.demo.domain.member.domain.MemberParty;
+import umc.cockple.demo.domain.party.domain.Party;
 import umc.cockple.demo.global.enums.Role;
 
 public interface MemberPartyRepository extends JpaRepository<MemberParty, Long> {
 
     boolean existsByPartyIdAndMemberIdAndRole(Long partyId, Long memberId, Role role);
+
+    boolean existsByPartyAndMember(Party party, Member member);
 }

--- a/src/main/java/umc/cockple/demo/domain/member/repository/MemberRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/member/repository/MemberRepository.java
@@ -1,0 +1,7 @@
+package umc.cockple.demo.domain.member.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import umc.cockple.demo.domain.member.domain.Member;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+}


### PR DESCRIPTION
## ❤️ 기능 설명
생성된 운동에 신청하는 API입니다.
- 이미 시작된 운동이 아닌지 확인합니다.
- 중복 신청이 아닌지 확인합니다.
- 파티 멤버인지, 아닐 경우 외부 게스트 허용인지 확인합니다.


![image](https://github.com/user-attachments/assets/69993fb6-2783-4de9-a705-23fd52e74953)

<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #19 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!
없습니다!

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
