### PR TITLE
[feat/#51] 특정 회원 운동 취소 API 구현

### DIFF
--- a/src/main/java/umc/cockple/demo/domain/exercise/controller/ExerciseController.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/controller/ExerciseController.java
@@ -103,4 +103,27 @@ public class ExerciseController {
 
         return BaseResponse.success(CommonSuccessCode.OK, response);
     }
+
+    @DeleteMapping("/exercises/{exerciseId}/participants/{participantId}")
+    @Operation(summary = "특정 참여자 운동 취소",
+            description = "모임장이나 부모임장이 특정 참여자의 운동 참여를 취소합니다.")
+    @ApiResponse(responseCode = "200", description = "운동 참여 취소 성공")
+    @ApiResponse(responseCode = "400", description = "취소할 수 없는 상태 (이미 시작됨, 참여하지 않음 등)")
+    @ApiResponse(responseCode = "403", description = "권한 없음 (매니저가 아님)")
+    @ApiResponse(responseCode = "404", description = "운동 또는 참여 기록을 찾을 수 없음")
+    public BaseResponse<ExerciseCancelResponseDTO> cancelParticipationByManager(
+            @PathVariable Long exerciseId,
+            @PathVariable Long participantId,
+            @RequestBody ExerciseManagerCancelRequestDTO request,
+            Authentication authentication
+    ) {
+
+        // TODO: JWT 인증 구현 후 교체 예정
+        Long memberId = 1L; // 임시값
+
+        ExerciseCancelResponseDTO response = exerciseCommandService.cancelParticipationByManager(
+                exerciseId, participantId, memberId, request);
+
+        return BaseResponse.success(CommonSuccessCode.OK, response);
+    }
 }

--- a/src/main/java/umc/cockple/demo/domain/exercise/converter/ExerciseConverter.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/converter/ExerciseConverter.java
@@ -74,4 +74,12 @@ public class ExerciseConverter {
                 .currentParticipants(exercise.getNowCapacity())
                 .build();
     }
+
+    public ExerciseCancelResponseDTO toCancelResponseDTO(Exercise exercise, Guest guest, Integer participantNumber) {
+        return ExerciseCancelResponseDTO.builder()
+                .memberName(guest.getGuestName())
+                .cancelledParticipationNumber(participantNumber)
+                .currentParticipants(exercise.getNowCapacity())
+                .build();
+    }
 }

--- a/src/main/java/umc/cockple/demo/domain/exercise/domain/Exercise.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/domain/Exercise.java
@@ -126,4 +126,9 @@ public class Exercise extends BaseEntity {
         this.memberExercises.remove(memberExercise);
         this.nowCapacity--;
     }
+
+    public void removeGuest(Guest guest) {
+        this.guests.remove(guest);
+        this.nowCapacity--;
+    }
 }

--- a/src/main/java/umc/cockple/demo/domain/exercise/dto/ExerciseManagerCancelRequestDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/dto/ExerciseManagerCancelRequestDTO.java
@@ -1,0 +1,9 @@
+package umc.cockple.demo.domain.exercise.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public record ExerciseManagerCancelRequestDTO(
+        @NotNull
+        Boolean isGuest
+) {
+}

--- a/src/main/java/umc/cockple/demo/domain/exercise/exception/ExerciseErrorCode.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/exception/ExerciseErrorCode.java
@@ -24,6 +24,7 @@ public enum ExerciseErrorCode implements BaseErrorCode {
     EXERCISE_NOT_FOUND(HttpStatus.NOT_FOUND, "EXERCISE202", "존재하지 않는 운동입니다."),
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "EXERCISE203", "존재하지 않는 멤버입니다."),
     MEMBER_EXERCISE_NOT_FOUND(HttpStatus.NOT_FOUND, "EXERCISE204", "존재하지 않는 운동 참여입니다."),
