### PR TITLE
[Feat/#96] 회원 주소 조회 관련 API 구현

### DIFF
--- a/src/main/java/umc/cockple/demo/domain/member/controller/MemberController.java
+++ b/src/main/java/umc/cockple/demo/domain/member/controller/MemberController.java
@@ -9,16 +9,14 @@ import org.springframework.http.MediaType;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
-import umc.cockple.demo.domain.member.dto.GetMyProfileResponseDTO;
-import umc.cockple.demo.domain.member.dto.GetNowAddressResponseDTO;
-import umc.cockple.demo.domain.member.dto.GetProfileResponseDTO;
-import umc.cockple.demo.domain.member.dto.UpdateProfileRequestDTO;
+import umc.cockple.demo.domain.member.dto.*;
 import umc.cockple.demo.domain.member.service.MemberCommandService;
 import umc.cockple.demo.domain.member.service.MemberQueryService;
 import umc.cockple.demo.global.response.BaseResponse;
 import umc.cockple.demo.global.response.code.status.CommonSuccessCode;
 
 import java.io.IOException;
+import java.util.List;
 
 import static umc.cockple.demo.domain.member.dto.CreateMemberAddrDTO.*;
 
@@ -125,4 +123,14 @@ public class MemberController {
 
     }
 
+    @GetMapping("/my/profile/locations")
+    @Operation(summary = "회원 주소 전체 조회 API",
+            description = "사용자가 등록한 모든 주소를 조회")
+    public BaseResponse<List<GetAllAddressResponseDTO>> getAllAddress() {
+        // 추후 시큐리티를 통해 id 가져옴
+        Long memberId = 1L;
+
+        List<GetAllAddressResponseDTO> addresses = memberQueryService.getAllAddress(memberId);
+        return BaseResponse.success(CommonSuccessCode.OK, addresses);
+    }
 }

--- a/src/main/java/umc/cockple/demo/domain/member/controller/MemberController.java
+++ b/src/main/java/umc/cockple/demo/domain/member/controller/MemberController.java
@@ -10,6 +10,7 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 import umc.cockple.demo.domain.member.dto.GetMyProfileResponseDTO;
+import umc.cockple.demo.domain.member.dto.GetNowAddressResponseDTO;
 import umc.cockple.demo.domain.member.dto.GetProfileResponseDTO;
 import umc.cockple.demo.domain.member.dto.UpdateProfileRequestDTO;
 import umc.cockple.demo.domain.member.service.MemberCommandService;
@@ -43,6 +44,10 @@ public class MemberController {
         return BaseResponse.success(CommonSuccessCode.NO_CONTENT);
     }
 
+
+    // ============== 프로필 관련 =================
+
+
     @GetMapping(value = "/profile/{memberId}")
     @Operation(summary = "프로필 조회 API",
             description = "사용자가 다른 사람의 프로필을 조회")
@@ -72,6 +77,10 @@ public class MemberController {
         memberCommandService.updateProfile(requestDTO, memberId);
         return BaseResponse.success(CommonSuccessCode.OK);
     }
+
+
+    // =========== 주소 관련 ==============
+
 
     @PostMapping("/my/profile/locations")
     @Operation(summary = "회원 주소 추가 API",
@@ -104,4 +113,16 @@ public class MemberController {
         memberCommandService.deleteMemberAddr(memberId, memberAddrId);
         return BaseResponse.success(CommonSuccessCode.OK);
     }
+
+    @GetMapping("/my/location")
+    @Operation(summary = "회원 현재 위치 조회 API",
+            description = "사용자의 현재 위치를 조회 (홈 화면 상단에 해당 위치의 동을 띄울 때 사용")
+    public BaseResponse<GetNowAddressResponseDTO> getNowAddress() {
+        // 추후 시큐리티를 통해 id 가져옴
+        Long memberId = 1L;
+
+        return BaseResponse.success(CommonSuccessCode.OK, memberQueryService.getNowAddress(memberId));
+
+    }
+
 }

