### PR TITLE
[feat/#152] 찜한 모임 전체 조회 API 구현

### DIFF
--- a/src/main/java/umc/cockple/demo/domain/bookmark/controller/BookmarkController.java
+++ b/src/main/java/umc/cockple/demo/domain/bookmark/controller/BookmarkController.java
@@ -6,9 +6,11 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import umc.cockple.demo.domain.bookmark.dto.GetAllExerciseBookmarksResponseDTO;
+import umc.cockple.demo.domain.bookmark.dto.GetAllPartyBookmarkResponseDTO;
 import umc.cockple.demo.domain.bookmark.service.BookmarkCommandService;
 import umc.cockple.demo.domain.bookmark.service.BookmarkQueryService;
 import umc.cockple.demo.global.enums.ExerciseOrderType;
+import umc.cockple.demo.global.enums.PartyOrderType;
 import umc.cockple.demo.global.response.BaseResponse;
 import umc.cockple.demo.global.response.code.status.CommonSuccessCode;
 
@@ -77,6 +79,15 @@ public class BookmarkController {
         return BaseResponse.success(CommonSuccessCode.OK, bookmarkQueryService.getAllExerciseBookmarks(memberId, orderType));
     }
 
+    @GetMapping(value = "/parties/bookmarks")
+    @Operation(summary = "찜한 모임 전체 조회 API",
+            description = "사용자가 찜한 모임을 모두 조회")
+    public BaseResponse<List<GetAllPartyBookmarkResponseDTO>> getAllPartyBookmarks(@RequestParam PartyOrderType orderType) {
+        // 추후 시큐리티를 통해 id 가져옴
+        Long memberId = 1L;
+
+        return BaseResponse.success(CommonSuccessCode.OK, bookmarkQueryService.getAllPartyBookmarks(memberId, orderType));
+    }
 
 
 }

--- a/src/main/java/umc/cockple/demo/domain/bookmark/converter/BookmarkConverter.java
+++ b/src/main/java/umc/cockple/demo/domain/bookmark/converter/BookmarkConverter.java
@@ -1,10 +1,13 @@
 package umc.cockple.demo.domain.bookmark.converter;
 
 import umc.cockple.demo.domain.bookmark.domain.ExerciseBookmark;
+import umc.cockple.demo.domain.bookmark.domain.PartyBookmark;
 import umc.cockple.demo.domain.bookmark.dto.GetAllExerciseBookmarksResponseDTO;
+import umc.cockple.demo.domain.bookmark.dto.GetAllPartyBookmarkResponseDTO;
 import umc.cockple.demo.domain.exercise.domain.Exercise;
 import umc.cockple.demo.domain.party.domain.Party;
 import umc.cockple.demo.domain.party.domain.PartyLevel;
+import umc.cockple.demo.global.enums.ActivityTime;
 import umc.cockple.demo.global.enums.Gender;
 import umc.cockple.demo.global.enums.Level;
 
@@ -29,6 +32,24 @@ public class BookmarkConverter {
                 .nowMemberCnt(exercise.getNowCapacity())
                 .includeParty(includeParty)
                 .includeExercise(includeExercise)
+                .build();
+    }
+
+    public static GetAllPartyBookmarkResponseDTO partyBookmarkToDTO(PartyBookmark partyBookmark, Exercise exercise, ActivityTime activityTime) {
+        Party party = partyBookmark.getParty();
+        String profileImg = party.getPartyImg() == null ? null : party.getPartyImg().getImgUrl();
+
+        return GetAllPartyBookmarkResponseDTO.builder()
+                .partyId(party.getId())
+                .partyName(party.getPartyName())
+                .addr1(party.getPartyAddr().getAddr1())
+                .addr2(party.getPartyAddr().getAddr2())
+                .maleLevel(getLevelList(party, Gender.MALE))
+                .femaleLevel(getLevelList(party, Gender.FEMALE))
+                .latestExerciseDate(exercise == null ? null : exercise.getDate())
+                .latestExerciseTime(activityTime)
+                .exerciseCnt(party.getExerciseCount())
+                .profileImgUrl(profileImg)
                 .build();
     }
 

