### PR TITLE
[refactor/#47] 엔티티 정적 팩토리 메서드의 매핑 로직 분리

### DIFF
--- a/src/main/java/umc/cockple/demo/domain/exercise/domain/Exercise.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/domain/Exercise.java
@@ -80,14 +80,6 @@ public class Exercise extends BaseEntity {
                 .build();
     }
 
-    public Guest addGuest(GuestInviteCommand command) {
-        Integer participantNum = calculateNextParticipantNumber();
-        Guest guest = Guest.createForExercise(this, command, participantNum);
-        addToGuests(guest);
-
-        return guest;
-    }
-
     public Integer removeParticipant(MemberExercise memberExercise) {
         int removedNum = memberExercise.getParticipantNum();
         removeFromParticipants(memberExercise);
@@ -118,6 +110,13 @@ public class Exercise extends BaseEntity {
     /**
      * 연관관계 매핑 메서드
      */
+    public void setParty(Party party) {
+        this.party = party;
+        if (party != null && !party.getExercises().contains(this)) {
+            party.getExercises().add(this);
+        }
+    }
+
     public void addParticipation(MemberExercise memberExercise) {
         this.memberExercises.add(memberExercise);
         memberExercise.setExercise(this);
@@ -129,16 +128,9 @@ public class Exercise extends BaseEntity {
         this.nowCapacity--;
     }
 
-    private void addToGuests(Guest guest) {
+    public void addGuest(Guest guest) {
         this.guests.add(guest);
         guest.setExercise(this);
         this.nowCapacity++;
-    }
-
-    public void setParty(Party party) {
-        this.party = party;
-        if (party != null && !party.getExercises().contains(this)) {
-            party.getExercises().add(this);
-        }
     }
 }

--- a/src/main/java/umc/cockple/demo/domain/exercise/domain/Exercise.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/domain/Exercise.java
@@ -2,6 +2,7 @@ package umc.cockple.demo.domain.exercise.domain;
 
 import jakarta.persistence.*;
 import lombok.*;
+import umc.cockple.demo.domain.exercise.dto.ExerciseAddrCreateCommand;
 import umc.cockple.demo.domain.exercise.dto.ExerciseCreateCommand;
 import umc.cockple.demo.domain.exercise.dto.GuestInviteCommand;
 import umc.cockple.demo.domain.member.domain.Member;
@@ -67,9 +68,8 @@ public class Exercise extends BaseEntity {
     @Builder.Default
     private List<Guest> guests = new ArrayList<>();
 
-    public static Exercise create(Party party, ExerciseAddr exerciseAddr, ExerciseCreateCommand command) {
+    public static Exercise create(ExerciseAddr exerciseAddr, ExerciseCreateCommand command) {
         return Exercise.builder()
-                .party(party)
                 .exerciseAddr(exerciseAddr)
                 .date(command.date())
                 .startTime(command.startTime())

--- a/src/main/java/umc/cockple/demo/domain/exercise/domain/Exercise.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/domain/Exercise.java
@@ -2,10 +2,8 @@ package umc.cockple.demo.domain.exercise.domain;
 
 import jakarta.persistence.*;
 import lombok.*;
-import umc.cockple.demo.domain.exercise.dto.ExerciseAddrCreateCommand;
 import umc.cockple.demo.domain.exercise.dto.ExerciseCreateCommand;
 import umc.cockple.demo.domain.exercise.dto.GuestInviteCommand;
-import umc.cockple.demo.domain.member.domain.Member;
 import umc.cockple.demo.domain.member.domain.MemberExercise;
 import umc.cockple.demo.domain.party.domain.Party;
 import umc.cockple.demo.global.common.BaseEntity;
@@ -82,14 +80,6 @@ public class Exercise extends BaseEntity {
                 .build();
     }
 
-    public MemberExercise addParticipant(Member member) {
-        Integer participantNum = calculateNextParticipantNumber();
-        MemberExercise memberExercise = MemberExercise.createParticipation(this, member, participantNum);
-        addToParticipants(memberExercise);
-
-        return memberExercise;
-    }
-
     public Guest addGuest(GuestInviteCommand command) {
         Integer participantNum = calculateNextParticipantNumber();
         Guest guest = Guest.createForExercise(this, command, participantNum);
@@ -111,7 +101,7 @@ public class Exercise extends BaseEntity {
         return exerciseDateTime.isBefore(LocalDateTime.now());
     }
 
-    private Integer calculateNextParticipantNumber() {
+    public Integer calculateNextParticipantNumber() {
         return this.nowCapacity + 1;
     }
 
@@ -128,7 +118,7 @@ public class Exercise extends BaseEntity {
     /**
      * 연관관계 매핑 메서드
      */
-    private void addToParticipants(MemberExercise memberExercise) {
+    public void addParticipation(MemberExercise memberExercise) {
         this.memberExercises.add(memberExercise);
         memberExercise.setExercise(this);
         this.nowCapacity++;

--- a/src/main/java/umc/cockple/demo/domain/exercise/domain/Exercise.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/domain/Exercise.java
@@ -80,12 +80,14 @@ public class Exercise extends BaseEntity {
                 .build();
     }
 
-    public Integer removeParticipant(MemberExercise memberExercise) {
-        int removedNum = memberExercise.getParticipantNum();
-        removeFromParticipants(memberExercise);
-        reorderParticipantNumbers(removedNum);
+    public void reorderParticipantNumbers(int removedNum) {
+        memberExercises.stream()
+                .filter(me -> me.getParticipantNum() > removedNum)
+                .forEach(MemberExercise::decrementParticipantNum);
 
-        return removedNum;
+        guests.stream()
+                .filter(g -> g.getParticipantNum() > removedNum)
+                .forEach(g -> g.decrementParticipantNum());
     }
 
     public boolean isAlreadyStarted() {
@@ -97,15 +99,6 @@ public class Exercise extends BaseEntity {
         return this.nowCapacity + 1;
     }
 
-    private void reorderParticipantNumbers(int removedNum) {
-        memberExercises.stream()
-                .filter(me -> me.getParticipantNum() > removedNum)
-                .forEach(MemberExercise::decrementParticipantNum);
-
-        guests.stream()
-                .filter(g -> g.getParticipantNum() > removedNum)
-                .forEach(g -> g.decrementParticipantNum());
-    }
 
     /**
      * 연관관계 매핑 메서드
@@ -123,14 +116,14 @@ public class Exercise extends BaseEntity {
         this.nowCapacity++;
     }
 
-    private void removeFromParticipants(MemberExercise memberExercise) {
-        this.memberExercises.remove(memberExercise);
-        this.nowCapacity--;
-    }
-
     public void addGuest(Guest guest) {
         this.guests.add(guest);
         guest.setExercise(this);
         this.nowCapacity++;
+    }
+
+    public void removeParticipation(MemberExercise memberExercise) {
+        this.memberExercises.remove(memberExercise);
+        this.nowCapacity--;
     }
 }

--- a/src/main/java/umc/cockple/demo/domain/exercise/domain/Guest.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/domain/Guest.java
@@ -39,9 +39,8 @@ public class Guest extends BaseEntity {
     @Column(nullable = false)
     private Integer participantNum;
 
-    public static Guest createForExercise(Exercise exercise, GuestInviteCommand command, Integer participantNum) {
+    public static Guest create(GuestInviteCommand command, Integer participantNum) {
         return Guest.builder()
-                .exercise(exercise)
                 .guestName(command.guestName())
                 .gender(command.gender())
                 .level(command.level())

--- a/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseCommandService.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseCommandService.java
@@ -65,7 +65,11 @@ public class ExerciseCommandService {
         Member member = findMemberOrThrow(memberId);
         validateJoinExercise(exercise, member);
 
-        MemberExercise memberExercise = exercise.addParticipant(member);
+        Integer participantNum = exercise.calculateNextParticipantNumber();
+        MemberExercise memberExercise = MemberExercise.createParticipation(participantNum);
+        member.addParticipation(memberExercise);
+        exercise.addParticipation(memberExercise);
+
         MemberExercise savedMemberExercise = memberExerciseRepository.save(memberExercise);
 
         log.info("운동 신청 종료 - memberExerciseId: {}", savedMemberExercise.getId());

--- a/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseCommandService.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseCommandService.java
@@ -66,6 +66,7 @@ public class ExerciseCommandService {
         validateJoinExercise(exercise, member);
 
         Integer participantNum = exercise.calculateNextParticipantNumber();
+
         MemberExercise memberExercise = MemberExercise.create(participantNum);
         member.addParticipation(memberExercise);
         exercise.addParticipation(memberExercise);
@@ -87,8 +88,8 @@ public class ExerciseCommandService {
         validateGuestInvitation(exercise, inviter);
 
         GuestInviteCommand command = exerciseConverter.toGuestInviteCommand(request, inviterId);
-
         Integer participantNum = exercise.calculateNextParticipantNumber();
+
         Guest guest = Guest.create(command, participantNum);
         exercise.addGuest(guest);
 
@@ -108,7 +109,13 @@ public class ExerciseCommandService {
         MemberExercise memberExercise = findMemberExerciseOrThrow(exercise, member);
         validateCancelParticipation(exercise);
 
-        Integer participantNumber = exercise.removeParticipant(memberExercise);
+        Integer participantNumber = memberExercise.getParticipantNum();
+
+        exercise.removeParticipation(memberExercise);
+        member.removeParticipation(memberExercise);
+
+        exercise.reorderParticipantNumbers(participantNumber);
+
         memberExerciseRepository.delete(memberExercise);
         exerciseRepository.save(exercise);
 

--- a/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseCommandService.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseCommandService.java
@@ -49,6 +49,7 @@ public class ExerciseCommandService {
         ExerciseAddrCreateCommand addrCommand = exerciseConverter.toAddrCreateCommand(request);
 
         Exercise exercise = party.createExercise(exerciseCommand, addrCommand);
+        party.addExercise(exercise);
         Exercise savedExercise = exerciseRepository.save(exercise);
 
         log.info("운동 생성 완료 - 운동ID: {}", savedExercise.getId());

--- a/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseCommandService.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseCommandService.java
@@ -66,7 +66,7 @@ public class ExerciseCommandService {
         validateJoinExercise(exercise, member);
 
         Integer participantNum = exercise.calculateNextParticipantNumber();
-        MemberExercise memberExercise = MemberExercise.createParticipation(participantNum);
+        MemberExercise memberExercise = MemberExercise.create(participantNum);
         member.addParticipation(memberExercise);
         exercise.addParticipation(memberExercise);
 
@@ -88,7 +88,10 @@ public class ExerciseCommandService {
 
         GuestInviteCommand command = exerciseConverter.toGuestInviteCommand(request, inviterId);
 
-        Guest guest = exercise.addGuest(command);
+        Integer participantNum = exercise.calculateNextParticipantNumber();
+        Guest guest = Guest.create(command, participantNum);
+        exercise.addGuest(guest);
+
         Guest savedGuest = guestRepository.save(guest);
 
         log.info("게스트 초대 완료 - guestId: {}", savedGuest.getId());

--- a/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseCommandService.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseCommandService.java
@@ -50,6 +50,7 @@ public class ExerciseCommandService {
 
         Exercise exercise = party.createExercise(exerciseCommand, addrCommand);
         party.addExercise(exercise);
+
         Exercise savedExercise = exerciseRepository.save(exercise);
 
         log.info("운동 생성 완료 - 운동ID: {}", savedExercise.getId());
@@ -115,8 +116,8 @@ public class ExerciseCommandService {
         member.removeParticipation(memberExercise);
 
         exercise.reorderParticipantNumbers(participantNumber);
-
         memberExerciseRepository.delete(memberExercise);
+
         exerciseRepository.save(exercise);
 
         log.info("운동 참여 취소 완료 - exerciseId: {}, memberId: {}, 현재 참여자 수: {}",

--- a/src/main/java/umc/cockple/demo/domain/member/domain/Member.java
+++ b/src/main/java/umc/cockple/demo/domain/member/domain/Member.java
@@ -78,4 +78,8 @@ public class Member extends BaseEntity {
         this.memberExercises.add(memberExercise);
         memberExercise.setMember(this);
     }
+
+    public void removeParticipation(MemberExercise memberExercise) {
+        this.memberExercises.remove(memberExercise);
+    }
 }

--- a/src/main/java/umc/cockple/demo/domain/member/domain/Member.java
+++ b/src/main/java/umc/cockple/demo/domain/member/domain/Member.java
@@ -74,4 +74,8 @@ public class Member extends BaseEntity {
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
     private List<PartyBookmark> partyBookmarks = new ArrayList<>();
 
+    public void addParticipation(MemberExercise memberExercise) {
+        this.memberExercises.add(memberExercise);
+        memberExercise.setMember(this);
+    }
 }

--- a/src/main/java/umc/cockple/demo/domain/member/domain/MemberExercise.java
+++ b/src/main/java/umc/cockple/demo/domain/member/domain/MemberExercise.java
@@ -33,10 +33,8 @@ public class MemberExercise extends BaseEntity {
     @Column(nullable = false)
     private Integer participantNum;
 
-    public static MemberExercise createParticipation(Exercise exercise, Member member, Integer participantNum) {
+    public static MemberExercise createParticipation(Integer participantNum) {
         return MemberExercise.builder()
-                .exercise(exercise)
-                .member(member)
                 .joinedAt(LocalDateTime.now())
                 .participantNum(participantNum)
                 .build();
@@ -46,6 +44,13 @@ public class MemberExercise extends BaseEntity {
         this.exercise = exercise;
         if (exercise != null && !exercise.getMemberExercises().contains(this)) {
             exercise.getMemberExercises().add(this);
+        }
+    }
+
+    public void setMember(Member member) {
+        this.member = member;
+        if (member != null && !member.getMemberExercises().contains(this)) {
+            member.getMemberExercises().add(this);
         }
     }
 

--- a/src/main/java/umc/cockple/demo/domain/member/domain/MemberExercise.java
+++ b/src/main/java/umc/cockple/demo/domain/member/domain/MemberExercise.java
@@ -3,7 +3,6 @@ package umc.cockple.demo.domain.member.domain;
 import jakarta.persistence.*;
 import lombok.*;
 import umc.cockple.demo.domain.exercise.domain.Exercise;
-import umc.cockple.demo.global.enums.ExerciseOrderType;
 import umc.cockple.demo.global.common.BaseEntity;
 
 import java.time.LocalDateTime;
@@ -33,7 +32,7 @@ public class MemberExercise extends BaseEntity {
     @Column(nullable = false)
     private Integer participantNum;
 
-    public static MemberExercise createParticipation(Integer participantNum) {
+    public static MemberExercise create(Integer participantNum) {
         return MemberExercise.builder()
                 .joinedAt(LocalDateTime.now())
                 .participantNum(participantNum)

--- a/src/main/java/umc/cockple/demo/domain/party/domain/Party.java
+++ b/src/main/java/umc/cockple/demo/domain/party/domain/Party.java
@@ -146,14 +146,14 @@ public class Party extends BaseEntity {
 
     public Exercise createExercise(ExerciseCreateCommand command, ExerciseAddrCreateCommand addrCommand) {
         ExerciseAddr exerciseAddr = ExerciseAddr.create(addrCommand);
-        Exercise exercise = Exercise.create(this, exerciseAddr, command);
+        return Exercise.create(exerciseAddr, command);
+    }
 
+    public void addExercise(Exercise exercise) {
         this.exercises.add(exercise);
         exercise.setParty(this);
 
         this.exerciseCount = exercises.size();
-
-        return exercise;
     }
 
 }


### PR DESCRIPTION
## ❤️ 기능 설명
기존에 생성 로직에 매핑 로직이 혼재되어 있어 양방향 매핑이 제대로 이루어지지 않는 문제가 있었습니다.
부모-자식 관계(Ex.  운동-운동 주소)를 제외하고는 정적 팩토리 메서드에서 매핑을 진행하지 않고,
별도의 매핑 메서드를 통해 양방향 매핑을 진행했습니다.

swagger 테스트 성공 결과 스크린샷 첨부

운동 생성
<img width="2134" height="1056" alt="image" src="https://github.com/user-attachments/assets/89968257-5de5-4f6c-890a-51b1ecdb5fb1" />


운동 참여
<img width="2145" height="830" alt="image" src="https://github.com/user-attachments/assets/1b9977b6-8402-46d0-865e-248ea23ae989" />


게스트 초대
<img width="2128" height="891" alt="image" src="https://github.com/user-attachments/assets/c2eaabaf-8a6f-4fee-b5a9-aa1eb798ea19" />

운동 참여 취소
<img width="2111" height="788" alt="image" src="https://github.com/user-attachments/assets/5437c43c-8fc2-4cae-ae26-9a4d01fa208f" />

<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #47 
<br>
<br>

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
