### PR TITLE
[feat/#130] 내 모임 조회 API 구현

### DIFF
--- a/src/main/java/umc/cockple/demo/domain/exercise/repository/ExerciseRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/repository/ExerciseRepository.java
@@ -4,7 +4,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import umc.cockple.demo.domain.exercise.domain.Exercise;
+import umc.cockple.demo.domain.party.dto.PartyExerciseInfoDTO;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface ExerciseRepository extends JpaRepository<Exercise, Long> {
@@ -24,4 +26,22 @@ public interface ExerciseRepository extends JpaRepository<Exercise, Long> {
             WHERE e.id = :exerciseId
             """)
     Optional<Exercise> findExerciseWithBasicInfo(@Param("exerciseId") Long exerciseId);
+
+    // 여러 partyId에 해당하는 모든 예정된 운동들의 개수를 각각 세어서 반환
+    @Query("""
+            SELECT new umc.cockple.demo.domain.party.dto.PartyExerciseInfoDTO(e.party.id, COUNT(e)) 
+            FROM Exercise e 
+            WHERE e.party.id IN :partyIds AND (e.date > CURRENT_DATE OR (e.date = CURRENT_DATE AND e.startTime > CURRENT_TIME))
+            GROUP BY e.party.id
+            """)
+    List<PartyExerciseInfoDTO> findTotalExerciseCountsByPartyIds(@Param("partyIds") List<Long> partyIds);
+
+    //각 partyId에 해당하는 모든 예정된 운동들을 시간순 정렬을 하여 반환
+    @Query("""
+            SELECT e 
+            FROM Exercise e
+            WHERE e.party.id IN :partyIds AND (e.date > CURRENT_DATE OR (e.date = CURRENT_DATE AND e.startTime > CURRENT_TIME)) 
+            ORDER BY e.date ASC, e.startTime ASC
+            """)
+    List<Exercise> findUpcomingExercisesByPartyIds(@Param("partyIds") List<Long> partyIds);
 }

--- a/src/main/java/umc/cockple/demo/domain/party/controller/PartyController.java
+++ b/src/main/java/umc/cockple/demo/domain/party/controller/PartyController.java
@@ -123,7 +123,7 @@ public class PartyController {
     @ApiResponse(responseCode = "404", description = "존재하지 않는 모임")
     public BaseResponse<Slice<PartyJoinDTO.Response>> getJoinRequests(
             @PathVariable Long partyId,
-            @RequestParam(name = "status") String status,
+            @RequestParam(name = "status", defaultValue = "PENDING") String status,
             @PageableDefault(page = 0, size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable,
             Authentication authentication
     ){
@@ -159,7 +159,7 @@ public class PartyController {
         Sort sorting = switch (sort) {
             case "oldest" -> Sort.by("createdAt").ascending();
             case "exercise_count" -> Sort.by("exerciseCount").descending();
-            default -> Sort.by("createdAt").descending(); //기본값은 최신순
+            default -> Sort.by("createdAt").descending(); //기본값은 최신순 (createdAt 내림차순)
         };
         return PageRequest.of(page, size, sorting);
     }

--- a/src/main/java/umc/cockple/demo/domain/party/controller/PartyController.java
+++ b/src/main/java/umc/cockple/demo/domain/party/controller/PartyController.java
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.*;
 import umc.cockple.demo.domain.party.dto.*;
 import umc.cockple.demo.domain.party.service.PartyCommandService;
 import umc.cockple.demo.domain.party.service.PartyQueryService;
+import umc.cockple.demo.global.enums.PartyOrderType;
 import umc.cockple.demo.global.response.BaseResponse;
 import umc.cockple.demo.global.response.code.status.CommonSuccessCode;
 
@@ -52,16 +53,15 @@ public class PartyController {
     @ApiResponse(responseCode = "404", description = "존재하지 않는 사용자")
     public BaseResponse<Slice<PartyDTO.Response>> getMyParties(
             @RequestParam(required = false, defaultValue = "false") Boolean created,
-            @RequestParam(required = false, defaultValue = "latest") String sort,
+            @RequestParam(required = false, defaultValue = "최신순") String sort,
             @PageableDefault(size = 10) Pageable pageable,
             Authentication authentication
     ){
         // TODO: JWT 인증 구현 후 교체 예정
         Long memberId = 1L; // 임시값
         // sort 파라미터에 따라 Pageable 객체를 새로 생성
-        Pageable sortedPageable = createPageable(pageable.getPageNumber(), pageable.getPageSize(), sort);
 
-        Slice<PartyDTO.Response> response = partyQueryService.getMyParties(memberId, created, sortedPageable);
+        Slice<PartyDTO.Response> response = partyQueryService.getMyParties(memberId, created, sort, pageable);
         return BaseResponse.success(CommonSuccessCode.OK, response);
     }
 
@@ -154,13 +154,4 @@ public class PartyController {
         return BaseResponse.success(CommonSuccessCode.OK);
     }
 
-    //정렬 로직 처리
-    private Pageable createPageable(int page, int size, String sort) {
-        Sort sorting = switch (sort) {
-            case "oldest" -> Sort.by("createdAt").ascending();
-            case "exercise_count" -> Sort.by("exerciseCount").descending();
-            default -> Sort.by("createdAt").descending(); //기본값은 최신순 (createdAt 내림차순)
-        };
-        return PageRequest.of(page, size, sorting);
-    }
 }

--- a/src/main/java/umc/cockple/demo/domain/party/converter/PartyConverter.java
+++ b/src/main/java/umc/cockple/demo/domain/party/converter/PartyConverter.java
@@ -29,6 +29,21 @@ public class PartyConverter {
                 .build();
     }
 
+    public PartyDTO.Response toMyPartyDTO(Party party, String nextExerciseInfo, Integer totalExerciseCount) {
+        //급수 조건 가공 필요
+        return PartyDTO.Response.builder()
+                .partyId(party.getId())
+                .partyName(party.getPartyName())
+                .addr1(party.getPartyAddr().getAddr1())
+                .addr2(party.getPartyAddr().getAddr2())
+                .femaleLevel(getLevelList(party, Gender.FEMALE))
+                .maleLevel(getLevelList(party, Gender.MALE))
+                .nextExerciseInfo(nextExerciseInfo)
+                .totalExerciseCount(totalExerciseCount)
+                .partyImgUrl(party.getPartyImg() != null ? party.getPartyImg().getImgUrl() : null)
+                .build();
+    }
+
     public PartyDetailDTO.Response toPartyDetailResponseDTO(Party party, Optional<MemberParty> memberPartyOpt) {
         // 급수 정보 가공
         List<String> femaleLevel = getLevelList(party, Gender.FEMALE);

--- a/src/main/java/umc/cockple/demo/domain/party/dto/PartyDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/party/dto/PartyDTO.java
@@ -1,0 +1,20 @@
+package umc.cockple.demo.domain.party.dto;
+
+import lombok.Builder;
+
+import java.util.List;
+
+public class PartyDTO {
+    @Builder
+    public record Response(
+            Long partyId,
+            String partyName,
+            String addr1,
+            String addr2,
+            List<String> femaleLevel,
+            List<String> maleLevel,
+            String nextExerciseInfo,
+            Integer totalExerciseCount,
+            String partyImgUrl
+    ) {}
+}

--- a/src/main/java/umc/cockple/demo/domain/party/dto/PartyExerciseInfoDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/party/dto/PartyExerciseInfoDTO.java
@@ -1,0 +1,4 @@
+package umc.cockple.demo.domain.party.dto;
+
+public class PartyExcerciesInfoDTO {
+}

--- a/src/main/java/umc/cockple/demo/domain/party/dto/PartyExerciseInfoDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/party/dto/PartyExerciseInfoDTO.java
@@ -1,4 +1,9 @@
 package umc.cockple.demo.domain.party.dto;
 
-public class PartyExcerciesInfoDTO {
-}
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+public record PartyExerciseInfoDTO(
+        Long partyId,
+        Long count
+) {}

--- a/src/main/java/umc/cockple/demo/domain/party/exception/PartyErrorCode.java
+++ b/src/main/java/umc/cockple/demo/domain/party/exception/PartyErrorCode.java
@@ -22,6 +22,7 @@ public enum PartyErrorCode implements BaseErrorCode {
     INVALID_LEVEL_FORMAT(HttpStatus.BAD_REQUEST, "PARTY104", "유효하지 않은 급수 형식입니다."),
     MALE_LEVEL_REQUIRED(HttpStatus.BAD_REQUEST, "PARTY105", "혼복 모임은 남녀 급수 설정이 필수입니다."),
     INVALID_REQUEST_STATUS(HttpStatus.BAD_REQUEST, "PARTY106", "유효하지 않은 가입 신청 상태입니다. (PENDING 또는 APPROVED를 입력해주세요.)"),
+    INVALID_ORDER_TYPE(HttpStatus.BAD_REQUEST, "PARTY107", "유효하지 않은 정렬 기준입니다. (최신순, 오래된 순, 운동 많은 순 중 하나여야 합니다.)"),
 
     PARTY_NOT_FOUND(HttpStatus.NOT_FOUND, "PARTY201", "존재하지 않는 모임입니다."),
     JoinRequest_NOT_FOUND(HttpStatus.NOT_FOUND, "PARTY202", "존재하지 않는 가입신청입니다."),

--- a/src/main/java/umc/cockple/demo/domain/party/repository/PartyRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/party/repository/PartyRepository.java
@@ -1,7 +1,18 @@
 package umc.cockple.demo.domain.party.repository;
 
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import umc.cockple.demo.domain.party.domain.Party;
 
 public interface PartyRepository extends JpaRepository<Party, Long> {
+
+    @Query("""
+            SELECT p FROM Party p JOIN p.memberParties mp 
+            WHERE mp.member.id = :memberId
+            AND (:created = false OR p.ownerId = :memberId) 
+            """) //created가 true라면 p.ownerId = :memberId로 내가 만든 모임을 조회 (false라면 모든 내 모임 조회)
+    Slice<Party> findMyParty(@Param("memberId") Long memberId, @Param("created") boolean created, Pageable pageable);
 }

--- a/src/main/java/umc/cockple/demo/domain/party/repository/PartyRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/party/repository/PartyRepository.java
@@ -10,9 +10,9 @@ import umc.cockple.demo.domain.party.domain.Party;
 public interface PartyRepository extends JpaRepository<Party, Long> {
 
     @Query("""
-            SELECT p FROM Party p JOIN p.memberParties mp 
+            SELECT p FROM Party p JOIN p.memberParties mp
             WHERE mp.member.id = :memberId
-            AND (:created = false OR p.ownerId = :memberId) 
+            AND (:created = false OR p.ownerId = :memberId)
             """) //created가 true라면 p.ownerId = :memberId로 내가 만든 모임을 조회 (false라면 모든 내 모임 조회)
     Slice<Party> findMyParty(@Param("memberId") Long memberId, @Param("created") boolean created, Pageable pageable);
 }

--- a/src/main/java/umc/cockple/demo/domain/party/service/PartyQueryService.java
+++ b/src/main/java/umc/cockple/demo/domain/party/service/PartyQueryService.java
@@ -11,5 +11,5 @@ public interface PartyQueryService {
     Slice<PartyJoinDTO.Response> getJoinRequests(Long partyId, Long memberId, String status, Pageable pageable);
     PartyDetailDTO.Response getPartyDetails(Long partyId, Long memberId);
     Slice<PartySimpleDTO.Response> getSimpleMyParties(Long memberId, Pageable pageable);
-    Slice<PartyDTO.Response> getMyParties(Long memberId, Boolean created, Pageable pageable);
+    Slice<PartyDTO.Response> getMyParties(Long memberId, Boolean created, String sort, Pageable pageable);
 }

--- a/src/main/java/umc/cockple/demo/domain/party/service/PartyQueryService.java
+++ b/src/main/java/umc/cockple/demo/domain/party/service/PartyQueryService.java
@@ -2,6 +2,7 @@ package umc.cockple.demo.domain.party.service;
 
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
+import umc.cockple.demo.domain.party.dto.PartyDTO;
 import umc.cockple.demo.domain.party.dto.PartyDetailDTO;
 import umc.cockple.demo.domain.party.dto.PartyJoinDTO;
 import umc.cockple.demo.domain.party.dto.PartySimpleDTO;
@@ -10,4 +11,5 @@ public interface PartyQueryService {
     Slice<PartyJoinDTO.Response> getJoinRequests(Long partyId, Long memberId, String status, Pageable pageable);
     PartyDetailDTO.Response getPartyDetails(Long partyId, Long memberId);
     Slice<PartySimpleDTO.Response> getSimpleMyParties(Long memberId, Pageable pageable);
+    Slice<PartyDTO.Response> getMyParties(Long memberId, Boolean created, Pageable pageable);
 }

--- a/src/main/java/umc/cockple/demo/global/enums/PartyOrderType.java
+++ b/src/main/java/umc/cockple/demo/global/enums/PartyOrderType.java
@@ -1,9 +1,29 @@
 package umc.cockple.demo.global.enums;
 
+import lombok.Getter;
+import umc.cockple.demo.domain.party.exception.PartyErrorCode;
+import umc.cockple.demo.domain.party.exception.PartyException;
+
+import java.util.Arrays;
+
 public enum PartyOrderType {
 
-    LATEST,
-    EARLIEST,
-    MANY_EXERCISE
+    LATEST("최신순"),
+    OLDEST("오래된 순"),
+    EXERCISE_COUNT("운동 많은 순");
+
+    @Getter
+    private final String koreanName;
+
+    PartyOrderType(String koreanName) {
+        this.koreanName = koreanName;
+    }
+
+    public static PartyOrderType fromKorean(String korean) {
+        return Arrays.stream(values())
+                .filter(sortType -> sortType.koreanName.equals(korean.trim()))
+                .findFirst()
+                .orElseThrow(() -> new PartyException(PartyErrorCode.INVALID_ORDER_TYPE));
+    }
 
 }


### PR DESCRIPTION
## ❤️ 기능 설명
사용자가 가입한 모든 내 모임 목록을 조회합니다.
- 내가 만든 모임을 체크할 시, 내가 만든 모임만 조회되도록 구현했습니다.
- 정렬 기준으로 최신순, 오래된 순, 운동 많은 순을 선택 가능하도록 구현했습니다.
- 운동 정보 (가장 최신의 운동, 모임의 총 운동 개수)가 출력되도록 구현했습니다.
- 정렬 기준을 한글로 입력할 수 있도록 리팩토링했습니다.

swagger 테스트 성공 결과 스크린샷 첨부
<img width="796" height="292" alt="image" src="https://github.com/user-attachments/assets/36870a3a-da6e-4f44-bd53-991d65cf6885" />
<img width="786" height="268" alt="image" src="https://github.com/user-attachments/assets/840bf442-343a-406e-91d4-226dd2427b2c" />
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #130
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- 없습니다!

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [ ] 이슈넘버를 적었는가?
