### PR TITLE
[feat/#66] 운동 수정 API 구현

### DIFF
--- a/src/main/java/umc/cockple/demo/domain/exercise/controller/ExerciseController.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/controller/ExerciseController.java
@@ -169,7 +169,7 @@ public class ExerciseController {
         return BaseResponse.success(CommonSuccessCode.OK, response);
     }
 
-    @PatchMapping("/exercises/{exerciseId")
+    @PatchMapping("/exercises/{exerciseId}")
     @Operation(summary = "운동 수정",
             description = "모임장이 생성한 운동의 정보를 수정합니다. 이미 시작된 운동은 수정할 수 없습니다.")
     @ApiResponse(responseCode = "200", description = "운동 수정 성공")

--- a/src/main/java/umc/cockple/demo/domain/exercise/controller/ExerciseController.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/controller/ExerciseController.java
@@ -168,4 +168,26 @@ public class ExerciseController {
 
         return BaseResponse.success(CommonSuccessCode.OK, response);
     }
+
+    @PatchMapping("/exercises/{exerciseId")
+    @Operation(summary = "운동 수정",
+            description = "모임장이 생성한 운동의 정보를 수정합니다. 이미 시작된 운동은 수정할 수 없습니다.")
+    @ApiResponse(responseCode = "200", description = "운동 수정 성공")
+    @ApiResponse(responseCode = "400", description = "입력값 오류 또는 비즈니스 룰 위반")
+    @ApiResponse(responseCode = "403", description = "권한 없음 (모임장이 아님)")
+    @ApiResponse(responseCode = "404", description = "존재하지 않는 운동")
+    public BaseResponse<ExerciseUpdateResponseDTO> updateExercise(
+            @PathVariable Long exerciseId,
+            @Valid @RequestBody ExerciseUpdateRequestDTO request,
+            Authentication authentication
+    ){
+
+        // TODO: JWT 인증 구현 후 교체 예정
+        Long memberId = 1L; // 임시값
+
+        ExerciseUpdateResponseDTO response = exerciseCommandService.updateExercise(
+                exerciseId, memberId, request);
+
+        return BaseResponse.success(CommonSuccessCode.OK, response);
+    }
 }

--- a/src/main/java/umc/cockple/demo/domain/exercise/controller/ExerciseController.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/controller/ExerciseController.java
@@ -136,7 +136,7 @@ public class ExerciseController {
     public BaseResponse<ExerciseCancelResponseDTO> cancelParticipationByManager(
             @PathVariable Long exerciseId,
             @PathVariable Long participantId,
-            @RequestBody ExerciseManagerCancelRequestDTO request,
+            @Valid @RequestBody ExerciseManagerCancelRequestDTO request,
             Authentication authentication
     ) {
 

--- a/src/main/java/umc/cockple/demo/domain/exercise/converter/ExerciseConverter.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/converter/ExerciseConverter.java
@@ -95,8 +95,6 @@ public class ExerciseConverter {
                 .startTime(request.toParsedStartTime())
                 .endTime(request.toParsedEndTime())
                 .maxCapacity(request.maxCapacity())
-                .partyGuestAccept(request.allowMemberGuestsInvitation())
-                .outsideGuestAccept(request.allowExternalGuests())
                 .notice(request.notice())
                 .build();
     }

--- a/src/main/java/umc/cockple/demo/domain/exercise/converter/ExerciseConverter.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/converter/ExerciseConverter.java
@@ -113,4 +113,11 @@ public class ExerciseConverter {
         }
         return null;
     }
+
+    public ExerciseUpdateResponseDTO toUpdateResponseDTO(Exercise exercise) {
+        return ExerciseUpdateResponseDTO.builder()
+                .exerciseId(exercise.getId())
+                .updatedAt(exercise.getUpdatedAt())
+                .build();
+    }
 }

--- a/src/main/java/umc/cockple/demo/domain/exercise/converter/ExerciseConverter.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/converter/ExerciseConverter.java
@@ -88,4 +88,29 @@ public class ExerciseConverter {
                 .deletedExerciseId(exercise.getId())
                 .build();
     }
+
+    public ExerciseUpdateCommand toUpdateCommand(ExerciseUpdateRequestDTO request) {
+        return ExerciseUpdateCommand.builder()
+                .date(request.toParsedDate())
+                .startTime(request.toParsedStartTime())
+                .endTime(request.toParsedEndTime())
+                .maxCapacity(request.maxCapacity())
+                .partyGuestAccept(request.allowMemberGuestsInvitation())
+                .outsideGuestAccept(request.allowExternalGuests())
+                .notice(request.notice())
+                .build();
+    }
+
+    public ExerciseAddrUpdateCommand toAddrUpdateCommand(ExerciseUpdateRequestDTO request) {
+        if (request.roadAddress() != null || request.buildingName() != null ||
+                request.latitude() != null || request.longitude() != null) {
+            return ExerciseAddrUpdateCommand.builder()
+                    .roadAddress(request.roadAddress())
+                    .buildingName(request.buildingName())
+                    .latitude(request.latitude())
+                    .longitude(request.longitude())
+                    .build();
+        }
+        return null;
+    }
 }

