### PR TITLE
[Feat/#53] 모임 가입신청 처리 API 구현

### DIFF
--- a/src/main/java/umc/cockple/demo/domain/member/domain/MemberParty.java
+++ b/src/main/java/umc/cockple/demo/domain/member/domain/MemberParty.java
@@ -58,4 +58,15 @@ public class MemberParty extends BaseEntity {
                 .status(ACTIVE)
                 .build();
     }
+
+    public static MemberParty create(Party party, Member member) {
+        return MemberParty.builder()
+                .member(member)
+                .party(party)
+                .role(Role.party_MEMBER)
+                .joinedAt(LocalDateTime.now())
+                .orderType(EARLIEST)
+                .status(ACTIVE)
+                .build();
+    }
 }

--- a/src/main/java/umc/cockple/demo/domain/party/controller/PartyController.java
+++ b/src/main/java/umc/cockple/demo/domain/party/controller/PartyController.java
@@ -5,21 +5,21 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.apache.coyote.Request;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.Authentication;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
-import umc.cockple.demo.domain.party.dto.PartyCreateRequestDTO;
-import umc.cockple.demo.domain.party.dto.PartyCreateResponseDTO;
-import umc.cockple.demo.domain.party.dto.PartyJoinCreateResponseDTO;
-import umc.cockple.demo.domain.party.dto.PartyJoinResponseDTO;
+import umc.cockple.demo.domain.party.dto.*;
 import umc.cockple.demo.domain.party.service.PartyCommandService;
 import umc.cockple.demo.domain.party.service.PartyQueryService;
+import umc.cockple.demo.global.enums.RequestAction;
 import umc.cockple.demo.global.response.BaseResponse;
 import umc.cockple.demo.global.response.code.status.CommonSuccessCode;
 
@@ -87,6 +87,20 @@ public class PartyController {
 
         Slice<PartyJoinResponseDTO> response = partyQueryService.getJoinRequests(partyId, memberId, pageable);
         return BaseResponse.success(CommonSuccessCode.OK, response);
+    }
+
+    @PatchMapping("parties/{partyId}/join-requests/{requestId}")
+    public BaseResponse<Void> actionJoinRequests(
+            @PathVariable Long partyId,
+            @PathVariable Long requestId,
+            @RequestParam PartyJoinActionRequestDTO request,
+            Authentication authentication
+    ){
+        // TODO: JWT 인증 구현 후 교체 예정
+        Long memberId = 2L; // 임시값
+
+        partyCommandService.actionJoinRequest(partyId, memberId, request, requestId);
+        return BaseResponse.success(CommonSuccessCode.OK);
     }
 
 }

--- a/src/main/java/umc/cockple/demo/domain/party/controller/PartyController.java
+++ b/src/main/java/umc/cockple/demo/domain/party/controller/PartyController.java
@@ -90,14 +90,20 @@ public class PartyController {
     }
 
     @PatchMapping("parties/{partyId}/join-requests/{requestId}")
+    @Operation(summary = "모임 가입 신청 처리",
+        description = "모임장이 가입 신청을 승인하거나 거절합니다.")
+    @ApiResponse(responseCode = "200", description = "가입 신청 처리 성공")
+    @ApiResponse(responseCode = "403", description = "모임장 권한 없음")
+    @ApiResponse(responseCode = "404", description = "존재하지 않는 모임 또는 가입 신청")
+    @ApiResponse(responseCode = "409", description = "이미 처리된 가입 신청")
     public BaseResponse<Void> actionJoinRequests(
             @PathVariable Long partyId,
             @PathVariable Long requestId,
-            @RequestParam PartyJoinActionRequestDTO request,
+            @RequestBody @Valid PartyJoinActionRequestDTO request,
             Authentication authentication
     ){
         // TODO: JWT 인증 구현 후 교체 예정
-        Long memberId = 2L; // 임시값
+        Long memberId = 1L; // 임시값
 
         partyCommandService.actionJoinRequest(partyId, memberId, request, requestId);
         return BaseResponse.success(CommonSuccessCode.OK);

--- a/src/main/java/umc/cockple/demo/domain/party/domain/PartyJoinRequest.java
+++ b/src/main/java/umc/cockple/demo/domain/party/domain/PartyJoinRequest.java
@@ -35,4 +35,8 @@ public class PartyJoinRequest extends BaseEntity {
                 .status(RequestStatus.PENDING)
                 .build();
     }
+
+    public void updateStatus(RequestStatus requestStatus) {
+        this.status=requestStatus;
+    }
 }

