### PR TITLE
[feat/#145] 전역 에러 핸들러에서 Validation 과정에서 에러 응답을 1개만 던지는 대신 전체를 던지도록 변경

### DIFF
--- a/src/main/java/umc/cockple/demo/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/umc/cockple/demo/global/exception/GlobalExceptionHandler.java
@@ -107,7 +107,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
         log.warn("Constraint violation: uri={}, message={}", requestURI, violations);
 
-        String errorMessage = buildErrorMessage(ex);
+        String errorMessage = buildAllErrorMessages(ex);
         BaseResponse<Void> response = BaseResponse.error(CommonErrorCode.VALIDATION_FAILED, errorMessage);
 
         return ResponseEntity
@@ -125,11 +125,21 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
                 .toList();
     }
 
-    private static String buildErrorMessage(ConstraintViolationException ex) {
-        return ex.getConstraintViolations().stream()
-                .findFirst()
+    private static String buildAllErrorMessages(ConstraintViolationException ex) {
+        List<String> violationMessages = ex.getConstraintViolations().stream()
                 .map(ConstraintViolation::getMessage)
-                .orElse("요청 파라미터가 올바르지 않습니다.");
+                .distinct()
+                .toList();
+
+        if (violationMessages.isEmpty()) {
+            return "요청 파라미터가 올바르지 않습니다.";
+        }
+
+        if (violationMessages.size() == 1) {
+            return violationMessages.get(0);
+        } else {
+            return String.join(", ", violationMessages);
+        }
     }
 
     /**
@@ -145,7 +155,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
         log.warn("Type mismatch: uri={}, param={}, value={}, expectedType={}",
                 requestURI, ex.getName(), ex.getValue(), expectedType);
 
-        String errorMessage = buildErrorMessage(ex, expectedType);
+        String errorMessage = buildAllErrorMessages(ex, expectedType);
         BaseResponse<Void> response = BaseResponse.error(CommonErrorCode.INVALID_PARAMETER_TYPE, errorMessage);
 
         return ResponseEntity
@@ -153,7 +163,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
                 .body(response);
     }
 
-    private static String buildErrorMessage(MethodArgumentTypeMismatchException ex, String expectedType) {
+    private static String buildAllErrorMessages(MethodArgumentTypeMismatchException ex, String expectedType) {
         return String.format("파라미터 '%s'는 %s 타입이어야 합니다.",
                 ex.getName(), expectedType);
     }

--- a/src/main/java/umc/cockple/demo/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/umc/cockple/demo/global/exception/GlobalExceptionHandler.java
@@ -62,7 +62,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
         log.warn("Validation failed: uri={}, errors={}", requestURI, fieldErrors);
 
-        String errorMessage = buildErrorMessage(ex);
+        String errorMessage = buildAllErrorMessages(ex);
         BaseResponse<Void> response = BaseResponse.error(CommonErrorCode.VALIDATION_FAILED, errorMessage);
 
         return ResponseEntity
@@ -76,11 +76,23 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
                 .toList();
     }
 
-    private static String buildErrorMessage(MethodArgumentNotValidException ex) {
-        return ex.getBindingResult().getFieldErrors().stream()
-                .findFirst()
+    private static String buildAllErrorMessages(MethodArgumentNotValidException ex) {
+        List<FieldError> fieldErrors = ex.getBindingResult().getFieldErrors();
+
+        if (fieldErrors.isEmpty()) {
+            return "입력값 검증에 실패했습니다.";
+        }
+
+        List<String> errorMessages = fieldErrors.stream()
                 .map(FieldError::getDefaultMessage)
-                .orElse("입력값 검증에 실패했습니다.");
+                .distinct()
+                .toList();
+
+        if (errorMessages.size() == 1) {
+            return errorMessages.get(0);
+        } else {
+            return String.join(", ", errorMessages);
+        }
     }
 
     /**


### PR DESCRIPTION
## ❤️ 기능 설명
RequestBody, RequestParam, PathVariable 검증 시 
성능을 위해 첫 번째 에러만 던지도록 코드를 구현했었는데,

그것보다는 UX가 중요하다고 생각이 들어 전체 에러를 반환하도록 하였습니다.

swagger 테스트 성공 결과 스크린샷 첨부
<img width="2126" height="1165" alt="image" src="https://github.com/user-attachments/assets/331555b4-cac1-4193-ba01-8d5390004086" />

위와 같이 명시하지 않은 필드 2개가 모두 표기됩니다.
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #145 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
