### PR TITLE
[Feat/#44] 대회 기록 삭제 API 구현

### DIFF
--- a/src/main/java/umc/cockple/demo/domain/contest/controller/ContestController.java
+++ b/src/main/java/umc/cockple/demo/domain/contest/controller/ContestController.java
@@ -6,6 +6,8 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -45,6 +47,10 @@ public class ContestController {
     }
 
     @PatchMapping(value = "/contests/my/{contestId}", consumes = {"multipart/form-data"})
+    @Operation(summary = "대회 기록 수정", description = "회원이 자신의 대회 기록을 수정합니다.")
+    @ApiResponse(responseCode = "201", description = "대회 기록 수정 성공")
+    @ApiResponse(responseCode = "400", description = "입력값 오류")
+    @ApiResponse(responseCode = "403", description = "권한 없음")
     public BaseResponse<ContestRecordUpdateResponseDTO> updateContestRecord(
             //@AuthenticationPrincipal Long memberId
             @PathVariable Long contestId,
@@ -58,6 +64,24 @@ public class ContestController {
         ContestRecordUpdateResponseDTO response = contestCommandService.updateContestRecord(memberId, contestId, contestImgsToAdd, request);
 
         return BaseResponse.success(CommonSuccessCode.CREATED, response);
+    }
+
+    @DeleteMapping(value = "/contests/my/{contestId}")
+    @Operation(summary = "대회 기록 삭제", description = "회원이 자신의 대회 기록을 삭제합니다.")
+    @ApiResponse(responseCode = "200", description = "대회 기록 삭제 성공")
+    @ApiResponse(responseCode = "403", description = "권한 없음")
+    public BaseResponse<ContestRecordDeleteResponseDTO> deleteContestRecord(
+            //@AuthenticationPrincipal Long memberId
+            @PathVariable Long contestId
+    ) {
+
+        // TODO: JWT 인증 구현 후 교체 예정
+        Long memberId = 1L; // 임시값
+
+        ContestRecordDeleteResponseDTO response =
+                contestCommandService.deleteContestRecord(memberId, contestId);
+
+        return BaseResponse.success(CommonSuccessCode.OK, response);
     }
 
 }

--- a/src/main/java/umc/cockple/demo/domain/contest/converter/ContestConverter.java
+++ b/src/main/java/umc/cockple/demo/domain/contest/converter/ContestConverter.java
@@ -43,4 +43,11 @@ public class ContestConverter {
                 .UpdatedAt(contest.getUpdatedAt())
                 .build();
     }
+
+    // 대회 기록 삭제
+    public ContestRecordDeleteResponseDTO toDeleteResponseDTO(Contest contest) {
+        return ContestRecordDeleteResponseDTO.builder()
+                .deleteContestId(contest.getId())
+                .build();
+    }
 }