--- a/src/main/java/umc/cockple/demo/domain/exercise/domain/Exercise.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/domain/Exercise.java
@@ -2,7 +2,9 @@ package umc.cockple.demo.domain.exercise.domain;
 
 import jakarta.persistence.*;
 import lombok.*;
+import umc.cockple.demo.domain.exercise.dto.ExerciseAddrUpdateCommand;
 import umc.cockple.demo.domain.exercise.dto.ExerciseCreateCommand;
+import umc.cockple.demo.domain.exercise.dto.ExerciseUpdateCommand;
 import umc.cockple.demo.domain.exercise.dto.GuestInviteCommand;
 import umc.cockple.demo.domain.member.domain.MemberExercise;
 import umc.cockple.demo.domain.party.domain.Party;
@@ -86,6 +88,30 @@ public class Exercise extends BaseEntity {
                 .forEach(Guest::decrementParticipantNum);
     }
 
+    public void updateExerciseInfo(ExerciseUpdateCommand command) {
+        if (command.date() != null) {
+            this.date = command.date();
+        }
+        if (command.startTime() != null) {
+            this.startTime = command.startTime();
+        }
+        if (command.endTime() != null) {
+            this.endTime = command.endTime();
+        }
+        if (command.maxCapacity() != null) {
+            this.maxCapacity = command.maxCapacity();
+        }
+        if (command.partyGuestAccept() != null) {
+            this.partyGuestAccept = command.partyGuestAccept();
+        }
+        if (command.outsideGuestAccept() != null) {
+            this.outsideGuestAccept = command.outsideGuestAccept();
+        }
+        if (command.notice() != null) {
+            this.notice = command.notice();
+        }
+    }
+
     public Integer getNowCapacity() {
         return memberExercises.size() + guests.size();
     }
@@ -126,4 +152,6 @@ public class Exercise extends BaseEntity {
     public void removeGuest(Guest guest) {
         this.guests.remove(guest);
     }
+
+
 }

--- a/src/main/java/umc/cockple/demo/domain/exercise/domain/Exercise.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/domain/Exercise.java
@@ -112,6 +112,12 @@ public class Exercise extends BaseEntity {
         }
     }
 
+    public void updateExerciseAddr(ExerciseAddrUpdateCommand command) {
+        if (this.exerciseAddr != null && command != null) {
+            this.exerciseAddr.updateAddress(command);
+        }
+    }
+
     public Integer getNowCapacity() {
         return memberExercises.size() + guests.size();
     }
@@ -152,6 +158,4 @@ public class Exercise extends BaseEntity {
     public void removeGuest(Guest guest) {
         this.guests.remove(guest);
     }
-
-
 }

--- a/src/main/java/umc/cockple/demo/domain/exercise/domain/ExerciseAddr.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/domain/ExerciseAddr.java
@@ -3,6 +3,7 @@ package umc.cockple.demo.domain.exercise.domain;
 import jakarta.persistence.*;
 import lombok.*;
 import umc.cockple.demo.domain.exercise.dto.ExerciseAddrCreateCommand;
+import umc.cockple.demo.domain.exercise.dto.ExerciseAddrUpdateCommand;
 import umc.cockple.demo.global.common.BaseEntity;
 
 @Entity
