### PR TITLE
[feat/#144] 모임 운동 캘린더 조회 API 구현

### DIFF
--- a/src/main/java/umc/cockple/demo/domain/exercise/controller/ExerciseController.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/controller/ExerciseController.java
@@ -240,7 +240,7 @@ public class ExerciseController {
     @ApiResponse(responseCode = "200", description = "모임 운동 캘린더 성공")
     @ApiResponse(responseCode = "400", description = "입력값 오류 또는 비즈니스 룰 위반")
     @ApiResponse(responseCode = "404", description = "존재하지 않는 모임")
-    public BaseResponse<PartyExerciseCalenderDTO.Response> getPartyExerciseCalender(
+    public BaseResponse<PartyExerciseCalendarDTO.Response> getPartyExerciseCalender(
             @PathVariable Long partyId,
             @RequestParam(required = false) LocalDate startDate,
             @RequestParam(required = false) LocalDate endDate,
@@ -250,7 +250,7 @@ public class ExerciseController {
         // TODO: JWT 인증 구현 후 교체 예정
         Long memberId = 1L; // 임시값
 
-        PartyExerciseCalenderDTO.Response response = exerciseQueryService.getPartyExerciseCalender(
+        PartyExerciseCalendarDTO.Response response = exerciseQueryService.getPartyExerciseCalender(
                 partyId, memberId, startDate, endDate);
 
         return BaseResponse.success(CommonSuccessCode.OK, response);

--- a/src/main/java/umc/cockple/demo/domain/exercise/controller/ExerciseController.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/controller/ExerciseController.java
@@ -14,6 +14,8 @@ import umc.cockple.demo.domain.exercise.service.ExerciseQueryService;
 import umc.cockple.demo.global.response.BaseResponse;
 import umc.cockple.demo.global.response.code.status.CommonSuccessCode;
 
+import java.time.LocalDate;
+
 @RestController
 @RequestMapping("/api")
 @RequiredArgsConstructor
@@ -55,7 +57,7 @@ public class ExerciseController {
     public BaseResponse<ExerciseJoinDTO.Response> JoinExercise(
             @PathVariable Long exerciseId,
             Authentication authentication
-    ){
+    ) {
 
         // TODO: JWT 인증 구현 후 교체 예정
         Long memberId = 1L; // 임시값
@@ -182,7 +184,7 @@ public class ExerciseController {
             @PathVariable Long exerciseId,
             @Valid @RequestBody ExerciseUpdateDTO.Request request,
             Authentication authentication
-    ){
+    ) {
 
         // TODO: JWT 인증 구현 후 교체 예정
         Long memberId = 1L; // 임시값
@@ -201,7 +203,7 @@ public class ExerciseController {
     public BaseResponse<ExerciseDetailDTO.Response> getExerciseDetail(
             @PathVariable Long exerciseId,
             Authentication authentication
-    ){
+    ) {
 
         // TODO: JWT 인증 구현 후 교체 예정
         Long memberId = 1L; // 임시값
@@ -220,7 +222,7 @@ public class ExerciseController {
     public BaseResponse<ExerciseMyGuestListDTO.Response> getMyInvitedGuests(
             @PathVariable Long exerciseId,
             Authentication authentication
-    ){
+    ) {
 
         // TODO: JWT 인증 구현 후 교체 예정
         Long memberId = 1L; // 임시값
@@ -230,4 +232,28 @@ public class ExerciseController {
 
         return BaseResponse.success(CommonSuccessCode.OK, response);
     }
+
+
+    @GetMapping("/parties/{partyId}/exercises/calender")
+    @Operation(summary = "모임 운동 캘린더 조회",
+            description = "모임 운동 캘린더를 조회합니다. 시작 날짜 ~ 종료 날짜까지의 데이터를 불러옵니다. 파라미터가 없으면 과거 1주 ~ 미래 3주까지의 데이터를 불러옵니다")
+    @ApiResponse(responseCode = "200", description = "모임 운동 캘린더 성공")
+    @ApiResponse(responseCode = "400", description = "입력값 오류 또는 비즈니스 룰 위반")
+    @ApiResponse(responseCode = "404", description = "존재하지 않는 모임")
+    public BaseResponse<PartyExerciseCalenderDTO.Response> getPartyExerciseCalender(
+            @PathVariable Long partyId,
+            @RequestParam(required = false) LocalDate startDate,
+            @RequestParam(required = false) LocalDate endDate,
+            Authentication authentication
+    ) {
+
+        // TODO: JWT 인증 구현 후 교체 예정
+        Long memberId = 1L; // 임시값
+
+        PartyExerciseCalenderDTO.Response response = exerciseQueryService.getPartyExerciseCalender(
+                partyId, memberId, startDate, endDate);
+
+        return BaseResponse.success(CommonSuccessCode.OK, response);
+    }
+
 }

--- a/src/main/java/umc/cockple/demo/domain/exercise/converter/ExerciseConverter.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/converter/ExerciseConverter.java
@@ -10,6 +10,7 @@ import umc.cockple.demo.domain.member.domain.MemberExercise;
 import umc.cockple.demo.global.enums.Role;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -225,6 +226,54 @@ public class ExerciseConverter {
                 .endDate(end)
                 .isMember(isMember)
                 .partyName(partyName)
+                .build();
+    }
+
+    private List<PartyExerciseCalendarDTO.WeeklyExercises> groupExerciseByWeek(List<Exercise> exercises, LocalDate start, LocalDate end) {
+
+        List<PartyExerciseCalendarDTO.WeeklyExercises> weeks = new ArrayList<>();
+
+        LocalDate weekStart = start.minusDays(start.getDayOfWeek().getValue() - 1);
+
+        while (!weekStart.isAfter(end)) {
+            LocalDate weekEnd = weekStart.plusDays(6);
+
+            LocalDate currentWeekStart = weekStart;
+            List<Exercise> weekExercises = exercises.stream()
+                    .filter(exercise -> {
+                        LocalDate exerciseDate = exercise.getDate();
+                        return (!exerciseDate.isBefore(currentWeekStart) && !exerciseDate.isAfter(weekEnd));
+                    })
+                    .toList();
+
+            List<PartyExerciseCalendarDTO.ExerciseCalendarItem> exerciseItems = weekExercises.stream()
+                    .map(this::toCalendarItem)
+                    .toList();
+
+            weeks.add(PartyExerciseCalendarDTO.WeeklyExercises.builder()
+                    .weekStartDate(currentWeekStart)
+                    .weekEndDate(weekEnd)
+                    .exercises(exerciseItems)
+                    .build());
+
+            weekStart = currentWeekStart.plusWeeks(1);
+        }
+
+        return weeks;
+    }
+
+    private PartyExerciseCalendarDTO.ExerciseCalendarItem toCalendarItem(Exercise exercise) {
+        return PartyExerciseCalendarDTO.ExerciseCalendarItem.builder()
+                .exerciseId(exercise.getId())
+                .date(exercise.getDate())
+                .dayOfWeek(exercise.getDate().getDayOfWeek().name())
+                .startTime(exercise.getStartTime())
+                .endTime(exercise.getEndTime())
+                .buildingName(exercise.getExerciseAddr().getBuildingName())
+                .femaleLevel()
+                .maleLevel()
+                .currentParticipants(exercise.getNowCapacity())
+                .maxCapacity(exercise.getMaxCapacity())
                 .build();
     }
 

--- a/src/main/java/umc/cockple/demo/domain/exercise/converter/ExerciseConverter.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/converter/ExerciseConverter.java
@@ -7,9 +7,9 @@ import umc.cockple.demo.domain.exercise.domain.Guest;
 import umc.cockple.demo.domain.exercise.dto.*;
 import umc.cockple.demo.domain.member.domain.Member;
 import umc.cockple.demo.domain.member.domain.MemberExercise;
-import umc.cockple.demo.global.enums.Gender;
 import umc.cockple.demo.global.enums.Role;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
 
@@ -212,6 +212,19 @@ public class ExerciseConverter {
                 .gender(guest.getGender())
                 .level(guest.getLevel())
                 .inviterName(inviterName)
+                .build();
+    }
+
+    public PartyExerciseCalenderDTO.Response toCalenderResponse(
+            List<Exercise> exercises, LocalDate start, LocalDate end, Boolean isMember, String partyName) {
+
+        List<PartyExerciseCalenderDTO.WeeklyExercises> weeks = groupExerciseByWeek(exercises, start, end);
+
+        return PartyExerciseCalenderDTO.Response.builder()
+                .startDate(start)
+                .endDate(end)
+                .isMember(isMember)
+                .partyName(partyName)
                 .build();
     }
 }

--- a/src/main/java/umc/cockple/demo/domain/exercise/converter/ExerciseConverter.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/converter/ExerciseConverter.java
@@ -215,16 +215,17 @@ public class ExerciseConverter {
                 .build();
     }
 
-    public PartyExerciseCalenderDTO.Response toCalenderResponse(
+    public PartyExerciseCalendarDTO.Response toCalenderResponse(
             List<Exercise> exercises, LocalDate start, LocalDate end, Boolean isMember, String partyName) {
 
-        List<PartyExerciseCalenderDTO.WeeklyExercises> weeks = groupExerciseByWeek(exercises, start, end);
+        List<PartyExerciseCalendarDTO.WeeklyExercises> weeks = groupExerciseByWeek(exercises, start, end);
 
-        return PartyExerciseCalenderDTO.Response.builder()
+        return PartyExerciseCalendarDTO.Response.builder()
                 .startDate(start)
                 .endDate(end)
                 .isMember(isMember)
                 .partyName(partyName)
                 .build();
     }
+
 }

--- a/src/main/java/umc/cockple/demo/domain/exercise/dto/PartyExerciseCalendarDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/dto/PartyExerciseCalendarDTO.java
@@ -6,7 +6,7 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.List;
 
-public class PartyExerciseCalenderDTO {
+public class PartyExerciseCalendarDTO {
 
     @Builder
     public record Response(

--- a/src/main/java/umc/cockple/demo/domain/exercise/dto/PartyExerciseCalenderDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/dto/PartyExerciseCalenderDTO.java
@@ -1,4 +1,43 @@
 package umc.cockple.demo.domain.exercise.dto;
 
+import lombok.Builder;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+
 public class PartyExerciseCalenderDTO {
+
+    @Builder
+    public record Response(
+            LocalDate startDate,
+            LocalDate endDate,
+            Boolean isMember,
+            String partyName,
+            List<WeeklyExercises> weeks
+    ) {
+    }
+
+    @Builder
+    public record WeeklyExercises(
+            LocalDate weekStartDate,
+            LocalDate weekEndDate,
+            List<ExerciseCalendarItem> exercises
+    ) {
+    }
+
+    @Builder
+    public record ExerciseCalendarItem(
+            Long exerciseId,
+            LocalDate date,
+            String dayOfWeek,
+            LocalTime startTime,
+            LocalTime endTime,
+            String buildingName,
+            List<String> femaleLevel,
+            List<String> maleLevel,
+            Integer currentParticipants,
+            Integer maxCapacity
+    ) {
+    }
 }

--- a/src/main/java/umc/cockple/demo/domain/exercise/dto/PartyExerciseCalenderDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/dto/PartyExerciseCalenderDTO.java
@@ -1,0 +1,4 @@
+package umc.cockple.demo.domain.exercise.dto;
+
+public class PartyExerciseCalenderDTO {
+}

--- a/src/main/java/umc/cockple/demo/domain/exercise/exception/ExerciseErrorCode.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/exception/ExerciseErrorCode.java
@@ -20,6 +20,8 @@ public enum ExerciseErrorCode implements BaseErrorCode {
     INVALID_START_TIME_FORMAT(HttpStatus.BAD_REQUEST, "EXERCISE102", "유효하지 않은 시작 시간 형식입니다. (HH:mm 형식으로 입력해주세요)"),
     INVALID_END_TIME_FORMAT(HttpStatus.BAD_REQUEST, "EXERCISE103", "유효하지 않은 종료 시간 형식입니다. (HH:mm 형식으로 입력해주세요)"),
     INVALID_EXERCISE_TIME(HttpStatus.BAD_REQUEST, "EXERCISE104", "종료 시간은 시작 시간보다 늦어야 합니다."),
+    INCOMPLETE_DATE_RANGE(HttpStatus.BAD_REQUEST, "EXERCISE105", "시작 날짜와 종료 날짜는 둘 다 null이거나 둘 다 null이 아니어야 합니다."),
+    INVALID_DATE_RANGE(HttpStatus.BAD_REQUEST, "EXERCISE106", "종료 날짜는 시작 날짜보다 이후여야 합니다"),
 
     PARTY_NOT_FOUND(HttpStatus.NOT_FOUND, "EXERCISE201", "존재하지 않는 파티입니다."),
     EXERCISE_NOT_FOUND(HttpStatus.NOT_FOUND, "EXERCISE202", "존재하지 않는 운동입니다."),
@@ -39,7 +41,7 @@ public enum ExerciseErrorCode implements BaseErrorCode {
     EXERCISE_ALREADY_STARTED_CANCEL(HttpStatus.BAD_REQUEST, "EXERCISE404", "이미 시작된 운동에는 취소할 수 없습니다."),
     EXERCISE_ALREADY_STARTED_UPDATE(HttpStatus.BAD_REQUEST, "EXERCISE405", "이미 시작된 운동은 수정할 수 없습니다."),
     ALREADY_JOINED_EXERCISE(HttpStatus.BAD_REQUEST, "EXERCISE406", "이미 참여 신청한 운동입니다."),
-    GUEST_IS_NOT_PARTICIPATED_IN_EXERCISE(HttpStatus.BAD_REQUEST, "EXERCISE407", "게스트가 이 운동에 참여해있지 않습니다.."),
+    GUEST_IS_NOT_PARTICIPATED_IN_EXERCISE(HttpStatus.BAD_REQUEST, "EXERCISE407", "게스트가 이 운동에 참여해있지 않습니다."),
     MEMBER_LEVEL_NOT_ALLOWED(HttpStatus.FORBIDDEN, "EXERCISE408", "해당 급수로는 이 운동에 참여할 수 없습니다."),
     MEMBER_AGE_NOT_ALLOWED(HttpStatus.FORBIDDEN, "EXERCISE409", "해당 나이로는 이 운동에 참여할 수 없습니다.");
 

--- a/src/main/java/umc/cockple/demo/domain/exercise/exception/ExerciseErrorCode.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/exception/ExerciseErrorCode.java
@@ -19,6 +19,7 @@ public enum ExerciseErrorCode implements BaseErrorCode {
     INVALID_DATE_FORMAT(HttpStatus.BAD_REQUEST, "EXERCISE101", "유효하지 않은 날짜 형식입니다. (YYYY-MM-DD 형식으로 입력해주세요)"),
     INVALID_START_TIME_FORMAT(HttpStatus.BAD_REQUEST, "EXERCISE102", "유효하지 않은 시작 시간 형식입니다. (HH:mm 형식으로 입력해주세요)"),
     INVALID_END_TIME_FORMAT(HttpStatus.BAD_REQUEST, "EXERCISE103", "유효하지 않은 종료 시간 형식입니다. (HH:mm 형식으로 입력해주세요)"),
+    INVALID_EXERCISE_TIME(HttpStatus.BAD_REQUEST, "EXERCISE104", "종료 시간은 시작 시간보다 늦어야 합니다."),
 
     PARTY_NOT_FOUND(HttpStatus.NOT_FOUND, "EXERCISE201", "존재하지 않는 파티입니다."),
     EXERCISE_NOT_FOUND(HttpStatus.NOT_FOUND, "EXERCISE202", "존재하지 않는 운동입니다."),
@@ -32,16 +33,15 @@ public enum ExerciseErrorCode implements BaseErrorCode {
     GUEST_INVITATION_NOT_ALLOWED(HttpStatus.FORBIDDEN, "EXERCISE304", "외부 게스트 초대가 허용되지 않았습니다."),
     GUEST_NOT_INVITED_BY_MEMBER(HttpStatus.FORBIDDEN, "EXERCISE305", "본인이 아닌 다른 사용자에 의해 초대된 게스트입니다."),
 
-    INVALID_EXERCISE_TIME(HttpStatus.BAD_REQUEST, "EXERCISE401", "종료 시간은 시작 시간보다 늦어야 합니다."),
-    PAST_TIME_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "EXERCISE402", "운동 시간은 과거로 할 수 없습니다."),
-    EXERCISE_ALREADY_STARTED_PARTICIPATION(HttpStatus.BAD_REQUEST, "EXERCISE403", "이미 시작된 운동에는 참여할 수 없습니다."),
-    EXERCISE_ALREADY_STARTED_INVITATION(HttpStatus.BAD_REQUEST, "EXERCISE404", "이미 시작된 운동에는 초대할 수 없습니다."),
-    EXERCISE_ALREADY_STARTED_CANCEL(HttpStatus.BAD_REQUEST, "EXERCISE405", "이미 시작된 운동에는 취소할 수 없습니다."),
-    EXERCISE_ALREADY_STARTED_UPDATE(HttpStatus.BAD_REQUEST, "EXERCISE406", "이미 시작된 운동은 수정할 수 없습니다."),
-    ALREADY_JOINED_EXERCISE(HttpStatus.BAD_REQUEST, "EXERCISE407", "이미 참여 신청한 운동입니다."),
-    GUEST_IS_NOT_PARTICIPATED_IN_EXERCISE(HttpStatus.BAD_REQUEST, "EXERCISE408", "게스트가 이 운동에 참여해있지 않습니다.."),
-    MEMBER_LEVEL_NOT_ALLOWED(HttpStatus.FORBIDDEN, "EXERCISE409", "해당 급수로는 이 운동에 참여할 수 없습니다."),
-    MEMBER_AGE_NOT_ALLOWED(HttpStatus.FORBIDDEN, "EXERCISE410", "해당 나이로는 이 운동에 참여할 수 없습니다.");
+    PAST_TIME_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "EXERCISE401", "운동 시간은 과거로 할 수 없습니다."),
+    EXERCISE_ALREADY_STARTED_PARTICIPATION(HttpStatus.BAD_REQUEST, "EXERCISE402", "이미 시작된 운동에는 참여할 수 없습니다."),
+    EXERCISE_ALREADY_STARTED_INVITATION(HttpStatus.BAD_REQUEST, "EXERCISE403", "이미 시작된 운동에는 초대할 수 없습니다."),
+    EXERCISE_ALREADY_STARTED_CANCEL(HttpStatus.BAD_REQUEST, "EXERCISE404", "이미 시작된 운동에는 취소할 수 없습니다."),
+    EXERCISE_ALREADY_STARTED_UPDATE(HttpStatus.BAD_REQUEST, "EXERCISE405", "이미 시작된 운동은 수정할 수 없습니다."),
+    ALREADY_JOINED_EXERCISE(HttpStatus.BAD_REQUEST, "EXERCISE406", "이미 참여 신청한 운동입니다."),
+    GUEST_IS_NOT_PARTICIPATED_IN_EXERCISE(HttpStatus.BAD_REQUEST, "EXERCISE407", "게스트가 이 운동에 참여해있지 않습니다.."),
+    MEMBER_LEVEL_NOT_ALLOWED(HttpStatus.FORBIDDEN, "EXERCISE408", "해당 급수로는 이 운동에 참여할 수 없습니다."),
+    MEMBER_AGE_NOT_ALLOWED(HttpStatus.FORBIDDEN, "EXERCISE409", "해당 나이로는 이 운동에 참여할 수 없습니다.");
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/umc/cockple/demo/domain/exercise/repository/ExerciseRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/repository/ExerciseRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.repository.query.Param;
 import umc.cockple.demo.domain.exercise.domain.Exercise;
 import umc.cockple.demo.domain.party.dto.PartyExerciseInfoDTO;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
@@ -44,4 +45,18 @@ public interface ExerciseRepository extends JpaRepository<Exercise, Long> {
             ORDER BY e.date ASC, e.startTime ASC
             """)
     List<Exercise> findUpcomingExercisesByPartyIds(@Param("partyIds") List<Long> partyIds);
+
+    @Query("""
+            SELECT e FROM Exercise e 
+            JOIN FETCH e.exerciseAddr addr
+            LEFT JOIN FETCH e.memberExercises me
+            LEFT JOIN FETCH e.guests g
+            WHERE e.party.id = :partyId 
+            AND e.date BETWEEN :startDate AND :endDate
+            ORDER BY e.date ASC, e.startTime ASC
+            """)
+    List<Exercise> findByPartyIdAndDateRange(
+            @Param("partyId") Long partyId,
+            @Param("startDate") LocalDate startDate,
+            @Param("endDate") LocalDate endDate);
 }

--- a/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseQueryService.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseQueryService.java
@@ -99,7 +99,12 @@ public class ExerciseQueryService {
         Member member = findMemberOrThrow(memberId);
         validateGetPartyExerciseCalender(startDate, endDate);
 
-        return null;
+        List<Exercise> exercises = exerciseRepository.findByPartyIdAndDateRange(
+                partyId, startDate, endDate);
+
+        log.info("모임 운동 캘린더 조회 완료 - partyId: {}, 조회된 운동 수: {}", partyId, exercises.size());
+
+        return exerciseConverter.toCalenderResponse(exercises, startDate, endDate);
     }
 
     // ========== 검증 메서드들 ==========

--- a/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseQueryService.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseQueryService.java
@@ -95,7 +95,7 @@ public class ExerciseQueryService {
         log.info("모임 운동 캘린더 조회 시작 - partyId = {}, memberId = {}, startDate = {}, endDate = {}",
                 partyId, memberId, startDate, endDate);
 
-        Party party = findPartyOrThrow(partyId);
+        Party party = findPartyWithLevelsOrThrow(partyId);
         Member member = findMemberOrThrow(memberId);
         validateGetPartyExerciseCalender(startDate, endDate);
 
@@ -106,7 +106,7 @@ public class ExerciseQueryService {
 
         log.info("모임 운동 캘린더 조회 완료 - partyId: {}, 조회된 운동 수: {}", partyId, exercises.size());
 
-        return exerciseConverter.toCalenderResponse(exercises, dateRange.start(), dateRange.end(), isMember, party.getPartyName());
+        return exerciseConverter.toCalenderResponse(exercises, dateRange.start(), dateRange.end(), isMember, party);
     }
 
     // ========== 검증 메서드들 ==========
@@ -400,8 +400,8 @@ public class ExerciseQueryService {
         return guestRepository.findByExerciseIdAndInviterId(exerciseId, memberId);
     }
 
-    private Party findPartyOrThrow(Long partyId) {
-        return partyRepository.findById(partyId)
+    private Party findPartyWithLevelsOrThrow(Long partyId) {
+        return partyRepository.findByIdWithLevels(partyId)
                 .orElseThrow(() -> new ExerciseException(ExerciseErrorCode.PARTY_NOT_FOUND));
     }
 

--- a/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseQueryService.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseQueryService.java
@@ -99,13 +99,14 @@ public class ExerciseQueryService {
         Member member = findMemberOrThrow(memberId);
         validateGetPartyExerciseCalender(startDate, endDate);
 
+        Boolean isMember = isPartyMember(party, member);
         DateRange dateRange = calculateDateRange(startDate, endDate);
 
         List<Exercise> exercises = findExercisesByPartyIdAndDateRange(partyId, dateRange.start(), dateRange.end());
 
         log.info("모임 운동 캘린더 조회 완료 - partyId: {}, 조회된 운동 수: {}", partyId, exercises.size());
 
-        return exerciseConverter.toCalenderResponse(exercises, dateRange.start(), dateRange.end());
+        return exerciseConverter.toCalenderResponse(exercises, dateRange.start(), dateRange.end(), isMember, party.getPartyName());
     }
 
     // ========== 검증 메서드들 ==========
@@ -242,6 +243,10 @@ public class ExerciseQueryService {
         int femaleCount = totalCount - maleCount;
 
         return new ExerciseMyGuestListDTO.GuestStatistics(totalCount, maleCount, femaleCount);
+    }
+
+    private boolean isPartyMember(Party party, Member member) {
+        return memberPartyRepository.existsByPartyAndMember(party, member);
     }
 
     private DateRange calculateDateRange(LocalDate startDate, LocalDate endDate) {

--- a/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseQueryService.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseQueryService.java
@@ -11,7 +11,7 @@ import umc.cockple.demo.domain.exercise.domain.Guest;
 import umc.cockple.demo.domain.exercise.dto.ExerciseDetailDTO;
 import umc.cockple.demo.domain.exercise.dto.ExerciseDetailDTO.ParticipantInfo;
 import umc.cockple.demo.domain.exercise.dto.ExerciseMyGuestListDTO;
-import umc.cockple.demo.domain.exercise.dto.PartyExerciseCalenderDTO;
+import umc.cockple.demo.domain.exercise.dto.PartyExerciseCalendarDTO;
 import umc.cockple.demo.domain.exercise.exception.ExerciseErrorCode;
 import umc.cockple.demo.domain.exercise.exception.ExerciseException;
 import umc.cockple.demo.domain.exercise.repository.ExerciseRepository;
@@ -90,7 +90,7 @@ public class ExerciseQueryService {
         return exerciseConverter.toMyGuestListResponse(statistics, guestInfoList);
     }
 
-    public PartyExerciseCalenderDTO.Response getPartyExerciseCalender(Long partyId, Long memberId, LocalDate startDate, LocalDate endDate) {
+    public PartyExerciseCalendarDTO.Response getPartyExerciseCalender(Long partyId, Long memberId, LocalDate startDate, LocalDate endDate) {
 
         log.info("모임 운동 캘린더 조회 시작 - partyId = {}, memberId = {}, startDate = {}, endDate = {}",
                 partyId, memberId, startDate, endDate);

--- a/src/main/java/umc/cockple/demo/domain/party/repository/PartyRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/party/repository/PartyRepository.java
@@ -7,6 +7,8 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import umc.cockple.demo.domain.party.domain.Party;
 
+import java.util.Optional;
+
 public interface PartyRepository extends JpaRepository<Party, Long> {
 
     @Query("""
@@ -15,4 +17,11 @@ public interface PartyRepository extends JpaRepository<Party, Long> {
             AND (:created = false OR p.ownerId = :memberId)
             """) //created가 true라면 p.ownerId = :memberId로 내가 만든 모임을 조회 (false라면 모든 내 모임 조회)
     Slice<Party> findMyParty(@Param("memberId") Long memberId, @Param("created") boolean created, Pageable pageable);
+
+    @Query("""
+            SELECT p FROM Party p 
+            LEFT JOIN FETCH p.levels pl
+            WHERE p.id = :partyId
+            """)
+    Optional<Party> findByIdWithLevels(@Param("partyId") Long partyId);
 }


### PR DESCRIPTION
## ❤️ 기능 설명
모임의 운동 캘린더 조회 API입니다.

startDate와 endDate를 받을경우 그 기간 내에 데이터를 가져오고,
없을 경우 과거 1주, 이번 주, 다음 3주 총 5주의 데이터를 가져옵니다.

startDate와 endDate가 1개만 null이거나 endDate보다 startDate가 나중일경우 에러를 던집니다.

운동마다 참여자 가져오는 건 성능상 따로 쿼리를 날립니다.

swagger 테스트 성공 결과 스크린샷 첨부
<img width="2118" height="1137" alt="image" src="https://github.com/user-attachments/assets/51c4245a-5a6f-48c0-b74b-611c78ea1fca" />

<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #144 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
