### PR TITLE
[feat/#166] 모임 운동 캘린더 조회 API에 찜 여부 추가

### DIFF
--- a/src/main/java/umc/cockple/demo/domain/bookmark/repository/ExerciseBookmarkRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/bookmark/repository/ExerciseBookmarkRepository.java
@@ -1,6 +1,8 @@
 package umc.cockple.demo.domain.bookmark.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import umc.cockple.demo.domain.bookmark.domain.ExerciseBookmark;
 import umc.cockple.demo.domain.exercise.domain.Exercise;
 import umc.cockple.demo.domain.member.domain.Member;
@@ -15,4 +17,16 @@ public interface ExerciseBookmarkRepository extends JpaRepository<ExerciseBookma
     boolean existsByMemberAndExercise(Member member, Exercise exercise);
 
     List<ExerciseBookmark> findAllByMember(Member member);
+
+
+    @Query("""
+            SELECT eb.exercise.id FROM ExerciseBookmark eb
+            WHERE eb.member.id = :memberId 
+            AND eb.exercise.id IN :exerciseIds
+            """)
+    List<Long> findAllExerciseIdsByMemberIdAndExerciseIds(
+            @Param("memberId") Long memberId,
+            @Param("exerciseIds") List<Long> exerciseIds
+    );
+
 }

