### PR TITLE
[feat/#132] 내가 초대한 운동 게스트 조회 API 구현

### DIFF
--- a/src/main/java/umc/cockple/demo/domain/exercise/controller/ExerciseController.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/controller/ExerciseController.java
@@ -215,7 +215,7 @@ public class ExerciseController {
     @GetMapping("/exercises/{exerciseId}/guests")
     @Operation(summary = "내가 초대한 운동 게스트 조회",
             description = "내가 초대한 운동 게스트 목록을 조회합니다.")
-    @ApiResponse(responseCode = "200", description = "운동 상세 조회 성공")
+    @ApiResponse(responseCode = "200", description = "내가 초대한 운동 게스트 조회 성공")
     @ApiResponse(responseCode = "404", description = "존재하지 않는 운동")
     public BaseResponse<ExerciseMyGuestListDTO.Response> getMyInvitedGuests(
             @PathVariable Long exerciseId,

--- a/src/main/java/umc/cockple/demo/domain/exercise/controller/ExerciseController.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/controller/ExerciseController.java
@@ -211,4 +211,23 @@ public class ExerciseController {
 
         return BaseResponse.success(CommonSuccessCode.OK, response);
     }
+
+    @GetMapping("/exercises/{exerciseId}/guests")
+    @Operation(summary = "내가 초대한 운동 게스트 조회",
+            description = "내가 초대한 운동 게스트 목록을 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "운동 상세 조회 성공")
+    @ApiResponse(responseCode = "404", description = "존재하지 않는 운동")
+    public BaseResponse<ExerciseMyGuestListDTO.Response> getMyInvitedGuests(
+            @PathVariable Long exerciseId,
+            Authentication authentication
+    ){
+
+        // TODO: JWT 인증 구현 후 교체 예정
+        Long memberId = 1L; // 임시값
+
+        ExerciseMyGuestListDTO.Response response = exerciseQueryService.getMyInvitedGuests(
+                exerciseId, memberId);
+
+        return BaseResponse.success(CommonSuccessCode.OK, response);
+    }
 }

--- a/src/main/java/umc/cockple/demo/domain/exercise/converter/ExerciseConverter.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/converter/ExerciseConverter.java
@@ -7,8 +7,10 @@ import umc.cockple.demo.domain.exercise.domain.Guest;
 import umc.cockple.demo.domain.exercise.dto.*;
 import umc.cockple.demo.domain.member.domain.Member;
 import umc.cockple.demo.domain.member.domain.MemberExercise;
+import umc.cockple.demo.global.enums.Gender;
 import umc.cockple.demo.global.enums.Role;
 
+import java.util.List;
 import java.util.Map;
 
 @Component
@@ -180,6 +182,36 @@ public class ExerciseConverter {
                 .info(exerciseInfo)
                 .participants(participantGroup)
                 .waiting(waitingGroup)
+                .build();
+    }
+
+    public ExerciseMyGuestListDTO.Response toMyGuestListResponse(
+            ExerciseMyGuestListDTO.GuestStatistics statistics,
+            List<ExerciseMyGuestListDTO.GuestInfo> guestInfoList) {
+
+        return ExerciseMyGuestListDTO.Response.builder()
+                .totalCount(statistics.totalCount())
+                .maleCount(statistics.maleCount())
+                .femaleCount(statistics.femaleCount())
+                .list(guestInfoList)
+                .build();
+    }
+
+    public ExerciseMyGuestListDTO.GuestInfo toGuestInfo(
+            Guest guest,
+            Map<Long, ExerciseMyGuestListDTO.GuestGroups> guestStatusMap,
+            String inviterName) {
+
+        ExerciseMyGuestListDTO.GuestGroups guestGroup = guestStatusMap.get(guest.getId());
+
+        return ExerciseMyGuestListDTO.GuestInfo.builder()
+                .guestId(guest.getId())
+                .isWaiting(guestGroup.isWaiting())
+                .participantNumber(guestGroup.participantNumber())
+                .name(guest.getGuestName())
+                .gender(guest.getGender())
+                .level(guest.getLevel())
+                .inviterName(inviterName)
                 .build();
     }
 }

--- a/src/main/java/umc/cockple/demo/domain/exercise/dto/ExerciseMyGuestListDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/dto/ExerciseMyGuestListDTO.java
@@ -1,0 +1,30 @@
+package umc.cockple.demo.domain.exercise.dto;
+
+import lombok.Builder;
+import umc.cockple.demo.global.enums.Gender;
+import umc.cockple.demo.global.enums.Level;
+
+import java.util.List;
+
+public class ExerciseMyGuestListDTO {
+
+    @Builder
+    public record Response(
+            Integer totalCount,
+            Integer maleCount,
+            Integer femaleCount,
+            List<GuestInfo> list
+    ) {
+    }
+
+    @Builder
+    public record GuestInfo(
+            Long guestId,
+            Integer participantNumber,
+            String name,
+            Gender gender,
+            Level level,
+            String inviterName
+    ) {
+    }
+}

--- a/src/main/java/umc/cockple/demo/domain/exercise/dto/ExerciseMyGuestListDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/dto/ExerciseMyGuestListDTO.java
@@ -28,4 +28,36 @@ public class ExerciseMyGuestListDTO {
             String inviterName
     ) {
     }
+
+    @Builder
+    public record GuestGroups(
+            Integer participantNumber,
+            Boolean isWaiting
+    ){
+        public static GuestGroups participant(int number) {
+            return new GuestGroups(number, false);
+        }
+
+        public static GuestGroups waiting(int number) {
+            return new GuestGroups(number, true);
+        }
+    }
+
+    @Builder
+    public record GuestStatistics(
+            int totalCount,     // 전체 게스트 수
+            int maleCount,      // 남자 게스트 수
+            int femaleCount     // 여자 게스트 수
+    ) {
+
+        public static GuestStatistics empty() {
+            return new GuestStatistics(0, 0, 0);
+        }
+
+        public static GuestStatistics of(int totalCount, int maleCount, int femaleCount) {
+            return new GuestStatistics(totalCount, maleCount, femaleCount);
+        }
+    }
+
+
 }

--- a/src/main/java/umc/cockple/demo/domain/exercise/dto/ExerciseMyGuestListDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/dto/ExerciseMyGuestListDTO.java
@@ -20,6 +20,7 @@ public class ExerciseMyGuestListDTO {
     @Builder
     public record GuestInfo(
             Long guestId,
+            Boolean isWaiting,
             Integer participantNumber,
             String name,
             Gender gender,

--- a/src/main/java/umc/cockple/demo/domain/exercise/repository/GuestRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/repository/GuestRepository.java
@@ -15,4 +15,13 @@ public interface GuestRepository extends JpaRepository<Guest, Long> {
             ORDER BY g.createdAt ASC
             """)
     List<Guest> findByExerciseId(@Param("exerciseId") Long exerciseId);
+
+    @Query("""
+            SELECT g FROM Guest g 
+            WHERE g.exercise.id = :exerciseId 
+            AND g.inviterId = :inviterId
+            ORDER BY g.createdAt ASC
+            """)
+    List<Guest> findByExerciseIdAndInviterId(@Param("exerciseId") Long exerciseId,
+                                             @Param("inviterId") Long inviterId);
 }

--- a/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseQueryService.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseQueryService.java
@@ -71,6 +71,8 @@ public class ExerciseQueryService {
 
         List<Guest> myGuests = guestRepository.findByExerciseIdAndInviterId(exerciseId, memberId);
 
+        List<ExerciseDetailDTO.ParticipantInfo> allParticipants = getAllSortedParticipants(exerciseId, exercise.getParty());
+
 
 
     }

--- a/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseQueryService.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseQueryService.java
@@ -10,6 +10,7 @@ import umc.cockple.demo.domain.exercise.domain.ExerciseAddr;
 import umc.cockple.demo.domain.exercise.domain.Guest;
 import umc.cockple.demo.domain.exercise.dto.ExerciseDetailDTO;
 import umc.cockple.demo.domain.exercise.dto.ExerciseDetailDTO.ParticipantInfo;
+import umc.cockple.demo.domain.exercise.dto.ExerciseMyGuestListDTO;
 import umc.cockple.demo.domain.exercise.exception.ExerciseErrorCode;
 import umc.cockple.demo.domain.exercise.exception.ExerciseException;
 import umc.cockple.demo.domain.exercise.repository.ExerciseRepository;
@@ -60,6 +61,18 @@ public class ExerciseQueryService {
         ExerciseDetailDTO.WaitingGroup waitingGroup = createWaitingGroup(groups.waiting());
 
         return exerciseConverter.toDetailResponseDTO(isManager, exerciseInfo, participantGroup, waitingGroup);
+    }
+
+    public ExerciseMyGuestListDTO.Response getMyInvitedGuests(Long exerciseId, Long memberId) {
+
+        log.info("내가 초대한 게스트 조회 시작 - exerciseId = {}, memberId = {}", exerciseId, memberId);
+
+        Exercise exercise = findExerciseOrThrow(exerciseId);
+
+        List<Guest> myGuests = guestRepository.findByExerciseIdAndInviterId(exerciseId, memberId);
+
+
+
     }
 
     // ========== 비즈니스 메서드 ==========
@@ -242,6 +255,11 @@ public class ExerciseQueryService {
 
     private Exercise findExerciseWithBasicInfoOrThrow(Long exerciseId) {
         return exerciseRepository.findExerciseWithBasicInfo(exerciseId)
+                .orElseThrow(() -> new ExerciseException(ExerciseErrorCode.EXERCISE_NOT_FOUND));
+    }
+
+    private Exercise findExerciseOrThrow(Long exerciseId) {
+        return exerciseRepository.findById(exerciseId)
                 .orElseThrow(() -> new ExerciseException(ExerciseErrorCode.EXERCISE_NOT_FOUND));
     }
 

--- a/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseQueryService.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseQueryService.java
@@ -67,7 +67,7 @@ public class ExerciseQueryService {
 
         log.info("내가 초대한 게스트 조회 시작 - exerciseId = {}, memberId = {}", exerciseId, memberId);
 
-        Exercise exercise = findExerciseOrThrow(exerciseId);
+        Exercise exercise = findExerciseWithBasicInfoOrThrow(exerciseId);
 
         List<Guest> myGuests = guestRepository.findByExerciseIdAndInviterId(exerciseId, memberId);
 


### PR DESCRIPTION
## ❤️ 기능 설명

- 내가 초대한 게스트 목록을 불러온 뒤,
- 운동 전체 참여자 목록을 조회해서 운동 내 순번을 조회합니다.
- 내 게스트 목록과 운동 내 순번, 초대자 이름으로 게스트 정보 리스트를 생성합니다.
- 그 후, 통계를 계산하고,
- Response로 반환합니다.

swagger 테스트 성공 결과 스크린샷 첨부
<img width="2127" height="1145" alt="image" src="https://github.com/user-attachments/assets/62a6f9df-562b-47fe-b0ca-f97d6bcf72d1" />

<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #132 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 순번을 찍는 게 생각보다 쉽지 않네요...
- [ ] 중간에 커밋하는 걸 깜빡해서 커밋마다 로직이 분리되어 있지 않은 것도 있습니다.

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
