### PR TITLE
[feat/#43] 운동 게스트 삭제 API 구현

### DIFF
--- a/src/main/java/umc/cockple/demo/domain/exercise/controller/ExerciseController.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/controller/ExerciseController.java
@@ -104,6 +104,28 @@ public class ExerciseController {
         return BaseResponse.success(CommonSuccessCode.OK, response);
     }
 
+    @DeleteMapping("/exercises/{exerciseId}/guests/{guestId}")
+    @Operation(summary = "게스트 초대 취소",
+            description = "사용자가 본인이 초대한 게스트를 취소합니다.")
+    @ApiResponse(responseCode = "200", description = "게스트 초대 취소 성공")
+    @ApiResponse(responseCode = "400", description = "취소할 수 없는 상태 (이미 시작됨)")
+    @ApiResponse(responseCode = "403", description = "본인이 초대한 게스트가 아닌 경우 취소할 수 없음")
+    @ApiResponse(responseCode = "404", description = "운동 또는 참여 기록을 찾을 수 없음")
+    public BaseResponse<ExerciseCancelResponseDTO> cancelGuestInvitation(
+            @PathVariable Long exerciseId,
+            @PathVariable Long guestId,
+            Authentication authentication
+    ) {
+
+        // TODO: JWT 인증 구현 후 교체 예정
+        Long memberId = 1L; // 임시값
+
+        ExerciseCancelResponseDTO response = exerciseCommandService.cancelGuestInvitation(
+                exerciseId, guestId, memberId);
+
+        return BaseResponse.success(CommonSuccessCode.OK, response);
+    }
+
     @DeleteMapping("/exercises/{exerciseId}/participants/{participantId}")
     @Operation(summary = "특정 참여자 운동 취소",
             description = "모임장이나 부모임장이 특정 참여자의 운동 참여를 취소합니다.")

--- a/src/main/java/umc/cockple/demo/domain/exercise/exception/ExerciseErrorCode.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/exception/ExerciseErrorCode.java
@@ -30,6 +30,7 @@ public enum ExerciseErrorCode implements BaseErrorCode {
     NOT_PARTY_MEMBER(HttpStatus.FORBIDDEN, "EXERCISE302", "파티 멤버만 참여할 수 있습니다."),
     NOT_PARTY_MEMBER_FOR_GUEST_INVITE(HttpStatus.FORBIDDEN, "EXERCISE303", "파티 멤버만 게스트를 초대할 수 있습니다."),
     GUEST_INVITATION_NOT_ALLOWED(HttpStatus.FORBIDDEN, "EXERCISE304", "외부 게스트 초대가 허용되지 않았습니다."),
+    GUEST_NOT_INVITED_BY_MEMBER(HttpStatus.FORBIDDEN, "EXERCISE305", "본인이 아닌 다른 사용자에 의해 초대된 게스트입니다."),
 
     INVALID_EXERCISE_TIME(HttpStatus.BAD_REQUEST, "EXERCISE401", "종료 시간은 시작 시간보다 늦어야 합니다."),
     PAST_TIME_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "EXERCISE402", "운동 시간은 과거로 할 수 없습니다."),

--- a/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseCommandService.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseCommandService.java
@@ -189,6 +189,7 @@ public class ExerciseCommandService {
     }
 
     private void validateCancelGuestInvitation(Exercise exercise, Guest guest, Member member) {
+        validateAlreadyStarted(exercise, ExerciseErrorCode.EXERCISE_ALREADY_STARTED_CANCEL);
         validateGuestBelongsToExercise(guest, exercise);
         validateGuestInvitedByMember(guest, member);
     }

--- a/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseCommandService.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseCommandService.java
@@ -126,6 +126,16 @@ public class ExerciseCommandService {
         return exerciseConverter.toCancelResponseDTO(exercise, member, participantNumber);
     }
 
+    public ExerciseCancelResponseDTO cancelGuestInvitation(Long exerciseId, Long guestId, Long memberId) {
+
+        log.info("운동 참여 취소 시작 - exerciseId: {}, guestId: {}, memberId: {}", exerciseId, guestId, memberId);
+
+        Exercise exercise = findExerciseOrThrow(exerciseId);
+        Member member = findMemberOrThrow(memberId);
+        Guest guest = findGuestOrThrow(guestId);
+        validateCancelGuestInvitation(exercise, guest, member);
+    }
+
     public ExerciseCancelResponseDTO cancelParticipationByManager(
             Long exerciseId, Long participantId, Long memberId, ExerciseManagerCancelRequestDTO request) {
 
@@ -165,6 +175,11 @@ public class ExerciseCommandService {
 
     private void validateCancelParticipation(Exercise exercise) {
         validateAlreadyStarted(exercise, ExerciseErrorCode.EXERCISE_ALREADY_STARTED_CANCEL);
+    }
+
+    private void validateCancelGuestInvitation(Exercise exercise, Guest guest, Member member) {
+        validateGuestBelongsToExercise(guest, exercise);
+        validateGuestInvitedByMember(guest, member);
     }
 
     private void validateCancelParticipationByManager(Exercise exercise, Member manager) {
@@ -238,6 +253,12 @@ public class ExerciseCommandService {
     private void validateGuestBelongsToExercise(Guest guest, Exercise exercise) {
         if (!guest.getExercise().getId().equals(exercise.getId())) {
             throw new ExerciseException(ExerciseErrorCode.GUEST_IS_NOT_PARTICIPATED_IN_EXERCISE);
+        }
+    }
+
+    private void validateGuestInvitedByMember(Guest guest, Member member) {
+        if (!guest.getInviterId().equals(member.getId())) {
+            throw new ExerciseException(ExerciseErrorCode.GUEST_NOT_INVITED_BY_MEMBER);
         }
     }
 

--- a/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseCommandService.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseCommandService.java
@@ -134,6 +134,17 @@ public class ExerciseCommandService {
         Member member = findMemberOrThrow(memberId);
         Guest guest = findGuestOrThrow(guestId);
         validateCancelGuestInvitation(exercise, guest, member);
+
+        Integer participantNumber = guest.getParticipantNum();
+
+        exercise.removeGuest(guest);
+
+        exercise.reorderParticipantNumbers(participantNumber);
+        guestRepository.delete(guest);
+
+        exerciseRepository.save(exercise);
+
+        return exerciseConverter.toCancelResponseDTO(exercise, guest, participantNumber);
     }
 
     public ExerciseCancelResponseDTO cancelParticipationByManager(


### PR DESCRIPTION
## ❤️ 기능 설명
사용자가 본인이 초대한 게스트를 운동에서 삭제합니다.

검증
- 운동 시작 여부
- 게스트가 운동에 참여되어 있는지
- 게스트가 본인에 의해 초대되었는지

swagger 테스트 성공 결과 스크린샷 첨부
<img width="2137" height="1357" alt="image" src="https://github.com/user-attachments/assets/a8fa77b6-1d0d-496b-9dbe-6bff5d5830d2" />

<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #43 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!
운동 취소 응답 DTO는 모두 같은 ExerciseCancelResponseDTO를 사용했습니다.

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