--- a/src/main/java/umc/cockple/demo/domain/exercise/converter/ExerciseConverter.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/converter/ExerciseConverter.java
@@ -224,11 +224,12 @@ public class ExerciseConverter {
             LocalDate end,
             Boolean isMember,
             Party party,
-            Map<Long, Integer> participantCounts) {
+            Map<Long, Integer> participantCounts,
+            Map<Long, Boolean> bookmarkStatus) {
 
         PartyLevelCache levelCache = createPartyLevelCache(party);
 
-        List<PartyExerciseCalendarDTO.WeeklyExercises> weeks = groupExerciseByWeek(exercises, levelCache, participantCounts, start, end);
+        List<PartyExerciseCalendarDTO.WeeklyExercises> weeks = groupExerciseByWeek(exercises, levelCache, participantCounts, bookmarkStatus, start, end);
 
         return PartyExerciseCalendarDTO.Response.builder()
                 .startDate(start)
@@ -270,6 +271,7 @@ public class ExerciseConverter {
             List<Exercise> exercises,
             PartyLevelCache levelCache,
             Map<Long, Integer> participantCounts,
+            Map<Long, Boolean> bookmarkStatus,
             LocalDate start,
             LocalDate end) {
 
@@ -281,7 +283,7 @@ public class ExerciseConverter {
             List<Exercise> weekExercises = filterExercisesByWeek(exercises, weekStart, weekEnd);
 
             List<PartyExerciseCalendarDTO.ExerciseCalendarItem> exerciseItems =
-                    convertToExerciseItems(weekExercises, levelCache, participantCounts);
+                    convertToExerciseItems(weekExercises, levelCache, participantCounts, bookmarkStatus);
 
             weeks.add(this.createPartyWeeklyExercises(weekStart, weekEnd, exerciseItems));
         }
@@ -322,10 +324,11 @@ public class ExerciseConverter {
     private List<PartyExerciseCalendarDTO.ExerciseCalendarItem> convertToExerciseItems(
             List<Exercise> exercises,
             PartyLevelCache levelCache,
-            Map<Long, Integer> participantCounts) {
+            Map<Long, Integer> participantCounts,
+            Map<Long, Boolean> bookmarkStatus) {
 
         return exercises.stream()
-                .map(exercise -> toCalendarItem(exercise, levelCache, participantCounts))
+                .map(exercise -> toCalendarItem(exercise, levelCache, participantCounts, bookmarkStatus))
                 .toList();
     }
 
@@ -360,12 +363,16 @@ public class ExerciseConverter {
     }
 
     private PartyExerciseCalendarDTO.ExerciseCalendarItem toCalendarItem(
-            Exercise exercise, PartyLevelCache levelCache, Map<Long, Integer> participantCounts) {
+            Exercise exercise,
+            PartyLevelCache levelCache,
+            Map<Long, Integer> participantCounts,
+            Map<Long, Boolean> bookmarkStatus) {
 
         Integer currentParticipants = participantCounts.getOrDefault(exercise.getId(), 0);
 
         return PartyExerciseCalendarDTO.ExerciseCalendarItem.builder()
                 .exerciseId(exercise.getId())
+                .isBookmarked(bookmarkStatus.getOrDefault(exercise.getId(), false))
                 .date(exercise.getDate())
                 .dayOfWeek(exercise.getDate().getDayOfWeek().name())
                 .startTime(exercise.getStartTime())

--- a/src/main/java/umc/cockple/demo/domain/exercise/dto/PartyExerciseCalendarDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/dto/PartyExerciseCalendarDTO.java
@@ -29,6 +29,7 @@ public class PartyExerciseCalendarDTO {
     @Builder
     public record ExerciseCalendarItem(
             Long exerciseId,
+            Boolean isBookmarked,
             LocalDate date,
             String dayOfWeek,
             LocalTime startTime,

--- a/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseQueryService.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseQueryService.java
@@ -116,7 +116,7 @@ public class ExerciseQueryService {
         log.info("모임 운동 캘린더 조회 완료 - partyId: {}, 조회된 운동 수: {}", partyId, exercises.size());
 
         return exerciseConverter.toCalendarResponse(
-                exercises, dateRange.start(), dateRange.end(), isMember, party, participantCounts);
+                exercises, dateRange.start(), dateRange.end(), isMember, party, participantCounts, bookmarkStatus);
     }
 
     public MyExerciseCalendarDTO.Response getMyExerciseCalendar(Long memberId, LocalDate startDate, LocalDate endDate) {

--- a/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseQueryService.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseQueryService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import umc.cockple.demo.domain.bookmark.repository.ExerciseBookmarkRepository;
 import umc.cockple.demo.domain.exercise.converter.ExerciseConverter;
 import umc.cockple.demo.domain.exercise.domain.Exercise;
 import umc.cockple.demo.domain.exercise.domain.ExerciseAddr;
@@ -45,6 +46,7 @@ public class ExerciseQueryService {
     private final MemberExerciseRepository memberExerciseRepository;
     private final GuestRepository guestRepository;
     private final PartyRepository partyRepository;
+    private final ExerciseBookmarkRepository exerciseBookmarkRepository;
 
     private final ExerciseConverter exerciseConverter;
 
@@ -107,6 +109,9 @@ public class ExerciseQueryService {
 
         Map<Long, Integer> participantCounts = getParticipantCountsMap(
                 partyId, dateRange.start(), dateRange.end());
+
+        List<Long> exerciseIds = getExerciseIds(exercises);
+        Map<Long, Boolean> bookmarkStatus = getExerciseBookmarkStatus(memberId, exerciseIds);
 
         log.info("모임 운동 캘린더 조회 완료 - partyId: {}, 조회된 운동 수: {}", partyId, exercises.size());
 
@@ -397,6 +402,10 @@ public class ExerciseQueryService {
                 .count();
     }
 
+    private static List<Long> getExerciseIds(List<Exercise> exercises) {
+        return exercises.stream().map(Exercise::getId).toList();
+    }
+
     // ========== 조회 메서드 ==========
 
     private Exercise findExerciseWithBasicInfoOrThrow(Long exerciseId) {
@@ -445,6 +454,21 @@ public class ExerciseQueryService {
                 row -> ((Number) row[0]).longValue(),
                 row -> ((Number) row[1]).intValue()
         ));
+    }
+
+    private Map<Long, Boolean> getExerciseBookmarkStatus(Long memberId, List<Long> exerciseIds) {
+        if (exerciseIds.isEmpty()) {
+            return Collections.emptyMap();
+        }
+
+        List<Long> bookmarkedExerciseIds = exerciseBookmarkRepository
+                .findAllExerciseIdsByMemberIdAndExerciseIds(memberId, exerciseIds);
+
+        return exerciseIds.stream()
+                .collect(Collectors.toMap(
+                        exerciseId -> exerciseId,
+                        bookmarkedExerciseIds::contains
+                ));
     }
 
     private record ParticipantGroups(


### PR DESCRIPTION
## ❤️ 기능 설명
모임 운동 캘린더 조회 API에서 누락된 필드인 찜 여부 반환 로직을 구현했습니다.

찜을 하지 않았을경우 false를 반환합니다.

swagger 테스트 성공 결과 스크린샷 첨부
<img width="2164" height="1183" alt="image" src="https://github.com/user-attachments/assets/668935ef-6473-47fe-8a02-6f2683115002" />


<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #166 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!


<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
