### PR TITLE
[refactor/#61] 운동 참여자 수 계산 로직 수동 증가에서 사이즈 계산으로 변경

### DIFF
--- a/src/main/java/umc/cockple/demo/domain/exercise/domain/Exercise.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/domain/Exercise.java
@@ -70,7 +70,6 @@ public class Exercise extends BaseEntity {
                 .startTime(command.startTime())
                 .endTime(command.endTime())
                 .maxCapacity(command.maxCapacity())
-                .nowCapacity(0)
                 .partyGuestAccept(command.partyGuestAccept())
                 .outsideGuestAccept(command.outsideGuestAccept())
                 .notice(command.notice())
@@ -92,11 +91,6 @@ public class Exercise extends BaseEntity {
         return exerciseDateTime.isBefore(LocalDateTime.now());
     }
 
-    public Integer calculateNextParticipantNumber() {
-        return this.nowCapacity + 1;
-    }
-
-
     /**
      * 연관관계 매핑 메서드
      */
@@ -110,22 +104,18 @@ public class Exercise extends BaseEntity {
     public void addParticipation(MemberExercise memberExercise) {
         this.memberExercises.add(memberExercise);
         memberExercise.setExercise(this);
-        this.nowCapacity++;
     }
 
     public void addGuest(Guest guest) {
         this.guests.add(guest);
         guest.setExercise(this);
-        this.nowCapacity++;
     }
 
     public void removeParticipation(MemberExercise memberExercise) {
         this.memberExercises.remove(memberExercise);
-        this.nowCapacity--;
     }
 
     public void removeGuest(Guest guest) {
         this.guests.remove(guest);
-        this.nowCapacity--;
     }
 }

--- a/src/main/java/umc/cockple/demo/domain/exercise/domain/Exercise.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/domain/Exercise.java
@@ -90,6 +90,10 @@ public class Exercise extends BaseEntity {
         return memberExercises.size() + guests.size();
     }
 
+    public Integer calculateNextParticipantNumber() {
+        return getNowCapacity() + 1;
+    }
+
     public boolean isAlreadyStarted() {
         LocalDateTime exerciseDateTime = LocalDateTime.of(this.date, this.startTime);
         return exerciseDateTime.isBefore(LocalDateTime.now());

--- a/src/main/java/umc/cockple/demo/domain/exercise/domain/Exercise.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/domain/Exercise.java
@@ -86,6 +86,10 @@ public class Exercise extends BaseEntity {
                 .forEach(g -> g.decrementParticipantNum());
     }
 
+    public Integer getNowCapacity() {
+        return memberExercises.size() + guests.size();
+    }
+
     public boolean isAlreadyStarted() {
         LocalDateTime exerciseDateTime = LocalDateTime.of(this.date, this.startTime);
         return exerciseDateTime.isBefore(LocalDateTime.now());

--- a/src/main/java/umc/cockple/demo/domain/exercise/domain/Exercise.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/domain/Exercise.java
@@ -45,9 +45,6 @@ public class Exercise extends BaseEntity {
     private Integer maxCapacity;
 
     @Column(nullable = false)
-    private Integer nowCapacity;
-
-    @Column(nullable = false)
     private Boolean partyGuestAccept;
 
     @Column(nullable = false)

--- a/src/main/java/umc/cockple/demo/domain/exercise/domain/Exercise.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/domain/Exercise.java
@@ -83,7 +83,7 @@ public class Exercise extends BaseEntity {
 
         guests.stream()
                 .filter(g -> g.getParticipantNum() > removedNum)
-                .forEach(g -> g.decrementParticipantNum());
+                .forEach(Guest::decrementParticipantNum);
     }
 
     public Integer getNowCapacity() {


### PR DESCRIPTION
## ❤️ 기능 설명
기존의 nowCapacity 필드를 통한 계산에서
Guest와 MemberExercise의 .size()의 합으로 참여자 수를 계산합니다.


swagger 테스트 성공 결과 스크린샷 첨부
<img width="2146" height="959" alt="image" src="https://github.com/user-attachments/assets/c40127e2-da91-499b-97cb-2f43c814b129" />

<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #61 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!
연산 때문에 성능이 조금 떨어질 수는 있으나 이게 데이터 안전성에 좋은 방향이라고 생각했습니다!
의견 부탁드립니다!

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