@@ -45,6 +46,27 @@ public class ExerciseAddr extends BaseEntity {
                 .latitude(command.latitude().floatValue())
                 .longitude(command.longitude().floatValue())
                 .build();
+    }
+
+    public void updateAddress(ExerciseAddrUpdateCommand command) {
+        if (command.roadAddress() != null && !command.roadAddress().isEmpty()) {
+            AddressParts addressParts = parseRoadAddress(command.roadAddress());
+            this.addr1 = addressParts.addr1();
+            this.addr2 = addressParts.addr2();
+            this.streetAddr = command.roadAddress();
+        }
+
+        if (command.buildingName() != null) {
+            this.buildingName = command.buildingName();
+        }
+
+        if (command.latitude() != null) {
+            this.latitude = command.latitude().floatValue();
+        }
+
+        if (command.longitude() != null) {
+            this.longitude = command.longitude().floatValue();
+        }
     }
 
     private static AddressParts parseRoadAddress(String roadAddress) {

--- a/src/main/java/umc/cockple/demo/domain/exercise/dto/ExerciseAddrUpdateCommand.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/dto/ExerciseAddrUpdateCommand.java
@@ -1,0 +1,12 @@
+package umc.cockple.demo.domain.exercise.dto;
+
+import lombok.Builder;
+
+@Builder
+public record ExerciseAddrUpdateCommand(
+        String roadAddress,
+        String buildingName,
+        Double latitude,
+        Double longitude
+) {
+}

--- a/src/main/java/umc/cockple/demo/domain/exercise/dto/ExerciseUpdateCommand.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/dto/ExerciseUpdateCommand.java
@@ -1,0 +1,18 @@
+package umc.cockple.demo.domain.exercise.dto;
+
+import lombok.Builder;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Builder
+public record ExerciseUpdateCommand(
+        LocalDate date,
+        LocalTime startTime,
+        LocalTime endTime,
+        Integer maxCapacity,
+        Boolean partyGuestAccept,
+        Boolean outsideGuestAccept,
+        String notice
+) {
+}

--- a/src/main/java/umc/cockple/demo/domain/exercise/dto/ExerciseUpdateRequestDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/dto/ExerciseUpdateRequestDTO.java
@@ -33,10 +33,6 @@ public record ExerciseUpdateRequestDTO(
         @Max(value = 45, message = "모집 인원은 최대 45명 이하입니다.")
         Integer maxCapacity,
 
-        Boolean allowMemberGuestsInvitation,
-
-        Boolean allowExternalGuests,
-
         @Size(max = 45, message = "공지사항은 45자를 초과할 수 없습니다")
         String notice
 ) {

--- a/src/main/java/umc/cockple/demo/domain/exercise/dto/ExerciseUpdateRequestDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/dto/ExerciseUpdateRequestDTO.java
@@ -1,0 +1,69 @@
+package umc.cockple.demo.domain.exercise.dto;
+
+import jakarta.validation.constraints.*;
+import umc.cockple.demo.domain.exercise.exception.ExerciseErrorCode;
+import umc.cockple.demo.domain.exercise.exception.ExerciseException;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.format.DateTimeParseException;
+
+public record ExerciseUpdateRequestDTO(
+
+        @Pattern(regexp = "^\\d{4}-\\d{2}-\\d{2}$", message = "날짜 형식: YYYY-MM-DD")
+        String date,
+
+        String buildingName,
+
+        String roadAddress,
+
+        @DecimalMin(value = "33.0") @DecimalMax(value = "43.0")
+        Double latitude,
+
+        @DecimalMin(value = "124.0") @DecimalMax(value = "132.0")
+        Double longitude,
+
+        @Pattern(regexp = "^([01]\\d|2[0-3]):[0-5]\\d$", message = "시간 형식: HH:mm")
+        String startTime,
+
+        @Pattern(regexp = "^([01]\\d|2[0-3]):[0-5]\\d$", message = "시간 형식: HH:mm")
+        String endTime,
+
+        @Min(value = 2, message = "모집 인원은 최소 2명 이상입니다.")
+        @Max(value = 45, message = "모집 인원은 최대 45명 이하입니다.")
+        Integer maxCapacity,
+
+        Boolean allowMemberGuestsInvitation,
+
+        Boolean allowExternalGuests,
+
+        @Size(max = 45, message = "공지사항은 45자를 초과할 수 없습니다")
+        String notice
+) {
+    public LocalDate toParsedDate() {
+        if (date == null || date.isEmpty()) return null;
+        try {
+            return LocalDate.parse(date);
+        } catch (DateTimeParseException e) {
+            throw new ExerciseException(ExerciseErrorCode.INVALID_DATE_FORMAT);
+        }
+    }
+
+    public LocalTime toParsedStartTime() {
+        if (startTime == null || startTime.isEmpty()) return null;
+        try {
+            return LocalTime.parse(startTime);
+        } catch (DateTimeParseException e) {
+            throw new ExerciseException(ExerciseErrorCode.INVALID_START_TIME_FORMAT);
+        }
+    }
+
+    public LocalTime toParsedEndTime() {
+        if (endTime == null || endTime.isEmpty()) return null;
+        try {
+            return LocalTime.parse(endTime);
+        } catch (DateTimeParseException e) {
+            throw new ExerciseException(ExerciseErrorCode.INVALID_END_TIME_FORMAT);
+        }
+    }
+}

--- a/src/main/java/umc/cockple/demo/domain/exercise/dto/ExerciseUpdateResponseDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/dto/ExerciseUpdateResponseDTO.java
@@ -1,0 +1,12 @@
+package umc.cockple.demo.domain.exercise.dto;
+
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder
+public record ExerciseUpdateResponseDTO(
+        Long exerciseId,
+        LocalDateTime updatedAt
+) {
+}

--- a/src/main/java/umc/cockple/demo/domain/exercise/exception/ExerciseErrorCode.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/exception/ExerciseErrorCode.java
@@ -37,8 +37,9 @@ public enum ExerciseErrorCode implements BaseErrorCode {
     EXERCISE_ALREADY_STARTED_PARTICIPATION(HttpStatus.BAD_REQUEST, "EXERCISE403", "이미 시작된 운동에는 참여할 수 없습니다."),
     EXERCISE_ALREADY_STARTED_INVITATION(HttpStatus.BAD_REQUEST, "EXERCISE404", "이미 시작된 운동에는 초대할 수 없습니다."),
     EXERCISE_ALREADY_STARTED_CANCEL(HttpStatus.BAD_REQUEST, "EXERCISE405", "이미 시작된 운동에는 취소할 수 없습니다."),
-    ALREADY_JOINED_EXERCISE(HttpStatus.BAD_REQUEST, "EXERCISE406", "이미 참여 신청한 운동입니다."),
-    GUEST_IS_NOT_PARTICIPATED_IN_EXERCISE(HttpStatus.BAD_REQUEST, "EXERCISE407", "게스트가 이 운동에 참여해있지 않습니다..");
+    EXERCISE_ALREADY_STARTED_UPDATE(HttpStatus.BAD_REQUEST, "EXERCISE406", "이미 시작된 운동은 수정할 수 없습니다."),
+    ALREADY_JOINED_EXERCISE(HttpStatus.BAD_REQUEST, "EXERCISE407", "이미 참여 신청한 운동입니다."),
+    GUEST_IS_NOT_PARTICIPATED_IN_EXERCISE(HttpStatus.BAD_REQUEST, "EXERCISE408", "게스트가 이 운동에 참여해있지 않습니다..");
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseCommandService.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseCommandService.java
@@ -196,6 +196,11 @@ public class ExerciseCommandService {
         exercise.updateExerciseInfo(updateCommand);
         exercise.updateExerciseAddr(addrUpdateCommand);
 
+        Exercise savedExercise = exerciseRepository.save(exercise);
+
+        log.info("운동 수정 완료 - exerciseId: {}", savedExercise.getId());
+
+        return exerciseConverter.toUpdateResponseDTO(savedExercise);
     }
 
 

--- a/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseCommandService.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseCommandService.java
@@ -190,6 +190,9 @@ public class ExerciseCommandService {
         Member member = findMemberOrThrow(memberId);
         validateUpdateExercise(exercise, member, request);
 
+        ExerciseUpdateCommand updateCommand = exerciseConverter.toUpdateCommand(request);
+        ExerciseAddrUpdateCommand addrUpdateCommand = exerciseConverter.toAddrUpdateCommand(request);
+
     }
 
 

--- a/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseCommandService.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseCommandService.java
@@ -246,7 +246,6 @@ public class ExerciseCommandService {
         validateMemberPermission(member.getId(), exercise.getParty());
         validateAlreadyStarted(exercise, ExerciseErrorCode.EXERCISE_ALREADY_STARTED_UPDATE);
         validateUpdateTime(request, exercise);
-
     }
 
     // ========== 세부 검증 메서드들 ==========

--- a/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseCommandService.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseCommandService.java
@@ -193,6 +193,8 @@ public class ExerciseCommandService {
         ExerciseUpdateCommand updateCommand = exerciseConverter.toUpdateCommand(request);
         ExerciseAddrUpdateCommand addrUpdateCommand = exerciseConverter.toAddrUpdateCommand(request);
 
+        exercise.updateExerciseInfo(updateCommand);
+
     }
 
 

--- a/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseCommandService.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseCommandService.java
@@ -194,6 +194,7 @@ public class ExerciseCommandService {
         ExerciseAddrUpdateCommand addrUpdateCommand = exerciseConverter.toAddrUpdateCommand(request);
 
         exercise.updateExerciseInfo(updateCommand);
+        exercise.updateExerciseAddr(addrUpdateCommand);
 
     }
 


### PR DESCRIPTION
## ❤️ 기능 설명
모임장이 운동을 수정하는 API를 구현합니다.

검증
- 멤버가 모임장의 권한인지
- 운동이 이미 시작한 운동인지
- 운동의 시간이 제대로 설정되어 있는지

swagger 테스트 성공 결과 스크린샷 첨부
<img width="2136" height="880" alt="image" src="https://github.com/user-attachments/assets/0e482453-133d-4e9b-a952-b4a5b33dc6dc" />

<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #66 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!
엔티티에서 DTO에 접근하는 게 싫어서 command 패턴을 도입했는데, 뭔가 투머치인거 같기도 하고요...
create에서도 같은 방법을 사용했는데, 정답은 잘 모르겠습니다.

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
