### PR TITLE
[feat/#100] 회원 탈퇴 기능 구현

### DIFF
--- a/src/main/java/umc/cockple/demo/domain/member/controller/MemberController.java
+++ b/src/main/java/umc/cockple/demo/domain/member/controller/MemberController.java
@@ -29,6 +29,19 @@ public class MemberController {
     private final MemberCommandService memberCommandService;
     private final MemberQueryService memberQueryService;
 
+
+    @PatchMapping(value = "/member")
+    @Operation(summary = "회원 탈퇴 API",
+            description = "사용자 회원 탈퇴")
+    public BaseResponse<String> withdraw() {
+        // 추후 시큐리티를 통해 id 가져옴
+        Long memberId = 1L;
+
+        memberCommandService.withdrawMember(memberId);
+        return BaseResponse.success(CommonSuccessCode.NO_CONTENT);
+    }
+
+
     @PatchMapping(value = "/my/profile")
     @Operation(summary = "프로필 수정 API",
             description = "사용자가 자신의 프로필 수정")

--- a/src/main/java/umc/cockple/demo/domain/member/domain/Member.java
+++ b/src/main/java/umc/cockple/demo/domain/member/domain/Member.java
@@ -57,25 +57,25 @@ public class Member extends BaseEntity {
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
     private List<Contest> contests = new ArrayList<>();
 
-    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Notification> notifications = new ArrayList<>();
 
-    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<MemberKeyword> keywords = new ArrayList<>();
 
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<MemberAddr> addresses = new ArrayList<>();
 
-    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<MemberParty> memberParties = new ArrayList<>();
 
-    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<MemberExercise> memberExercises = new ArrayList<>();
 
-    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ExerciseBookmark> exerciseBookmarks = new ArrayList<>();
 
-    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<PartyBookmark> partyBookmarks = new ArrayList<>();
 
     @OneToOne(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
@@ -133,5 +133,9 @@ public class Member extends BaseEntity {
                                 addr.getLatitude().equals(requestDTO.latitude()) &&
                                 addr.getLongitude().equals(requestDTO.longitude())
                         );
+    }
+
+    public void withdraw() {
+        this.isActive = MemberStatus.INACTIVE;
     }
 }

--- a/src/main/java/umc/cockple/demo/domain/member/domain/MemberParty.java
+++ b/src/main/java/umc/cockple/demo/domain/member/domain/MemberParty.java
@@ -62,4 +62,9 @@ public class MemberParty extends BaseEntity {
                 .status(ACTIVE)
                 .build();
     }
+
+    public boolean isLeader() {
+        if (this.role == Role.party_MANAGER) return true;
+        return false;
+    }
 }

--- a/src/main/java/umc/cockple/demo/domain/member/exception/MemberErrorCode.java
+++ b/src/main/java/umc/cockple/demo/domain/member/exception/MemberErrorCode.java
@@ -20,6 +20,9 @@ public enum MemberErrorCode implements BaseErrorCode {
     // 회원 관련
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER201", "해당 사용자를 찾을 수 없습니다."),
 
+    ALREADY_WITHDRAW(HttpStatus.UNAUTHORIZED, "MEMBER301", "이미 탈퇴한 회원입니다."),
+
+    MANAGER_CANNOT_LEAVE(HttpStatus.BAD_REQUEST, "MEMBER401", "모임장은 탈퇴할 수 없습니다. 모임 삭제를 먼저 해주세요."),
 
     // 회원 주소 관련
     ADDRESS_NOT_FOUND(HttpStatus.NOT_FOUND, "MEM_ADDR201", "해당 주소를 찾을 수 없습니다."),


### PR DESCRIPTION
## ❤️ 기능 설명
회원 탈퇴 기능 구현
- 모임장일 경우 탈퇴 불가능
- 재가입 가능성이 있으므로 soft delete
- 소속된 모임과 운동은 로직에서 다 나가게 해서 괜찮으나, 채팅의 경우  다른 유저들이 해당 유저의 탈퇴 사실을 알 수 있도록 조치를 해야 할 것 같음
- MemberExercise에서 운동의 대기순서를 위해 participantNum을 사용하고 있는데, 대기중인 다른 유저가 탈퇴했을 때 participantNum이 망가질 가능성이 있어보임
(예를들어 대기 3번이 탈퇴하면 대기 4,5번이 앞 순서로 와야하는데 해당 로직을 구현하거나, 아니면 participant를 없애고 joinedt을 이용해 순서를 확인하는 방식을 이용해야 할 거 같음)
- 우선 soft delete로 구현하긴 했으나, 만약 hard delete로 구현하는 게 나을 거 같은 분들은 이야기해주세요!

swagger 테스트 성공 결과 스크린샷 첨부
<img width="742" height="1015" alt="image" src="https://github.com/user-attachments/assets/ddc35314-b579-4b5b-8a61-dcef52ef2dbc" />

<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #100
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 기능 설명부분 읽어주시고, 의견 코멘트로 달아주시면 감사하겠습니다!

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
