### PR TITLE
[feat/#124] 모임 가입 승인 멤버 조회 API 구현

### DIFF
--- a/src/main/java/umc/cockple/demo/domain/party/controller/PartyController.java
+++ b/src/main/java/umc/cockple/demo/domain/party/controller/PartyController.java
@@ -75,13 +75,14 @@ public class PartyController {
     @ApiResponse(responseCode = "404", description = "존재하지 않는 모임")
     public BaseResponse<Slice<PartyJoinDTO.Response>> getJoinRequests(
             @PathVariable Long partyId,
+            @RequestParam(name = "status") String status,
             @PageableDefault(page = 0, size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable,
             Authentication authentication
     ){
         // TODO: JWT 인증 구현 후 교체 예정
         Long memberId = 1L; // 임시값
 
-        Slice<PartyJoinDTO.Response> response = partyQueryService.getJoinRequests(partyId, memberId, pageable);
+        Slice<PartyJoinDTO.Response> response = partyQueryService.getJoinRequests(partyId, memberId, status, pageable);
         return BaseResponse.success(CommonSuccessCode.OK, response);
     }
 

--- a/src/main/java/umc/cockple/demo/domain/party/converter/PartyConverter.java
+++ b/src/main/java/umc/cockple/demo/domain/party/converter/PartyConverter.java
@@ -7,6 +7,9 @@ import umc.cockple.demo.domain.party.domain.PartyJoinRequest;
 import umc.cockple.demo.domain.party.dto.PartyCreateDTO;
 import umc.cockple.demo.domain.party.dto.PartyJoinCreateDTO;
 import umc.cockple.demo.domain.party.dto.PartyJoinDTO;
+import umc.cockple.demo.global.enums.RequestStatus;
+
+import java.time.LocalDateTime;
 
 @Component
 public class PartyConverter {
@@ -56,6 +59,8 @@ public class PartyConverter {
     //모임 가입신청의 정보를 응답 DTO로 변환
     public PartyJoinDTO.Response toPartyJoinResponseDTO(PartyJoinRequest request) {
         Member member = request.getMember();
+        // status가 PENDING이 아닐 경우에만 updatedAt 값을 설정
+        LocalDateTime updatedAt = (request.getStatus() != RequestStatus.PENDING) ? request.getUpdatedAt() : null;
         //이미지가 null인 경우 null을 전달
         String imageUrl = (member.getProfileImg() != null) ? member.getProfileImg().getImgUrl() : null;
         return PartyJoinDTO.Response.builder()
@@ -66,7 +71,7 @@ public class PartyConverter {
                 .gender(member.getGender().name())
                 .level(member.getLevel().name())
                 .createdAt(request.getCreatedAt())
-                .updatedAt(request.getUpdatedAt())
+                .updatedAt(updatedAt)
                 .build();
     }
 }

--- a/src/main/java/umc/cockple/demo/domain/party/converter/PartyConverter.java
+++ b/src/main/java/umc/cockple/demo/domain/party/converter/PartyConverter.java
@@ -66,6 +66,7 @@ public class PartyConverter {
                 .gender(member.getGender().name())
                 .level(member.getLevel().name())
                 .createdAt(request.getCreatedAt())
+                .updatedAt(request.getUpdatedAt())
                 .build();
     }
 }

--- a/src/main/java/umc/cockple/demo/domain/party/dto/PartyCreateDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/party/dto/PartyCreateDTO.java
@@ -1,5 +1,6 @@
 package umc.cockple.demo.domain.party.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
@@ -20,6 +21,7 @@ import java.util.List;
 public class PartyCreateDTO {
 
     @Builder
+    @Schema(name = "PartyCreateRequestDTO", description = "모임 생성 요청")
     public record Request(
 
             @NotBlank(message = "모임 이름은 필수입니다.")

--- a/src/main/java/umc/cockple/demo/domain/party/dto/PartyJoinActionDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/party/dto/PartyJoinActionDTO.java
@@ -1,11 +1,13 @@
 package umc.cockple.demo.domain.party.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import umc.cockple.demo.global.enums.RequestAction;
 
 public class PartyJoinActionDTO {
 
     @Builder
+    @Schema(name = "PartyJoinActionRequestDTO", description = "모임 가입 신청 처리 요청")
     public record Request(
             RequestAction action
     ){

--- a/src/main/java/umc/cockple/demo/domain/party/dto/PartyJoinDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/party/dto/PartyJoinDTO.java
@@ -1,5 +1,6 @@
 package umc.cockple.demo.domain.party.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 import java.time.LocalDateTime;

--- a/src/main/java/umc/cockple/demo/domain/party/dto/PartyJoinDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/party/dto/PartyJoinDTO.java
@@ -1,7 +1,6 @@
 package umc.cockple.demo.domain.party.dto;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 import java.time.LocalDateTime;

--- a/src/main/java/umc/cockple/demo/domain/party/dto/PartyJoinDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/party/dto/PartyJoinDTO.java
@@ -1,5 +1,6 @@
 package umc.cockple.demo.domain.party.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
@@ -8,6 +9,7 @@ import java.time.LocalDateTime;
 public class PartyJoinDTO {
 
     @Builder
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public record Response(
             Long joinRequestId,
             Long userId,

--- a/src/main/java/umc/cockple/demo/domain/party/dto/PartyJoinDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/party/dto/PartyJoinDTO.java
@@ -14,7 +14,8 @@ public class PartyJoinDTO {
             String profileImageUrl,
             String gender,
             String level,
-            LocalDateTime createdAt
+            LocalDateTime createdAt,
+            LocalDateTime updatedAt
     ) {
     }
 }

--- a/src/main/java/umc/cockple/demo/domain/party/exception/PartyErrorCode.java
+++ b/src/main/java/umc/cockple/demo/domain/party/exception/PartyErrorCode.java
@@ -21,6 +21,7 @@ public enum PartyErrorCode implements BaseErrorCode {
     INVALID_ACTIVITY_TIME(HttpStatus.BAD_REQUEST, "PARTY103", "유효하지 않은 활동 시간입니다. (MORNING 또는 AFTERNOON 또는 ALWAYS를 입력해주세요.)"),
     INVALID_LEVEL_FORMAT(HttpStatus.BAD_REQUEST, "PARTY104", "유효하지 않은 급수 형식입니다."),
     MALE_LEVEL_REQUIRED(HttpStatus.BAD_REQUEST, "PARTY105", "혼복 모임은 남녀 급수 설정이 필수입니다."),
+    INVALID_REQUEST_STATUS(HttpStatus.BAD_REQUEST, "PARTY106", "유효하지 않은 가입 신청 상태입니다. (PENDING 또는 APPROVED를 입력해주세요.)"),
 
     PARTY_NOT_FOUND(HttpStatus.NOT_FOUND, "PARTY201", "존재하지 않는 모임입니다."),
     JoinRequest_NOT_FOUND(HttpStatus.NOT_FOUND, "PARTY202", "존재하지 않는 가입신청입니다."),

--- a/src/main/java/umc/cockple/demo/domain/party/service/PartyQueryService.java
+++ b/src/main/java/umc/cockple/demo/domain/party/service/PartyQueryService.java
@@ -5,5 +5,5 @@ import org.springframework.data.domain.Slice;
 import umc.cockple.demo.domain.party.dto.PartyJoinDTO;
 
 public interface PartyQueryService {
-    Slice<PartyJoinDTO.Response> getJoinRequests(Long partyId, Long memberId, Pageable pageable);
+    Slice<PartyJoinDTO.Response> getJoinRequests(Long partyId, Long memberId, String status, Pageable pageable);
 }

--- a/src/main/java/umc/cockple/demo/domain/party/service/PartyQueryServiceImpl.java
+++ b/src/main/java/umc/cockple/demo/domain/party/service/PartyQueryServiceImpl.java
@@ -27,17 +27,19 @@ public class PartyQueryServiceImpl implements PartyQueryService{
     private final PartyConverter partyConverter;
 
     @Override
-    public Slice<PartyJoinDTO.Response> getJoinRequests(Long partyId, Long memberId, Pageable pageable) {
+    public Slice<PartyJoinDTO.Response> getJoinRequests(Long partyId, Long memberId, String status, Pageable pageable) {
         log.info("가입 신청 목록 조회 시작 - partyId: {}, memberId: {}", partyId, memberId);
 
         //모임 조회
         Party party = findPartyOrThrow(partyId);
         //모임장 권한이 있는지 확인
         validateOwnerPermission(party, memberId);
+        //status ENUM으로 변환
+        RequestStatus requestStatus = RequestStatus.valueOf(status.toUpperCase());
 
         //조회 로직 수행
         Slice<PartyJoinRequest> requestSlice = partyJoinRequestRepository
-                .findByPartyAndStatus(party, RequestStatus.PENDING, pageable);
+                .findByPartyAndStatus(party, requestStatus, pageable);
 
         log.info("가입 신청 목록 조회 완료. 조회된 항목 수: {}", requestSlice.getNumberOfElements());
         return requestSlice.map(partyConverter::toPartyJoinResponseDTO);

--- a/src/main/java/umc/cockple/demo/domain/party/service/PartyQueryServiceImpl.java
+++ b/src/main/java/umc/cockple/demo/domain/party/service/PartyQueryServiceImpl.java
@@ -34,8 +34,8 @@ public class PartyQueryServiceImpl implements PartyQueryService{
         Party party = findPartyOrThrow(partyId);
         //모임장 권한이 있는지 확인
         validateOwnerPermission(party, memberId);
-        //status ENUM으로 변환
-        RequestStatus requestStatus = RequestStatus.valueOf(status.toUpperCase());
+        //status를 ENUM으로 변환 및 검증
+        RequestStatus requestStatus = parseRequestStatus(status);
 
         //조회 로직 수행
         Slice<PartyJoinRequest> requestSlice = partyJoinRequestRepository
@@ -56,5 +56,13 @@ public class PartyQueryServiceImpl implements PartyQueryService{
     private Party findPartyOrThrow(Long partyId) {
         return partyRepository.findById(partyId)
                 .orElseThrow(() -> new PartyException(PartyErrorCode.PARTY_NOT_FOUND));
+    }
+
+    private RequestStatus parseRequestStatus(String status) {
+        try {
+            return RequestStatus.valueOf(status.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new PartyException(PartyErrorCode.INVALID_REQUEST_STATUS);
+        }
     }
 }


### PR DESCRIPTION
## ❤️ 기능 설명
모임 가입 신청이 승인된 사용자들의 목록 조회를 구현했습니다. 
- 기존의 모임 가입 신청 목록 조회 API를 활용하여 구현했습니다. 쿼리 파라메터로 PENDING 또는 APPROVED를 넣어 구분하여 출력되도록 구현했습니다.
- status에 PENDING 또는 APPROVED가 들어가지 않을 경우 예러 처리를 했습니다.
- APPROVED( 승인된 목록)인 경우에만 updatedAt이 출력되도록 했습니다.

swagger 테스트 성공 결과 스크린샷 첨부
<img width="797" height="287" alt="image" src="https://github.com/user-attachments/assets/bd08ce6f-3b00-4389-ad8f-670142e7920c" />
<img width="790" height="166" alt="image" src="https://github.com/user-attachments/assets/1cdb03e9-44a1-4134-85fc-6f9893d5e332" />

<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #124 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- 없습니다!

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
