### PR TITLE
[feat/#110] 모임 신청 API 검증 로직 추가 구현

### DIFF
--- a/src/main/java/umc/cockple/demo/domain/party/controller/PartyController.java
+++ b/src/main/java/umc/cockple/demo/domain/party/controller/PartyController.java
@@ -61,7 +61,7 @@ public class PartyController {
             Authentication authentication
     ){
         // TODO: JWT 인증 구현 후 교체 예정
-        Long memberId = 2L; // 임시값
+        Long memberId = 8L; // 임시값
 
         PartyJoinCreateDTO.Response response = partyCommandService.createJoinRequest(partyId, memberId);
         return BaseResponse.success(CommonSuccessCode.CREATED, response);

--- a/src/main/java/umc/cockple/demo/domain/party/domain/Party.java
+++ b/src/main/java/umc/cockple/demo/domain/party/domain/Party.java
@@ -40,8 +40,10 @@ public class Party extends BaseEntity {
     @Column(nullable = false)
     private Long ownerId;
 
+    @Column(nullable = false)
     private Integer minAge;
 
+    @Column(nullable = false)
     private Integer maxAge;
 
     @Column(nullable = false)

--- a/src/main/java/umc/cockple/demo/domain/party/exception/PartyErrorCode.java
+++ b/src/main/java/umc/cockple/demo/domain/party/exception/PartyErrorCode.java
@@ -29,7 +29,8 @@ public enum PartyErrorCode implements BaseErrorCode {
 
     ALREADY_MEMBER(HttpStatus.CONFLICT, "PARTY401", "이미 가입된 모임입니다."),
     JOIN_REQUEST_ALREADY_EXISTS(HttpStatus.CONFLICT, "PARTY402", "처리 대기중인 가입 신청이 존재합니다."),
-    JOIN_REQUEST_ALREADY_ACTIONS(HttpStatus.CONFLICT, "PARTY403", "이미 처리된 가입 신청입니다.");
+    JOIN_REQUEST_ALREADY_ACTIONS(HttpStatus.CONFLICT, "PARTY403", "이미 처리된 가입 신청입니다."),
+    LEVEL_NOT_MATCH(HttpStatus.BAD_REQUEST, "PARTY404", "모임의 급수 조건에 맞지 않습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/umc/cockple/demo/domain/party/exception/PartyErrorCode.java
+++ b/src/main/java/umc/cockple/demo/domain/party/exception/PartyErrorCode.java
@@ -31,7 +31,9 @@ public enum PartyErrorCode implements BaseErrorCode {
     JOIN_REQUEST_ALREADY_EXISTS(HttpStatus.CONFLICT, "PARTY402", "처리 대기중인 가입 신청이 존재합니다."),
     JOIN_REQUEST_ALREADY_ACTIONS(HttpStatus.CONFLICT, "PARTY403", "이미 처리된 가입 신청입니다."),
     LEVEL_NOT_MATCH(HttpStatus.BAD_REQUEST, "PARTY404", "모임의 급수 조건에 맞지 않습니다."),
-    GENDER_NOT_MATCH(HttpStatus.BAD_REQUEST, "PARTY405", "모임 유형에 맞지 않는 성별입니다.");
+    GENDER_NOT_MATCH(HttpStatus.BAD_REQUEST, "PARTY405", "모임 유형에 맞지 않는 성별입니다."),
+    AGE_NOT_MATCH(HttpStatus.BAD_REQUEST, "PARTY406", "모임의 나이 조건에 맞지 않습니다.");
+
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/umc/cockple/demo/domain/party/exception/PartyErrorCode.java
+++ b/src/main/java/umc/cockple/demo/domain/party/exception/PartyErrorCode.java
@@ -30,7 +30,8 @@ public enum PartyErrorCode implements BaseErrorCode {
     ALREADY_MEMBER(HttpStatus.CONFLICT, "PARTY401", "이미 가입된 모임입니다."),
     JOIN_REQUEST_ALREADY_EXISTS(HttpStatus.CONFLICT, "PARTY402", "처리 대기중인 가입 신청이 존재합니다."),
     JOIN_REQUEST_ALREADY_ACTIONS(HttpStatus.CONFLICT, "PARTY403", "이미 처리된 가입 신청입니다."),
-    LEVEL_NOT_MATCH(HttpStatus.BAD_REQUEST, "PARTY404", "모임의 급수 조건에 맞지 않습니다.");
+    LEVEL_NOT_MATCH(HttpStatus.BAD_REQUEST, "PARTY404", "모임의 급수 조건에 맞지 않습니다."),
+    GENDER_NOT_MATCH(HttpStatus.BAD_REQUEST, "PARTY405", "모임 유형에 맞지 않는 성별입니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/umc/cockple/demo/domain/party/service/PartyCommandServiceImpl.java
+++ b/src/main/java/umc/cockple/demo/domain/party/service/PartyCommandServiceImpl.java
@@ -23,9 +23,7 @@ import umc.cockple.demo.domain.party.exception.PartyException;
 import umc.cockple.demo.domain.party.repository.PartyAddrRepository;
 import umc.cockple.demo.domain.party.repository.PartyJoinRequestRepository;
 import umc.cockple.demo.domain.party.repository.PartyRepository;
-import umc.cockple.demo.global.enums.Level;
-import umc.cockple.demo.global.enums.RequestAction;
-import umc.cockple.demo.global.enums.RequestStatus;
+import umc.cockple.demo.global.enums.*;
 
 import java.util.List;
 
@@ -161,9 +159,21 @@ public class PartyCommandServiceImpl implements PartyCommandService{
         if (partyJoinRequestRepository.existsByPartyAndMemberAndStatus(party, member, RequestStatus.PENDING)) {
             throw new PartyException(PartyErrorCode.JOIN_REQUEST_ALREADY_EXISTS);
         }
+        //해당 모임의 모임 유형에 맞는 성별인지 확인
+        validateGenderRequirement(member, party);
 
-        //해당 모임의 급수 조건에 적합한지 검증
+        //해당 모임의 급수 조건에 적합한지 확인
         validateLevelRequirement(member, party);
+    }
+
+    private void validateGenderRequirement(Member member, Party party) {
+        ParticipationType partyType = party.getPartyType();
+        Gender memberGender = member.getGender();
+
+        //현재 모임유형에 남복은 존재하지 않으므로, 여복만 확인
+        if (partyType == ParticipationType.WOMEN_DOUBLES && memberGender != Gender.FEMALE) {
+            throw new PartyException(PartyErrorCode.GENDER_NOT_MATCH);
+        }
     }
 
     private void validateLevelRequirement(Member member, Party party) {

--- a/src/main/java/umc/cockple/demo/domain/party/service/PartyCommandServiceImpl.java
+++ b/src/main/java/umc/cockple/demo/domain/party/service/PartyCommandServiceImpl.java
@@ -164,6 +164,19 @@ public class PartyCommandServiceImpl implements PartyCommandService{
 
         //해당 모임의 급수 조건에 적합한지 확인
         validateLevelRequirement(member, party);
+
+        //해당 모임의 나이 조건에 적합한지 확인
+        validateAgeRequirement(member, party);
+    }
+
+    private void validateAgeRequirement(Member member, Party party) {
+        Integer minAge = party.getMinAge();
+        Integer maxAge = party.getMaxAge();
+        Integer memberBirthYear = member.getBirth().getYear();
+
+        if(minAge > memberBirthYear || memberBirthYear > maxAge){
+            throw new PartyException(PartyErrorCode.AGE_NOT_MATCH);
+        }
     }
 
     private void validateGenderRequirement(Member member, Party party) {


### PR DESCRIPTION
## ❤️ 기능 설명
- 모임 신청 시, 모임의 급수 조건에 해당하는 인원만 신청 가능하도록 검증하는 로직을 구현했습니다.
- 모임 신청 시, 모임 유형에 해당하는 성별만 신청 가능하도록 검증하는 로직을 구현했습니다.

swagger 테스트 성공 결과 스크린샷 첨부
<img width="527" height="362" alt="image" src="https://github.com/user-attachments/assets/048cbef9-f8a8-4dc7-9eb3-dc88a2cee26e" />
<img width="533" height="362" alt="image" src="https://github.com/user-attachments/assets/43c8fdbe-358f-460a-bfb4-4ad6f9c32af3" />
<img width="702" height="382" alt="image" src="https://github.com/user-attachments/assets/42d0b1a6-74f9-472b-a272-49bf72a80cf5" />

<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #110
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!
- 급수와 성별로 검증되는지 테스트 완료했습니다.

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
