### PR TITLE
[feat/#113] 모임 생성 API 검증 로직 추가 구현

### DIFF
--- a/src/main/java/umc/cockple/demo/domain/party/dto/PartyCreateDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/party/dto/PartyCreateDTO.java
@@ -1,6 +1,7 @@
 package umc.cockple.demo.domain.party.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.Builder;
@@ -28,7 +29,7 @@ public class PartyCreateDTO {
             @NotNull(message = "모임 유형은 필수입니다.")
             String partyType,
 
-            @NotNull(message = "여자 급수는 필수 선택 항목입니다.")
+            @NotEmpty(message = "여자 급수는 필수 선택 항목입니다.")
             List<String> femaleLevel,
 
             List<String> maleLevel,
@@ -39,10 +40,10 @@ public class PartyCreateDTO {
             @NotNull(message = "활동 지역(시/군/구)은 필수 선택 항목입니다.")
             String addr2,
 
-            @NotNull(message = "활동 요일은 필수 선택 항목입니다.")
+            @NotEmpty(message = "활동 요일은 필수 선택 항목입니다.")
             List<String> activityDay,
 
-            @NotNull(message = "활동 시간은 필수 선택 항목입니다.")
+            @NotEmpty(message = "활동 시간은 필수 선택 항목입니다.")
             String activityTime,
 
             @NotNull(message = "지정콕 정보는 필수입니다. 없는 경우 없음을 체크해주세요.")

--- a/src/main/java/umc/cockple/demo/domain/party/exception/PartyErrorCode.java
+++ b/src/main/java/umc/cockple/demo/domain/party/exception/PartyErrorCode.java
@@ -20,6 +20,7 @@ public enum PartyErrorCode implements BaseErrorCode {
     INVALID_ACTIVITY_DAY(HttpStatus.BAD_REQUEST, "PARTY102", "유효하지 않은 활동 요일입니다. (SUNDAY~SATURDAY를 리스트로 입력해주세요.)"),
     INVALID_ACTIVITY_TIME(HttpStatus.BAD_REQUEST, "PARTY103", "유효하지 않은 활동 시간입니다. (MORNING 또는 AFTERNOON 또는 ALWAYS를 입력해주세요.)"),
     INVALID_LEVEL_FORMAT(HttpStatus.BAD_REQUEST, "PARTY104", "유효하지 않은 급수 형식입니다."),
+    MALE_LEVEL_REQUIRED(HttpStatus.BAD_REQUEST, "PARTY105", "혼복 모임은 남녀 급수 설정이 필수입니다."),
 
     PARTY_NOT_FOUND(HttpStatus.NOT_FOUND, "PARTY201", "존재하지 않는 모임입니다."),
     JoinRequest_NOT_FOUND(HttpStatus.NOT_FOUND, "PARTY202", "존재하지 않는 가입신청입니다."),

--- a/src/main/java/umc/cockple/demo/domain/party/service/PartyCommandServiceImpl.java
+++ b/src/main/java/umc/cockple/demo/domain/party/service/PartyCommandServiceImpl.java
@@ -151,11 +151,20 @@ public class PartyCommandServiceImpl implements PartyCommandService{
     }
 
     private void validateCreateParty(Member owner, PartyCreateDTO.Command command) {
-        //생성하려는 모임의 모임 유형에 본인도 적합한 성별인지 확인
+        //생성하려는 모임의 모임 유형의 성별에 본인도 적합한지 확인
         ParticipationType partyType = command.partyType();
         Gender memberGender = owner.getGender();
         if (partyType == ParticipationType.WOMEN_DOUBLES && memberGender != Gender.FEMALE) {
             throw new PartyException(PartyErrorCode.GENDER_NOT_MATCH);
+        }
+
+        //생성하려는 모임의 나이 조건에 본인도 적합한지 확인
+        Integer minAge = command.minAge();
+        Integer maxAge = command.maxAge();
+        Integer ownerBirthYear = owner.getBirth().getYear();
+
+        if(minAge > ownerBirthYear || ownerBirthYear > maxAge){
+            throw new PartyException(PartyErrorCode.AGE_NOT_MATCH);
         }
 
     }

--- a/src/main/java/umc/cockple/demo/domain/party/service/PartyCommandServiceImpl.java
+++ b/src/main/java/umc/cockple/demo/domain/party/service/PartyCommandServiceImpl.java
@@ -52,6 +52,7 @@ public class PartyCommandServiceImpl implements PartyCommandService{
         //주소 처리 (조회 또는 새로 생성)
         PartyAddr partyAddr = findOrCreatePartyAddr(addrCommand);
 
+        //모임 생성 가능한지 검증
         validateCreateParty(owner, partyCommand);
 
         //Party 엔티티 생성
@@ -151,8 +152,16 @@ public class PartyCommandServiceImpl implements PartyCommandService{
     }
 
     private void validateCreateParty(Member owner, PartyCreateDTO.Command command) {
-        //생성하려는 모임의 모임 유형의 성별에 본인도 적합한지 확인
+        // 혼복인 경우, 남녀 급수 정보가 모두 있는지 검증
         ParticipationType partyType = command.partyType();
+        if (partyType == ParticipationType.MIX_DOUBLES) {
+            //FEMALE은 DTO단에서 검증 완료
+            if (command.maleLevel() == null || command.maleLevel().isEmpty()) {
+                throw new PartyException(PartyErrorCode.MALE_LEVEL_REQUIRED);
+            }
+        }
+
+        //생성하려는 모임의 모임 유형의 성별에 본인도 적합한지 확인
         Gender ownerGender = owner.getGender();
         if (partyType == ParticipationType.WOMEN_DOUBLES && ownerGender != Gender.FEMALE) {
             throw new PartyException(PartyErrorCode.GENDER_NOT_MATCH);

--- a/src/main/java/umc/cockple/demo/domain/party/service/PartyCommandServiceImpl.java
+++ b/src/main/java/umc/cockple/demo/domain/party/service/PartyCommandServiceImpl.java
@@ -153,8 +153,8 @@ public class PartyCommandServiceImpl implements PartyCommandService{
     private void validateCreateParty(Member owner, PartyCreateDTO.Command command) {
         //생성하려는 모임의 모임 유형의 성별에 본인도 적합한지 확인
         ParticipationType partyType = command.partyType();
-        Gender memberGender = owner.getGender();
-        if (partyType == ParticipationType.WOMEN_DOUBLES && memberGender != Gender.FEMALE) {
+        Gender ownerGender = owner.getGender();
+        if (partyType == ParticipationType.WOMEN_DOUBLES && ownerGender != Gender.FEMALE) {
             throw new PartyException(PartyErrorCode.GENDER_NOT_MATCH);
         }
 
@@ -165,6 +165,20 @@ public class PartyCommandServiceImpl implements PartyCommandService{
 
         if(minAge > ownerBirthYear || ownerBirthYear > maxAge){
             throw new PartyException(PartyErrorCode.AGE_NOT_MATCH);
+        }
+
+        //생성하려는 모임의 급수 조건에 본인도 적합한지 확인
+        Level ownerLevel = owner.getLevel();
+        List<Level> requiredLevels;
+
+        if (ownerGender == Gender.FEMALE) {
+            requiredLevels = command.femaleLevel();
+        } else { // MALE
+            requiredLevels = command.maleLevel();
+        }
+
+        if (!requiredLevels.contains(ownerLevel)) {
+            throw new PartyException(PartyErrorCode.LEVEL_NOT_MATCH);
         }
 
     }


### PR DESCRIPTION
## ❤️ 기능 설명
- 모임을 생성할 시, 해당 사용자가 모임 급수 조건에 해당할 경우에만 생성할 수 있도록 검증하는 로직 구현
- 모임을 생성할 시, 해당 사용자가 모임 유형에 해당하는 성별인 경우에만 생성할 수 있도록 검증하는 로직 구현
- 모임을 생성할 시, 해당 사용자가 모임 나이 조건에 해당하는 경우에만 생성할 수 있도록 검증하는 로직 구현
- 모임 생성 시, 남성 급수 조건이 빈 리스트로 들어갈 경우 에러 처리 

swagger 테스트 성공 결과 스크린샷 첨부
<img width="797" height="338" alt="image" src="https://github.com/user-attachments/assets/a9d1280d-87af-425c-88d3-b9ca1767a93a" />
<img width="795" height="110" alt="image" src="https://github.com/user-attachments/assets/1841d115-6cdc-4952-9a6a-6b8404554042" />
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #113
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- 없습니다

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [ ] 이슈넘버를 적었는가?