--- a/src/main/java/umc/cockple/demo/domain/contest/domain/Contest.java
+++ b/src/main/java/umc/cockple/demo/domain/contest/domain/Contest.java
@@ -60,9 +60,15 @@ public class Contest extends BaseEntity {
     @OneToMany(mappedBy = "contest", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ContestVideo> contestVideos = new ArrayList<>();
 
+    public void setMember(Member member) {
+        this.member = member;
+        if (!member.getContests().contains(this)) {
+            member.getContests().add(this);
+        }
+    }
 
     public static Contest create(ContestRecordCreateCommand command, Member member) {
-        return Contest.builder()
+        Contest contest =  Contest.builder()
                 .member(member)
                 .contestName(command.contestName())
                 .date(command.date())
@@ -72,9 +78,21 @@ public class Contest extends BaseEntity {
                 .content(command.content())
                 .contentIsOpen(command.contentIsOpen())
                 .videoIsOpen(command.videoIsOpen())
-                .contestImgs(new ArrayList<>()) // 이거 꼭!
-                .contestVideos(new ArrayList<>())  // 안전하게 초기화
+                .contestImgs(new ArrayList<>())
+                .contestVideos(new ArrayList<>())
                 .build();
+
+        // 양방향 설정
+        contest.setMember(member);
+
+        return contest;
+    }
+
+    public void removeMember() {
+        if (this.member != null) {
+            this.member.getContests().remove(this);
+            this.member = null;
+        }
     }
 
     public void addContestImg(ContestImg img) {

--- a/src/main/java/umc/cockple/demo/domain/contest/domain/ContestVideo.java
+++ b/src/main/java/umc/cockple/demo/domain/contest/domain/ContestVideo.java
@@ -26,11 +26,21 @@ public class ContestVideo {
     @Column(nullable = false)
     private Integer videoOrder;
 
+    public void setContest(Contest contest) {
+        this.contest = contest;
+
+        if (!contest.getContestVideos().contains(this)) {
+            contest.getContestVideos().add(this);
+        }
+    }
+
     public static ContestVideo of(Contest contest, String videoUrl, Integer videoOrder) {
-        return ContestVideo.builder()
-                .contest(contest)
+        ContestVideo video = ContestVideo.builder()
                 .videoUrl(videoUrl)
                 .videoOrder(videoOrder)
                 .build();
+        video.setContest(contest);
+        return video;
     }
+
 }

--- a/src/main/java/umc/cockple/demo/domain/contest/dto/ContestRecordDeleteCommand.java
+++ b/src/main/java/umc/cockple/demo/domain/contest/dto/ContestRecordDeleteCommand.java
@@ -1,0 +1,10 @@
+package umc.cockple.demo.domain.contest.dto;
+
+import lombok.Builder;
+
+@Builder
+public record ContestRecordDeleteCommand(
+        Long contestId,
+        Long memberId
+) {
+}

--- a/src/main/java/umc/cockple/demo/domain/contest/dto/ContestRecordDeleteResponseDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/contest/dto/ContestRecordDeleteResponseDTO.java
@@ -1,0 +1,12 @@
+package umc.cockple.demo.domain.contest.dto;
+
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder
+public record ContestRecordDeleteResponseDTO(
+        Long deleteContestId
+) {
+
+}

--- a/src/main/java/umc/cockple/demo/domain/contest/dto/ContestRecordDetailResponseDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/contest/dto/ContestRecordDetailResponseDTO.java
@@ -1,0 +1,27 @@
+package umc.cockple.demo.domain.contest.dto;
+
+import lombok.Builder;
+import org.springframework.web.multipart.MultipartFile;
+import umc.cockple.demo.global.enums.Level;
+import umc.cockple.demo.global.enums.MedalType;
+import umc.cockple.demo.global.enums.ParticipationType;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Builder
+public record ContestRecordDetailResponseDTO(
+        Long contestId,
+        String contestName,
+        LocalDate date,
+        MedalType medalType,
+        ParticipationType type,
+        Level level,
+        String content,
+        Boolean contentIsOpen,
+        Boolean videoIsOpen,
+        List<String> contestVideos,
+        List<String> contestImgs
+
+) {
+}

--- a/src/main/java/umc/cockple/demo/domain/contest/repository/ContestRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/contest/repository/ContestRepository.java
@@ -3,5 +3,8 @@ package umc.cockple.demo.domain.contest.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import umc.cockple.demo.domain.contest.domain.Contest;
 
+import java.util.Optional;
+
 public interface ContestRepository extends JpaRepository<Contest, Long> {
+    Optional<Contest> findByIdAndMember_Id(Long contestId, Long memberId);
 }

--- a/src/main/java/umc/cockple/demo/domain/contest/service/ContestCommandService.java
+++ b/src/main/java/umc/cockple/demo/domain/contest/service/ContestCommandService.java
@@ -1,10 +1,7 @@
 package umc.cockple.demo.domain.contest.service;
 
 import org.springframework.web.multipart.MultipartFile;
-import umc.cockple.demo.domain.contest.dto.ContestRecordCreateRequestDTO;
-import umc.cockple.demo.domain.contest.dto.ContestRecordCreateResponseDTO;
-import umc.cockple.demo.domain.contest.dto.ContestRecordUpdateRequestDTO;
-import umc.cockple.demo.domain.contest.dto.ContestRecordUpdateResponseDTO;
+import umc.cockple.demo.domain.contest.dto.*;
 
 import java.util.List;
 
@@ -16,4 +13,7 @@ public interface ContestCommandService {
     ContestRecordUpdateResponseDTO updateContestRecord(
             Long memberId, Long contestId, List<MultipartFile> ContestImage, ContestRecordUpdateRequestDTO request
     );
+
+    ContestRecordDeleteResponseDTO deleteContestRecord(
+            Long memberId, Long contestId);
 }

--- a/src/main/java/umc/cockple/demo/domain/contest/service/ContestCommandServiceImpl.java
+++ b/src/main/java/umc/cockple/demo/domain/contest/service/ContestCommandServiceImpl.java
@@ -96,14 +96,8 @@ public class ContestCommandServiceImpl implements ContestCommandService {
 
         log.info("[대회 기록 수정 시작] - memberId: {}, contestId: {}", memberId, contestId);
 
-        // 1. 대회 조회
-        Contest contest = contestRepository.findById(contestId)
+        Contest contest = contestRepository.findByIdAndMember_Id(contestId, memberId)
                 .orElseThrow(() -> new ContestException(ContestErrorCode.CONTEST_NOT_FOUND));
-
-        // 1-1. 본인 확인
-        if (!contest.getMember().getId().equals(memberId)) {
-            throw new ContestException(ContestErrorCode.NO_DELETE_AUTHORITY);
-        }
 
         // 2. 기본 필드 수정
         contest.updateFromRequest(request);
@@ -164,7 +158,24 @@ public class ContestCommandServiceImpl implements ContestCommandService {
         return contestConverter.toUpdateResponseDTO(contest);
     }
 
-    // todo: 삭제
+    // 삭제
+    @Override
+    public ContestRecordDeleteResponseDTO deleteContestRecord(Long memberId, Long contestId) {
+
+        log.info("[대회 기록 삭제 시작] - memberId: {}, contestId: {}", memberId, contestId);
+
+        // 1. 대회 조회
+        Contest contest = contestRepository.findByIdAndMember_Id(contestId, memberId)
+                .orElseThrow(() -> new ContestException(ContestErrorCode.CONTEST_NOT_FOUND));
+
+        // 2. 대회 삭제
+        contestRepository.delete(contest);
+
+        log.info("대회 기록 삭제 완료 - contestId: {}", contestId);
+
+        return contestConverter.toDeleteResponseDTO(contest);
+    }
+
 
     private static void extractedVideo(ContestRecordUpdateRequestDTO request, Contest contest) {
         if (request.contestVideos() != null) {

--- a/src/main/java/umc/cockple/demo/domain/contest/service/ContestCommandServiceImpl.java
+++ b/src/main/java/umc/cockple/demo/domain/contest/service/ContestCommandServiceImpl.java
@@ -168,7 +168,10 @@ public class ContestCommandServiceImpl implements ContestCommandService {
         Contest contest = contestRepository.findByIdAndMember_Id(contestId, memberId)
                 .orElseThrow(() -> new ContestException(ContestErrorCode.CONTEST_NOT_FOUND));
 
-        // 2. 대회 삭제
+        // 2. 연관관계 해제 (양방향)
+        contest.removeMember();
+
+        // 3. 삭제
         contestRepository.delete(contest);
 
         log.info("대회 기록 삭제 완료 - contestId: {}", contestId);


### PR DESCRIPTION
## ❤️ 기능 설명

swagger 테스트 성공 결과 스크린샷 첨부
<br>
<img width="1470" height="956" alt="스크린샷 2025-07-14 16 22 27" src="https://github.com/user-attachments/assets/6d7be53c-6385-4b4c-86d8-675eede5f64f" />
<img width="369" height="185" alt="스크린샷 2025-07-14 16 22 51" src="https://github.com/user-attachments/assets/bcc7f86a-2de4-44cb-8057-53bbdd6d7600" />
이미지랑 동영상도 잘 삭제 되었습니다.

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #44 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.


<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?