--- a/src/main/java/umc/cockple/demo/domain/bookmark/converter/BookmarkConverter.java
+++ b/src/main/java/umc/cockple/demo/domain/bookmark/converter/BookmarkConverter.java
@@ -55,7 +55,7 @@ public class BookmarkConverter {
 
     private  static List<Level> getLevelList(Party party, Gender gender) {
         return party.getLevels().stream()
-                .filter(lever -> lever.getGender() == gender)
+                .filter(level -> level.getGender() == gender)
                 .map(PartyLevel::getLevel)
                 .toList();
     }

--- a/src/main/java/umc/cockple/demo/domain/bookmark/dto/GetAllPartyBookmarkResponseDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/bookmark/dto/GetAllPartyBookmarkResponseDTO.java
@@ -1,0 +1,25 @@
+package umc.cockple.demo.domain.bookmark.dto;
+
+import lombok.Builder;
+import umc.cockple.demo.global.enums.ActivityTime;
+import umc.cockple.demo.global.enums.Level;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+
+@Builder
+public record GetAllPartyBookmarkResponseDTO(
+        Long partyId,
+        String partyName,
+        String addr1,
+        String addr2,
+        List<Level> maleLevel,
+        List<Level> femaleLevel,
+        LocalDate latestExerciseDate,
+        ActivityTime latestExerciseTime,
+        Integer exerciseCnt,
+        String profileImgUrl
+
+        ) {
+}

--- a/src/main/java/umc/cockple/demo/domain/bookmark/repository/PartyBookmarkRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/bookmark/repository/PartyBookmarkRepository.java
@@ -1,10 +1,13 @@
 package umc.cockple.demo.domain.bookmark.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import umc.cockple.demo.domain.bookmark.domain.PartyBookmark;
 import umc.cockple.demo.domain.member.domain.Member;
 import umc.cockple.demo.domain.party.domain.Party;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -13,4 +16,13 @@ public interface PartyBookmarkRepository extends JpaRepository<PartyBookmark, Lo
     boolean existsByMemberAndParty(Member member, Party party);
 
     Optional<PartyBookmark> findByMemberAndParty(Member member, Party party);
+
+    @Query("""
+        SELECT DISTINCT pb
+        FROM PartyBookmark pb
+        JOIN FETCH pb.party p
+        LEFT JOIN FETCH p.exercises
+        WHERE pb.member = :member
+        """)
+    List<PartyBookmark> findAllByMemberWithParty(@Param("member") Member member);
 }

--- a/src/main/java/umc/cockple/demo/domain/bookmark/service/BookmarkQueryService.java
+++ b/src/main/java/umc/cockple/demo/domain/bookmark/service/BookmarkQueryService.java
@@ -6,20 +6,30 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import umc.cockple.demo.domain.bookmark.converter.BookmarkConverter;
 import umc.cockple.demo.domain.bookmark.domain.ExerciseBookmark;
+import umc.cockple.demo.domain.bookmark.domain.PartyBookmark;
 import umc.cockple.demo.domain.bookmark.dto.GetAllExerciseBookmarksResponseDTO;
+import umc.cockple.demo.domain.bookmark.dto.GetAllPartyBookmarkResponseDTO;
 import umc.cockple.demo.domain.bookmark.repository.ExerciseBookmarkRepository;
 import umc.cockple.demo.domain.bookmark.repository.PartyBookmarkRepository;
+import umc.cockple.demo.domain.exercise.domain.Exercise;
 import umc.cockple.demo.domain.member.domain.Member;
 import umc.cockple.demo.domain.member.exception.MemberErrorCode;
 import umc.cockple.demo.domain.member.exception.MemberException;
 import umc.cockple.demo.domain.member.repository.MemberExerciseRepository;
 import umc.cockple.demo.domain.member.repository.MemberPartyRepository;
 import umc.cockple.demo.domain.member.repository.MemberRepository;
