### PR TITLE
[feat/#103] 운동 신청 API에서 검증 로직 추가

### DIFF
--- a/src/main/java/umc/cockple/demo/domain/exercise/controller/ExerciseController.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/controller/ExerciseController.java
@@ -49,7 +49,7 @@ public class ExerciseController {
             description = "모임에서 생성한 운동에 신청합니다. 외부 게스트 허용일 경우 모임 멤버가 아니어도 가능합니다.")
     @ApiResponse(responseCode = "200", description = "운동 신청 성공")
     @ApiResponse(responseCode = "400", description = "입력값 오류 또는 비즈니스 룰 위반")
-    @ApiResponse(responseCode = "403", description = "권한 없음")
+    @ApiResponse(responseCode = "403", description = "권한 없음, 급수 위반")
     public BaseResponse<ExerciseJoinDTO.Response> JoinExercise(
             @PathVariable Long exerciseId,
             Authentication authentication

--- a/src/main/java/umc/cockple/demo/domain/exercise/exception/ExerciseErrorCode.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/exception/ExerciseErrorCode.java
@@ -31,7 +31,7 @@ public enum ExerciseErrorCode implements BaseErrorCode {
     NOT_PARTY_MEMBER_FOR_GUEST_INVITE(HttpStatus.FORBIDDEN, "EXERCISE303", "파티 멤버만 게스트를 초대할 수 있습니다."),
     GUEST_INVITATION_NOT_ALLOWED(HttpStatus.FORBIDDEN, "EXERCISE304", "외부 게스트 초대가 허용되지 않았습니다."),
     GUEST_NOT_INVITED_BY_MEMBER(HttpStatus.FORBIDDEN, "EXERCISE305", "본인이 아닌 다른 사용자에 의해 초대된 게스트입니다."),
-    LEVEL_NOT_ALLOWED(HttpStatus.FORBIDDEN, "EXERCISE306", "해당 급수로는 이 운동에 참여할 수 없습니다."),
+    MEMBER_LEVEL_NOT_ALLOWED(HttpStatus.FORBIDDEN, "EXERCISE306", "해당 급수로는 이 운동에 참여할 수 없습니다."),
 
     INVALID_EXERCISE_TIME(HttpStatus.BAD_REQUEST, "EXERCISE401", "종료 시간은 시작 시간보다 늦어야 합니다."),
     PAST_TIME_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "EXERCISE402", "운동 시간은 과거로 할 수 없습니다."),

--- a/src/main/java/umc/cockple/demo/domain/exercise/exception/ExerciseErrorCode.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/exception/ExerciseErrorCode.java
@@ -32,6 +32,7 @@ public enum ExerciseErrorCode implements BaseErrorCode {
     GUEST_INVITATION_NOT_ALLOWED(HttpStatus.FORBIDDEN, "EXERCISE304", "외부 게스트 초대가 허용되지 않았습니다."),
     GUEST_NOT_INVITED_BY_MEMBER(HttpStatus.FORBIDDEN, "EXERCISE305", "본인이 아닌 다른 사용자에 의해 초대된 게스트입니다."),
     MEMBER_LEVEL_NOT_ALLOWED(HttpStatus.FORBIDDEN, "EXERCISE306", "해당 급수로는 이 운동에 참여할 수 없습니다."),
+    MEMBER_AGE_NOT_ALLOWED(HttpStatus.FORBIDDEN, "EXERCISE307", "해당 나이로는 이 운동에 참여할 수 없습니다."),
 
     INVALID_EXERCISE_TIME(HttpStatus.BAD_REQUEST, "EXERCISE401", "종료 시간은 시작 시간보다 늦어야 합니다."),
     PAST_TIME_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "EXERCISE402", "운동 시간은 과거로 할 수 없습니다."),

--- a/src/main/java/umc/cockple/demo/domain/exercise/exception/ExerciseErrorCode.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/exception/ExerciseErrorCode.java
@@ -31,6 +31,7 @@ public enum ExerciseErrorCode implements BaseErrorCode {
     NOT_PARTY_MEMBER_FOR_GUEST_INVITE(HttpStatus.FORBIDDEN, "EXERCISE303", "파티 멤버만 게스트를 초대할 수 있습니다."),
     GUEST_INVITATION_NOT_ALLOWED(HttpStatus.FORBIDDEN, "EXERCISE304", "외부 게스트 초대가 허용되지 않았습니다."),
     GUEST_NOT_INVITED_BY_MEMBER(HttpStatus.FORBIDDEN, "EXERCISE305", "본인이 아닌 다른 사용자에 의해 초대된 게스트입니다."),
+    LEVEL_NOT_ALLOWED(HttpStatus.FORBIDDEN, "EXERCISE306", "해당 급수로는 이 운동에 참여할 수 없습니다."),
 
     INVALID_EXERCISE_TIME(HttpStatus.BAD_REQUEST, "EXERCISE401", "종료 시간은 시작 시간보다 늦어야 합니다."),
     PAST_TIME_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "EXERCISE402", "운동 시간은 과거로 할 수 없습니다."),

--- a/src/main/java/umc/cockple/demo/domain/exercise/exception/ExerciseErrorCode.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/exception/ExerciseErrorCode.java
@@ -31,8 +31,6 @@ public enum ExerciseErrorCode implements BaseErrorCode {
     NOT_PARTY_MEMBER_FOR_GUEST_INVITE(HttpStatus.FORBIDDEN, "EXERCISE303", "파티 멤버만 게스트를 초대할 수 있습니다."),
     GUEST_INVITATION_NOT_ALLOWED(HttpStatus.FORBIDDEN, "EXERCISE304", "외부 게스트 초대가 허용되지 않았습니다."),
     GUEST_NOT_INVITED_BY_MEMBER(HttpStatus.FORBIDDEN, "EXERCISE305", "본인이 아닌 다른 사용자에 의해 초대된 게스트입니다."),
-    MEMBER_LEVEL_NOT_ALLOWED(HttpStatus.FORBIDDEN, "EXERCISE306", "해당 급수로는 이 운동에 참여할 수 없습니다."),
-    MEMBER_AGE_NOT_ALLOWED(HttpStatus.FORBIDDEN, "EXERCISE307", "해당 나이로는 이 운동에 참여할 수 없습니다."),
 
     INVALID_EXERCISE_TIME(HttpStatus.BAD_REQUEST, "EXERCISE401", "종료 시간은 시작 시간보다 늦어야 합니다."),
     PAST_TIME_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "EXERCISE402", "운동 시간은 과거로 할 수 없습니다."),
@@ -41,7 +39,9 @@ public enum ExerciseErrorCode implements BaseErrorCode {
     EXERCISE_ALREADY_STARTED_CANCEL(HttpStatus.BAD_REQUEST, "EXERCISE405", "이미 시작된 운동에는 취소할 수 없습니다."),
     EXERCISE_ALREADY_STARTED_UPDATE(HttpStatus.BAD_REQUEST, "EXERCISE406", "이미 시작된 운동은 수정할 수 없습니다."),
     ALREADY_JOINED_EXERCISE(HttpStatus.BAD_REQUEST, "EXERCISE407", "이미 참여 신청한 운동입니다."),
-    GUEST_IS_NOT_PARTICIPATED_IN_EXERCISE(HttpStatus.BAD_REQUEST, "EXERCISE408", "게스트가 이 운동에 참여해있지 않습니다..");
+    GUEST_IS_NOT_PARTICIPATED_IN_EXERCISE(HttpStatus.BAD_REQUEST, "EXERCISE408", "게스트가 이 운동에 참여해있지 않습니다.."),
+    MEMBER_LEVEL_NOT_ALLOWED(HttpStatus.FORBIDDEN, "EXERCISE409", "해당 급수로는 이 운동에 참여할 수 없습니다."),
+    MEMBER_AGE_NOT_ALLOWED(HttpStatus.FORBIDDEN, "EXERCISE410", "해당 나이로는 이 운동에 참여할 수 없습니다.");
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/umc/cockple/demo/domain/exercise/repository/ExerciseRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/repository/ExerciseRepository.java
@@ -1,7 +1,19 @@
 package umc.cockple.demo.domain.exercise.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import umc.cockple.demo.domain.exercise.domain.Exercise;
 
+import java.util.Optional;
+
 public interface ExerciseRepository extends JpaRepository<Exercise, Long> {
+
+    @Query("""
+        SELECT e FROM Exercise e 
+        JOIN FETCH e.party p 
+        JOIN FETCH p.levels 
+        WHERE e.id = :exerciseId
+        """)
+    Optional<Exercise> findByIdWithPartyLevels(@Param("exerciseId") Long exerciseId);
 }

--- a/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseCommandService.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseCommandService.java
@@ -209,6 +209,7 @@ public class ExerciseCommandService {
         validateAlreadyJoined(exercise, member);
         validateJoinPermission(exercise, member);
         validateMemberLevel(exercise.getParty(), member);
+        validateMemberAge(exercise.getParty(), member);
     }
 
     private void validateGuestInvitation(Exercise exercise, Member inviter) {
@@ -297,6 +298,12 @@ public class ExerciseCommandService {
 
         if (!isLevelAllowed) {
             throw new ExerciseException(ExerciseErrorCode.MEMBER_LEVEL_NOT_ALLOWED);
+        }
+    }
+
+    private void validateMemberAge(Party party, Member member) {
+        if(!party.isAgeValid(member)){
+            throw new ExerciseException(ExerciseErrorCode.MEMBER_AGE_NOT_ALLOWED);
         }
     }
 

--- a/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseCommandService.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseCommandService.java
@@ -208,6 +208,7 @@ public class ExerciseCommandService {
         validateAlreadyStarted(exercise, ExerciseErrorCode.EXERCISE_ALREADY_STARTED_PARTICIPATION);
         validateAlreadyJoined(exercise, member);
         validateJoinPermission(exercise, member);
+        validateMemberLevel(exercise, member);
     }
 
     private void validateGuestInvitation(Exercise exercise, Member inviter) {
@@ -286,6 +287,14 @@ public class ExerciseCommandService {
 
         if(Boolean.FALSE.equals(exercise.getOutsideGuestAccept())) {
             throw new ExerciseException(ExerciseErrorCode.NOT_PARTY_MEMBER);
+        }
+    }
+
+    private void validateMemberLevel(Exercise exercise, Member member) {
+        Party party = exercise.getParty();
+
+        if(!party.isLevelAllowed(member)){
+            throw new ExerciseException(ExerciseErrorCode.LEVEL_NOT_ALLOWED);
         }
     }
 

--- a/src/main/java/umc/cockple/demo/domain/member/domain/Member.java
+++ b/src/main/java/umc/cockple/demo/domain/member/domain/Member.java
@@ -14,6 +14,7 @@ import umc.cockple.demo.global.enums.MemberStatus;
 import umc.cockple.demo.global.common.BaseEntity;
 
 import java.time.LocalDate;
+import java.time.Period;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -137,5 +138,9 @@ public class Member extends BaseEntity {
 
     public void withdraw() {
         this.isActive = MemberStatus.INACTIVE;
+    }
+
+    public int getAge(){
+        return Period.between(birth, LocalDate.now()).getYears();
     }
 }

--- a/src/main/java/umc/cockple/demo/domain/party/domain/Party.java
+++ b/src/main/java/umc/cockple/demo/domain/party/domain/Party.java
@@ -14,6 +14,7 @@ import umc.cockple.demo.global.enums.*;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Entity
 @Builder
@@ -125,6 +126,18 @@ public class Party extends BaseEntity {
     public Exercise createExercise(ExerciseCreateDTO.Command command, ExerciseCreateDTO.AddrCommand addrCommand) {
         ExerciseAddr exerciseAddr = ExerciseAddr.create(addrCommand);
         return Exercise.create(exerciseAddr, command);
+    }
+
+    public boolean isLevelAllowed(Member member) {
+        List<Level> allowedLevels = getAllowedLevels(member.getGender());
+        return allowedLevels.contains(member.getLevel());
+    }
+
+    public List<Level> getAllowedLevels(Gender gender) {
+        return this.levels.stream()
+                .filter(partyLevel -> partyLevel.getGender() == gender)
+                .map(PartyLevel::getLevel)
+                .collect(Collectors.toList());
     }
 
     public void addMember(MemberParty memberParty) {

--- a/src/main/java/umc/cockple/demo/domain/party/domain/Party.java
+++ b/src/main/java/umc/cockple/demo/domain/party/domain/Party.java
@@ -128,6 +128,17 @@ public class Party extends BaseEntity {
         return Exercise.create(exerciseAddr, command);
     }
 
+    public boolean isAgeValid(Member member){
+        int age = member.getAge();
+
+        if(minAge != null && age < minAge){
+            return false;
+        }if(maxAge != null && age > maxAge){
+            return false;
+        }
+        return true;
+    }
+
     public void addMember(MemberParty memberParty) {
         this.memberParties.add(memberParty);
         memberParty.setParty(this);

--- a/src/main/java/umc/cockple/demo/domain/party/domain/Party.java
+++ b/src/main/java/umc/cockple/demo/domain/party/domain/Party.java
@@ -128,18 +128,6 @@ public class Party extends BaseEntity {
         return Exercise.create(exerciseAddr, command);
     }
 
-    public boolean isLevelAllowed(Member member) {
-        List<Level> allowedLevels = getAllowedLevels(member.getGender());
-        return allowedLevels.contains(member.getLevel());
-    }
-
-    public List<Level> getAllowedLevels(Gender gender) {
-        return this.levels.stream()
-                .filter(partyLevel -> partyLevel.getGender() == gender)
-                .map(PartyLevel::getLevel)
-                .collect(Collectors.toList());
-    }
-
     public void addMember(MemberParty memberParty) {
         this.memberParties.add(memberParty);
         memberParty.setParty(this);


### PR DESCRIPTION
## ❤️ 기능 설명

- 급수 검증 로직 추가
- 나이 검증 로직 추가

swagger 테스트 성공 결과 스크린샷 첨부
<img width="2148" height="823" alt="image" src="https://github.com/user-attachments/assets/41f4b41f-2374-4384-85e5-42913864d28c" />

<img width="2147" height="827" alt="image" src="https://github.com/user-attachments/assets/c08fbd2c-a609-498d-a43b-a2084f4c207e" />

<img width="2147" height="838" alt="image" src="https://github.com/user-attachments/assets/b5a1783c-f610-4960-b66f-5d10e3a3eda3" />


<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #103 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!
Sorting이나 Paging이 필요없는 경우 Lazy Loading하는 엔티티를 Fetch join으로 한 번에 가져오면 좋을 거 같습니다!

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
