### PR TITLE
[feat/#70] 다른 회원의 대회 기록 상세조회 API 구현

### DIFF
--- a/src/main/java/umc/cockple/demo/domain/contest/controller/ContestController.java
+++ b/src/main/java/umc/cockple/demo/domain/contest/controller/ContestController.java
@@ -96,7 +96,7 @@ public class ContestController {
         // TODO: JWT 인증 구현 후 교체 예정
         Long memberId = 1L; // 임시값
 
-        ContestRecordDetailResponseDTO response = contestQueryService.getMyContestRecordDetail(memberId, contestId);
+        ContestRecordDetailResponseDTO response = contestQueryService.getContestRecordDetail(memberId, memberId, contestId);
         return BaseResponse.success(CommonSuccessCode.OK, response);
     }
 
@@ -127,4 +127,20 @@ public class ContestController {
 
         return BaseResponse.success(CommonSuccessCode.OK,response);
     }
+
+    @GetMapping(value = "/members/{memberId}/contests/{contestId}")
+    @Operation(summary = "다른 사람의 대회 기록 상세 조회", description = "다른 사람의 대회 기록 하나를 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "조회 성공")
+    public BaseResponse<ContestRecordDetailResponseDTO> getOtherMemberContestRecordDetail(
+            //@AuthenticationPrincipal Long loginMemberId,
+            @PathVariable Long memberId,
+            @PathVariable Long contestId
+    ) {
+        // TODO: JWT 인증 구현 후 교체 예정
+        Long loginMemberId = 2L; // 임시값
+
+        ContestRecordDetailResponseDTO response = contestQueryService.getContestRecordDetail(loginMemberId, memberId, contestId);
+        return BaseResponse.success(CommonSuccessCode.OK, response);
+    }
+
 }

--- a/src/main/java/umc/cockple/demo/domain/contest/converter/ContestConverter.java
+++ b/src/main/java/umc/cockple/demo/domain/contest/converter/ContestConverter.java
@@ -55,17 +55,25 @@ public class ContestConverter {
                 .build();
     }
 
-    // 내 대회 기록 상세 조회
-    public ContestRecordDetailResponseDTO toDetailResponseDTO(Contest contest) {
+    // 대회 기록 상세 조회
+    public ContestRecordDetailResponseDTO toDetailResponseDTO(Contest contest, Boolean isOwner) {
         List<String> imgUrls = contest.getContestImgs().stream()
                 .sorted(Comparator.comparing(ContestImg::getImgOrder))
                 .map(ContestImg::getImgUrl)
                 .collect(Collectors.toList());
 
-        List<String> videoUrls = contest.getContestVideos().stream()
-                .sorted(Comparator.comparing(ContestVideo::getVideoOrder))
+        // video 링크 공개여부 처리
+        List<String> videoUrls = (contest.getVideoIsOpen() || isOwner)
+                ? contest.getContestVideos().stream()
+                .sorted(Comparator.comparingInt(ContestVideo::getVideoOrder))
                 .map(ContestVideo::getVideoUrl)
-                .collect(Collectors.toList());
+                .collect(Collectors.toList())
+                : List.of();
+
+        // 기록 공개여부 처리
+        String content = (contest.getContentIsOpen() || isOwner)
+                ? contest.getContent()
+                : "";
 
         return ContestRecordDetailResponseDTO.builder()
                 .contestId(contest.getId())
@@ -74,8 +82,10 @@ public class ContestConverter {
                 .medalType(contest.getMedalType())
                 .type(contest.getType())
                 .level(contest.getLevel())
-                .content(contest.getContent())
+                .contentIsOpen(contest.getContentIsOpen())
+                .content(content)
                 .contestImgUrls(imgUrls)
+                .videoIsOpen(contest.getVideoIsOpen())
                 .contestVideoUrls(videoUrls)
                 .build();
     }

--- a/src/main/java/umc/cockple/demo/domain/contest/dto/ContestRecordDetailResponseDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/contest/dto/ContestRecordDetailResponseDTO.java
@@ -17,6 +17,8 @@ public record ContestRecordDetailResponseDTO(
         ParticipationType type,
         Level level,
         String content,
+        Boolean contentIsOpen,
+        Boolean videoIsOpen,
         List<String> contestImgUrls,
         List<String> contestVideoUrls
 ) {

--- a/src/main/java/umc/cockple/demo/domain/contest/service/ContestQueryService.java
+++ b/src/main/java/umc/cockple/demo/domain/contest/service/ContestQueryService.java
@@ -8,9 +8,10 @@ import umc.cockple.demo.global.enums.MedalType;
 import java.util.List;
 
 public interface ContestQueryService {
-    ContestRecordDetailResponseDTO getMyContestRecordDetail(Long memberId, Long contestId);
+    ContestRecordDetailResponseDTO getContestRecordDetail(Long loginMemberId, Long memberId, Long contestId);
 
     List<ContestRecordSimpleResponseDTO> getMyContestRecordsByMedalType(Long memberId, MedalType medalType);
 
     ContestMedalSummaryResponseDTO getMyMedalSummary(Long memberId);
+
 }

--- a/src/main/java/umc/cockple/demo/domain/contest/service/ContestQueryServiceImpl.java
+++ b/src/main/java/umc/cockple/demo/domain/contest/service/ContestQueryServiceImpl.java
@@ -25,19 +25,20 @@ public class ContestQueryServiceImpl implements ContestQueryService {
     private final ContestRepository contestRepository;
     private final ContestConverter contestConverter;
 
-    // 내 대회 기록 상세 조회
+    // 대회 기록 상세 조회
     @Override
-    public ContestRecordDetailResponseDTO getMyContestRecordDetail(Long memberId, Long contestId) {
+    public ContestRecordDetailResponseDTO getContestRecordDetail(Long loginMemberId, Long memberId, Long contestId) {
 
-        log.info("[내 대회 기록 상세조회 시작] - memberId: {}, contestId: {}", memberId, contestId);
+        log.info("[대회 기록 상세조회 시작] - 요청자: {}, 기록주인: {}, contestId: {}", loginMemberId, memberId, contestId);
 
-        // 1. 대회 조회 + 본인 확인
         Contest contest = contestRepository.findByIdAndMember_Id(contestId, memberId)
                 .orElseThrow(() -> new ContestException(ContestErrorCode.CONTEST_NOT_FOUND));
 
+        boolean isOwner = loginMemberId.equals(memberId);
+
         log.info("대회 기록 상세조회 완료 - contestId: {}", contestId);
 
-        return contestConverter.toDetailResponseDTO(contest);
+        return contestConverter.toDetailResponseDTO(contest, isOwner);
     }
 
     // 내 대회 기록 리스트 조회 (전체, 미입상)


### PR DESCRIPTION
## ❤️ 기능 설명

swagger 테스트 성공 결과 스크린샷 첨부
<br>
<img width="710" height="669" alt="스크린샷 2025-07-15 22 29 36" src="https://github.com/user-attachments/assets/4806e567-7415-496f-8881-ceec3f0fcaf0" />

영상, 기록 다 비공개 일때

<img width="667" height="688" alt="스크린샷 2025-07-15 22 29 17" src="https://github.com/user-attachments/assets/94ba01ee-632d-4916-b956-28c7bd697c1f" />

영상, 기록 다 공개 일때

<img width="680" height="703" alt="스크린샷 2025-07-15 22 28 47" src="https://github.com/user-attachments/assets/db30aff1-687b-4dd9-9637-a985c6beeef1" />

기록만 비공개 일때


## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #70 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!
<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
