### PR TITLE
[feat/#153] 내 운동 캘린더 조회 API 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,5 @@ out/
 src/main/resources/application-dev.yml
 
 .env
+
+application-dev.yml

--- a/src/main/java/umc/cockple/demo/domain/exercise/controller/ExerciseController.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/controller/ExerciseController.java
@@ -256,4 +256,24 @@ public class ExerciseController {
         return BaseResponse.success(CommonSuccessCode.OK, response);
     }
 
+    @GetMapping("/exercises/my/calender")
+    @Operation(summary = "내 운동 캘린더 조회",
+            description = "내 운동 캘린더를 조회합니다. 시작 날짜 ~ 종료 날짜까지의 데이터를 불러옵니다. 파라미터가 없으면 과거 1주 ~ 미래 3주까지의 데이터를 불러옵니다")
+    @ApiResponse(responseCode = "200", description = "내 운동 캘린더 성공")
+    @ApiResponse(responseCode = "400", description = "입력값 오류 또는 비즈니스 룰 위반")
+    public BaseResponse<MyExerciseCalendarDTO.Response> getMyExerciseCalender(
+            @RequestParam(required = false) LocalDate startDate,
+            @RequestParam(required = false) LocalDate endDate,
+            Authentication authentication
+    ) {
+
+        // TODO: JWT 인증 구현 후 교체 예정
+        Long memberId = 1L; // 임시값
+
+        MyExerciseCalendarDTO.Response response = exerciseQueryService.getMyExerciseCalender(
+                memberId, startDate, endDate);
+
+        return BaseResponse.success(CommonSuccessCode.OK, response);
+    }
+
 }

