### PR TITLE
[feat/#94] 회원 주소 삭제 API 구현

### DIFF
--- a/src/main/java/umc/cockple/demo/domain/member/controller/MemberController.java
+++ b/src/main/java/umc/cockple/demo/domain/member/controller/MemberController.java
@@ -61,4 +61,14 @@ public class MemberController {
         return BaseResponse.success(CommonSuccessCode.OK);
     }
 
+    @DeleteMapping("/my/profile/locations/{memberAddrId}")
+    @Operation(summary = "회원 주소 삭제 API",
+            description = "사용자가 자신의 주소 중 원하는 주소를 삭제")
+    public BaseResponse<String> deleteMemberAddr(@PathVariable Long memberAddrId) {
+        // 추후 시큐리티를 통해 id 가져옴
+        Long memberId = 1L;
+
+        memberCommandService.deleteMemberAddr(memberId, memberAddrId);
+        return BaseResponse.success(CommonSuccessCode.OK);
+    }
 }

--- a/src/main/java/umc/cockple/demo/domain/member/domain/Member.java
+++ b/src/main/java/umc/cockple/demo/domain/member/domain/Member.java
@@ -63,7 +63,7 @@ public class Member extends BaseEntity {
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
     private List<MemberKeyword> keywords = new ArrayList<>();
 
-    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<MemberAddr> addresses = new ArrayList<>();
 
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)

--- a/src/main/java/umc/cockple/demo/domain/member/exception/MemberErrorCode.java
+++ b/src/main/java/umc/cockple/demo/domain/member/exception/MemberErrorCode.java
@@ -26,7 +26,8 @@ public enum MemberErrorCode implements BaseErrorCode {
 
     DUPLICATE_ADDRESS(HttpStatus.BAD_REQUEST, "MEM_ADDR401", "이미 같은 주소가 존재합니다."),
     OVER_NUMBER_OF_ADDR(HttpStatus.BAD_REQUEST, "MEM_ADDR402", "주소 개수가 5개를 초과합니다."),
-
+    CANNOT_REMOVE_MAIN_ADDR(HttpStatus.BAD_REQUEST, "MEM_ADDR403", "대표주소는 삭제할 수 없습니다."),
+    MEMBER_ADDRESS_MINIMUM_REQUIRED(HttpStatus.BAD_REQUEST, "MEM_ADDR404", "주소가 적어도 1개 이상 필요합니다."),
 
     ;
 

--- a/src/main/java/umc/cockple/demo/domain/member/service/MemberCommandService.java
+++ b/src/main/java/umc/cockple/demo/domain/member/service/MemberCommandService.java
@@ -149,6 +149,28 @@ public class MemberCommandService {
         newMainAddr.beMainAddr();
     }
 
+    public void deleteMemberAddr(Long memberId, Long addrId) {
+        // 회원 찾기
+        Member member = findByMemberId(memberId);
+
+        // 지우려는 주소 조회
+        MemberAddr addr = findByAddrId(addrId);
+
+        // 지우려는 주소가 대표주소인지 확인 -> 대표주소면 지울 수 없음
+        if (addr.getIsMain()) {
+            throw new MemberException(MemberErrorCode.CANNOT_REMOVE_MAIN_ADDR);
+        }
+
+        // 주소가 1개 이하면 삭제 불가
+        if (member.getAddresses().size() <= 1) {
+            throw new MemberException(MemberErrorCode.MEMBER_ADDRESS_MINIMUM_REQUIRED);
+        }
+
+        // 회원 -> addr에서 삭제
+        member.getAddresses().remove(addr);
+
+    }
+
 
     private Member findByMemberId(Long memberId) {
         return memberRepository.findById(memberId)


### PR DESCRIPTION
## ❤️ 기능 설명
회원 주소 삭제 기능
- 대표 주소 삭제 불가 (UI상으로는 프론트에서 1차 검증을 진행하지만 백엔드에서도 진행)
- 회원의 주소는 최소 1개 이상 존재하도록 구현

swagger 테스트 성공 결과 스크린샷 첨부
대표주소 삭제 시도시
<img width="999" height="1198" alt="스크린샷 2025-07-17 124936" src="https://github.com/user-attachments/assets/27f3eca6-8657-4858-a42a-87494d488b8b" />

다른 주소는 삭제 성공
<img width="986" height="1167" alt="스크린샷 2025-07-17 124947" src="https://github.com/user-attachments/assets/0b2f15c3-bff0-4b69-966d-4be6d4607578" />

<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #94 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!


<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
