### PR TITLE
[feat/#149] 운동 도메인에 빈 응답 조기 반환(Early Return) 패턴 도입

### DIFF
--- a/src/main/java/umc/cockple/demo/domain/exercise/converter/ExerciseConverter.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/converter/ExerciseConverter.java
@@ -255,6 +255,14 @@ public class ExerciseConverter {
                 .build();
     }
 
+    public MyExerciseCalendarDTO.Response toEmptyMyCalendarResponse(LocalDate start, LocalDate end) {
+        return MyExerciseCalendarDTO.Response.builder()
+                .startDate(start)
+                .endDate(end)
+                .weeks(Collections.emptyList())
+                .build();
+    }
+
     public MyExerciseCalendarDTO.Response toCalendarResponse(List<Exercise> exercises, LocalDate start, LocalDate end) {
 
         List<MyExerciseCalendarDTO.WeeklyExercises> weeks = groupExerciseByWeek(exercises, start, end);

--- a/src/main/java/umc/cockple/demo/domain/exercise/converter/ExerciseConverter.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/converter/ExerciseConverter.java
@@ -189,6 +189,15 @@ public class ExerciseConverter {
                 .build();
     }
 
+    public ExerciseMyGuestListDTO.Response toEmptyGuestListResponse() {
+        return ExerciseMyGuestListDTO.Response.builder()
+                .totalCount(0)
+                .maleCount(0)
+                .femaleCount(0)
+                .list(Collections.emptyList())
+                .build();
+    }
+
     public ExerciseMyGuestListDTO.Response toMyGuestListResponse(
             ExerciseMyGuestListDTO.GuestStatistics statistics,
             List<ExerciseMyGuestListDTO.GuestInfo> guestInfoList) {

--- a/src/main/java/umc/cockple/demo/domain/exercise/converter/ExerciseConverter.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/converter/ExerciseConverter.java
@@ -13,6 +13,7 @@ import umc.cockple.demo.global.enums.Role;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -215,6 +216,21 @@ public class ExerciseConverter {
                 .gender(guest.getGender())
                 .level(guest.getLevel())
                 .inviterName(inviterName)
+                .build();
+    }
+
+    public PartyExerciseCalendarDTO.Response toEmptyPartyExerciseCalendar(
+            LocalDate start,
+            LocalDate end,
+            Boolean isMember,
+            Party party) {
+
+        return PartyExerciseCalendarDTO.Response.builder()
+                .startDate(start)
+                .endDate(end)
+                .isMember(isMember)
+                .partyName(party.getPartyName())
+                .weeks(Collections.emptyList())
                 .build();
     }
 

--- a/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseQueryService.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseQueryService.java
@@ -78,6 +78,11 @@ public class ExerciseQueryService {
 
         List<Guest> myGuests = findGuestsByExerciseIdAndInviterId(exerciseId, memberId);
 
+        if (myGuests.isEmpty()) {
+            log.info("초대한 게스트가 없어 빈 응답 반환 - exerciseId: {}, memberId: {}", exerciseId, memberId);
+            return exerciseConverter.toEmptyGuestListResponse();
+        }
+
         List<ExerciseDetailDTO.ParticipantInfo> allParticipants = getAllSortedParticipants(exerciseId, exercise.getParty());
         Map<Long, ExerciseMyGuestListDTO.GuestGroups> guestNumberMap = createGuestNumberMap(allParticipants, exercise.getMaxCapacity());
 

--- a/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseQueryService.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseQueryService.java
@@ -134,6 +134,12 @@ public class ExerciseQueryService {
 
         List<Exercise> exercises = findExercisesByMemberIdAndDateRange(memberId, dateRange.start(), dateRange.end());
 
+        if (exercises.isEmpty()) {
+            log.info("해당 기간에 참여한 운동이 없어 빈 응답 반환 - memberId: {}, 기간: {} ~ {}",
+                    memberId, dateRange.start(), dateRange.end());
+            return exerciseConverter.toEmptyMyCalendarResponse(dateRange.start(), dateRange.end());
+        }
+
         log.info("내 운동 캘린더 조회 완료 - memberId: {}, 조회된 운동 수: {}", memberId, exercises.size());
 
         return exerciseConverter.toCalendarResponse(exercises, dateRange.start(), dateRange.end());

--- a/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseQueryService.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseQueryService.java
@@ -105,6 +105,14 @@ public class ExerciseQueryService {
 
         List<Exercise> exercises = findExercisesByPartyIdAndDateRange(partyId, dateRange.start(), dateRange.end());
 
+        if (exercises.isEmpty()) {
+            log.info("해당 기간에 운동이 없어 빈 응답 반환 - partyId: {}, 기간: {} ~ {}",
+                    partyId, dateRange.start(), dateRange.end());
+
+            return exerciseConverter.toEmptyPartyExerciseCalendar(
+                    dateRange.start(), dateRange.end(), isMember, party);
+        }
+
         Map<Long, Integer> participantCounts = getParticipantCountsMap(
                 partyId, dateRange.start(), dateRange.end());
 


### PR DESCRIPTION
## ❤️ 기능 설명
조회할 게 없을 때 나머지 로직을 처리하지 않고 바로 빈 응답을 반환하도록 변경합니다.

swagger 테스트 성공 결과 스크린샷 첨부
- 내가 초대한 게스트 조회
1. 초대한 게스트가 있을 때
<img width="2133" height="1145" alt="image" src="https://github.com/user-attachments/assets/acf29067-a3f0-471d-877f-410f46f55af5" />

2. 초대한 게스트가 없을 때
<img width="2158" height="1137" alt="image" src="https://github.com/user-attachments/assets/dffdbf72-03a0-4bf4-abba-50b2b7b93d9b" />


- 모임 운동 캘린더 조회
1. 운동이 없는 모임
<img width="2167" height="885" alt="image" src="https://github.com/user-attachments/assets/d125bbbb-6603-4583-b815-775e4d7d7e4e" />

2. 운동이 있는 모임
<img width="2125" height="1159" alt="image" src="https://github.com/user-attachments/assets/0b78ac6e-ed5e-4c7a-906e-c2e38e751ed2" />


- 내 운동 캘린더 조회
1. 운동이 없는 사용자
<img width="2143" height="804" alt="image" src="https://github.com/user-attachments/assets/4caa50fd-d58b-4a8c-af6b-c11dcc7137f1" />

2. 운동이 있는 사용자
<img width="2153" height="1153" alt="image" src="https://github.com/user-attachments/assets/a76e9303-f2cf-4fac-9ab4-52d41727b558" />


<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #149 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!
운동 상세 조회는 운동의 여부를 확인하면서 예외를 던지므로 따로 패턴 도입을 하지 않았습니다.

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