+import umc.cockple.demo.domain.party.domain.Party;
+import umc.cockple.demo.global.enums.ActivityTime;
 import umc.cockple.demo.global.enums.ExerciseOrderType;
+import umc.cockple.demo.global.enums.PartyOrderType;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @Transactional(readOnly = true)
@@ -63,8 +73,60 @@ public class BookmarkQueryService {
     }
 
 
+    public List<GetAllPartyBookmarkResponseDTO> getAllPartyBookmarks(Long memberId, PartyOrderType orderType) {
+        // 회원 조회하기
+        Member member = findByMemberId(memberId);
+
+        // 찜한 모임 가져오기
+        List<PartyBookmark> bookmarks = partyBookmarkRepository.findAllByMemberWithParty(member);
+
+        // orderType에 따른 정렬
+        Comparator<PartyBookmark> comparator = switch (orderType) {
+            case EXERCISE_COUNT ->
+                    Comparator.comparingInt((PartyBookmark b) -> b.getParty().getExerciseCount()).reversed();
+            case LATEST ->
+                    Comparator.comparing(PartyBookmark::getCreatedAt).reversed();
+            default ->
+                    Comparator.comparing(PartyBookmark::getCreatedAt);
+        };
+
+        bookmarks.sort(comparator);
+
+        return bookmarks.stream()
+                 .map(bookmark -> {
+                     // 가장 가까운 시일에 진행하는 운동 찾기
+                     Exercise exercise = latestExercise(bookmark.getParty()).orElse(null);
+                     ActivityTime activityTime = makeActiveTime(exercise);
+                     return BookmarkConverter.partyBookmarkToDTO(bookmark, exercise, activityTime);
+                 })
+                .toList();
+    }
+
     private Member findByMemberId(Long memberId) {
         return memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
     }
+
+    private Optional<Exercise> latestExercise(Party party) {
+        LocalDate today = LocalDate.now();
+        LocalTime nowTime = LocalTime.now();
+
+        return party.getExercises().stream()
+                .filter(exercise ->
+                        exercise.getDate().isAfter(today) ||
+                                (exercise.getDate().isEqual(today) && exercise.getStartTime().isAfter(nowTime))
+                )
+                .min(Comparator.comparing(Exercise::getDate)
+                        .thenComparing(Exercise::getStartTime));
+    }
+
+    private ActivityTime makeActiveTime(Exercise exercise) {
+        if (exercise == null) return null;
+        LocalTime time = exercise.getStartTime();
+
+        if (time.isBefore(LocalTime.of(12, 0))) return ActivityTime.MORNING;
+        return ActivityTime.AFTERNOON;
+    }
+
+
 }

--- a/src/main/java/umc/cockple/demo/domain/notification/domain/Notification.java
+++ b/src/main/java/umc/cockple/demo/domain/notification/domain/Notification.java
@@ -20,6 +20,8 @@ public class Notification extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     private Member member;
 
+    private String title;
+
     @Column(nullable = false)
     private String content;
 


### PR DESCRIPTION
## ❤️ 기능 설명
- 찜한 모임 전체 조회
- 운동 많은순, 최신순, 오래된 순 정렬 구현

swagger 테스트 성공 결과 스크린샷 첨부

운동 많은 순
<img width="751" height="1048" alt="스크린샷 2025-07-23 192225" src="https://github.com/user-attachments/assets/ba61ab3d-4e42-4e29-bf7b-8013aa2bff5a" />

오래된 순
<img width="772" height="1119" alt="스크린샷 2025-07-23 192235" src="https://github.com/user-attachments/assets/d947a2f7-8ce4-4b66-b6c6-e797221d4b2d" />

최신순
<img width="743" height="1156" alt="스크린샷 2025-07-23 192249" src="https://github.com/user-attachments/assets/d1feb6ed-99c0-42ab-a47e-7f6bc37a57b6" />

<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #152 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!


<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [ ] 이슈넘버를 적었는가?
