### PR TITLE
[refactor#102] MemberExercise와 Guest에서 participantNum 필드 제거

### DIFF
--- a/src/main/java/umc/cockple/demo/domain/exercise/converter/ExerciseConverter.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/converter/ExerciseConverter.java
@@ -43,7 +43,6 @@ public class ExerciseConverter {
     public ExerciseJoinDTO.Response toJoinResponseDTO(MemberExercise memberExercise, Exercise exercise) {
         return ExerciseJoinDTO.Response.builder()
                 .participantId(memberExercise.getId())
-                .participantNumber(memberExercise.getParticipantNum())
                 .joinedAt(memberExercise.getJoinedAt())
                 .currentParticipants(exercise.getNowCapacity())
                 .build();
@@ -61,24 +60,21 @@ public class ExerciseConverter {
     public ExerciseGuestInviteDTO.Response toGuestInviteResponseDTO(Guest guest, Exercise exercise) {
         return ExerciseGuestInviteDTO.Response.builder()
                 .guestId(guest.getId())
-                .participantNumber(guest.getParticipantNum())
                 .invitedAt(guest.getCreatedAt())
                 .currentParticipants(exercise.getNowCapacity())
                 .build();
     }
 
-    public ExerciseCancelDTO.Response toCancelResponseDTO(Exercise exercise, Member member, Integer participantNumber) {
+    public ExerciseCancelDTO.Response toCancelResponseDTO(Exercise exercise, Member member) {
         return ExerciseCancelDTO.Response.builder()
                 .memberName(member.getMemberName())
-                .cancelledParticipationNumber(participantNumber)
                 .currentParticipants(exercise.getNowCapacity())
                 .build();
     }
 
-    public ExerciseCancelDTO.Response toCancelResponseDTO(Exercise exercise, Guest guest, Integer participantNumber) {
+    public ExerciseCancelDTO.Response toCancelResponseDTO(Exercise exercise, Guest guest) {
         return ExerciseCancelDTO.Response.builder()
                 .memberName(guest.getGuestName())
-                .cancelledParticipationNumber(participantNumber)
                 .currentParticipants(exercise.getNowCapacity())
                 .build();
     }

--- a/src/main/java/umc/cockple/demo/domain/exercise/domain/Exercise.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/domain/Exercise.java
@@ -76,16 +76,6 @@ public class Exercise extends BaseEntity {
                 .build();
     }
 
-    public void reorderParticipantNumbers(int removedNum) {
-        memberExercises.stream()
-                .filter(me -> me.getParticipantNum() > removedNum)
-                .forEach(MemberExercise::decrementParticipantNum);
-
-        guests.stream()
-                .filter(g -> g.getParticipantNum() > removedNum)
-                .forEach(Guest::decrementParticipantNum);
-    }
-
     public void updateExerciseInfo(ExerciseUpdateDTO.Command command) {
         if (command.date() != null) {
             this.date = command.date();

--- a/src/main/java/umc/cockple/demo/domain/exercise/domain/Guest.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/domain/Guest.java
@@ -36,16 +36,12 @@ public class Guest extends BaseEntity {
     @Column(nullable = false)
     private Long inviterId;
 
-    @Column(nullable = false)
-    private Integer participantNum;
-
-    public static Guest create(ExerciseGuestInviteDTO.Command command, Integer participantNum) {
+    public static Guest create(ExerciseGuestInviteDTO.Command command) {
         return Guest.builder()
                 .guestName(command.guestName())
                 .gender(command.gender())
                 .level(command.level())
                 .inviterId(command.inviterId())
-                .participantNum(participantNum)
                 .build();
     }
 
@@ -53,12 +49,6 @@ public class Guest extends BaseEntity {
         this.exercise = exercise;
         if (exercise != null && !exercise.getGuests().contains(this)) {
             exercise.getGuests().add(this);
-        }
-    }
-
-    public void decrementParticipantNum() {
-        if (this.participantNum > 1) {
-            this.participantNum--;
         }
     }
 }

--- a/src/main/java/umc/cockple/demo/domain/exercise/dto/ExerciseCancelDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/dto/ExerciseCancelDTO.java
@@ -14,7 +14,6 @@ public class ExerciseCancelDTO {
     @Builder
     public record Response(
             String memberName,
-            Integer cancelledParticipationNumber,
             Integer currentParticipants
     ) {
     }

--- a/src/main/java/umc/cockple/demo/domain/exercise/dto/ExerciseGuestInviteDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/dto/ExerciseGuestInviteDTO.java
@@ -1,5 +1,6 @@
 package umc.cockple.demo.domain.exercise.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import lombok.Builder;
@@ -10,6 +11,7 @@ import java.time.LocalDateTime;
 
 public class ExerciseGuestInviteDTO {
 
+    @Schema(name = "ExerciseGuestInviteRequest", description = "게스트 초대 요청")
     public record Request(
             @NotBlank(message = "게스트 이름은 필수입니다.")
             @Size(max = 17, message = "게스트 이름은 17자 이하여야 합니다.")
@@ -42,7 +44,6 @@ public class ExerciseGuestInviteDTO {
     @Builder
     public record Response(
             Long guestId,
-            Integer participantNumber,
             LocalDateTime invitedAt,
             Integer currentParticipants
     ) {

--- a/src/main/java/umc/cockple/demo/domain/exercise/dto/ExerciseJoinDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/dto/ExerciseJoinDTO.java
@@ -9,7 +9,6 @@ public class ExerciseJoinDTO {
     @Builder
     public record Response(
             Long participantId,
-            Integer participantNumber,
             LocalDateTime joinedAt,
             Integer currentParticipants
     ) {

--- a/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseCommandService.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseCommandService.java
@@ -66,9 +66,7 @@ public class ExerciseCommandService {
         Member member = findMemberOrThrow(memberId);
         validateJoinExercise(exercise, member);
 
-        Integer participantNum = exercise.calculateNextParticipantNumber();
-
-        MemberExercise memberExercise = MemberExercise.create(participantNum);
+        MemberExercise memberExercise = MemberExercise.create();
         member.addParticipation(memberExercise);
         exercise.addParticipation(memberExercise);
 
@@ -89,9 +87,8 @@ public class ExerciseCommandService {
         validateGuestInvitation(exercise, inviter);
 
         ExerciseGuestInviteDTO.Command command = exerciseConverter.toGuestInviteCommand(request, inviterId);
-        Integer participantNum = exercise.calculateNextParticipantNumber();
 
-        Guest guest = Guest.create(command, participantNum);
+        Guest guest = Guest.create(command);
         exercise.addGuest(guest);
 
         Guest savedGuest = guestRepository.save(guest);
@@ -110,12 +107,9 @@ public class ExerciseCommandService {
         MemberExercise memberExercise = findMemberExerciseOrThrow(exercise, member);
         validateCancelParticipation(exercise);
 
-        Integer participantNumber = memberExercise.getParticipantNum();
-
         exercise.removeParticipation(memberExercise);
         member.removeParticipation(memberExercise);
 
-        exercise.reorderParticipantNumbers(participantNumber);
         memberExerciseRepository.delete(memberExercise);
 
         exerciseRepository.save(exercise);
@@ -123,7 +117,7 @@ public class ExerciseCommandService {
         log.info("운동 참여 취소 완료 - exerciseId: {}, memberId: {}, 현재 참여자 수: {}",
                 exerciseId, memberId, exercise.getNowCapacity());
 
-        return exerciseConverter.toCancelResponseDTO(exercise, member, participantNumber);
+        return exerciseConverter.toCancelResponseDTO(exercise, member);
     }
 
     public ExerciseCancelDTO.Response cancelGuestInvitation(Long exerciseId, Long guestId, Long memberId) {
@@ -135,18 +129,15 @@ public class ExerciseCommandService {
         Guest guest = findGuestOrThrow(guestId);
         validateCancelGuestInvitation(exercise, guest, member);
 
-        Integer participantNumber = guest.getParticipantNum();
-
         exercise.removeGuest(guest);
 
-        exercise.reorderParticipantNumbers(participantNumber);
         guestRepository.delete(guest);
 
         exerciseRepository.save(exercise);
 
         log.info("게스트 초대 취소 완료 - exerciseId: {}, guestId: {}, memberId: {}", exerciseId, guestId, memberId);
 
-        return exerciseConverter.toCancelResponseDTO(exercise, guest, participantNumber);
+        return exerciseConverter.toCancelResponseDTO(exercise, guest);
     }
 
     public ExerciseCancelDTO.Response cancelParticipationByManager(
@@ -369,33 +360,27 @@ public class ExerciseCommandService {
         Guest guest = findGuestOrThrow(participantId);
         validateGuestBelongsToExercise(guest, exercise);
 
-        Integer participantNumber = guest.getParticipantNum();
-
         exercise.removeGuest(guest);
 
-        exercise.reorderParticipantNumbers(participantNumber);
         guestRepository.delete(guest);
 
         exerciseRepository.save(exercise);
 
-        return exerciseConverter.toCancelResponseDTO(exercise, guest, participantNumber);
+        return exerciseConverter.toCancelResponseDTO(exercise, guest);
     }
 
     private ExerciseCancelDTO.Response cancelMemberParticipation(Exercise exercise, Long participantId) {
         Member participant = findMemberOrThrow(participantId);
         MemberExercise memberExercise = findMemberExerciseOrThrow(exercise, participant);
 
-        Integer participantNumber = memberExercise.getParticipantNum();
-
         exercise.removeParticipation(memberExercise);
         participant.removeParticipation(memberExercise);
 
-        exercise.reorderParticipantNumbers(participantNumber);
         memberExerciseRepository.delete(memberExercise);
 
         exerciseRepository.save(exercise);
 
-        return exerciseConverter.toCancelResponseDTO(exercise, participant, participantNumber);
+        return exerciseConverter.toCancelResponseDTO(exercise, participant);
     }
 
     // ========== 조회 메서드 ==========

--- a/src/main/java/umc/cockple/demo/domain/member/domain/MemberExercise.java
+++ b/src/main/java/umc/cockple/demo/domain/member/domain/MemberExercise.java
@@ -29,13 +29,9 @@ public class MemberExercise extends BaseEntity {
     @Column(nullable = false)
     private LocalDateTime joinedAt;
 
-    @Column(nullable = false)
-    private Integer participantNum;
-
-    public static MemberExercise create(Integer participantNum) {
+    public static MemberExercise create() {
         return MemberExercise.builder()
                 .joinedAt(LocalDateTime.now())
-                .participantNum(participantNum)
                 .build();
     }
 
@@ -50,12 +46,6 @@ public class MemberExercise extends BaseEntity {
         this.member = member;
         if (member != null && !member.getMemberExercises().contains(this)) {
             member.getMemberExercises().add(this);
-        }
-    }
-
-    public void decrementParticipantNum() {
-        if (this.participantNum > 1) {
-            this.participantNum--;
         }
     }
 }


### PR DESCRIPTION
## ❤️ 기능 설명
운동 내 순번을 필드를 따로 두는 대신
createdAt 필드를 통해서 GET할 때 정렬하는 방식으로 구현하겠습니다.

swagger 테스트 성공 결과 스크린샷 첨부
운동 신청
<img width="2139" height="1249" alt="image" src="https://github.com/user-attachments/assets/16c1ad2f-d3c0-4aec-83cc-8630f6d31dc0" />

게스트 초대
<img width="2151" height="886" alt="image" src="https://github.com/user-attachments/assets/96bbbd69-8138-4764-a792-6cccc8552f75" />

게스트 초대 취소
<img width="2145" height="770" alt="image" src="https://github.com/user-attachments/assets/460881d5-129a-44c4-8fa2-e7614efba928" />

운동 신청 취소
<img width="2148" height="780" alt="image" src="https://github.com/user-attachments/assets/941fef4b-4c13-474f-b9d7-f24ea14efd68" />




<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #102 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [ ] 이슈넘버를 적었는가?