--- a/src/main/java/umc/cockple/demo/domain/member/controller/MemberController.java
+++ b/src/main/java/umc/cockple/demo/domain/member/controller/MemberController.java
@@ -116,7 +116,7 @@ public class MemberController {
 
     @GetMapping("/my/location")
     @Operation(summary = "회원 현재 위치 조회 API",
-            description = "사용자의 현재 위치를 조회 (홈 화면 상단에 해당 위치의 동을 띄울 때 사용")
+            description = "사용자의 현재 위치를 조회 (홈 화면 상단에 해당 위치의 동을 띄울 때 사용)")
     public BaseResponse<GetNowAddressResponseDTO> getNowAddress() {
         // 추후 시큐리티를 통해 id 가져옴
         Long memberId = 1L;

--- a/src/main/java/umc/cockple/demo/domain/member/controller/MemberController.java
+++ b/src/main/java/umc/cockple/demo/domain/member/controller/MemberController.java
@@ -85,7 +85,7 @@ public class MemberController {
     @PostMapping("/my/profile/locations")
     @Operation(summary = "회원 주소 추가 API",
             description = "사용자가 자신의 주소 추가")
-    public BaseResponse<CreateMemberAddrResponseDTO> createMemberAddress(@RequestBody CreateMemberAddrRequestDTO requestDto) {
+    public BaseResponse<CreateMemberAddrResponseDTO> createMemberAddress(@RequestBody @Valid CreateMemberAddrRequestDTO requestDto) {
         // 추후 시큐리티를 통해 id 가져옴
         Long memberId = 1L;
 

--- a/src/main/java/umc/cockple/demo/domain/member/converter/MemberConverter.java
+++ b/src/main/java/umc/cockple/demo/domain/member/converter/MemberConverter.java
@@ -3,6 +3,7 @@ package umc.cockple.demo.domain.member.converter;
 import umc.cockple.demo.domain.member.domain.Member;
 import umc.cockple.demo.domain.member.domain.MemberAddr;
 import umc.cockple.demo.domain.member.dto.GetMyProfileResponseDTO;
+import umc.cockple.demo.domain.member.dto.GetNowAddressResponseDTO;
 import umc.cockple.demo.domain.member.dto.GetProfileResponseDTO;
 
 public class MemberConverter {
@@ -37,6 +38,15 @@ public class MemberConverter {
                 .myGoldMedalCnt(dto.myGoldMedalCnt())
                 .mySilverMedalCnt(dto.mySilverMedalCnt())
                 .myBronzeMedalCnt(dto.myBronzeMedalCnt())
+                .build();
+    }
+
+    public static GetNowAddressResponseDTO toGetNowAddressResponseDTO(MemberAddr addr) {
+        return GetNowAddressResponseDTO.builder()
+                .memberAddrId(addr.getId())
+                .addr3(addr.getAddr3())
+                .buildingName(addr.getBuildingName())
+                .streetAddr(addr.getStreetAddr())
                 .build();
     }
 }

--- a/src/main/java/umc/cockple/demo/domain/member/converter/MemberConverter.java
+++ b/src/main/java/umc/cockple/demo/domain/member/converter/MemberConverter.java
@@ -2,6 +2,7 @@ package umc.cockple.demo.domain.member.converter;
 
 import umc.cockple.demo.domain.member.domain.Member;
 import umc.cockple.demo.domain.member.domain.MemberAddr;
+import umc.cockple.demo.domain.member.dto.GetAllAddressResponseDTO;
 import umc.cockple.demo.domain.member.dto.GetMyProfileResponseDTO;
 import umc.cockple.demo.domain.member.dto.GetNowAddressResponseDTO;
 import umc.cockple.demo.domain.member.dto.GetProfileResponseDTO;
@@ -49,6 +50,20 @@ public class MemberConverter {
                 .addr3(addr.getAddr3())
                 .buildingName(addr.getBuildingName())
                 .streetAddr(addr.getStreetAddr())
+                .build();
+    }
+
+    public static GetAllAddressResponseDTO toGetAllAddressResponseDTO(MemberAddr addr) {
+        return GetAllAddressResponseDTO.builder()
+                .addrId(addr.getId())
+                .addr1(addr.getAddr1())
+                .addr2(addr.getAddr2())
+                .addr3(addr.getAddr3())
+                .streetAddr(addr.getStreetAddr())
+                .buildingName(addr.getBuildingName())
+                .latitude(addr.getLatitude())
+                .longitude(addr.getLongitude())
+                .isMainAddr(addr.getIsMain())
                 .build();
     }
 }

--- a/src/main/java/umc/cockple/demo/domain/member/converter/MemberConverter.java
+++ b/src/main/java/umc/cockple/demo/domain/member/converter/MemberConverter.java
@@ -30,6 +30,8 @@ public class MemberConverter {
                 .gender(dto.gender())
                 .level(dto.level())
                 .addr3(mainAddr.getAddr3())
+                .streetAddr(mainAddr.getStreetAddr())
+                .buildingName(mainAddr.getBuildingName())
                 .latitude(mainAddr.getLatitude())
                 .longitude(mainAddr.getLongitude())
                 .profileImgUrl(dto.profileImgUrl())

--- a/src/main/java/umc/cockple/demo/domain/member/domain/MemberAddr.java
+++ b/src/main/java/umc/cockple/demo/domain/member/domain/MemberAddr.java
@@ -28,6 +28,7 @@ public class MemberAddr extends BaseEntity {
     @Column(nullable = false)
     private String addr3; // 동읍면
 
+    @Column(nullable = false)
     private String streetAddr; // 도로명주소
 
     private String buildingName; // 건물명

--- a/src/main/java/umc/cockple/demo/domain/member/dto/CreateMemberAddrDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/member/dto/CreateMemberAddrDTO.java
@@ -15,7 +15,7 @@ public class CreateMemberAddrDTO {
             String addr3,
             @NotBlank(message = "도로명은 필수입니다.")
             String streetAddr,
-            @NotBlank(message = "건물명은 필수입니다.")
+
             String buildingName,
             @NotNull(message = "위도는 필수입니다.")
             Float latitude,

--- a/src/main/java/umc/cockple/demo/domain/member/dto/GetAllAddressResponseDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/member/dto/GetAllAddressResponseDTO.java
@@ -1,0 +1,17 @@
+package umc.cockple.demo.domain.member.dto;
+
+import lombok.Builder;
+
+@Builder
+public record GetAllAddressResponseDTO(
+        Long addrId,
+        String addr1,
+        String addr2,
+        String addr3,
+        String streetAddr,
+        String buildingName,
+        Float latitude,
+        Float longitude,
+        Boolean isMainAddr
+) {
+}

--- a/src/main/java/umc/cockple/demo/domain/member/dto/GetMyProfileResponseDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/member/dto/GetMyProfileResponseDTO.java
@@ -1,5 +1,7 @@
 package umc.cockple.demo.domain.member.dto;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 import umc.cockple.demo.global.enums.Gender;
 import umc.cockple.demo.global.enums.Level;

--- a/src/main/java/umc/cockple/demo/domain/member/dto/GetMyProfileResponseDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/member/dto/GetMyProfileResponseDTO.java
@@ -16,6 +16,8 @@ public record GetMyProfileResponseDTO(
         Gender gender,
         Level level,
         String addr3,
+        String streetAddr,
+        String buildingName,
         Float latitude,
         Float longitude,
         String profileImgUrl,

--- a/src/main/java/umc/cockple/demo/domain/member/dto/GetNowAddressResponseDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/member/dto/GetNowAddressResponseDTO.java
@@ -6,7 +6,7 @@ import lombok.Builder;
 public record GetNowAddressResponseDTO(
         Long memberAddrId,
         String addr3,
-        Float latitude,
-        Float longitude
+        String buildingName,
+        String streetAddr
 ) {
 }

--- a/src/main/java/umc/cockple/demo/domain/member/dto/GetNowAddressResponseDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/member/dto/GetNowAddressResponseDTO.java
@@ -1,5 +1,8 @@
 package umc.cockple.demo.domain.member.dto;
 
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 
 @Builder

--- a/src/main/java/umc/cockple/demo/domain/member/dto/GetNowAddressResponseDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/member/dto/GetNowAddressResponseDTO.java
@@ -1,0 +1,12 @@
+package umc.cockple.demo.domain.member.dto;
+
+import lombok.Builder;
+
+@Builder
+public record GetNowAddressResponseDTO(
+        Long memberAddrId,
+        String addr3,
+        Float latitude,
+        Float longitude
+) {
+}

--- a/src/main/java/umc/cockple/demo/domain/member/dto/GetProfileResponseDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/member/dto/GetProfileResponseDTO.java
@@ -1,5 +1,6 @@
 package umc.cockple.demo.domain.member.dto;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.Builder;
 import umc.cockple.demo.global.enums.Gender;
 import umc.cockple.demo.global.enums.Level;

--- a/src/main/java/umc/cockple/demo/domain/member/service/MemberQueryService.java
+++ b/src/main/java/umc/cockple/demo/domain/member/service/MemberQueryService.java
@@ -9,6 +9,7 @@ import umc.cockple.demo.domain.member.converter.MemberConverter;
 import umc.cockple.demo.domain.member.domain.Member;
 import umc.cockple.demo.domain.member.domain.MemberAddr;
 import umc.cockple.demo.domain.member.dto.GetMyProfileResponseDTO;
+import umc.cockple.demo.domain.member.dto.GetNowAddressResponseDTO;
 import umc.cockple.demo.domain.member.dto.GetProfileResponseDTO;
 import umc.cockple.demo.domain.member.exception.MemberErrorCode;
 import umc.cockple.demo.domain.member.exception.MemberException;
@@ -28,6 +29,9 @@ public class MemberQueryService {
 
     private final MemberRepository memberRepository;
 
+    /*
+    * 프로필 관련 조회 메서드
+    * */
     public GetMyProfileResponseDTO getMyProfile(Long memberId) {
         // 회원 조회
         Member member = findByMemberId(memberId);
@@ -36,10 +40,7 @@ public class MemberQueryService {
         GetProfileResponseDTO profileDto = getProfile(memberId);
 
         // 대표 주소 추출
-        MemberAddr memberAddr = member.getAddresses().stream()
-                .filter(MemberAddr::getIsMain)
-                .findFirst()
-                .orElseThrow(() -> new MemberException(MemberErrorCode.MAIN_ADDRESS_NULL));
+        MemberAddr memberAddr = findMainAddress(member);
 
         // 운동 개수 추출
         int exerciseCnt = member.getMemberExercises().size();
@@ -70,10 +71,19 @@ public class MemberQueryService {
     }
 
 
-
-
+    /*
+     * private 메서드
+     * */
     private Member findByMemberId(Long memberId) {
         return memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
     }
+
+    private static MemberAddr findMainAddress(Member member) {
+        return member.getAddresses().stream()
+                .filter(MemberAddr::getIsMain)
+                .findFirst()
+                .orElseThrow(() -> new MemberException(MemberErrorCode.MAIN_ADDRESS_NULL));
+    }
+
 }

--- a/src/main/java/umc/cockple/demo/domain/member/service/MemberQueryService.java
+++ b/src/main/java/umc/cockple/demo/domain/member/service/MemberQueryService.java
@@ -70,6 +70,20 @@ public class MemberQueryService {
         return memberToGetProfileResponseDTO(member, goldMedal, silverMedal, bronzeMedal, imgUrl);
     }
 
+    /*
+     * 주소 관련 조회 메서드
+     * */
+
+    public GetNowAddressResponseDTO getNowAddress(Long memberId) {
+        // 해당 회원 조회
+        Member member = findByMemberId(memberId);
+
+        // 대표 주소 추출
+        MemberAddr mainAddress = findMainAddress(member);
+
+        return toGetNowAddressResponseDTO(mainAddress);
+    }
+
 
     /*
      * private 메서드

--- a/src/main/java/umc/cockple/demo/domain/member/service/MemberQueryService.java
+++ b/src/main/java/umc/cockple/demo/domain/member/service/MemberQueryService.java
@@ -97,9 +97,13 @@ public class MemberQueryService {
 
         // 모든 주소 -> DTO convert
         return member.getAddresses().stream()
+                .sorted((a, b) -> {
+                    if (a.getIsMain() && !b.getIsMain()) return -1;  // 대표주소 먼저
+                    if (!a.getIsMain() && b.getIsMain()) return 1;
+                    return a.getId().compareTo(b.getId());  // 나머지는 id 순
+                })
                 .map(MemberConverter::toGetAllAddressResponseDTO)
-                .collect(Collectors.toList())
-        ;
+                .toList();
     }
 
 

--- a/src/main/java/umc/cockple/demo/domain/member/service/MemberQueryService.java
+++ b/src/main/java/umc/cockple/demo/domain/member/service/MemberQueryService.java
@@ -8,6 +8,7 @@ import umc.cockple.demo.domain.contest.domain.Contest;
 import umc.cockple.demo.domain.member.converter.MemberConverter;
 import umc.cockple.demo.domain.member.domain.Member;
 import umc.cockple.demo.domain.member.domain.MemberAddr;
+import umc.cockple.demo.domain.member.dto.GetAllAddressResponseDTO;
 import umc.cockple.demo.domain.member.dto.GetMyProfileResponseDTO;
 import umc.cockple.demo.domain.member.dto.GetNowAddressResponseDTO;
 import umc.cockple.demo.domain.member.dto.GetProfileResponseDTO;
@@ -16,6 +17,7 @@ import umc.cockple.demo.domain.member.exception.MemberException;
 import umc.cockple.demo.domain.member.repository.MemberRepository;
 import umc.cockple.demo.global.enums.MedalType;
 
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -84,6 +86,22 @@ public class MemberQueryService {
         return toGetNowAddressResponseDTO(mainAddress);
     }
 
+    public List<GetAllAddressResponseDTO> getAllAddress(Long memberId) {
+        // 해당 회원 조회
+        Member member = findByMemberId(memberId);
+
+        // 주소가 존재하지 않을 시 예외처리
+        if (member.getAddresses().isEmpty()) {
+            throw new MemberException(MemberErrorCode.MEMBER_ADDRESS_MINIMUM_REQUIRED);
+        }
+
+        // 모든 주소 -> DTO convert
+        return member.getAddresses().stream()
+                .map(MemberConverter::toGetAllAddressResponseDTO)
+                .collect(Collectors.toList())
+        ;
+    }
+
 
     /*
      * private 메서드
@@ -99,5 +117,4 @@ public class MemberQueryService {
                 .findFirst()
                 .orElseThrow(() -> new MemberException(MemberErrorCode.MAIN_ADDRESS_NULL));
     }
-
 }


### PR DESCRIPTION
## ❤️ 기능 설명
- 회원의 대표주소 (Main 화면 상단에 띄우는) 조회 
- 프로필 수정 시 나오는 회원의 주소 전체 조회

swagger 테스트 성공 결과 스크린샷 첨부
1-1. 회원의 대표주소 조회 (건물명 존재)
<img width="875" height="1141" alt="스크린샷 2025-07-18 145029" src="https://github.com/user-attachments/assets/d265d2e3-f4a5-48b5-a936-518228d66a7c" />

1-2. 회원의 대표주소 조회 (건물명 부재 -> 건물명은 NULL 가능, 없는 경우에는 도로명 사용)
<img width="878" height="1137" alt="스크린샷 2025-07-18 145139" src="https://github.com/user-attachments/assets/4aae29bc-3112-4677-95cf-8f02baa2fc1a" />

2. 회원의 등록된 주소 전체 조회
<img width="885" height="1304" alt="image" src="https://github.com/user-attachments/assets/15ce6d56-1810-4fc4-9fe4-bd1e5307d57a" />


<br>

## 연결된 issue
연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #96 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
