### PR TITLE
[feat/#78] 운동 상세 조회 API 구현

### DIFF
--- a/src/main/java/umc/cockple/demo/domain/exercise/controller/ExerciseController.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/controller/ExerciseController.java
@@ -21,6 +21,7 @@ import umc.cockple.demo.global.response.code.status.CommonSuccessCode;
 public class ExerciseController {
 
     private final ExerciseCommandService exerciseCommandService;
+    private final ExerciseQueryService exerciseQueryService;
 
     @PostMapping("/parties/{partyId}/exercises")
     @Operation(summary = "운동 생성",
@@ -187,6 +188,25 @@ public class ExerciseController {
 
         ExerciseUpdateDTO.Response response = exerciseCommandService.updateExercise(
                 exerciseId, memberId, request);
+
+        return BaseResponse.success(CommonSuccessCode.OK, response);
+    }
+
+    @GetMapping("/exercises/{exerciseId}")
+    @Operation(summary = "운동 상세 조회",
+            description = "운동의 상세 정보를 조회합니다. 권한, 멤버 여부, 게스트 여부에 따라 반환되는 값이 달라집니다.")
+    @ApiResponse(responseCode = "200", description = "운동 상세 조회 성공")
+    @ApiResponse(responseCode = "404", description = "존재하지 않는 운동")
+    public BaseResponse<ExerciseDetailDTO.Response> getExerciseDetail(
+            @PathVariable Long exerciseId,
+            Authentication authentication
+    ){
+
+        // TODO: JWT 인증 구현 후 교체 예정
+        Long memberId = 1L; // 임시값
+
+        ExerciseDetailDTO.Response response = exerciseQueryService.getExerciseDetail(
+                exerciseId, memberId);
 
         return BaseResponse.success(CommonSuccessCode.OK, response);
     }

--- a/src/main/java/umc/cockple/demo/domain/exercise/controller/ExerciseController.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/controller/ExerciseController.java
@@ -10,6 +10,7 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import umc.cockple.demo.domain.exercise.dto.*;
 import umc.cockple.demo.domain.exercise.service.ExerciseCommandService;
+import umc.cockple.demo.domain.exercise.service.ExerciseQueryService;
 import umc.cockple.demo.global.response.BaseResponse;
 import umc.cockple.demo.global.response.code.status.CommonSuccessCode;
 

--- a/src/main/java/umc/cockple/demo/domain/exercise/converter/ExerciseConverter.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/converter/ExerciseConverter.java
@@ -168,4 +168,18 @@ public class ExerciseConverter {
                 .joinedAt(guest.getCreatedAt())
                 .build();
     }
+
+    public ExerciseDetailDTO.Response toDetailResponseDTO(
+            boolean isManager,
+            ExerciseDetailDTO.ExerciseInfo exerciseInfo,
+            ExerciseDetailDTO.ParticipantGroup participantGroup,
+            ExerciseDetailDTO.WaitingGroup waitingGroup) {
+
+        return ExerciseDetailDTO.Response.builder()
+                .isManager(isManager)
+                .info(exerciseInfo)
+                .participants(participantGroup)
+                .waiting(waitingGroup)
+                .build();
+    }
 }

--- a/src/main/java/umc/cockple/demo/domain/exercise/converter/ExerciseConverter.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/converter/ExerciseConverter.java
@@ -150,4 +150,19 @@ public class ExerciseConverter {
                 .inviterName(null)
                 .build();
     }
+
+    public ExerciseDetailDTO.ParticipantInfo toParticipantInfo(Guest guest, String inviterName) {
+
+        return ExerciseDetailDTO.ParticipantInfo.builder()
+                .participantId(guest.getId())
+                .participantNumber(0)
+                .imgUrl(null)
+                .name(guest.getGuestName())
+                .gender(guest.getGender().name())
+                .level(guest.getLevel().name())
+                .participantType(guest.getExerciseMemberShipStatus().name())
+                .partyPosition(null)
+                .inviterName(inviterName)
+                .build();
+    }
 }

--- a/src/main/java/umc/cockple/demo/domain/exercise/converter/ExerciseConverter.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/converter/ExerciseConverter.java
@@ -7,6 +7,9 @@ import umc.cockple.demo.domain.exercise.domain.Guest;
 import umc.cockple.demo.domain.exercise.dto.*;
 import umc.cockple.demo.domain.member.domain.Member;
 import umc.cockple.demo.domain.member.domain.MemberExercise;
+import umc.cockple.demo.global.enums.Role;
+
+import java.util.Map;
 
 @Component
 @RequiredArgsConstructor
@@ -112,6 +115,39 @@ public class ExerciseConverter {
         return ExerciseUpdateDTO.Response.builder()
                 .exerciseId(exercise.getId())
                 .updatedAt(exercise.getUpdatedAt())
+                .build();
+    }
+
+    public ExerciseDetailDTO.ParticipantInfo toParticipantInfo(MemberExercise memberParticipant, Map<Long, Role> memberRoles) {
+        Member member = memberParticipant.getMember();
+        Role role = memberRoles.get(member.getId());
+
+        return ExerciseDetailDTO.ParticipantInfo.builder()
+                .participantId(memberParticipant.getId())
+                .participantNumber(0)
+                .imgUrl(member.getProfileImg() != null ? member.getProfileImg().getImgUrl() : null)
+                .name(member.getMemberName())
+                .gender(member.getGender().name())
+                .level(member.getLevel().name())
+                .participantType(memberParticipant.getExerciseMemberShipStatus().name())
+                .partyPosition(role.name())
+                .inviterName(null)
+                .build();
+    }
+
+    public ExerciseDetailDTO.ParticipantInfo toExeternalParticipantInfo(MemberExercise memberParticipant) {
+        Member member = memberParticipant.getMember();
+
+        return ExerciseDetailDTO.ParticipantInfo.builder()
+                .participantId(memberParticipant.getId())
+                .participantNumber(0)
+                .imgUrl(member.getProfileImg() != null ? member.getProfileImg().getImgUrl() : null)
+                .name(member.getMemberName())
+                .gender(member.getGender().name())
+                .level(member.getLevel().name())
+                .participantType(memberParticipant.getExerciseMemberShipStatus().name())
+                .partyPosition(null)
+                .inviterName(null)
                 .build();
     }
 }

