### PR TITLE
[feat/#73] 다른 회원의 대회 기록 리스트 (전체, 미입상) API 구현

### DIFF
--- a/src/main/java/umc/cockple/demo/domain/contest/controller/ContestController.java
+++ b/src/main/java/umc/cockple/demo/domain/contest/controller/ContestController.java
@@ -143,4 +143,14 @@ public class ContestController {
         return BaseResponse.success(CommonSuccessCode.OK, response);
     }
 
+    @GetMapping(value = "/members/{memberId}/contests")
+    @Operation(summary = "다른 사람의 대회 기록 리스트 조회", description = "회원이 다른 사람의 전체 또는 미입상(NONE) 대회 기록 리스트를 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "조회 성공")
+    public BaseResponse<List<ContestRecordSimpleResponseDTO>> getOtherMemberContestRecord(
+            @RequestParam Long memberId,
+            @RequestParam(required = false) MedalType medalType
+    ) {
+        List<ContestRecordSimpleResponseDTO> response = contestQueryService.getMyContestRecordsByMedalType(memberId, medalType);
+        return BaseResponse.success(CommonSuccessCode.OK, response);
+    }
 }

--- a/src/main/java/umc/cockple/demo/domain/contest/converter/ContestConverter.java
+++ b/src/main/java/umc/cockple/demo/domain/contest/converter/ContestConverter.java
@@ -90,7 +90,7 @@ public class ContestConverter {
                 .build();
     }
 
-    // 내 대회 기록 심플 조회
+    // 대회 기록 심플 조회
     public static ContestRecordSimpleResponseDTO toSimpleResponseDTO(Contest contest) {
         return ContestRecordSimpleResponseDTO.builder()
                 .contestId(contest.getId())
@@ -102,7 +102,7 @@ public class ContestConverter {
                 .build();
     }
 
-    // 내 대회 기록 리스트 변환
+    // 대회 기록 리스트 변환
     public List<ContestRecordSimpleResponseDTO> toSimpleDTOList(List<Contest> contests) {
         return contests.stream()
                 .map(ContestConverter::toSimpleResponseDTO)

--- a/src/main/java/umc/cockple/demo/domain/contest/service/ContestQueryServiceImpl.java
+++ b/src/main/java/umc/cockple/demo/domain/contest/service/ContestQueryServiceImpl.java
@@ -41,11 +41,11 @@ public class ContestQueryServiceImpl implements ContestQueryService {
         return contestConverter.toDetailResponseDTO(contest, isOwner);
     }
 
-    // 내 대회 기록 리스트 조회 (전체, 미입상)
+    // 대회 기록 리스트 조회 (전체, 미입상)
     @Override
     public List<ContestRecordSimpleResponseDTO> getMyContestRecordsByMedalType(Long memberId, MedalType medalType) {
 
-        log.info("[내 대회 기록 리스트 조회 시작] - memberId: {}", memberId);
+        log.info("[대회 기록 리스트 조회 시작] - memberId: {}", memberId);
 
         // 1. 대회 전체 조회
         List<Contest> contests = contestRepository.findAllByMember_Id(memberId);


### PR DESCRIPTION
## ❤️ 기능 설명
기존에 내 대회 기록 리스트 조회에서 조금 수정해서 통합으로 만들었습니다.

swagger 테스트 성공 결과 스크린샷 첨부
<br>
<img width="768" height="804" alt="스크린샷 2025-07-16 00 01 43" src="https://github.com/user-attachments/assets/25bff44e-204a-4655-ab78-37b150cc833b" />

미입상 조회

<img width="774" height="754" alt="스크린샷 2025-07-16 00 01 27" src="https://github.com/user-attachments/assets/9796362b-b72d-42a8-8d28-54dad5225444" />

전체 리스트 조회

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #73  
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
