### PR TITLE
[feat/#154] 내 모임 운동 조회 API 구현

### DIFF
--- a/src/main/java/umc/cockple/demo/domain/exercise/controller/ExerciseController.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/controller/ExerciseController.java
@@ -278,7 +278,7 @@ public class ExerciseController {
 
     @GetMapping("/exercises/parties/my")
     @Operation(summary = "내 모임 운동 조회",
-            description = "내 모임의 운동 목록을 조회합니다. 시작하지 않은 운동만 표시되며, 최대 6개의 운동만 반환합니다.)
+            description = "내 모임의 운동 목록을 조회합니다. 시작하지 않은 운동만 표시되며, 최대 6개의 운동만 반환합니다.")
     @ApiResponse(responseCode = "200", description = "내 모임 운동 조회 성공")
     public BaseResponse<MyPartyExerciseDTO.Response> getMyPartyExercise(
             Authentication authentication

--- a/src/main/java/umc/cockple/demo/domain/exercise/controller/ExerciseController.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/controller/ExerciseController.java
@@ -276,4 +276,19 @@ public class ExerciseController {
         return BaseResponse.success(CommonSuccessCode.OK, response);
     }
 
+    @GetMapping("/exercises/parties/my")
+    @Operation(summary = "내 모임 운동 조회",
+            description = "내 모임의 운동 목록을 조회합니다. 시작하지 않은 운동만 표시되며, 최대 6개의 운동만 반환합니다.)
+    @ApiResponse(responseCode = "200", description = "내 모임 운동 조회 성공")
+    public BaseResponse<MyPartyExerciseDTO.Response> getMyPartyExercise(
+            Authentication authentication
+    ){
+
+        // TODO: JWT 인증 구현 후 교체 예정
+        Long memberId = 1L; // 임시값
+
+        MyPartyExerciseDTO.Response response = exerciseQueryService.getMyPartyExercise(memberId);
+
+        return BaseResponse.success(CommonSuccessCode.OK, response);
+    }
 }

--- a/src/main/java/umc/cockple/demo/domain/exercise/converter/ExerciseConverter.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/converter/ExerciseConverter.java
@@ -395,6 +395,13 @@ public class ExerciseConverter {
                 .build();
     }
 
+    public MyPartyExerciseDTO.Response toEmptyExerciseResponse() {
+        return MyPartyExerciseDTO.Response.builder()
+                .totalExercises(0)
+                .exercises(List.of())
+                .build();
+    }
+
     private record PartyLevelCache(
             List<String> femaleLevel,
             List<String> maleLevel

--- a/src/main/java/umc/cockple/demo/domain/exercise/converter/ExerciseConverter.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/converter/ExerciseConverter.java
@@ -250,6 +250,25 @@ public class ExerciseConverter {
                 .build();
     }
 
+    public MyPartyExerciseDTO.Response toEmptyExerciseResponse() {
+        return MyPartyExerciseDTO.Response.builder()
+                .totalExercises(0)
+                .exercises(List.of())
+                .build();
+    }
+
+    public MyPartyExerciseDTO.Response toMyPartyExerciseDTO(List<Exercise> recentExercises) {
+
+        List<MyPartyExerciseDTO.Exercises> exercises = recentExercises.stream()
+                .map(this::convertToExercises)
+                .toList();
+
+        return MyPartyExerciseDTO.Response.builder()
+                .totalExercises(recentExercises.size())
+                .exercises(exercises)
+                .build();
+    }
+
     private PartyLevelCache createPartyLevelCache(Party party) {
         List<String> femaleLevel = extractLevelsByGender(party, Gender.FEMALE);
         List<String> maleLevel = extractLevelsByGender(party, Gender.MALE);
@@ -395,10 +414,18 @@ public class ExerciseConverter {
                 .build();
     }
 
-    public MyPartyExerciseDTO.Response toEmptyExerciseResponse() {
-        return MyPartyExerciseDTO.Response.builder()
-                .totalExercises(0)
-                .exercises(List.of())
+    private MyPartyExerciseDTO.Exercises convertToExercises(Exercise exercise) {
+        Party party = exercise.getParty();
+
+        return MyPartyExerciseDTO.Exercises.builder()
+                .exerciseId(exercise.getId())
+                .partyId(party.getId())
+                .partyName(party.getPartyName())
+                .buildingName(exercise.getExerciseAddr().getBuildingName())
+                .date(exercise.getDate())
+                .dayOfWeek(exercise.getDate().getDayOfWeek().name())
+                .startTime(exercise.getStartTime())
+                .profileImageUrl(party.getPartyImg() != null ? party.getPartyImg().getImgUrl() : null)
                 .build();
     }
 

--- a/src/main/java/umc/cockple/demo/domain/exercise/dto/MyPartyExerciseDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/dto/MyPartyExerciseDTO.java
@@ -1,0 +1,30 @@
+package umc.cockple.demo.domain.exercise.dto;
+
+import lombok.Builder;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+
+public class MyPartyExerciseDTO {
+
+    @Builder
+    public record Response(
+            Integer totalExercises,
+            List<Exercises> exercises
+    ) {
+    }
+
+    @Builder
+    public record Exercises(
+            Long exerciseId,
+            Long partyId,
+            String partyName,
+            String buildingName,
+            LocalDate date,
+            String dayOfWeek,
+            LocalTime startTime,
+            String profileImageUrl
+    ){
+    }
+}

--- a/src/main/java/umc/cockple/demo/domain/exercise/repository/ExerciseRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/repository/ExerciseRepository.java
@@ -1,5 +1,6 @@
 package umc.cockple.demo.domain.exercise.repository;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -96,4 +97,15 @@ public interface ExerciseRepository extends JpaRepository<Exercise, Long> {
             @Param("memberId") Long memberId,
             @Param("startDate") LocalDate startDate,
             @Param("endDate") LocalDate endDate);
+
+    @Query("""
+            SELECT e FROM Exercise e
+            JOIN FETCH e.exerciseAddr addr
+            JOIN FETCH e.party p
+            LEFT JOIN FETCH p.partyImg
+            WHERE e.party.id IN :partyIds
+            AND (e.date > CURRENT_DATE OR (e.date = CURRENT_DATE AND e.startTime >= CURRENT_TIME))
+            ORDER BY e.date ASC, e.startTime ASC
+            """)
+    List<Exercise> findRecentExercisesByPartyIds(@Param("partyIds") List<Long> partyIds, Pageable pageable);
 }

--- a/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseQueryService.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseQueryService.java
@@ -145,6 +145,10 @@ public class ExerciseQueryService {
 
         Pageable pageable = PageRequest.of(0, 6);
         List<Exercise> recentExercises = findRecentExercisesByPartyIds(myPartyIds, pageable);
+
+        log.info("내 모임 운동 조회 종료 - 조회된 운동 수 = {}", recentExercises.size());
+
+        return exerciseConverter.toMyPartyExerciseDTO(recentExercises);
     }
 
     // ========== 검증 메서드들 ==========

--- a/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseQueryService.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseQueryService.java
@@ -142,6 +142,9 @@ public class ExerciseQueryService {
             log.info("내가 속한 모임이 없음 - memberId = {}", memberId);
             return exerciseConverter.toEmptyExerciseResponse();
         }
+
+        Pageable pageable = PageRequest.of(0, 6);
+        List<Exercise> recentExercises = findRecentExercisesByPartyIds(myPartyIds, pageable);
     }
 
     // ========== 검증 메서드들 ==========
@@ -425,6 +428,10 @@ public class ExerciseQueryService {
     private List<Exercise> findExercisesByMemberIdAndDateRange(Long memberId, LocalDate startDate, LocalDate endDate) {
         return exerciseRepository.findByMemberIdAndDateRange(
                 memberId, startDate, endDate);
+    }
+
+    private List<Exercise> findRecentExercisesByPartyIds(List<Long> myPartyIds, Pageable pageable) {
+        return exerciseRepository.findRecentExercisesByPartyIds(myPartyIds, pageable);
     }
 
     private Member findMemberOrThrow(Long memberId) {

--- a/src/main/java/umc/cockple/demo/domain/member/repository/MemberPartyRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/member/repository/MemberPartyRepository.java
@@ -38,4 +38,11 @@ public interface MemberPartyRepository extends JpaRepository<MemberParty, Long> 
             "where mp.member.id = :memberId and mp.party.id in :partyIds")
     List<Long> findAllPartyIdsByMemberAndPartyIds(@Param("memberId") Long memberId,
                                                   @Param("partyIds") List<Long> partyIds);
+
+    @Query("""
+            SELECT mp.party.id
+            FROM MemberParty mp
+            WHERE mp.member.id = :memberId
+            """)
+    List<Long> findPartyIdsByMemberId(@Param("memberId") Long memberId);
 }


### PR DESCRIPTION
## ❤️ 기능 설명

내가 속한 모임의 시작하지 않은 운동 리스트를 최대 6개 가져옵니다.
이 때 순서는 지금 시간과 가까운 순서로 정렬되어 있습니다.

swagger 테스트 성공 결과 스크린샷 첨부
- 운동이 없을 때
![image.png](attachment:91413bf4-697f-41aa-a71d-761c4ff4b770:image.png)

- 운동이 있을 때
<img width="2109" height="873" alt="image" src="https://github.com/user-attachments/assets/817d3560-62b8-46ac-8823-25c810919934" />
<img width="1987" height="643" alt="image" src="https://github.com/user-attachments/assets/2a7f141d-7a39-41b1-9308-c4f1bd5a4389" />
<img width="1981" height="293" alt="image" src="https://github.com/user-attachments/assets/6fd9d67a-3079-4882-94f4-017f0b265f62" />

<img width="1029" height="205" alt="image" src="https://github.com/user-attachments/assets/92294b73-c6ba-4eee-9175-9f731e567eda" />
디비 상에는 총 7개의 운동이 있지만 6개만 반환되는 것을 확인할 수 있습니다.
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #154 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