--- a/src/main/java/umc/cockple/demo/domain/exercise/converter/ExerciseConverter.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/converter/ExerciseConverter.java
@@ -132,6 +132,7 @@ public class ExerciseConverter {
                 .participantType(memberParticipant.getExerciseMemberShipStatus().name())
                 .partyPosition(role.name())
                 .inviterName(null)
+                .joinedAt(memberParticipant.getCreatedAt())
                 .build();
     }
 
@@ -148,6 +149,7 @@ public class ExerciseConverter {
                 .participantType(memberParticipant.getExerciseMemberShipStatus().name())
                 .partyPosition(null)
                 .inviterName(null)
+                .joinedAt(memberParticipant.getCreatedAt())
                 .build();
     }
 
@@ -163,6 +165,7 @@ public class ExerciseConverter {
                 .participantType(guest.getExerciseMemberShipStatus().name())
                 .partyPosition(null)
                 .inviterName(inviterName)
+                .joinedAt(guest.getCreatedAt())
                 .build();
     }
 }

--- a/src/main/java/umc/cockple/demo/domain/exercise/dto/ExerciseDetailDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/dto/ExerciseDetailDTO.java
@@ -2,6 +2,8 @@ package umc.cockple.demo.domain.exercise.dto;
 
 import lombok.Builder;
 
+import java.time.LocalDateTime;
+
 public class ExerciseDetailDTO {
 
     @Builder
@@ -50,7 +52,8 @@ public class ExerciseDetailDTO {
             String level,
             String participantType,
             String partyPosition,
-            String inviterName
+            String inviterName,
+            LocalDateTime joinedAt
     ) {
     }
 }

