### PR TITLE
[feat/#57] 운동 삭제 API 구현

### DIFF
--- a/src/main/java/umc/cockple/demo/domain/exercise/controller/ExerciseController.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/controller/ExerciseController.java
@@ -126,4 +126,24 @@ public class ExerciseController {
 
         return BaseResponse.success(CommonSuccessCode.OK, response);
     }
+
+    @DeleteMapping("/exercises/{exerciseId}")
+    @Operation(summary = "운동 삭제",
+            description = "모임장이 운동을 삭제합니다. 삭제된 운동의 모든 참여자와 게스트도 함께 삭제됩니다.")
+    @ApiResponse(responseCode = "200", description = "운동 삭제 성공")
+    @ApiResponse(responseCode = "403", description = "권한 없음 (모임장이 아님)")
+    @ApiResponse(responseCode = "404", description = "운동을 찾을 수 없음")
+    public BaseResponse<ExerciseDeleteResponseDTO> deleteExercise(
+            @PathVariable Long exerciseId,
+            Authentication authentication
+    ) {
+
+        // TODO: JWT 인증 구현 후 교체 예정
+        Long memberId = 1L; // 임시값
+
+        ExerciseDeleteResponseDTO response = exerciseCommandService.deleteExercise(
+                exerciseId, memberId);
+
+        return BaseResponse.success(CommonSuccessCode.OK, response);
+    }
 }

--- a/src/main/java/umc/cockple/demo/domain/exercise/converter/ExerciseConverter.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/converter/ExerciseConverter.java
@@ -82,4 +82,10 @@ public class ExerciseConverter {
                 .currentParticipants(exercise.getNowCapacity())
                 .build();
     }
+
+    public ExerciseDeleteResponseDTO toDeleteResponseDTO(Exercise exercise) {
+        return ExerciseDeleteResponseDTO.builder()
+                .deletedExerciseId(exercise.getId())
+                .build();
+    }
 }

--- a/src/main/java/umc/cockple/demo/domain/exercise/dto/ExerciseDeleteResponseDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/dto/ExerciseDeleteResponseDTO.java
@@ -1,0 +1,6 @@
+package umc.cockple.demo.domain.exercise.dto;
+
+public record ExerciseDeleteResponseDTO(
+        Long deletedExerciseId
+) {
+}

--- a/src/main/java/umc/cockple/demo/domain/exercise/dto/ExerciseDeleteResponseDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/dto/ExerciseDeleteResponseDTO.java
@@ -1,5 +1,8 @@
 package umc.cockple.demo.domain.exercise.dto;
 
+import lombok.Builder;
+
+@Builder
 public record ExerciseDeleteResponseDTO(
         Long deletedExerciseId
 ) {

--- a/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseCommandService.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseCommandService.java
@@ -157,6 +157,8 @@ public class ExerciseCommandService {
         partyRepository.save(party);
 
         log.info("운동 삭제 종료 - exerciseId: {}, memberId: {}", exerciseId, memberId);
+
+        return exerciseConverter.toDeleteResponseDTO(exercise);
     }
 
 

--- a/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseCommandService.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseCommandService.java
@@ -149,6 +149,14 @@ public class ExerciseCommandService {
 
         Exercise exercise = findExerciseOrThrow(exerciseId);
         validateDeleteExercise(exercise, memberId);
+
+        Party party = exercise.getParty();
+        party.removeExercise(exercise);
+        exerciseRepository.delete(exercise);
+
+        partyRepository.save(party);
+
+        log.info("운동 삭제 종료 - exerciseId: {}, memberId: {}", exerciseId, memberId);
     }
 
 

--- a/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseCommandService.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseCommandService.java
@@ -143,6 +143,14 @@ public class ExerciseCommandService {
         return response;
     }
 
+    public ExerciseDeleteResponseDTO deleteExercise(Long exerciseId, Long memberId) {
+
+        log.info("운동 삭제 시작 - exerciseId: {}, memberId: {}", exerciseId, memberId);
+
+        Exercise exercise = findExerciseOrThrow(exerciseId);
+        validateDeleteExercise(exercise, memberId);
+    }
+
 
     // ========== 검증 메서드들 ==========
 
@@ -170,6 +178,10 @@ public class ExerciseCommandService {
     private void validateCancelParticipationByManager(Exercise exercise, Member manager) {
         validateAlreadyStarted(exercise, ExerciseErrorCode.EXERCISE_ALREADY_STARTED_CANCEL);
         validateMemberPermission(manager.getId(), exercise.getParty());
+    }
+
+    private void validateDeleteExercise(Exercise exercise, Long memberId) {
+        validateMemberPermission(memberId, exercise.getParty());
     }
 
     // ========== 세부 검증 메서드들 ==========

--- a/src/main/java/umc/cockple/demo/domain/party/domain/Party.java
+++ b/src/main/java/umc/cockple/demo/domain/party/domain/Party.java
@@ -122,6 +122,11 @@ public class Party extends BaseEntity {
         return party;
     }
 
+    public Exercise createExercise(ExerciseCreateCommand command, ExerciseAddrCreateCommand addrCommand) {
+        ExerciseAddr exerciseAddr = ExerciseAddr.create(addrCommand);
+        return Exercise.create(exerciseAddr, command);
+    }
+
     public void addMember(MemberParty memberParty) {
         this.memberParties.add(memberParty);
         memberParty.setParty(this);
@@ -142,11 +147,6 @@ public class Party extends BaseEntity {
                 .party(this)
                 .build();
         this.levels.add(partyLevel);
-    }
-
-    public Exercise createExercise(ExerciseCreateCommand command, ExerciseAddrCreateCommand addrCommand) {
-        ExerciseAddr exerciseAddr = ExerciseAddr.create(addrCommand);
-        return Exercise.create(exerciseAddr, command);
     }
 
     public void addExercise(Exercise exercise) {

--- a/src/main/java/umc/cockple/demo/domain/party/domain/Party.java
+++ b/src/main/java/umc/cockple/demo/domain/party/domain/Party.java
@@ -156,4 +156,10 @@ public class Party extends BaseEntity {
         this.exerciseCount = exercises.size();
     }
 
+    public void removeExercise(Exercise exercise) {
+        this.exercises.remove(exercise);
+
+        this.exerciseCount = exercises.size();
+    }
+
 }


### PR DESCRIPTION
## ❤️ 기능 설명
모임장이 운동을 삭제하는 API를 구현합니다.

검증
- 운동이 존재하는지
- 운동 삭제 권한이 있는지

swagger 테스트 성공 결과 스크린샷 첨부
<img width="2133" height="1129" alt="image" src="https://github.com/user-attachments/assets/2fd97786-7d90-443e-bfc8-cfe16770fb82" />

<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #57 

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
