### PR TITLE
[refactor/#89] 모임 생성 API 이미지 업로드 방식 변경

### DIFF
--- a/src/main/java/umc/cockple/demo/domain/party/controller/PartyController.java
+++ b/src/main/java/umc/cockple/demo/domain/party/controller/PartyController.java
@@ -9,7 +9,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
-import org.springframework.http.MediaType;
 import org.springframework.security.core.Authentication;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
@@ -30,23 +29,21 @@ public class PartyController {
     private final PartyCommandService partyCommandService;
     private final PartyQueryService partyQueryService;
 
-    @PostMapping(value = "/parties", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @PostMapping(value = "/parties")
     @Operation(summary = "모임 생성",
             description = "새로운 모임을 생성합니다. 성공 시 사용자는 해당 모임의 모임장이 됩니다.")
     @ApiResponse(responseCode = "201", description = "모임 생성 성공")
     @ApiResponse(responseCode = "400", description = "입력값 유효성 검증 실패 또는 잘못된 요청 형식")
     @ApiResponse(responseCode = "403", description = "모임 생성 권한 없음")
     public BaseResponse<PartyCreateResponseDTO> createParty(
-            //사진 파일을 함께 보내기 위해 @RequestPart로 구현
-            @RequestPart("createPartyRequest") @Valid PartyCreateRequestDTO request,
-            @RequestPart(value = "profileImg", required = false) MultipartFile profileImage,
+            @RequestBody @Valid PartyCreateRequestDTO request,
             Authentication authentication
     ){
         // TODO: JWT 인증 구현 후 교체 예정
         Long memberId = 1L; // 임시값
 
         //서비스 호출
-        PartyCreateResponseDTO response = partyCommandService.createParty(memberId, profileImage, request);
+        PartyCreateResponseDTO response = partyCommandService.createParty(memberId, request);
 
         return BaseResponse.success(CommonSuccessCode.CREATED, response);
     }

--- a/src/main/java/umc/cockple/demo/domain/party/converter/PartyConverter.java
+++ b/src/main/java/umc/cockple/demo/domain/party/converter/PartyConverter.java
@@ -24,6 +24,7 @@ public class PartyConverter {
                 .joinPrice(request.joinPrice())
                 .designatedCock(request.designatedCock())
                 .content(request.content())
+                .imgUrl(request.imgUrl())
                 .build();
     }
 

--- a/src/main/java/umc/cockple/demo/domain/party/domain/Party.java
+++ b/src/main/java/umc/cockple/demo/domain/party/domain/Party.java
@@ -88,7 +88,7 @@ public class Party extends BaseEntity {
     @OneToOne(mappedBy = "party", cascade = CascadeType.ALL, orphanRemoval = true)
     private PartyImg partyImg;
 
-    public static Party create(PartyCreateCommand command, PartyAddr addr, String imageUrl, Member owner) {
+    public static Party create(PartyCreateCommand command, PartyAddr addr, Member owner) {
         Party party = Party.builder()
                 .partyName(command.partyName())
                 .partyType(ParticipationType.valueOf(command.partyType())) //enum으로 변환
@@ -105,7 +105,8 @@ public class Party extends BaseEntity {
 
         party.addMember(MemberParty.createOwner(owner, party));
 
-        if (imageUrl != null) {
+        String imageUrl = command.imgUrl();
+        if (imageUrl != null && !imageUrl.isBlank()) {
             party.setPartyImg(PartyImg.create(imageUrl, party));
         }
 

--- a/src/main/java/umc/cockple/demo/domain/party/dto/PartyCreateCommand.java
+++ b/src/main/java/umc/cockple/demo/domain/party/dto/PartyCreateCommand.java
@@ -17,6 +17,7 @@ public record PartyCreateCommand(
         Integer price,
         Integer joinPrice,
         String designatedCock,
-        String content
+        String content,
+        String imgUrl
 ) {
 }

--- a/src/main/java/umc/cockple/demo/domain/party/dto/PartyCreateRequestDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/party/dto/PartyCreateRequestDTO.java
@@ -48,6 +48,8 @@ public record PartyCreateRequestDTO (
     Integer maxAge,
 
     @Size(max = 45, message = "모임 소개는 최대 45글자입니다.")
-    String content
+    String content,
+
+    String imgUrl
 ){
 }

--- a/src/main/java/umc/cockple/demo/domain/party/service/PartyCommandService.java
+++ b/src/main/java/umc/cockple/demo/domain/party/service/PartyCommandService.java
@@ -8,7 +8,7 @@ import umc.cockple.demo.domain.party.dto.PartyJoinCreateResponseDTO;
 
 public interface PartyCommandService {
 
-    PartyCreateResponseDTO createParty(Long memberId, MultipartFile profileImage, PartyCreateRequestDTO request);
+    PartyCreateResponseDTO createParty(Long memberId, PartyCreateRequestDTO request);
 
     PartyJoinCreateResponseDTO createJoinRequest(Long partyId, Long memberId);
 

--- a/src/main/java/umc/cockple/demo/domain/party/service/PartyCommandServiceImpl.java
+++ b/src/main/java/umc/cockple/demo/domain/party/service/PartyCommandServiceImpl.java
@@ -37,10 +37,9 @@ public class PartyCommandServiceImpl implements PartyCommandService{
     private final MemberRepository memberRepository;
     private final MemberPartyRepository memberPartyRepository;
     private final PartyConverter partyConverter;
-    private final ImageService imageService;
 
     @Override
-    public PartyCreateResponseDTO createParty(Long memberId, MultipartFile profileImage, PartyCreateRequestDTO request) {
+    public PartyCreateResponseDTO createParty(Long memberId, PartyCreateRequestDTO request) {
         log.info("모임 생성 시작 - memberId: {}", memberId);
 
         //DTO -> Command 객체로 변환
@@ -53,11 +52,8 @@ public class PartyCommandServiceImpl implements PartyCommandService{
         //주소 처리 (조회 또는 새로 생성)
         PartyAddr partyAddr = findOrCreatePartyAddr(addrCommand);
 
-        //이미지 업로드 처리
-        String imageUrl = imageService.uploadImage(profileImage);
-
         //Party 엔티티 생성
-        Party newParty = Party.create(partyCommand, partyAddr, imageUrl, owner);
+        Party newParty = Party.create(partyCommand, partyAddr, owner);
 
         //DB에 Party 저장
         Party savedParty = partyRepository.save(newParty);


### PR DESCRIPTION
## ❤️ 기능 설명
모임 생성 API의 이미지 업로드를 받아오는 방식을 변경했습니다.
- requestPart -> requestBody
- 기존의 DTO, 정적팩토리메서드 등 관련 코드 변경

swagger 테스트 성공 결과 스크린샷 첨부
<img width="790" height="337" alt="image" src="https://github.com/user-attachments/assets/6b3cb652-9c13-458b-a8ba-03249cb190cc" />
<img width="788" height="125" alt="image" src="https://github.com/user-attachments/assets/74da365f-54da-4054-a8d3-5347c6ef699c" />

<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #89
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- 없습니다!

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