--- a/src/main/java/umc/cockple/demo/domain/exercise/dto/ExerciseDetailDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/dto/ExerciseDetailDTO.java
@@ -3,6 +3,7 @@ package umc.cockple.demo.domain.exercise.dto;
 import lombok.Builder;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 public class ExerciseDetailDTO {
 
@@ -29,7 +30,7 @@ public class ExerciseDetailDTO {
             Integer totalCount,
             Integer manCount,
             Integer womenCount,
-            ParticipantInfo list
+            List<ParticipantInfo> list
     ) {
     }
 
@@ -38,7 +39,7 @@ public class ExerciseDetailDTO {
             Integer currentWaitingCount,
             Integer manCount,
             Integer womenCount,
-            ParticipantInfo list
+            List<ParticipantInfo> list
     ) {
     }
 

--- a/src/main/java/umc/cockple/demo/domain/exercise/dto/ExerciseDetailDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/dto/ExerciseDetailDTO.java
@@ -1,0 +1,56 @@
+package umc.cockple.demo.domain.exercise.dto;
+
+import lombok.Builder;
+
+public class ExerciseDetailDTO {
+
+    @Builder
+    public record Response(
+            Boolean isManager,
+            ExerciseInfo info,
+            ParticipantGroup participants,
+            WaitingGroup waiting
+    ) {
+    }
+
+    @Builder
+    public record ExerciseInfo(
+            String notice,
+            String buildingName,
+            String location
+    ) {
+    }
+
+    @Builder
+    public record ParticipantGroup(
+            Integer currentParticipantCount,
+            Integer totalCount,
+            Integer manCount,
+            Integer womenCount,
+            ParticipantInfo list
+    ) {
+    }
+
+    @Builder
+    public record WaitingGroup(
+            Integer currentWaitingCount,
+            Integer manCount,
+            Integer womenCount,
+            ParticipantInfo list
+    ) {
+    }
+
+    @Builder
+    public record ParticipantInfo(
+            Long participantId,
+            Integer participantNumber,
+            String imgUrl,
+            String name,
+            String gender,
+            String level,
+            String participantType,
+            String partyPosition,
+            String inviterName
+    ) {
+    }
+}

--- a/src/main/java/umc/cockple/demo/domain/exercise/repository/ExerciseRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/repository/ExerciseRepository.java
@@ -10,10 +10,18 @@ import java.util.Optional;
 public interface ExerciseRepository extends JpaRepository<Exercise, Long> {
 
     @Query("""
-        SELECT e FROM Exercise e 
-        JOIN FETCH e.party p 
-        JOIN FETCH p.levels 
-        WHERE e.id = :exerciseId
-        """)
+            SELECT e FROM Exercise e 
+            JOIN FETCH e.party p 
+            JOIN FETCH p.levels 
+            WHERE e.id = :exerciseId
+            """)
     Optional<Exercise> findByIdWithPartyLevels(@Param("exerciseId") Long exerciseId);
+
+    @Query("""
+            SELECT e FROM Exercise e 
+            JOIN FETCH e.party p 
+            JOIN FETCH e.exerciseAddr
+            WHERE e.id = :exerciseId
+            """)
+    Optional<Exercise> findExerciseWithBasicInfo(@Param("exerciseId") Long exerciseId);
 }

--- a/src/main/java/umc/cockple/demo/domain/exercise/repository/GuestRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/repository/GuestRepository.java
@@ -1,7 +1,18 @@
 package umc.cockple.demo.domain.exercise.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import umc.cockple.demo.domain.exercise.domain.Guest;
 
+import java.util.List;
+
 public interface GuestRepository extends JpaRepository<Guest, Long> {
+
+    @Query("""
+            SELECT g FROM Guest g 
+            WHERE g.exercise.id = :exerciseId 
+            ORDER BY g.createdAt ASC
+            """)
+    List<Guest> findByExerciseId(@Param("exerciseId") Long exerciseId);
 }

--- a/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseQueryService.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseQueryService.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import umc.cockple.demo.domain.exercise.converter.ExerciseConverter;
 import umc.cockple.demo.domain.exercise.domain.Exercise;
+import umc.cockple.demo.domain.exercise.domain.ExerciseAddr;
 import umc.cockple.demo.domain.exercise.domain.Guest;
 import umc.cockple.demo.domain.exercise.dto.ExerciseDetailDTO;
 import umc.cockple.demo.domain.exercise.dto.ExerciseDetailDTO.ParticipantInfo;
@@ -50,6 +51,8 @@ public class ExerciseQueryService {
         Party party = exercise.getParty();
         boolean isManager = checkManagerPermission(party, member);
 
+        ExerciseDetailDTO.ExerciseInfo exerciseInfo = createExerciseInfo(exercise);
+
         List<MemberExercise> memberExercises = findMemberExercisesWithMemberAndProfile(exerciseId);
         List<ParticipantInfo> memberParticipants = buildMemberParticipantInfos(memberExercises, party);
 
@@ -65,6 +68,16 @@ public class ExerciseQueryService {
     private boolean checkManagerPermission(Party party, Member member) {
         return memberPartyRepository.existsByPartyIdAndMemberIdAndRole(
                 party.getId(), member.getId(), Role.party_MANAGER);
+    }
+
+    private ExerciseDetailDTO.ExerciseInfo createExerciseInfo(Exercise exercise) {
+        ExerciseAddr addr = exercise.getExerciseAddr();
+
+        return ExerciseDetailDTO.ExerciseInfo.builder()
+                .notice(exercise.getNotice())
+                .buildingName(addr.getBuildingName())
+                .location(addr.getStreetAddr())
+                .build();
     }
 
     private List<ParticipantInfo> buildMemberParticipantInfos(List<MemberExercise> memberExercises, Party party) {

--- a/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseQueryService.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseQueryService.java
@@ -23,9 +23,7 @@ import umc.cockple.demo.domain.party.domain.Party;
 import umc.cockple.demo.global.enums.MemberStatus;
 import umc.cockple.demo.global.enums.Role;
 
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Service

--- a/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseQueryService.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseQueryService.java
@@ -10,7 +10,10 @@ import umc.cockple.demo.domain.exercise.exception.ExerciseErrorCode;
 import umc.cockple.demo.domain.exercise.exception.ExerciseException;
 import umc.cockple.demo.domain.exercise.repository.ExerciseRepository;
 import umc.cockple.demo.domain.member.domain.Member;
+import umc.cockple.demo.domain.member.repository.MemberPartyRepository;
 import umc.cockple.demo.domain.member.repository.MemberRepository;
+import umc.cockple.demo.domain.party.domain.Party;
+import umc.cockple.demo.global.enums.Role;
 
 @Service
 @Transactional(readOnly = true)
@@ -20,6 +23,7 @@ public class ExerciseQueryService {
 
     private final ExerciseRepository exerciseRepository;
     private final MemberRepository memberRepository;
+    private final MemberPartyRepository memberPartyRepository;
 
     public ExerciseDetailDTO.Response getExerciseDetail(Long exerciseId, Long memberId) {
 
@@ -28,7 +32,16 @@ public class ExerciseQueryService {
         Exercise exercise = findExerciseWithBasicInfoOrThrow(exerciseId);
         Member member = findMemberOrThrow(memberId);
 
+        boolean isManager = checkManagerPermission(exercise.getParty(), member);
+
         return null;
+    }
+
+    // ========== 비즈니스 메서드 ==========
+
+    private boolean checkManagerPermission(Party party, Member member) {
+        return memberPartyRepository.existsByPartyIdAndMemberIdAndRole(
+                party.getId(), member.getId(), Role.party_MANAGER);
     }
 
     // ========== 조회 메서드 ==========

--- a/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseQueryService.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseQueryService.java
@@ -1,0 +1,19 @@
+package umc.cockple.demo.domain.exercise.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import umc.cockple.demo.domain.exercise.dto.ExerciseDetailDTO;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Slf4j
+public class ExerciseQueryService {
+
+    public ExerciseDetailDTO.Response getExerciseDetail(Long exerciseId, Long memberId) {
+
+        return null;
+    }
+}

--- a/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseQueryService.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseQueryService.java
@@ -56,6 +56,10 @@ public class ExerciseQueryService {
         List<ExerciseDetailDTO.ParticipantInfo> allParticipants = getAllSortedParticipants(exerciseId, party);
         ParticipantGroups groups = splitParticipants(allParticipants, exercise.getMaxCapacity());
 
+        ExerciseDetailDTO.ParticipantGroup participantGroup = createParticipantGroup(
+                groups.participants(), exercise.getMaxCapacity());
+        ExerciseDetailDTO.WaitingGroup waitingGroup = createWaitingGroup(groups.waiting());
+
 
         return null;
     }
@@ -101,6 +105,30 @@ public class ExerciseQueryService {
         List<ExerciseDetailDTO.ParticipantInfo> waitingList = createWaitingList(allParticipants, maxCapacity);
 
         return new ParticipantGroups(participantList, waitingList);
+    }
+
+    private ExerciseDetailDTO.ParticipantGroup createParticipantGroup(
+            List<ExerciseDetailDTO.ParticipantInfo> participants,
+            int maxCapacity) {
+
+        return ExerciseDetailDTO.ParticipantGroup.builder()
+                .currentParticipantCount(participants.size())
+                .totalCount(maxCapacity)
+                .manCount(countByGender(participants, "MALE"))
+                .womenCount(countByGender(participants, "FEMALE"))
+                .list(participants)
+                .build();
+    }
+
+    private ExerciseDetailDTO.WaitingGroup createWaitingGroup(
+            List<ExerciseDetailDTO.ParticipantInfo> waiting) {
+
+        return ExerciseDetailDTO.WaitingGroup.builder()
+                .currentWaitingCount(waiting.size())
+                .manCount(countByGender(waiting, "MALE"))
+                .womenCount(countByGender(waiting, "FEMALE"))
+                .list(waiting)
+                .build();
     }
 
     // ========== 세부 비즈니스 메서드 ==========
@@ -204,6 +232,12 @@ public class ExerciseQueryService {
                 .inviterName(original.inviterName())
                 .joinedAt(original.joinedAt())
                 .build();
+    }
+
+    private int countByGender(List<ExerciseDetailDTO.ParticipantInfo> participants, String gender) {
+        return (int) participants.stream()
+                .filter(p -> gender.equals(p.gender()))
+                .count();
     }
 
     // ========== 조회 메서드 ==========

--- a/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseQueryService.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseQueryService.java
@@ -56,12 +56,10 @@ public class ExerciseQueryService {
         List<ExerciseDetailDTO.ParticipantInfo> allParticipants = getAllSortedParticipants(exerciseId, party);
         ParticipantGroups groups = splitParticipants(allParticipants, exercise.getMaxCapacity());
 
-        ExerciseDetailDTO.ParticipantGroup participantGroup = createParticipantGroup(
-                groups.participants(), exercise.getMaxCapacity());
+        ExerciseDetailDTO.ParticipantGroup participantGroup = createParticipantGroup(groups.participants(), exercise.getMaxCapacity());
         ExerciseDetailDTO.WaitingGroup waitingGroup = createWaitingGroup(groups.waiting());
 
-
-        return null;
+        return exerciseConverter.toDetailResponseDTO(isManager, exerciseInfo, participantGroup, waitingGroup);
     }
 
     // ========== 비즈니스 메서드 ==========

--- a/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseQueryService.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseQueryService.java
@@ -11,6 +11,7 @@ import umc.cockple.demo.domain.exercise.dto.ExerciseDetailDTO.ParticipantInfo;
 import umc.cockple.demo.domain.exercise.exception.ExerciseErrorCode;
 import umc.cockple.demo.domain.exercise.exception.ExerciseException;
 import umc.cockple.demo.domain.exercise.repository.ExerciseRepository;
+import umc.cockple.demo.domain.exercise.repository.GuestRepository;
 import umc.cockple.demo.domain.member.domain.Member;
 import umc.cockple.demo.domain.member.domain.MemberExercise;
 import umc.cockple.demo.domain.member.domain.MemberParty;
@@ -35,6 +36,7 @@ public class ExerciseQueryService {
     private final MemberRepository memberRepository;
     private final MemberPartyRepository memberPartyRepository;
     private final MemberExerciseRepository memberExerciseRepository;
+    private final GuestRepository guestRepository;
 
     private final ExerciseConverter exerciseConverter;
 
@@ -48,7 +50,7 @@ public class ExerciseQueryService {
         Party party = exercise.getParty();
         boolean isManager = checkManagerPermission(party, member);
 
-        List<MemberExercise> memberExercises = findMemberExercisesWithInfo(exerciseId);
+        List<MemberExercise> memberExercises = findMemberExercisesWithMemberAndProfile(exerciseId);
         List<ParticipantInfo> memberParticipants = buildMemberParticipantInfos(memberExercises, party);
 
 
@@ -102,7 +104,7 @@ public class ExerciseQueryService {
                 .orElseThrow(() -> new ExerciseException(ExerciseErrorCode.MEMBER_NOT_FOUND));
     }
 
-    private List<MemberExercise> findMemberExercisesWithInfo(Long exerciseId) {
-        return memberExerciseRepository.findMemberParticipantsByExerciseId(exerciseId, MemberStatus.ACTIVE);
+    private List<MemberExercise> findMemberExercisesWithMemberAndProfile(Long exerciseId) {
+        return memberExerciseRepository.findByExerciseIdWithMemberAndProfile(exerciseId, MemberStatus.ACTIVE);
     }
 }

--- a/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseQueryService.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseQueryService.java
@@ -4,7 +4,13 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import umc.cockple.demo.domain.exercise.domain.Exercise;
 import umc.cockple.demo.domain.exercise.dto.ExerciseDetailDTO;
+import umc.cockple.demo.domain.exercise.exception.ExerciseErrorCode;
+import umc.cockple.demo.domain.exercise.exception.ExerciseException;
+import umc.cockple.demo.domain.exercise.repository.ExerciseRepository;
+import umc.cockple.demo.domain.member.domain.Member;
+import umc.cockple.demo.domain.member.repository.MemberRepository;
 
 @Service
 @Transactional(readOnly = true)
@@ -12,8 +18,28 @@ import umc.cockple.demo.domain.exercise.dto.ExerciseDetailDTO;
 @Slf4j
 public class ExerciseQueryService {
 
+    private final ExerciseRepository exerciseRepository;
+    private final MemberRepository memberRepository;
+
     public ExerciseDetailDTO.Response getExerciseDetail(Long exerciseId, Long memberId) {
 
+        log.info("운동 조회 시작 - exerciseId = {}, memberId = {}", exerciseId, memberId);
+
+        Exercise exercise = findExerciseWithBasicInfoOrThrow(exerciseId);
+        Member member = findMemberOrThrow(memberId);
+
         return null;
+    }
+
+    // ========== 조회 메서드 ==========
+
+    private Exercise findExerciseWithBasicInfoOrThrow(Long exerciseId) {
+        return exerciseRepository.findExerciseWithBasicInfo(exerciseId)
+                .orElseThrow(() -> new ExerciseException(ExerciseErrorCode.EXERCISE_NOT_FOUND));
+    }
+
+    private Member findMemberOrThrow(Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new ExerciseException(ExerciseErrorCode.MEMBER_NOT_FOUND));
     }
 }

--- a/src/main/java/umc/cockple/demo/domain/member/domain/MemberExercise.java
+++ b/src/main/java/umc/cockple/demo/domain/member/domain/MemberExercise.java
@@ -33,7 +33,7 @@ public class MemberExercise extends BaseEntity {
 
     public static MemberExercise create(boolean isPartyMember) {
         ExerciseMemberShipStatus status = isPartyMember ?
-                ExerciseMemberShipStatus.PARTY_MEMBER : ExerciseMemberShipStatus.EXTERNAL_MEMBER;
+                ExerciseMemberShipStatus.PARTY_MEMBER : ExerciseMemberShipStatus.EXTERNAL_PARTICIPANT;
 
         return MemberExercise.builder()
                 .exerciseMemberShipStatus(status)

--- a/src/main/java/umc/cockple/demo/domain/member/repository/MemberExerciseRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/member/repository/MemberExerciseRepository.java
@@ -25,6 +25,6 @@ public interface MemberExerciseRepository extends JpaRepository<MemberExercise, 
             AND m.isActive = :memberStatus
             ORDER BY me.createdAt ASC
             """)
-    List<MemberExercise> findMemberParticipantsByExerciseId(
+    List<MemberExercise> findByExerciseIdWithMemberAndProfile(
             @Param("exerciseId") Long exerciseId, @Param("memberStatus") MemberStatus memberStatus);
 }

--- a/src/main/java/umc/cockple/demo/domain/member/repository/MemberExerciseRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/member/repository/MemberExerciseRepository.java
@@ -1,10 +1,14 @@
 package umc.cockple.demo.domain.member.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import umc.cockple.demo.domain.exercise.domain.Exercise;
 import umc.cockple.demo.domain.member.domain.Member;
 import umc.cockple.demo.domain.member.domain.MemberExercise;
+import umc.cockple.demo.global.enums.MemberStatus;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface MemberExerciseRepository extends JpaRepository<MemberExercise, Long> {
@@ -12,4 +16,15 @@ public interface MemberExerciseRepository extends JpaRepository<MemberExercise, 
     boolean existsByExerciseAndMember(Exercise exercise, Member member);
 
     Optional<MemberExercise> findByExerciseAndMember(Exercise exercise, Member member);
+
+    @Query("""
+            SELECT me FROM MemberExercise me
+            JOIN FETCH me.member m
+            LEFT JOIN FETCH m.profileImg mp
+            WHERE me.exercise.id = :exerciseId
+            AND m.isActive = :memberStatus
+            ORDER BY me.createdAt ASC
+            """)
+    List<MemberExercise> findMemberParticipantsByExerciseId(
+            @Param("exerciseId") Long exerciseId, @Param("memberStatus") MemberStatus memberStatus);
 }

--- a/src/main/java/umc/cockple/demo/domain/member/repository/MemberPartyRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/member/repository/MemberPartyRepository.java
@@ -1,14 +1,27 @@
 package umc.cockple.demo.domain.member.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import umc.cockple.demo.domain.member.domain.Member;
 import umc.cockple.demo.domain.member.domain.MemberParty;
 import umc.cockple.demo.domain.party.domain.Party;
 import umc.cockple.demo.global.enums.Role;
+
+import java.util.List;
 
 public interface MemberPartyRepository extends JpaRepository<MemberParty, Long> {
 
     boolean existsByPartyIdAndMemberIdAndRole(Long partyId, Long memberId, Role role);
 
     boolean existsByPartyAndMember(Party party, Member member);
+
+    @Query("""
+            SELECT mp FROM MemberParty mp
+            WHERE mp.party.id = :partyId
+            AND mp.member.id IN :memberIds
+            """)
+    List<MemberParty> findMemberRolesByPartyAndMembers(
+            @Param("partyId") Long partyId, @Param("memberIds") List<Long> memberIds);
+
 }

--- a/src/main/java/umc/cockple/demo/domain/member/repository/MemberRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/member/repository/MemberRepository.java
@@ -1,7 +1,32 @@
 package umc.cockple.demo.domain.member.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import umc.cockple.demo.domain.member.domain.Member;
 
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
 public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    default Map<Long, String> findMemberNamesByIds(Set<Long> memberIds) {
+        if (memberIds.isEmpty()) {
+            return Map.of();
+        }
+
+        return findMemberNameMapsByIds(memberIds).stream()
+                .collect(Collectors.toMap(
+                        map -> (Long) map.get("id"),
+                        map -> (String) map.get("name")
+                ));
+    }
+
+    @Query("""
+            SELECT new map(m.id as id, m.memberName as name) FROM Member m 
+            WHERE m.id IN :memberIds
+            """)
+    List<Map<String, Object>> findMemberNameMapsByIds(@Param("memberIds") Set<Long> memberIds);
 }

