### PR TITLE
[feat/#131] 내 모임 조회 (간략화) API 구현

### DIFF
--- a/src/main/java/umc/cockple/demo/domain/member/repository/MemberPartyRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/member/repository/MemberPartyRepository.java
@@ -1,5 +1,7 @@
 package umc.cockple.demo.domain.member.repository;
 
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -26,4 +28,6 @@ public interface MemberPartyRepository extends JpaRepository<MemberParty, Long> 
             @Param("partyId") Long partyId, @Param("memberIds") List<Long> memberIds);
 
     Optional<MemberParty> findByPartyAndMember(Party party, Member member);
+
+    Slice<MemberParty> findByMember(Member member, Pageable pageable);
 }

--- a/src/main/java/umc/cockple/demo/domain/party/controller/PartyController.java
+++ b/src/main/java/umc/cockple/demo/domain/party/controller/PartyController.java
@@ -28,10 +28,27 @@ public class PartyController {
     private final PartyCommandService partyCommandService;
     private final PartyQueryService partyQueryService;
 
+    @GetMapping("/my/parties/simple")
+    @Operation(summary = "내 모임 간략화 조회",
+            description = "사용자가 가입한 내 모임을 간략화하여 조회합니다. ")
+    @ApiResponse(responseCode = "200", description = "모임 조회 성공")
+    @ApiResponse(responseCode = "404", description = "존재하지 않는 사용자")
+    public BaseResponse<Slice<PartySimpleDTO.Response>> getSimpleParties(
+            @PageableDefault(page = 0, size = 10, sort = {"createdAt", "party.partyName"}, direction = Sort.Direction.DESC) Pageable pageable,
+            Authentication authentication
+    ){
+        // TODO: JWT 인증 구현 후 교체 예정
+        Long memberId = 1L; // 임시값
+
+        Slice<PartySimpleDTO.Response> response = partyQueryService.getSimpleMyParties(memberId, pageable);
+        return BaseResponse.success(CommonSuccessCode.OK, response);
+    }
+
+
     @GetMapping("/{partyId}")
     @Operation(summary = "모임 상세 정보 조회",
             description = "특정 모임의 상세 정보를 조회합니다.")
-    @ApiResponse(responseCode = "200", description = "모임 생성 성공")
+    @ApiResponse(responseCode = "200", description = "모임 상세 조회 성공")
     @ApiResponse(responseCode = "404", description = "존재하지 않는 모임 또는 사용자")
     public BaseResponse<PartyDetailDTO.Response> getPartyDetails(
             @PathVariable Long partyId,

--- a/src/main/java/umc/cockple/demo/domain/party/converter/PartyConverter.java
+++ b/src/main/java/umc/cockple/demo/domain/party/converter/PartyConverter.java
@@ -5,10 +5,7 @@ import umc.cockple.demo.domain.member.domain.Member;
 import umc.cockple.demo.domain.member.domain.MemberParty;
 import umc.cockple.demo.domain.party.domain.Party;
 import umc.cockple.demo.domain.party.domain.PartyJoinRequest;
-import umc.cockple.demo.domain.party.dto.PartyCreateDTO;
-import umc.cockple.demo.domain.party.dto.PartyDetailDTO;
-import umc.cockple.demo.domain.party.dto.PartyJoinCreateDTO;
-import umc.cockple.demo.domain.party.dto.PartyJoinDTO;
+import umc.cockple.demo.domain.party.dto.*;
 import umc.cockple.demo.global.enums.Gender;
 import umc.cockple.demo.global.enums.ParticipationType;
 import umc.cockple.demo.global.enums.RequestStatus;
@@ -20,6 +17,17 @@ import java.util.stream.Collectors;
 
 @Component
 public class PartyConverter {
+
+    public PartySimpleDTO.Response toPartySimpleDTO(MemberParty memberParty) {
+        Party party = memberParty.getParty();
+        return PartySimpleDTO.Response.builder()
+                .partyId(party.getId())
+                .partyName(party.getPartyName())
+                .addr1(party.getPartyAddr().getAddr1())
+                .addr2(party.getPartyAddr().getAddr2())
+                .partyImgUrl(party.getPartyImg() != null ? party.getPartyImg().getImgUrl() : null)
+                .build();
+    }
 
     public PartyDetailDTO.Response toPartyDetailResponseDTO(Party party, Optional<MemberParty> memberPartyOpt) {
         // 급수 정보 가공
@@ -121,4 +129,5 @@ public class PartyConverter {
 
         return levelList.isEmpty() ? null : levelList;
     }
+
 }

--- a/src/main/java/umc/cockple/demo/domain/party/dto/PartySimpleDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/party/dto/PartySimpleDTO.java
@@ -1,0 +1,14 @@
+package umc.cockple.demo.domain.party.dto;
+
+import lombok.Builder;
+
+public class PartySimpleDTO {
+    @Builder
+    public record Response(
+            Long partyId,
+            String partyName,
+            String addr1,
+            String addr2,
+            String partyImgUrl
+    ) {}
+}

--- a/src/main/java/umc/cockple/demo/domain/party/service/PartyQueryService.java
+++ b/src/main/java/umc/cockple/demo/domain/party/service/PartyQueryService.java
@@ -9,5 +9,5 @@ import umc.cockple.demo.domain.party.dto.PartySimpleDTO;
 public interface PartyQueryService {
     Slice<PartyJoinDTO.Response> getJoinRequests(Long partyId, Long memberId, String status, Pageable pageable);
     PartyDetailDTO.Response getPartyDetails(Long partyId, Long memberId);
-    Slice<PartySimpleDTO> getSimpleMyParties(Long memberId, Pageable pageable);
+    Slice<PartySimpleDTO.Response> getSimpleMyParties(Long memberId, Pageable pageable);
 }

--- a/src/main/java/umc/cockple/demo/domain/party/service/PartyQueryService.java
+++ b/src/main/java/umc/cockple/demo/domain/party/service/PartyQueryService.java
@@ -4,8 +4,10 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import umc.cockple.demo.domain.party.dto.PartyDetailDTO;
 import umc.cockple.demo.domain.party.dto.PartyJoinDTO;
+import umc.cockple.demo.domain.party.dto.PartySimpleDTO;
 
 public interface PartyQueryService {
     Slice<PartyJoinDTO.Response> getJoinRequests(Long partyId, Long memberId, String status, Pageable pageable);
     PartyDetailDTO.Response getPartyDetails(Long partyId, Long memberId);
+    Slice<PartySimpleDTO> getSimpleMyParties(Long memberId, Pageable pageable);
 }

--- a/src/main/java/umc/cockple/demo/domain/party/service/PartyQueryServiceImpl.java
+++ b/src/main/java/umc/cockple/demo/domain/party/service/PartyQueryServiceImpl.java
@@ -17,6 +17,7 @@ import umc.cockple.demo.domain.party.domain.Party;
 import umc.cockple.demo.domain.party.domain.PartyJoinRequest;
 import umc.cockple.demo.domain.party.dto.PartyDetailDTO;
 import umc.cockple.demo.domain.party.dto.PartyJoinDTO;
+import umc.cockple.demo.domain.party.dto.PartySimpleDTO;
 import umc.cockple.demo.domain.party.exception.PartyErrorCode;
 import umc.cockple.demo.domain.party.exception.PartyException;
 import umc.cockple.demo.domain.party.repository.PartyJoinRequestRepository;
@@ -38,6 +39,17 @@ public class PartyQueryServiceImpl implements PartyQueryService{
     private final MemberPartyRepository memberPartyRepository;
 
     @Override
+    public Slice<PartySimpleDTO.Response> getSimpleMyParties(Long memberId, Pageable pageable) {
+        //사용자 조회
+        Member member = findMemberOrThrow(memberId);
+
+        //memberParty 조회 로직 수행
+        Slice<MemberParty> memberPartySlice = memberPartyRepository.findByMember(member, pageable);
+
+        return memberPartySlice.map(partyConverter::toPartySimpleDTO);
+    }
+
+    @Override
     public PartyDetailDTO.Response getPartyDetails(Long partyId, Long memberId) {
         log.info("모임 상세 정보 조회 시작 - partyId: {}, memberId: {}", partyId, memberId);
 
@@ -45,7 +57,7 @@ public class PartyQueryServiceImpl implements PartyQueryService{
         Party party = findPartyOrThrow(partyId);
         Member member = findMemberOrThrow(memberId);
 
-        //memberParty 반환
+        //memberParty 조회 로직 수행
         Optional<MemberParty> memberParty = memberPartyRepository.findByPartyAndMember(party, member);
 
         PartyDetailDTO.Response response = partyConverter.toPartyDetailResponseDTO(party, memberParty);

--- a/src/main/java/umc/cockple/demo/domain/party/service/PartyQueryServiceImpl.java
+++ b/src/main/java/umc/cockple/demo/domain/party/service/PartyQueryServiceImpl.java
@@ -40,12 +40,14 @@ public class PartyQueryServiceImpl implements PartyQueryService{
 
     @Override
     public Slice<PartySimpleDTO.Response> getSimpleMyParties(Long memberId, Pageable pageable) {
+        log.info("내 모임 간략화 조회 시작 - partyId: {}", memberId);
         //사용자 조회
         Member member = findMemberOrThrow(memberId);
 
         //memberParty 조회 로직 수행
         Slice<MemberParty> memberPartySlice = memberPartyRepository.findByMember(member, pageable);
 
+        log.info("내 모임 간략화 목록 조회 완료. 조회된 항목 수: {}", memberPartySlice.getNumberOfElements());
         return memberPartySlice.map(partyConverter::toPartySimpleDTO);
     }
 


### PR DESCRIPTION
## ❤️ 기능 설명
사용자가 가입한 모든 내 모임 목록을 조회합니다. 위 경우, 간략화하여 모임명과 지역 정보만 조회합니다.

swagger 테스트 성공 결과 스크린샷 첨부
<img width="793" height="308" alt="image" src="https://github.com/user-attachments/assets/e9cb40fa-0356-4e20-8af2-3b00928d6d56" />
<img width="789" height="277" alt="image" src="https://github.com/user-attachments/assets/9cc5839d-251c-4fdb-9606-13ee5b19e80f" />
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #131
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 조회 조건이 최신순으로 같은 경우, 모임 이름 가나다 순으로 정렬하라고 하셔서 정렬 조건에 추가는 했는데 어차피 최신순으로 할 경우 가입 자체가 마이크로초 단위라 상관없지 않을까요?

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