--- a/src/main/java/umc/cockple/demo/domain/exercise/controller/ExerciseController.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/controller/ExerciseController.java
@@ -250,7 +250,7 @@ public class ExerciseController {
         // TODO: JWT 인증 구현 후 교체 예정
         Long memberId = 1L; // 임시값
 
-        PartyExerciseCalendarDTO.Response response = exerciseQueryService.getPartyExerciseCalender(
+        PartyExerciseCalendarDTO.Response response = exerciseQueryService.getPartyExerciseCalendar(
                 partyId, memberId, startDate, endDate);
 
         return BaseResponse.success(CommonSuccessCode.OK, response);
@@ -270,7 +270,7 @@ public class ExerciseController {
         // TODO: JWT 인증 구현 후 교체 예정
         Long memberId = 1L; // 임시값
 
-        MyExerciseCalendarDTO.Response response = exerciseQueryService.getMyExerciseCalender(
+        MyExerciseCalendarDTO.Response response = exerciseQueryService.getMyExerciseCalendar(
                 memberId, startDate, endDate);
 
         return BaseResponse.success(CommonSuccessCode.OK, response);

--- a/src/main/java/umc/cockple/demo/domain/exercise/converter/ExerciseConverter.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/converter/ExerciseConverter.java
@@ -218,7 +218,7 @@ public class ExerciseConverter {
                 .build();
     }
 
-    public PartyExerciseCalendarDTO.Response toCalenderResponse(
+    public PartyExerciseCalendarDTO.Response toCalendarResponse(
             List<Exercise> exercises,
             LocalDate start,
             LocalDate end,

--- a/src/main/java/umc/cockple/demo/domain/exercise/converter/ExerciseConverter.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/converter/ExerciseConverter.java
@@ -239,6 +239,17 @@ public class ExerciseConverter {
                 .build();
     }
 
+    public MyExerciseCalendarDTO.Response toCalendarResponse(List<Exercise> exercises, LocalDate start, LocalDate end) {
+
+        List<MyExerciseCalendarDTO.WeeklyExercises> weeks = groupExerciseByWeek(exercises, start, end);
+
+        return MyExerciseCalendarDTO.Response.builder()
+                .startDate(start)
+                .endDate(end)
+                .weeks(weeks)
+                .build();
+    }
+
     private PartyLevelCache createPartyLevelCache(Party party) {
         List<String> femaleLevel = extractLevelsByGender(party, Gender.FEMALE);
         List<String> maleLevel = extractLevelsByGender(party, Gender.MALE);

--- a/src/main/java/umc/cockple/demo/domain/exercise/converter/ExerciseConverter.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/converter/ExerciseConverter.java
@@ -283,7 +283,24 @@ public class ExerciseConverter {
             List<PartyExerciseCalendarDTO.ExerciseCalendarItem> exerciseItems =
                     convertToExerciseItems(weekExercises, levelCache, participantCounts);
 
-            weeks.add(createWeeklyExercises(weekStart, weekEnd, exerciseItems));
+            weeks.add(this.createPartyWeeklyExercises(weekStart, weekEnd, exerciseItems));
+        }
+
+        return weeks;
+    }
+
+    private List<MyExerciseCalendarDTO.WeeklyExercises> groupExerciseByWeek(List<Exercise> exercises, LocalDate start, LocalDate end) {
+
+        List<MyExerciseCalendarDTO.WeeklyExercises> weeks = new ArrayList<>();
+
+        for (LocalDate weekStart = getWeekStart(start); !weekStart.isAfter(end); weekStart = weekStart.plusWeeks(1)) {
+            LocalDate weekEnd = weekStart.plusDays(6);
+
+            List<Exercise> weekExercises = filterExercisesByWeek(exercises, weekStart, weekEnd);
+
+            List<MyExerciseCalendarDTO.ExerciseCalendarItem> exerciseItems = convertToExerciseItems(weekExercises);
+
+            weeks.add(createMyWeeklyExercises(weekStart, weekEnd, exerciseItems));
         }
 
         return weeks;
@@ -312,12 +329,30 @@ public class ExerciseConverter {
                 .toList();
     }
 
-    private PartyExerciseCalendarDTO.WeeklyExercises createWeeklyExercises(
+    private List<MyExerciseCalendarDTO.ExerciseCalendarItem> convertToExerciseItems(List<Exercise> exercises) {
+        return exercises.stream()
+                .map(this::toCalendarItem)
+                .toList();
+    }
+
+    private PartyExerciseCalendarDTO.WeeklyExercises createPartyWeeklyExercises(
             LocalDate weekStart,
             LocalDate weekEnd,
             List<PartyExerciseCalendarDTO.ExerciseCalendarItem> exerciseItems) {
 
         return PartyExerciseCalendarDTO.WeeklyExercises.builder()
+                .weekStartDate(weekStart)
+                .weekEndDate(weekEnd)
+                .exercises(exerciseItems)
+                .build();
+    }
+
+    private MyExerciseCalendarDTO.WeeklyExercises createMyWeeklyExercises(
+            LocalDate weekStart,
+            LocalDate weekEnd,
+            List<MyExerciseCalendarDTO.ExerciseCalendarItem> exerciseItems) {
+
+        return MyExerciseCalendarDTO.WeeklyExercises.builder()
                 .weekStartDate(weekStart)
                 .weekEndDate(weekEnd)
                 .exercises(exerciseItems)
@@ -340,6 +375,23 @@ public class ExerciseConverter {
                 .maleLevel(levelCache.maleLevel())
                 .currentParticipants(currentParticipants)
                 .maxCapacity(exercise.getMaxCapacity())
+                .build();
+    }
+
+    private MyExerciseCalendarDTO.ExerciseCalendarItem toCalendarItem(Exercise exercise) {
+
+        Party party = exercise.getParty();
+
+        return MyExerciseCalendarDTO.ExerciseCalendarItem.builder()
+                .exerciseId(exercise.getId())
+                .date(exercise.getDate())
+                .dayOfWeek(exercise.getDate().getDayOfWeek().name())
+                .partyId(party.getId())
+                .partyName(party.getPartyName())
+                .buildingName(exercise.getExerciseAddr().getBuildingName())
+                .startTime(exercise.getStartTime())
+                .endTime(exercise.getEndTime())
+                .profileImageUrl(party.getPartyImg() != null ? party.getPartyImg().getImgUrl() : null)
                 .build();
     }
 

--- a/src/main/java/umc/cockple/demo/domain/exercise/dto/MyExerciseCalendarDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/dto/MyExerciseCalendarDTO.java
@@ -1,0 +1,40 @@
+package umc.cockple.demo.domain.exercise.dto;
+
+import lombok.Builder;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+
+public class MyExerciseCalendarDTO {
+
+    @Builder
+    public record Response(
+            LocalDate startDate,
+            LocalDate endDate,
+            List<MyExerciseCalendarDTO.WeeklyExercises> weeks
+    ) {
+    }
+
+    @Builder
+    public record WeeklyExercises(
+            LocalDate weekStartDate,
+            LocalDate weekEndDate,
+            List<MyExerciseCalendarDTO.ExerciseCalendarItem> exercises
+    ) {
+    }
+
+    @Builder
+    public record ExerciseCalendarItem(
+            Long exerciseId,
+            LocalDate date,
+            String dayOfWeek,
+            Long partyId,
+            String partyName,
+            String buildingName,
+            LocalTime startTime,
+            LocalTime endTime,
+            String profileImageUrl
+    ) {
+    }
+}

--- a/src/main/java/umc/cockple/demo/domain/exercise/repository/ExerciseRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/repository/ExerciseRepository.java
@@ -87,6 +87,7 @@ public interface ExerciseRepository extends JpaRepository<Exercise, Long> {
             JOIN FETCH e.memberExercises me
             JOIN FETCH e.exerciseAddr addr
             JOIN FETCH e.party p
+            LEFT JOIN FETCH p.partyImg
             WHERE me.member.id = :memberId
             AND e.date BETWEEN :startDate AND :endDate
             ORDER BY e.date ASC, e.startTime ASC

--- a/src/main/java/umc/cockple/demo/domain/exercise/repository/ExerciseRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/repository/ExerciseRepository.java
@@ -81,4 +81,18 @@ public interface ExerciseRepository extends JpaRepository<Exercise, Long> {
             @Param("startDate") LocalDate startDate,
             @Param("endDate") LocalDate endDate
     );
+
+    @Query("""
+            SELECT e FROM Exercise e 
+            JOIN FETCH e.memberExercises me
+            JOIN FETCH e.exerciseAddr addr
+            JOIN FETCH e.party p
+            WHERE me.member.id = :memberId
+            AND e.date BETWEEN :startDate AND :endDate
+            ORDER BY e.date ASC, e.startTime ASC
+            """)
+    List<Exercise> findByMemberIdAndDateRange(
+            @Param("memberId") Long memberId,
+            @Param("startDate") LocalDate startDate,
+            @Param("endDate") LocalDate endDate);
 }

--- a/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseQueryService.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseQueryService.java
@@ -110,7 +110,7 @@ public class ExerciseQueryService {
 
         log.info("모임 운동 캘린더 조회 완료 - partyId: {}, 조회된 운동 수: {}", partyId, exercises.size());
 
-        return exerciseConverter.toCalenderResponse(
+        return exerciseConverter.toCalendarResponse(
                 exercises, dateRange.start(), dateRange.end(), isMember, party, participantCounts);
     }
 

--- a/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseQueryService.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseQueryService.java
@@ -114,9 +114,30 @@ public class ExerciseQueryService {
                 exercises, dateRange.start(), dateRange.end(), isMember, party, participantCounts);
     }
 
+    public MyExerciseCalendarDTO.Response getMyExerciseCalendar(Long memberId, LocalDate startDate, LocalDate endDate) {
+
+        log.info("내 운동 캘린더 조회 시작 - memberId = {}, startDate = {}, endDate = {}",
+                memberId, startDate, endDate);
+
+        Member member = findMemberOrThrow(memberId);
+        validateGetMyExerciseCalendar(startDate, endDate);
+
+        DateRange dateRange = calculateDateRange(startDate, endDate);
+
+        List<Exercise> exercises = findExercisesByMemberIdAndDateRange(memberId, dateRange.start(), dateRange.end());
+
+        log.info("내 운동 캘린더 조회 완료 - memberId: {}, 조회된 운동 수: {}", memberId, exercises.size());
+
+        return exerciseConverter.toCalendarResponse(exercises, dateRange.start(), dateRange.end());
+    }
+
     // ========== 검증 메서드들 ==========
 
     private void validateGetPartyExerciseCalender(LocalDate startDate, LocalDate endDate) {
+        validateDateRange(startDate, endDate);
+    }
+
+    private void validateGetMyExerciseCalendar(LocalDate startDate, LocalDate endDate) {
         validateDateRange(startDate, endDate);
     }
 
@@ -386,6 +407,11 @@ public class ExerciseQueryService {
     private List<Exercise> findExercisesByPartyIdAndDateRange(Long partyId, LocalDate startDate, LocalDate endDate) {
         return exerciseRepository.findByPartyIdAndDateRange(
                 partyId, startDate, endDate);
+    }
+
+    private List<Exercise> findExercisesByMemberIdAndDateRange(Long memberId, LocalDate startDate, LocalDate endDate) {
+        return exerciseRepository.findByMemberIdAndDateRange(
+                memberId, startDate, endDate);
     }
 
     private Member findMemberOrThrow(Long memberId) {

--- a/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseQueryService.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseQueryService.java
@@ -11,6 +11,7 @@ import umc.cockple.demo.domain.exercise.domain.Guest;
 import umc.cockple.demo.domain.exercise.dto.ExerciseDetailDTO;
 import umc.cockple.demo.domain.exercise.dto.ExerciseDetailDTO.ParticipantInfo;
 import umc.cockple.demo.domain.exercise.dto.ExerciseMyGuestListDTO;
+import umc.cockple.demo.domain.exercise.dto.MyExerciseCalendarDTO;
 import umc.cockple.demo.domain.exercise.dto.PartyExerciseCalendarDTO;
 import umc.cockple.demo.domain.exercise.exception.ExerciseErrorCode;
 import umc.cockple.demo.domain.exercise.exception.ExerciseException;
@@ -90,7 +91,7 @@ public class ExerciseQueryService {
         return exerciseConverter.toMyGuestListResponse(statistics, guestInfoList);
     }
 
-    public PartyExerciseCalendarDTO.Response getPartyExerciseCalender(Long partyId, Long memberId, LocalDate startDate, LocalDate endDate) {
+    public PartyExerciseCalendarDTO.Response getPartyExerciseCalendar(Long partyId, Long memberId, LocalDate startDate, LocalDate endDate) {
 
         log.info("모임 운동 캘린더 조회 시작 - partyId = {}, memberId = {}, startDate = {}, endDate = {}",
                 partyId, memberId, startDate, endDate);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -29,3 +29,16 @@ spring:
         format_sql: true
         use_sql_comments: true
         default_batch_fetch_size: 1000
+
+cloud:
+  aws:
+    s3:
+      bucket: ${S3_BUCKET}
+    credentials:
+      access-key: ${AWS_ACCESS_KEY}
+      secret-key: ${AWS_SECRET_KEY}
+    region:
+      static: ap-northeast-2
+      auto: false
+    stack:
+      auto: false


### PR DESCRIPTION
## ❤️ 기능 설명

내가 참여하고 있는 운동 캘린더를 조회합니다.

swagger 테스트 성공 결과 스크린샷 첨부
<img width="2133" height="1201" alt="image" src="https://github.com/user-attachments/assets/04e010e3-cbf7-46e7-a10a-545f9fc8a036" />

<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #153 

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 비슷한 캘린더 로직이 많은데 제네릭을 쓰면 뭔가 리팩토링이 될 거 같기도 하고요.. 음... 나중에 시도해보겠습니다.
- [ ] application.yml의 설정이 AWS 관련으로 변경되었습니다. 환경 변수 값은 카톡 확인해서 넣어주세요!

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
