### PR TITLE
[feat/#140] 모임 찜 관련 API 구현

### DIFF
--- a/src/main/java/umc/cockple/demo/domain/bookmark/controller/BookmarkController.java
+++ b/src/main/java/umc/cockple/demo/domain/bookmark/controller/BookmarkController.java
@@ -1,0 +1,44 @@
+package umc.cockple.demo.domain.bookmark.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+import umc.cockple.demo.domain.bookmark.service.BookmarkCommandService;
+import umc.cockple.demo.domain.bookmark.service.BookmarkQueryService;
+import umc.cockple.demo.global.response.BaseResponse;
+import umc.cockple.demo.global.response.code.status.CommonSuccessCode;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+@Validated
+@Tag(name = "Bookmark", description = "찜 API")
+public class BookmarkController {
+
+    private final BookmarkCommandService bookmarkCommandService;
+    private final BookmarkQueryService bookmarkQueryService;
+
+    @PostMapping(value = "/parties/{partyId}/bookmark")
+    @Operation(summary = "모임 찜 API",
+            description = "사용자가 원하는 모임을 찜해둘 수 있음")
+    public BaseResponse<Long> partyBookmark(@PathVariable Long partyId) {
+        // 추후 시큐리티를 통해 id 가져옴
+        Long memberId = 1L;
+
+        return BaseResponse.success(CommonSuccessCode.CREATED, bookmarkCommandService.partyBookmark(memberId, partyId));
+    }
+
+    @DeleteMapping(value = "/parties/{partyId}/bookmark")
+    @Operation(summary = "모임 찜 해제 API",
+            description = "사용자가 찜한 모임을 해제할 수 있음")
+    public BaseResponse<Long> releasePartyBookmark(@PathVariable Long partyId) {
+        // 추후 시큐리티를 통해 id 가져옴
+        Long memberId = 1L;
+
+        bookmarkCommandService.releasePartyBookmark(memberId, partyId);
+        return BaseResponse.success(CommonSuccessCode.NO_CONTENT);
+    }
+
+}

--- a/src/main/java/umc/cockple/demo/domain/bookmark/exception/BookmarkErrorCode.java
+++ b/src/main/java/umc/cockple/demo/domain/bookmark/exception/BookmarkErrorCode.java
@@ -1,0 +1,35 @@
+package umc.cockple.demo.domain.bookmark.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import umc.cockple.demo.global.response.code.BaseErrorCode;
+import umc.cockple.demo.global.response.dto.ErrorReasonDTO;
+
+@Getter
+@RequiredArgsConstructor
+public enum BookmarkErrorCode implements BaseErrorCode {
+
+    /**
+     * 1xx: 클라이언트가 수정해야 할 입력값 문제
+     * 2xx: 서버에서 리소스를 찾을 수 없는 문제
+     * 3xx: 권한/인증 문제
+     * 4xx: 비즈니스 로직 위반
+     */
+
+    ALREADY_BOOKMARK(HttpStatus.BAD_REQUEST, "BOOKMARK401", "이미 북마크가 되어있습니다"),
+    ALREADY_RELEASE_BOOKMARK(HttpStatus.BAD_REQUEST, "BOOKMARK402", "이미 찜이 되어있지 않습니다."),
+    NOT_FOUND_PARTY_BOOKMARK(HttpStatus.NOT_FOUND, "BOOKMARK403", "해당 모임 찜이 존재하지 않습니다."),
+
+
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    @Override
+    public ErrorReasonDTO getReason() {
+        return ErrorReasonDTO.of(code, message, httpStatus);
+    }
+}

--- a/src/main/java/umc/cockple/demo/domain/bookmark/exception/BookmarkException.java
+++ b/src/main/java/umc/cockple/demo/domain/bookmark/exception/BookmarkException.java
@@ -1,0 +1,9 @@
+package umc.cockple.demo.domain.bookmark.exception;
+
+import umc.cockple.demo.global.exception.GeneralException;
+import umc.cockple.demo.global.response.code.BaseErrorCode;
+
+public class BookmarkException extends GeneralException {
+
+    public BookmarkException(BaseErrorCode code) { super(code); }
+}

--- a/src/main/java/umc/cockple/demo/domain/bookmark/repository/ExerciseBookmarkRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/bookmark/repository/ExerciseBookmarkRepository.java
@@ -1,0 +1,7 @@
+package umc.cockple.demo.domain.bookmark.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import umc.cockple.demo.domain.bookmark.domain.ExerciseBookmark;
+
+public interface ExerciseBookmarkRepository extends JpaRepository<ExerciseBookmark, Long> {
+}

--- a/src/main/java/umc/cockple/demo/domain/bookmark/repository/PartyBookmarkRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/bookmark/repository/PartyBookmarkRepository.java
@@ -1,0 +1,16 @@
+package umc.cockple.demo.domain.bookmark.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import umc.cockple.demo.domain.bookmark.domain.PartyBookmark;
+import umc.cockple.demo.domain.member.domain.Member;
+import umc.cockple.demo.domain.party.domain.Party;
+
+import java.util.Map;
+import java.util.Optional;
+
+public interface PartyBookmarkRepository extends JpaRepository<PartyBookmark, Long> {
+
+    boolean existsByMemberAndParty(Member member, Party party);
+
+    Optional<PartyBookmark> findByMemberAndParty(Member member, Party party);
+}

--- a/src/main/java/umc/cockple/demo/domain/bookmark/service/BookmarkCommandService.java
+++ b/src/main/java/umc/cockple/demo/domain/bookmark/service/BookmarkCommandService.java
@@ -1,0 +1,97 @@
+package umc.cockple.demo.domain.bookmark.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import umc.cockple.demo.domain.bookmark.domain.PartyBookmark;
+import umc.cockple.demo.domain.bookmark.exception.BookmarkErrorCode;
+import umc.cockple.demo.domain.bookmark.exception.BookmarkException;
+import umc.cockple.demo.domain.bookmark.repository.ExerciseBookmarkRepository;
+import umc.cockple.demo.domain.bookmark.repository.PartyBookmarkRepository;
+import umc.cockple.demo.domain.exercise.repository.ExerciseRepository;
+import umc.cockple.demo.domain.member.domain.Member;
+import umc.cockple.demo.domain.member.exception.MemberErrorCode;
+import umc.cockple.demo.domain.member.exception.MemberException;
+import umc.cockple.demo.domain.member.repository.MemberRepository;
+import umc.cockple.demo.domain.party.domain.Party;
+import umc.cockple.demo.domain.party.exception.PartyErrorCode;
+import umc.cockple.demo.domain.party.exception.PartyException;
+import umc.cockple.demo.domain.party.repository.PartyRepository;
+import umc.cockple.demo.global.enums.PartyOrderType;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+@Slf4j
+public class BookmarkCommandService {
+
+    private final PartyBookmarkRepository partyBookmarkRepository;
+    private final ExerciseBookmarkRepository exerciseBookmarkRepository;
+    private final MemberRepository memberRepository;
+    private final PartyRepository partyRepository;
+    private final ExerciseRepository exerciseRepository;
+
+    public Long partyBookmark(Long memberId, Long partyId) {
+        // 회원 조회하기
+        Member member = findByMemberId(memberId);
+
+        // 찜하고 싶은 모임 조회
+        Party party = findByPartyId(partyId);
+
+        // 찜 여부 확인
+        if (partyBookmarkRepository.existsByMemberAndParty(member, party)) {
+            throw new BookmarkException(BookmarkErrorCode.ALREADY_BOOKMARK);
+        }
+
+        PartyBookmark bookmark = PartyBookmark.builder()
+                .party(party)
+                .member(member)
+                .orderType(PartyOrderType.LATEST) // 없앨수도
+                .build()
+        ;
+
+        // 찜하기
+        partyBookmarkRepository.save(bookmark);
+        return bookmark.getId();
+    }
+
+
+    public void releasePartyBookmark(Long memberId, Long partyId) {
+        // 회원 조회하기
+        Member member = findByMemberId(memberId);
+
+        // 찜 해제 싶은 모임 조회
+        Party party = findByPartyId(partyId);
+
+        // 찜 여부 확인
+        if (!partyBookmarkRepository.existsByMemberAndParty(member, party)) {
+            throw new BookmarkException(BookmarkErrorCode.ALREADY_RELEASE_BOOKMARK);
+        }
+
+        // 모임 찜 찾기
+        PartyBookmark bookmark = findByMemberAndParty(member, party);
+
+        // 찜 지우기
+        partyBookmarkRepository.delete(bookmark);
+        member.getPartyBookmarks().remove(bookmark);
+    }
+
+
+    private Member findByMemberId(Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
+    }
+
+    private Party findByPartyId(Long partyId) {
+        return partyRepository.findById(partyId)
+                .orElseThrow(() -> new PartyException(PartyErrorCode.PARTY_NOT_FOUND));
+    }
+
+    private PartyBookmark findByMemberAndParty(Member member, Party party) {
+        return partyBookmarkRepository.findByMemberAndParty(member, party)
+                .orElseThrow(() -> new BookmarkException(BookmarkErrorCode.NOT_FOUND_PARTY_BOOKMARK));
+    }
+
+
+}

--- a/src/main/java/umc/cockple/demo/domain/bookmark/service/BookmarkQueryService.java
+++ b/src/main/java/umc/cockple/demo/domain/bookmark/service/BookmarkQueryService.java
@@ -1,0 +1,13 @@
+package umc.cockple.demo.domain.bookmark.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Slf4j
+public class BookmarkQueryService {
+}


### PR DESCRIPTION
## ❤️ 기능 설명
- 모임 찜하기
- 모임 찜 해제하기

모임 찜하기 결과
<img width="702" height="834" alt="스크린샷 2025-07-21 021403" src="https://github.com/user-attachments/assets/04078a42-6bf8-4ec1-a193-99631564f865" />

모임 찜 테이블에 데이터 생성됨을 확인
<img width="997" height="133" alt="스크린샷 2025-07-21 021426" src="https://github.com/user-attachments/assets/65b616ac-7d32-4893-99eb-f8a8df12455c" />


찜 해제시 삭제
<img width="710" height="802" alt="스크린샷 2025-07-21 022639" src="https://github.com/user-attachments/assets/995a7b60-8a06-4f39-8889-3b39b9de8b4e" />

<br>

## 연결된 issue
연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #140 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [ ] 이슈넘버를 적었는가?
