### PR TITLE
[docs#142] 운동 도메인 DTO의 Request 객체에 @Schema 어노테이션 추가

### DIFF
--- a/src/main/java/umc/cockple/demo/domain/exercise/dto/ExerciseCancelDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/dto/ExerciseCancelDTO.java
@@ -1,10 +1,12 @@
 package umc.cockple.demo.domain.exercise.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 
 public class ExerciseCancelDTO {
 
+    @Schema(name = "ExerciseCancelByManagerRequest", description = "매니저 권한에 의한 운동 참여 취소 요청")
     public record ByManagerRequest(
             @NotNull
             Boolean isGuest

--- a/src/main/java/umc/cockple/demo/domain/exercise/dto/ExerciseCreateDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/dto/ExerciseCreateDTO.java
@@ -1,5 +1,6 @@
 package umc.cockple.demo.domain.exercise.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.*;
 import lombok.Builder;
 import umc.cockple.demo.domain.exercise.exception.ExerciseErrorCode;
@@ -13,6 +14,7 @@ import java.time.format.DateTimeParseException;
 public class ExerciseCreateDTO {
 
     @Builder
+    @Schema(name = "ExerciseCreateRequest", description = "운동 생성 요청")
     public record Request(
 
             @NotBlank(message = "운동 날짜는 필수입니다.")

--- a/src/main/java/umc/cockple/demo/domain/exercise/dto/ExerciseUpdateDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/dto/ExerciseUpdateDTO.java
@@ -1,5 +1,6 @@
 package umc.cockple.demo.domain.exercise.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.*;
 import lombok.Builder;
 import umc.cockple.demo.domain.exercise.exception.ExerciseErrorCode;
@@ -12,6 +13,7 @@ import java.time.format.DateTimeParseException;
 
 public class ExerciseUpdateDTO {
 
+    @Schema(name = "ExerciseUpdateRequest", description = "운동 수정 요청")
     public record Request(
 
             @Pattern(regexp = "^\\d{4}-\\d{2}-\\d{2}$", message = "날짜 형식: YYYY-MM-DD")


### PR DESCRIPTION
## ❤️ 기능 설명
@Schema 어노테이션을 통해 스웨거가 Request 객체를 구분하지 못하는 문제를 해결했습니다.

swagger 테스트 성공 결과 스크린샷 첨부
<img width="2149" height="1002" alt="image" src="https://github.com/user-attachments/assets/c0716204-cdc9-4288-a5a0-859a9cf3197a" />
<img width="2136" height="816" alt="image" src="https://github.com/user-attachments/assets/c7db304c-6279-48c9-a1b0-49b5cdbfef53" />
<img width="2171" height="969" alt="image" src="https://github.com/user-attachments/assets/eb22f688-1f42-4cf0-966a-85b5e1d97b74" />
<img width="2160" height="931" alt="image" src="https://github.com/user-attachments/assets/9ea896a6-d42d-465c-b632-8e2599500efb" />


<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #142 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!
일단 제 환경에서는 잘 되는데, 이게 사람마다 다르다고 하시니 한 번 PULL 받아서 확인 부탁드립니다!

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