--- a/src/main/java/umc/cockple/demo/domain/party/dto/PartyJoinActionRequestDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/party/dto/PartyJoinActionRequestDTO.java
@@ -1,0 +1,8 @@
+package umc.cockple.demo.domain.party.dto;
+
+import umc.cockple.demo.global.enums.RequestAction;
+
+public record PartyJoinActionRequestDTO (
+        RequestAction action
+){
+}

--- a/src/main/java/umc/cockple/demo/domain/party/exception/PartyErrorCode.java
+++ b/src/main/java/umc/cockple/demo/domain/party/exception/PartyErrorCode.java
@@ -17,12 +17,14 @@ public enum PartyErrorCode implements BaseErrorCode {
      * 4xx: 비즈니스 로직 위반
      */
     PARTY_NOT_FOUND(HttpStatus.NOT_FOUND, "PARTY201", "존재하지 않는 모임입니다."),
+    JoinRequest_NOT_FOUND(HttpStatus.NOT_FOUND, "PARTY202", "존재하지 않는 가입신청입니다."),
+    JOIN_REQUEST_PARTY_NOT_FOUND(HttpStatus.NOT_FOUND, "PARTY203", "해당 모임에서 존재하지 않는 가입신청입니다."),
 
     INSUFFICIENT_PERMISSION(HttpStatus.FORBIDDEN, "PARTY301", "해당 작업을 수행할 권한이 없습니다."),
 
     ALREADY_MEMBER(HttpStatus.CONFLICT, "PARTY401", "이미 가입된 모임입니다."),
-    JOIN_REQUEST_ALREADY_EXISTS(HttpStatus.CONFLICT, "PARTY402", "처리 대기중인 가입 신청이 존재합니다.");
-
+    JOIN_REQUEST_ALREADY_EXISTS(HttpStatus.CONFLICT, "PARTY402", "처리 대기중인 가입 신청이 존재합니다."),
+    JOIN_REQUEST_ALREADY_ACTIONS(HttpStatus.CONFLICT, "PARTY403", "이미 처리된 가입 신청입니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/umc/cockple/demo/domain/party/service/PartyCommandService.java
+++ b/src/main/java/umc/cockple/demo/domain/party/service/PartyCommandService.java
@@ -3,11 +3,15 @@ package umc.cockple.demo.domain.party.service;
 import org.springframework.web.multipart.MultipartFile;
 import umc.cockple.demo.domain.party.dto.PartyCreateRequestDTO;
 import umc.cockple.demo.domain.party.dto.PartyCreateResponseDTO;
+import umc.cockple.demo.domain.party.dto.PartyJoinActionRequestDTO;
 import umc.cockple.demo.domain.party.dto.PartyJoinCreateResponseDTO;
+import umc.cockple.demo.global.response.BaseResponse;
 
 public interface PartyCommandService {
 
     PartyCreateResponseDTO createParty(Long memberId, MultipartFile profileImage, PartyCreateRequestDTO request);
 
     PartyJoinCreateResponseDTO createJoinRequest(Long partyId, Long memberId);
+
+    void actionJoinRequest(Long partyId, Long memberId, PartyJoinActionRequestDTO request, Long requestId);
 }

--- a/src/main/java/umc/cockple/demo/domain/party/service/PartyCommandServiceImpl.java
+++ b/src/main/java/umc/cockple/demo/domain/party/service/PartyCommandServiceImpl.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 import umc.cockple.demo.domain.member.domain.Member;
+import umc.cockple.demo.domain.member.domain.MemberParty;
 import umc.cockple.demo.domain.member.repository.MemberPartyRepository;
 import umc.cockple.demo.domain.member.repository.MemberRepository;
 import umc.cockple.demo.domain.party.converter.PartyConverter;
@@ -20,6 +21,7 @@ import umc.cockple.demo.domain.party.exception.PartyException;
 import umc.cockple.demo.domain.party.repository.PartyAddrRepository;
 import umc.cockple.demo.domain.party.repository.PartyJoinRequestRepository;
 import umc.cockple.demo.domain.party.repository.PartyRepository;
+import umc.cockple.demo.global.enums.RequestAction;
 import umc.cockple.demo.global.enums.RequestStatus;
 import umc.cockple.demo.global.s3.ImageService;
 
@@ -89,6 +91,48 @@ public class PartyCommandServiceImpl implements PartyCommandService{
         return partyConverter.toJoinResponseDTO(savedPartyJoinRequest);
     }
 
+    @Override
+    public void actionJoinRequest(Long partyId, Long memberId, PartyJoinActionRequestDTO request, Long requestId) {
+        log.info("가입신청 처리 시작 - partyId: {}, memberId: {}, requestId: {}", partyId, memberId, requestId);
+
+        //모임, 가입신청 조회
+        Party party = findPartyOrThrow(partyId);
+        PartyJoinRequest partyJoinRequest = findJoinRequestOrThorow(requestId);
+
+        //모임장 권한 확인
+        validateOwnerPermission(party, memberId);
+
+        //가입신청 처리 가능한지 검증
+        validateJoinRequestAction(party, partyJoinRequest);
+
+        //비즈니스 로직 수행 (승인/거절에 따른 처리)
+        if(RequestAction.APPROVE.equals(request.action())){
+            approveJoinRequest(partyJoinRequest);
+        }else{
+            rejectJoinRequest(partyJoinRequest);
+        }
+
+        log.info("가입신청 처리 완료 - requestId: {}", requestId);
+    }
+
+    private void rejectJoinRequest(PartyJoinRequest partyJoinRequest) {
+        partyJoinRequest.updateStatus(RequestStatus.REJECTED);
+    }
+
+    private void approveJoinRequest(PartyJoinRequest partyJoinRequest) {
+        partyJoinRequest.updateStatus(RequestStatus.APPROVED);
+        Party party = partyJoinRequest.getParty();
+        Member member = partyJoinRequest.getMember();
+        MemberParty newMemberParty= MemberParty.create(party, member);
+        party.addMember(newMemberParty);
+    }
+
+    //가입신청 조회
+    private PartyJoinRequest findJoinRequestOrThorow(Long requestId) {
+        return partyJoinRequestRepository.findById(requestId)
+                .orElseThrow(() -> new PartyException(PartyErrorCode.JoinRequest_NOT_FOUND));
+    }
+
     //사용자 조회
     private Member findMemberOrThrow(Long memberId) {
         return memberRepository.findById(memberId)
@@ -101,6 +145,13 @@ public class PartyCommandServiceImpl implements PartyCommandService{
                 .orElseThrow(() -> new PartyException(PartyErrorCode.PARTY_NOT_FOUND));
     }
 
+    //모임장 권한 확인
+    private void validateOwnerPermission(Party party, Long memberId) {
+        if(!party.getOwnerId().equals(memberId)){
+            throw new PartyException(PartyErrorCode.INSUFFICIENT_PERMISSION);
+        }
+    }
+
     private void validateJoinRequest(Member member, Party party) {
         //이미 가입한 멤버인지 확인
         if (memberPartyRepository.existsByPartyAndMember(party, member)) {
@@ -109,6 +160,17 @@ public class PartyCommandServiceImpl implements PartyCommandService{
         //이미 보낸 신청이 있는지 확인
         if (partyJoinRequestRepository.existsByPartyAndMemberAndStatus(party, member, RequestStatus.PENDING)) {
             throw new PartyException(PartyErrorCode.JOIN_REQUEST_ALREADY_EXISTS);
+        }
+    }
+
+    private void validateJoinRequestAction(Party party, PartyJoinRequest joinRequest) {
+        //해당 모임의 가입신청인지 확인
+        if(!joinRequest.getParty().getId().equals(party.getId())){
+            throw new PartyException(PartyErrorCode.JOIN_REQUEST_PARTY_NOT_FOUND);
+        }
+        //이미 처리된 가입신청인지 확인
+        if(joinRequest.getStatus()!=RequestStatus.PENDING){
+            throw new PartyException(PartyErrorCode.JOIN_REQUEST_ALREADY_ACTIONS);
         }
     }
 

--- a/src/main/java/umc/cockple/demo/global/enums/RequestAction.java
+++ b/src/main/java/umc/cockple/demo/global/enums/RequestAction.java
@@ -1,0 +1,7 @@
+package umc.cockple.demo.global.enums;
+
+public enum RequestAction {
+    //승인, 거절 요청
+    APPROVE,
+    REJECT
+}


### PR DESCRIPTION
## ❤️ 기능 설명
모임장이 가입 신청을 승인하거나 거절하는 API를 구현했습니다.
검증
- 모임장 권한 검증
- 이미 가입한 멤버인지 검증
- 이미 보낸 신청이 있는지 검증

swagger 테스트 성공 결과 스크린샷 첨부
<img width="358" height="354" alt="image" src="https://github.com/user-attachments/assets/2739854f-dcc9-428a-9cd5-ecb977f2878b" />

<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #53
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!
없습니다!

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [ ] 이슈넘버를 적었는가?