--- a/src/main/java/umc/cockple/demo/global/enums/ExerciseMemberShipStatus.java
+++ b/src/main/java/umc/cockple/demo/global/enums/ExerciseMemberShipStatus.java
@@ -2,6 +2,6 @@ package umc.cockple.demo.global.enums;
 
 public enum ExerciseMemberShipStatus {
     PARTY_MEMBER,
-    EXTERNAL_MEMBER,
+    EXTERNAL_PARTICIPANT,
     GUEST
 }


### PR DESCRIPTION
## ❤️ 기능 설명
운동 상세 정보를 조회하는 API를 구현했습니다.

기초 검증
- 운동이 존재하는 지
- 조회하는 대상이 멤버인지

비즈니스 로직
- 조회하는 대상이 매니저(모임장)일경우 운동 수정 및 삭제 UI가 보여야하기에 관련 데이터를 조회합니다.
- 운동의 기초 정보를 생성합니다.
- 멤버 참가자와 게스트 참가자를 별도로 DB에서 조회한 후, 이를 ParticipantInfo 객체 List로 만듭니다.
- 그 리스트를 합치고 시간 순으로 정렬해 전체 참여자 리스트를 생성합니다.
- 전체 참여자 리스트를 운동의 최대 인원을 기준으로 참여자, 대기자로 구분하고 번호를 부여합니다.
- 이를 반환합니다.

swagger 테스트 성공 결과 스크린샷 첨부
<img width="582" height="604" alt="image" src="https://github.com/user-attachments/assets/1409c85f-c485-4766-831f-5eec52f01b8d" />
<img width="399" height="565" alt="image" src="https://github.com/user-attachments/assets/8ec4377f-3e2d-49ce-b82b-7b0dd186f78e" />
<img width="439" height="461" alt="image" src="https://github.com/user-attachments/assets/a2f180ab-b6ee-45a1-a536-5ed4ffbdc7f0" />

<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #78 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 게스트의 초대자 이름 정보가 매핑이 되어있지 않기에 fetch join 대신 배치 쿼리를 사용했습니다.
-> 이는 N개의 정보를 한 번에 가져와 성능상 효과적입니다.
- [ ] ExerciseMemberShipStatus의 외부 멤버 필드명을 EXTERNAL_PARTICIPANT로 변경했습니다.
- [ ] 코드가 상당히 깁니다...

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