+    GUEST_NOT_FOUND(HttpStatus.NOT_FOUND, "EXERCISE205", "존재하지 않는 게스트입니다."),
 
     INSUFFICIENT_PERMISSION(HttpStatus.FORBIDDEN, "EXERCISE301", "운동을 생성할 권한이 없습니다."),
     NOT_PARTY_MEMBER(HttpStatus.FORBIDDEN, "EXERCISE302", "파티 멤버만 참여할 수 있습니다."),
@@ -35,7 +36,8 @@ public enum ExerciseErrorCode implements BaseErrorCode {
     EXERCISE_ALREADY_STARTED_PARTICIPATION(HttpStatus.BAD_REQUEST, "EXERCISE403", "이미 시작된 운동에는 참여할 수 없습니다."),
     EXERCISE_ALREADY_STARTED_INVITATION(HttpStatus.BAD_REQUEST, "EXERCISE404", "이미 시작된 운동에는 초대할 수 없습니다."),
     EXERCISE_ALREADY_STARTED_CANCEL(HttpStatus.BAD_REQUEST, "EXERCISE405", "이미 시작된 운동에는 취소할 수 없습니다."),
-    ALREADY_JOINED_EXERCISE(HttpStatus.BAD_REQUEST, "EXERCISE406", "이미 참여 신청한 운동입니다.");
+    ALREADY_JOINED_EXERCISE(HttpStatus.BAD_REQUEST, "EXERCISE406", "이미 참여 신청한 운동입니다."),
+    GUEST_IS_NOT_PARTICIPATED_IN_EXERCISE(HttpStatus.BAD_REQUEST, "EXERCISE407", "게스트가 이 운동에 참여해있지 않습니다..");
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseCommandService.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseCommandService.java
@@ -126,8 +126,21 @@ public class ExerciseCommandService {
         return exerciseConverter.toCancelResponseDTO(exercise, member, participantNumber);
     }
 
-    // ========== 검증 메서드들 ==========
+    public ExerciseCancelResponseDTO cancelParticipationByManager(
+            Long exerciseId, Long participantId, Long memberId, ExerciseManagerCancelRequestDTO request) {
 
+        log.info("매니저에 의한 운동 참여 취소 시작 - exerciseId: {}, participantId: {}, memberId: {}", exerciseId, participantId, memberId);
+
+        Exercise exercise = findExerciseOrThrow(exerciseId);
+        Member manager = findMemberOrThrow(memberId);
+        Member participant = findMemberOrThrow(participantId);
+        validateCancelParticipationByManager(exercise, manager);
+
+
+    }
+
+
+    // ========== 검증 메서드들 ==========
     private void validateCreateExercise(Long memberId, ExerciseCreateRequestDTO request, Party party) {
         validateMemberPermission(memberId, party);
         validateExerciseTime(request);
@@ -147,6 +160,11 @@ public class ExerciseCommandService {
 
     private void validateCancelParticipation(Exercise exercise) {
         validateAlreadyStarted(exercise, ExerciseErrorCode.EXERCISE_ALREADY_STARTED_CANCEL);
+    }
+
+    private void validateCancelParticipationByManager(Exercise exercise, Member manager) {
+        validateAlreadyStarted(exercise, ExerciseErrorCode.EXERCISE_ALREADY_STARTED_CANCEL);
+        validateMemberPermission(manager.getId(), exercise.getParty());
     }
 
     // ========== 세부 검증 메서드들 ==========


### PR DESCRIPTION
## ❤️ 기능 설명
모임장 또는 부모임장이 운동의 특정 참가자의 참가를 취소시킵니다.

검증
- 운동이 존재하는지
- 멤버가 존재하는지
- 운동이 이미 시작하진 않았는지
- 멤버가 모임장 또는 부모임장인지

그 후, 참가자가 게스트인지 여부를 프론트에서 넘겨준 boolean값을 통해 확인한 뒤,
참가자를 제거하고, 순서를 재정렬시킵니다.

swagger 테스트 성공 결과 스크린샷 첨부
<img width="2123" height="857" alt="image" src="https://github.com/user-attachments/assets/3e5d6eff-4ae6-42f0-87e0-fddfe4d3182a" />

<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #51 
<br>
<br>

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
