### PR TITLE
[feat/#165] 내 모임 운동 캘린더 조회 API 구현

### DIFF
--- a/src/main/java/umc/cockple/demo/domain/exercise/controller/ExerciseController.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/controller/ExerciseController.java
@@ -299,8 +299,9 @@ public class ExerciseController {
                     내 모임의 운동 캘린더를 조회합니다.
                     시작 날짜 ~ 종료 날짜까지의 데이터를 불러옵니다. 파라미터가 없으면 과거 1주 ~ 미래 3주까지의 데이터를 불러옵니다.
                     정렬 방식은 최신순(LATEST)과 참여인원이 많은 순(POPULARITY) 2가지로 구분됩니다. 파라미터를 없으면 최신순으로 불러옵니다.
-                    """
-    )
+                    """)
+    @ApiResponse(responseCode = "200", description = "내 운동 캘린더 성공")
+    @ApiResponse(responseCode = "400", description = "입력값 오류 또는 비즈니스 룰 위반")
     public BaseResponse<MyPartyExerciseCalendarDTO.Response> getMyPartyExerciseCalendar(
             @RequestParam(defaultValue = "LATEST") MyPartyExerciseOrderType orderType,
             @RequestParam(required = false) LocalDate startDate,

--- a/src/main/java/umc/cockple/demo/domain/exercise/controller/ExerciseController.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/controller/ExerciseController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.*;
 import umc.cockple.demo.domain.exercise.dto.*;
 import umc.cockple.demo.domain.exercise.service.ExerciseCommandService;
 import umc.cockple.demo.domain.exercise.service.ExerciseQueryService;
+import umc.cockple.demo.global.enums.MyPartyExerciseOrderType;
 import umc.cockple.demo.global.response.BaseResponse;
 import umc.cockple.demo.global.response.code.status.CommonSuccessCode;
 
@@ -236,7 +237,7 @@ public class ExerciseController {
 
     @GetMapping("/parties/{partyId}/exercises/calender")
     @Operation(summary = "모임 운동 캘린더 조회",
-            description = "모임 운동 캘린더를 조회합니다. 시작 날짜 ~ 종료 날짜까지의 데이터를 불러옵니다. 파라미터가 없으면 과거 1주 ~ 미래 3주까지의 데이터를 불러옵니다")
+            description = "모임 운동 캘린더를 조회합니다. 시작 날짜 ~ 종료 날짜까지의 데이터를 불러옵니다. 파라미터가 없으면 과거 1주 ~ 미래 3주까지의 데이터를 불러옵니다.")
     @ApiResponse(responseCode = "200", description = "모임 운동 캘린더 성공")
     @ApiResponse(responseCode = "400", description = "입력값 오류 또는 비즈니스 룰 위반")
     @ApiResponse(responseCode = "404", description = "존재하지 않는 모임")
@@ -258,7 +259,7 @@ public class ExerciseController {
 
     @GetMapping("/exercises/my/calender")
     @Operation(summary = "내 운동 캘린더 조회",
-            description = "내 운동 캘린더를 조회합니다. 시작 날짜 ~ 종료 날짜까지의 데이터를 불러옵니다. 파라미터가 없으면 과거 1주 ~ 미래 3주까지의 데이터를 불러옵니다")
+            description = "내 운동 캘린더를 조회합니다. 시작 날짜 ~ 종료 날짜까지의 데이터를 불러옵니다. 파라미터가 없으면 과거 1주 ~ 미래 3주까지의 데이터를 불러옵니다.")
     @ApiResponse(responseCode = "200", description = "내 운동 캘린더 성공")
     @ApiResponse(responseCode = "400", description = "입력값 오류 또는 비즈니스 룰 위반")
     public BaseResponse<MyExerciseCalendarDTO.Response> getMyExerciseCalender(
@@ -288,6 +289,30 @@ public class ExerciseController {
         Long memberId = 1L; // 임시값
 
         MyPartyExerciseDTO.Response response = exerciseQueryService.getMyPartyExercise(memberId);
+
+        return BaseResponse.success(CommonSuccessCode.OK, response);
+    }
+    
+    @GetMapping("/exercises/parties/my/calendar")
+    @Operation(summary = "내 모임 운동 캘린더 조회",
+            description = """
+                    내 모임의 운동 캘린더를 조회합니다.
+                    시작 날짜 ~ 종료 날짜까지의 데이터를 불러옵니다. 파라미터가 없으면 과거 1주 ~ 미래 3주까지의 데이터를 불러옵니다.
+                    정렬 방식은 최신순(LATEST)과 참여인원이 많은 순(POPULARITY) 2가지로 구분됩니다. 파라미터를 없으면 최신순으로 불러옵니다.
+                    """
+    )
+    public BaseResponse<MyPartyExerciseCalendarDTO.Response> getMyPartyExerciseCalendar(
+            @RequestParam(defaultValue = "LATEST") MyPartyExerciseOrderType orderType,
+            @RequestParam(required = false) LocalDate startDate,
+            @RequestParam(required = false) LocalDate endDate,
+            Authentication authentication
+    ){
+
+        // TODO: JWT 인증 구현 후 교체 예정
+        Long memberId = 1L; // 임시값
+
+        MyPartyExerciseCalendarDTO.Response response = exerciseQueryService.getMyPartyExerciseCalendar(
+                memberId, orderType, startDate, endDate);
 
         return BaseResponse.success(CommonSuccessCode.OK, response);
     }

--- a/src/main/java/umc/cockple/demo/domain/exercise/converter/ExerciseConverter.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/converter/ExerciseConverter.java
@@ -21,6 +21,7 @@ import java.util.Map;
 @RequiredArgsConstructor
 public class ExerciseConverter {
 
+    // ========== Command 변환 메서드들 ==========
     public ExerciseCreateDTO.Command toCreateCommand(ExerciseCreateDTO.Request request) {
         return ExerciseCreateDTO.Command.builder()
                 .date(request.toParsedDate())
@@ -42,55 +43,12 @@ public class ExerciseConverter {
                 .build();
     }
 
-    public ExerciseCreateDTO.Response toCreateResponseDTO(Exercise exercise) {
-        return ExerciseCreateDTO.Response.builder()
-                .exerciseId(exercise.getId())
-                .createdAt(exercise.getCreatedAt())
-                .build();
-    }
-
-    public ExerciseJoinDTO.Response toJoinResponseDTO(MemberExercise memberExercise, Exercise exercise) {
-        return ExerciseJoinDTO.Response.builder()
-                .participantId(memberExercise.getId())
-                .joinedAt(memberExercise.getCreatedAt())
-                .currentParticipants(exercise.getNowCapacity())
-                .build();
-    }
-
     public ExerciseGuestInviteDTO.Command toGuestInviteCommand(ExerciseGuestInviteDTO.Request request, Long inviterId) {
         return ExerciseGuestInviteDTO.Command.builder()
                 .guestName(request.guestName())
                 .gender(request.toParsedGender())
                 .level(request.toParsedLevel())
                 .inviterId(inviterId)
-                .build();
-    }
-
-    public ExerciseGuestInviteDTO.Response toGuestInviteResponseDTO(Guest guest, Exercise exercise) {
-        return ExerciseGuestInviteDTO.Response.builder()
-                .guestId(guest.getId())
-                .invitedAt(guest.getCreatedAt())
-                .currentParticipants(exercise.getNowCapacity())
-                .build();
-    }
-
-    public ExerciseCancelDTO.Response toCancelResponseDTO(Exercise exercise, Member member) {
-        return ExerciseCancelDTO.Response.builder()
-                .memberName(member.getMemberName())
-                .currentParticipants(exercise.getNowCapacity())
-                .build();
-    }
-
-    public ExerciseCancelDTO.Response toCancelResponseDTO(Exercise exercise, Guest guest) {
-        return ExerciseCancelDTO.Response.builder()
-                .memberName(guest.getGuestName())
-                .currentParticipants(exercise.getNowCapacity())
-                .build();
-    }
-
-    public ExerciseDeleteDTO.Response toDeleteResponseDTO(Exercise exercise) {
-        return ExerciseDeleteDTO.Response.builder()
-                .deletedExerciseId(exercise.getId())
                 .build();
     }
 
@@ -117,65 +75,58 @@ public class ExerciseConverter {
         return null;
     }
 
-    public ExerciseUpdateDTO.Response toUpdateResponseDTO(Exercise exercise) {
+    // ========== Response 변환 메서드들 ==========
+    public ExerciseCreateDTO.Response toCreateResponse(Exercise exercise) {
+        return ExerciseCreateDTO.Response.builder()
+                .exerciseId(exercise.getId())
+                .createdAt(exercise.getCreatedAt())
+                .build();
+    }
+
+    public ExerciseJoinDTO.Response toJoinResponse(MemberExercise memberExercise, Exercise exercise) {
+        return ExerciseJoinDTO.Response.builder()
+                .participantId(memberExercise.getId())
+                .joinedAt(memberExercise.getCreatedAt())
+                .currentParticipants(exercise.getNowCapacity())
+                .build();
+    }
+
+    public ExerciseGuestInviteDTO.Response toGuestInviteResponse(Guest guest, Exercise exercise) {
+        return ExerciseGuestInviteDTO.Response.builder()
+                .guestId(guest.getId())
+                .invitedAt(guest.getCreatedAt())
+                .currentParticipants(exercise.getNowCapacity())
+                .build();
+    }
+
+    public ExerciseCancelDTO.Response toCancelResponse(Exercise exercise, Member member) {
+        return ExerciseCancelDTO.Response.builder()
+                .memberName(member.getMemberName())
+                .currentParticipants(exercise.getNowCapacity())
+                .build();
+    }
+
+    public ExerciseCancelDTO.Response toCancelResponse(Exercise exercise, Guest guest) {
+        return ExerciseCancelDTO.Response.builder()
+                .memberName(guest.getGuestName())
+                .currentParticipants(exercise.getNowCapacity())
+                .build();
+    }
+
+    public ExerciseDeleteDTO.Response toDeleteResponse(Exercise exercise) {
+        return ExerciseDeleteDTO.Response.builder()
+                .deletedExerciseId(exercise.getId())
+                .build();
+    }
+
+    public ExerciseUpdateDTO.Response toUpdateResponse(Exercise exercise) {
         return ExerciseUpdateDTO.Response.builder()
                 .exerciseId(exercise.getId())
                 .updatedAt(exercise.getUpdatedAt())
                 .build();
     }
 
-    public ExerciseDetailDTO.ParticipantInfo toParticipantInfo(MemberExercise memberParticipant, Map<Long, Role> memberRoles) {
-        Member member = memberParticipant.getMember();
-        Role role = memberRoles.get(member.getId());
-
-        return ExerciseDetailDTO.ParticipantInfo.builder()
-                .participantId(memberParticipant.getId())
-                .participantNumber(0)
-                .imgUrl(member.getProfileImg() != null ? member.getProfileImg().getImgUrl() : null)
-                .name(member.getMemberName())
-                .gender(member.getGender().name())
-                .level(member.getLevel().name())
-                .participantType(memberParticipant.getExerciseMemberShipStatus().name())
-                .partyPosition(role.name())
-                .inviterName(null)
-                .joinedAt(memberParticipant.getCreatedAt())
-                .build();
-    }
-
-    public ExerciseDetailDTO.ParticipantInfo toExeternalParticipantInfo(MemberExercise memberParticipant) {
-        Member member = memberParticipant.getMember();
-
-        return ExerciseDetailDTO.ParticipantInfo.builder()
-                .participantId(memberParticipant.getId())
-                .participantNumber(0)
-                .imgUrl(member.getProfileImg() != null ? member.getProfileImg().getImgUrl() : null)
-                .name(member.getMemberName())
-                .gender(member.getGender().name())
-                .level(member.getLevel().name())
-                .participantType(memberParticipant.getExerciseMemberShipStatus().name())
-                .partyPosition(null)
-                .inviterName(null)
-                .joinedAt(memberParticipant.getCreatedAt())
-                .build();
-    }
-
-    public ExerciseDetailDTO.ParticipantInfo toParticipantInfo(Guest guest, String inviterName) {
-
-        return ExerciseDetailDTO.ParticipantInfo.builder()
-                .participantId(guest.getId())
-                .participantNumber(0)
-                .imgUrl(null)
-                .name(guest.getGuestName())
-                .gender(guest.getGender().name())
-                .level(guest.getLevel().name())
-                .participantType(guest.getExerciseMemberShipStatus().name())
-                .partyPosition(null)
-                .inviterName(inviterName)
-                .joinedAt(guest.getCreatedAt())
-                .build();
-    }
-
-    public ExerciseDetailDTO.Response toDetailResponseDTO(
+    public ExerciseDetailDTO.Response toDetailResponse(
             boolean isManager,
             ExerciseDetailDTO.ExerciseInfo exerciseInfo,
             ExerciseDetailDTO.ParticipantGroup participantGroup,
@@ -210,25 +161,7 @@ public class ExerciseConverter {
                 .build();
     }
 
-    public ExerciseMyGuestListDTO.GuestInfo toGuestInfo(
-            Guest guest,
-            Map<Long, ExerciseMyGuestListDTO.GuestGroups> guestStatusMap,
-            String inviterName) {
-
-        ExerciseMyGuestListDTO.GuestGroups guestGroup = guestStatusMap.get(guest.getId());
-
-        return ExerciseMyGuestListDTO.GuestInfo.builder()
-                .guestId(guest.getId())
-                .isWaiting(guestGroup.isWaiting())
-                .participantNumber(guestGroup.participantNumber())
-                .name(guest.getGuestName())
-                .gender(guest.getGender())
-                .level(guest.getLevel())
-                .inviterName(inviterName)
-                .build();
-    }
-
-    public PartyExerciseCalendarDTO.Response toEmptyPartyExerciseCalendar(
+    public PartyExerciseCalendarDTO.Response toEmptyPartyCalendarResponse(
             LocalDate start,
             LocalDate end,
             Boolean isMember,
@@ -243,7 +176,7 @@ public class ExerciseConverter {
                 .build();
     }
 
-    public PartyExerciseCalendarDTO.Response toCalendarResponse(
+    public PartyExerciseCalendarDTO.Response toPartyCalendarResponse(
             List<Exercise> exercises,
             LocalDate start,
             LocalDate end,
@@ -254,7 +187,7 @@ public class ExerciseConverter {
 
         PartyLevelCache levelCache = createPartyLevelCache(party);
 
-        List<PartyExerciseCalendarDTO.WeeklyExercises> weeks = groupExerciseByWeek(exercises, levelCache, participantCounts, bookmarkStatus, start, end);
+        List<PartyExerciseCalendarDTO.WeeklyExercises> weeks = groupPartyExerciseByWeek(exercises, levelCache, participantCounts, bookmarkStatus, start, end);
 
         return PartyExerciseCalendarDTO.Response.builder()
                 .startDate(start)
@@ -273,9 +206,9 @@ public class ExerciseConverter {
                 .build();
     }
 
-    public MyExerciseCalendarDTO.Response toCalendarResponse(List<Exercise> exercises, LocalDate start, LocalDate end) {
+    public MyExerciseCalendarDTO.Response toMyCalendarResponse(List<Exercise> exercises, LocalDate start, LocalDate end) {
 
-        List<MyExerciseCalendarDTO.WeeklyExercises> weeks = groupExerciseByWeek(exercises, start, end);
+        List<MyExerciseCalendarDTO.WeeklyExercises> weeks = groupMyExerciseByWeek(exercises, start, end);
 
         return MyExerciseCalendarDTO.Response.builder()
                 .startDate(start)
@@ -284,7 +217,7 @@ public class ExerciseConverter {
                 .build();
     }
 
-    public MyPartyExerciseDTO.Response toEmptyExerciseResponse() {
+    public MyPartyExerciseDTO.Response toEmptyMyPartyExerciseResponse() {
         return MyPartyExerciseDTO.Response.builder()
                 .totalExercises(0)
                 .exercises(List.of())
@@ -294,7 +227,7 @@ public class ExerciseConverter {
     public MyPartyExerciseDTO.Response toMyPartyExerciseDTO(List<Exercise> recentExercises) {
 
         List<MyPartyExerciseDTO.Exercises> exercises = recentExercises.stream()
-                .map(this::convertToExercises)
+                .map(this::toPartyExerciseItem)
                 .toList();
 
         return MyPartyExerciseDTO.Response.builder()
@@ -303,6 +236,77 @@ public class ExerciseConverter {
                 .build();
     }
 
+    // ========== 내부 객체 변환 메서드들 ==========
+    public ExerciseDetailDTO.ParticipantInfo toParticipantInfoFromMember(MemberExercise memberParticipant, Map<Long, Role> memberRoles) {
+        Member member = memberParticipant.getMember();
+        Role role = memberRoles.get(member.getId());
+
+        return ExerciseDetailDTO.ParticipantInfo.builder()
+                .participantId(memberParticipant.getId())
+                .participantNumber(0)
+                .imgUrl(member.getProfileImg() != null ? member.getProfileImg().getImgUrl() : null)
+                .name(member.getMemberName())
+                .gender(member.getGender().name())
+                .level(member.getLevel().name())
+                .participantType(memberParticipant.getExerciseMemberShipStatus().name())
+                .partyPosition(role.name())
+                .inviterName(null)
+                .joinedAt(memberParticipant.getCreatedAt())
+                .build();
+    }
+
+    public ExerciseDetailDTO.ParticipantInfo toParticipantInfoFromExternalMember(MemberExercise memberParticipant) {
+        Member member = memberParticipant.getMember();
+
+        return ExerciseDetailDTO.ParticipantInfo.builder()
+                .participantId(memberParticipant.getId())
+                .participantNumber(0)
+                .imgUrl(member.getProfileImg() != null ? member.getProfileImg().getImgUrl() : null)
+                .name(member.getMemberName())
+                .gender(member.getGender().name())
+                .level(member.getLevel().name())
+                .participantType(memberParticipant.getExerciseMemberShipStatus().name())
+                .partyPosition(null)
+                .inviterName(null)
+                .joinedAt(memberParticipant.getCreatedAt())
+                .build();
+    }
+
+    public ExerciseDetailDTO.ParticipantInfo toParticipantInfoFromGuest(Guest guest, String inviterName) {
+
+        return ExerciseDetailDTO.ParticipantInfo.builder()
+                .participantId(guest.getId())
+                .participantNumber(0)
+                .imgUrl(null)
+                .name(guest.getGuestName())
+                .gender(guest.getGender().name())
+                .level(guest.getLevel().name())
+                .participantType(guest.getExerciseMemberShipStatus().name())
+                .partyPosition(null)
+                .inviterName(inviterName)
+                .joinedAt(guest.getCreatedAt())
+                .build();
+    }
+
+    public ExerciseMyGuestListDTO.GuestInfo toGuestInfo(
+            Guest guest,
+            Map<Long, ExerciseMyGuestListDTO.GuestGroups> guestStatusMap,
+            String inviterName) {
+
+        ExerciseMyGuestListDTO.GuestGroups guestGroup = guestStatusMap.get(guest.getId());
+
+        return ExerciseMyGuestListDTO.GuestInfo.builder()
+                .guestId(guest.getId())
+                .isWaiting(guestGroup.isWaiting())
+                .participantNumber(guestGroup.participantNumber())
+                .name(guest.getGuestName())
+                .gender(guest.getGender())
+                .level(guest.getLevel())
+                .inviterName(inviterName)
+                .build();
+    }
+
+    // ========== private 메서드들 ==========
     private PartyLevelCache createPartyLevelCache(Party party) {
         List<String> femaleLevel = extractLevelsByGender(party, Gender.FEMALE);
         List<String> maleLevel = extractLevelsByGender(party, Gender.MALE);
@@ -319,7 +323,21 @@ public class ExerciseConverter {
         return levelList.isEmpty() ? null : levelList;
     }
 
-    private List<PartyExerciseCalendarDTO.WeeklyExercises> groupExerciseByWeek(
+    private LocalDate getWeekStart(LocalDate date) {
+        return date.minusDays(date.getDayOfWeek().getValue() - 1);
+    }
+
+    private List<Exercise> filterExercisesByWeek(List<Exercise> exercises, LocalDate weekStart, LocalDate weekEnd) {
+        return exercises.stream()
+                .filter(exercise -> {
+                    LocalDate exerciseDate = exercise.getDate();
+                    return !exerciseDate.isBefore(weekStart) && !exerciseDate.isAfter(weekEnd);
+                })
+                .toList();
+    }
+
+    // 주별 그룹화 메서드
+    private List<PartyExerciseCalendarDTO.WeeklyExercises> groupPartyExerciseByWeek(
             List<Exercise> exercises,
             PartyLevelCache levelCache,
             Map<Long, Integer> participantCounts,
@@ -335,7 +353,7 @@ public class ExerciseConverter {
             List<Exercise> weekExercises = filterExercisesByWeek(exercises, weekStart, weekEnd);
 
             List<PartyExerciseCalendarDTO.ExerciseCalendarItem> exerciseItems =
-                    convertToExerciseItems(weekExercises, levelCache, participantCounts, bookmarkStatus);
+                    toPartyCalendarItems(weekExercises, levelCache, participantCounts, bookmarkStatus);
 
             weeks.add(this.createPartyWeeklyExercises(weekStart, weekEnd, exerciseItems));
         }
@@ -343,7 +361,7 @@ public class ExerciseConverter {
         return weeks;
     }
 
-    private List<MyExerciseCalendarDTO.WeeklyExercises> groupExerciseByWeek(List<Exercise> exercises, LocalDate start, LocalDate end) {
+    private List<MyExerciseCalendarDTO.WeeklyExercises> groupMyExerciseByWeek(List<Exercise> exercises, LocalDate start, LocalDate end) {
 
         List<MyExerciseCalendarDTO.WeeklyExercises> weeks = new ArrayList<>();
 
@@ -352,42 +370,12 @@ public class ExerciseConverter {
 
             List<Exercise> weekExercises = filterExercisesByWeek(exercises, weekStart, weekEnd);
 
-            List<MyExerciseCalendarDTO.ExerciseCalendarItem> exerciseItems = convertToExerciseItems(weekExercises);
+            List<MyExerciseCalendarDTO.ExerciseCalendarItem> exerciseItems = toMyExerciseItems(weekExercises);
 
             weeks.add(createMyWeeklyExercises(weekStart, weekEnd, exerciseItems));
         }
 
         return weeks;
-    }
-
-    private LocalDate getWeekStart(LocalDate date) {
-        return date.minusDays(date.getDayOfWeek().getValue() - 1);
-    }
-
-    private List<Exercise> filterExercisesByWeek(List<Exercise> exercises, LocalDate weekStart, LocalDate weekEnd) {
-        return exercises.stream()
-                .filter(exercise -> {
-                    LocalDate exerciseDate = exercise.getDate();
-                    return !exerciseDate.isBefore(weekStart) && !exerciseDate.isAfter(weekEnd);
-                })
-                .toList();
-    }
-
-    private List<PartyExerciseCalendarDTO.ExerciseCalendarItem> convertToExerciseItems(
-            List<Exercise> exercises,
-            PartyLevelCache levelCache,
-            Map<Long, Integer> participantCounts,
-            Map<Long, Boolean> bookmarkStatus) {
-
-        return exercises.stream()
-                .map(exercise -> toCalendarItem(exercise, levelCache, participantCounts, bookmarkStatus))
-                .toList();
-    }
-
-    private List<MyExerciseCalendarDTO.ExerciseCalendarItem> convertToExerciseItems(List<Exercise> exercises) {
-        return exercises.stream()
-                .map(this::toCalendarItem)
-                .toList();
     }
 
     private PartyExerciseCalendarDTO.WeeklyExercises createPartyWeeklyExercises(
@@ -414,7 +402,25 @@ public class ExerciseConverter {
                 .build();
     }
 
-    private PartyExerciseCalendarDTO.ExerciseCalendarItem toCalendarItem(
+    // 캘린더 아이템 변환
+    private List<PartyExerciseCalendarDTO.ExerciseCalendarItem> toPartyCalendarItems(
+            List<Exercise> exercises,
+            PartyLevelCache levelCache,
+            Map<Long, Integer> participantCounts,
+            Map<Long, Boolean> bookmarkStatus) {
+
+        return exercises.stream()
+                .map(exercise -> toPartyCalendarItem(exercise, levelCache, participantCounts, bookmarkStatus))
+                .toList();
+    }
+
+    private List<MyExerciseCalendarDTO.ExerciseCalendarItem> toMyExerciseItems(List<Exercise> exercises) {
+        return exercises.stream()
+                .map(this::toMyCalendarItem)
+                .toList();
+    }
+
+    private PartyExerciseCalendarDTO.ExerciseCalendarItem toPartyCalendarItem(
             Exercise exercise,
             PartyLevelCache levelCache,
             Map<Long, Integer> participantCounts,
@@ -437,7 +443,7 @@ public class ExerciseConverter {
                 .build();
     }
 
-    private MyExerciseCalendarDTO.ExerciseCalendarItem toCalendarItem(Exercise exercise) {
+    private MyExerciseCalendarDTO.ExerciseCalendarItem toMyCalendarItem(Exercise exercise) {
 
         Party party = exercise.getParty();
 
@@ -454,7 +460,7 @@ public class ExerciseConverter {
                 .build();
     }
 
-    private MyPartyExerciseDTO.Exercises convertToExercises(Exercise exercise) {
+    private MyPartyExerciseDTO.Exercises toPartyExerciseItem(Exercise exercise) {
         Party party = exercise.getParty();
 
         return MyPartyExerciseDTO.Exercises.builder()

--- a/src/main/java/umc/cockple/demo/domain/exercise/converter/ExerciseConverter.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/converter/ExerciseConverter.java
@@ -451,7 +451,7 @@ public class ExerciseConverter {
             }
 
             List<MyPartyExerciseCalendarDTO.ExerciseCalendarItem> exerciseItems =
-                    toMyPartyExerciseItems(dayExercises, bookmarkStatus);
+                    toMyPartyExerciseItems(dayExercises, bookmarkStatus, participantCounts);
 
             dailyExercisesList.add(createDailyExercises(date, exerciseItems));
         }
@@ -526,9 +526,10 @@ public class ExerciseConverter {
                 .toList();
     }
 
-    private List<MyPartyExerciseCalendarDTO.ExerciseCalendarItem> toMyPartyExerciseItems(List<Exercise> exercises, Map<Long, Boolean> bookmarkStatus) {
+    private List<MyPartyExerciseCalendarDTO.ExerciseCalendarItem> toMyPartyExerciseItems(
+            List<Exercise> exercises, Map<Long, Boolean> bookmarkStatus, Map<Long, Integer> participantCounts) {
         return exercises.stream()
-                .map(exercise -> toMyPartyCalendarItem(exercise, bookmarkStatus))
+                .map(exercise -> toMyPartyCalendarItem(exercise, bookmarkStatus, participantCounts))
                 .toList();
     }
 
@@ -588,7 +589,7 @@ public class ExerciseConverter {
     }
 
     private MyPartyExerciseCalendarDTO.ExerciseCalendarItem toMyPartyCalendarItem(
-            Exercise exercise, Map<Long, Boolean> bookmarkStatus) {
+            Exercise exercise, Map<Long, Boolean> bookmarkStatus, Map<Long, Integer> participantCounts) {
 
         Party party = exercise.getParty();
 
@@ -601,6 +602,7 @@ public class ExerciseConverter {
                 .endTime(exercise.getEndTime())
                 .profileImageUrl(party.getPartyImg() != null ? party.getPartyImg().getImgUrl() : null)
                 .isBookmarked(bookmarkStatus.getOrDefault(exercise.getId(), false))
+                .nowCapacity(participantCounts.getOrDefault(exercise.getId(), 0))
                 .build();
     }
 

--- a/src/main/java/umc/cockple/demo/domain/exercise/dto/MyPartyExerciseCalendarDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/dto/MyPartyExerciseCalendarDTO.java
@@ -12,7 +12,7 @@ public class MyPartyExerciseCalendarDTO {
     public record Response(
             LocalDate startDate,
             LocalDate endDate,
-            List<MyExerciseCalendarDTO.WeeklyExercises> weeks
+            List<MyPartyExerciseCalendarDTO.WeeklyExercises> weeks
     ) {
     }
 
@@ -20,7 +20,7 @@ public class MyPartyExerciseCalendarDTO {
     public record WeeklyExercises(
             LocalDate weekStartDate,
             LocalDate weekEndDate,
-            List<MyExerciseCalendarDTO.ExerciseCalendarItem> exercises
+            List<MyPartyExerciseCalendarDTO.ExerciseCalendarItem> exercises
     ) {
     }
 

--- a/src/main/java/umc/cockple/demo/domain/exercise/dto/MyPartyExerciseCalendarDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/dto/MyPartyExerciseCalendarDTO.java
@@ -20,15 +20,21 @@ public class MyPartyExerciseCalendarDTO {
     public record WeeklyExercises(
             LocalDate weekStartDate,
             LocalDate weekEndDate,
-            List<MyPartyExerciseCalendarDTO.ExerciseCalendarItem> exercises
+            List<MyPartyExerciseCalendarDTO.DailyExercises> days
+    ) {
+    }
+
+    @Builder
+    public record DailyExercises(
+            LocalDate date,
+            String dayOfWeek,
+            List<ExerciseCalendarItem> exercises
     ) {
     }
 
     @Builder
     public record ExerciseCalendarItem(
             Long exerciseId,
-            LocalDate date,
-            String dayOfWeek,
             Long partyId,
             String partyName,
             String buildingName,

--- a/src/main/java/umc/cockple/demo/domain/exercise/dto/MyPartyExerciseCalendarDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/dto/MyPartyExerciseCalendarDTO.java
@@ -1,0 +1,41 @@
+package umc.cockple.demo.domain.exercise.dto;
+
+import lombok.Builder;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+
+public class MyPartyExerciseCalendarDTO {
+
+    @Builder
+    public record Response(
+            LocalDate startDate,
+            LocalDate endDate,
+            List<MyExerciseCalendarDTO.WeeklyExercises> weeks
+    ) {
+    }
+
+    @Builder
+    public record WeeklyExercises(
+            LocalDate weekStartDate,
+            LocalDate weekEndDate,
+            List<MyExerciseCalendarDTO.ExerciseCalendarItem> exercises
+    ) {
+    }
+
+    @Builder
+    public record ExerciseCalendarItem(
+            Long exerciseId,
+            LocalDate date,
+            String dayOfWeek,
+            Long partyId,
+            String partyName,
+            String buildingName,
+            LocalTime startTime,
+            LocalTime endTime,
+            String profileImageUrl,
+            Boolean isBookmarked
+    ) {
+    }
+}

--- a/src/main/java/umc/cockple/demo/domain/exercise/dto/MyPartyExerciseCalendarDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/dto/MyPartyExerciseCalendarDTO.java
@@ -41,7 +41,8 @@ public class MyPartyExerciseCalendarDTO {
             LocalTime startTime,
             LocalTime endTime,
             String profileImageUrl,
-            Boolean isBookmarked
+            Boolean isBookmarked,
+            Integer nowCapacity
     ) {
     }
 }

--- a/src/main/java/umc/cockple/demo/domain/exercise/repository/ExerciseRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/repository/ExerciseRepository.java
@@ -108,4 +108,41 @@ public interface ExerciseRepository extends JpaRepository<Exercise, Long> {
             ORDER BY e.date ASC, e.startTime ASC
             """)
     List<Exercise> findRecentExercisesByPartyIds(@Param("partyIds") List<Long> partyIds, Pageable pageable);
+
+    @Query("""
+        SELECT e FROM Exercise e 
+        JOIN FETCH e.party p
+        WHERE p.id IN :partyIds 
+        AND e.date BETWEEN :startDate AND :endDate
+        ORDER BY e.date ASC, e.startTime ASC, p.partyName ASC
+        """)
+    List<Exercise> findByPartyIdsAndDateRangeOrderByLatestAndPartyName(
+            @Param("partyIds") List<Long> myPartyIds,
+            @Param("startDate") LocalDate startDate,
+            @Param("endDate") LocalDate endDate);
+
+    @Query(value = """
+            SELECT 
+                e.*,
+                COALESCE(me_count.member_count, 0) + COALESCE(g_count.guest_count, 0) as totalCount
+            FROM exercise e
+            JOIN party p ON e.party_id = p.id
+            LEFT JOIN (
+                SELECT exercise_id, COUNT(*) as member_count 
+                FROM member_exercise 
+                GROUP BY exercise_id
+            ) me_count ON e.id = me_count.exercise_id
+            LEFT JOIN (
+                SELECT exercise_id, COUNT(*) as guest_count 
+                FROM guest 
+                GROUP BY exercise_id
+            ) g_count ON e.id = g_count.exercise_id
+            WHERE p.id IN :partyIds
+            AND e.date BETWEEN :startDate AND :endDate
+            ORDER BY totalCount DESC, p.party_name ASC
+            """, nativeQuery = true)
+    List<Exercise> findByPartyIdsAndDateRangeOrderByParticipantsAndPartyName(
+            @Param("partyIds") List<Long> myPartyIds,
+            @Param("startDate") LocalDate startDate,
+            @Param("endDate") LocalDate endDate);
 }

--- a/src/main/java/umc/cockple/demo/domain/exercise/repository/ExerciseRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/repository/ExerciseRepository.java
@@ -116,40 +116,9 @@ public interface ExerciseRepository extends JpaRepository<Exercise, Long> {
             LEFT JOIN FETCH p.partyImg
             WHERE p.id IN :partyIds 
             AND e.date BETWEEN :startDate AND :endDate
-            ORDER BY e.date ASC, e.startTime ASC, p.partyName ASC
-            """)
-    List<Exercise> findByPartyIdsAndDateRangeOrderByLatest(
-            @Param("partyIds") List<Long> myPartyIds,
-            @Param("startDate") LocalDate startDate,
-            @Param("endDate") LocalDate endDate);
-
-    @Query("""
-            SELECT e FROM Exercise e 
-            JOIN FETCH e.party p
-            JOIN FETCH e.exerciseAddr addr
-            LEFT JOIN FETCH p.partyImg
-            WHERE p.id IN :partyIds 
-            AND e.date BETWEEN :startDate AND :endDate
             """)
     List<Exercise> findByPartyIdsAndDateRange(
             @Param("partyIds") List<Long> partyIds,
             @Param("startDate") LocalDate startDate,
             @Param("endDate") LocalDate endDate);
-
-    @Query(value = """
-            SELECT 
-                e.id,
-                COALESCE(me_count.member_count, 0) + COALESCE(g_count.guest_count, 0) as participant_count
-            FROM exercise e
-            LEFT JOIN (
-                SELECT exercise_id, COUNT(*) as member_count 
-                FROM member_exercise GROUP BY exercise_id
-            ) me_count ON e.id = me_count.exercise_id
-            LEFT JOIN (
-                SELECT exercise_id, COUNT(*) as guest_count 
-                FROM guest GROUP BY exercise_id
-            ) g_count ON e.id = g_count.exercise_id
-            WHERE e.id IN :exerciseIds
-            """, nativeQuery = true)
-    List<Object[]> findParticipantCounts(@Param("exerciseIds") List<Long> exerciseIds);
 }

--- a/src/main/java/umc/cockple/demo/domain/exercise/repository/ExerciseRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/repository/ExerciseRepository.java
@@ -121,4 +121,18 @@ public interface ExerciseRepository extends JpaRepository<Exercise, Long> {
             @Param("partyIds") List<Long> partyIds,
             @Param("startDate") LocalDate startDate,
             @Param("endDate") LocalDate endDate);
+
+    @Query(value = """
+            SELECT 
+                e.id as exerciseId,
+                (SELECT COUNT(*) FROM member_exercise me WHERE me.exercise_id = e.id) + 
+                (SELECT COUNT(*) FROM guest g WHERE g.exercise_id = e.id) as totalCount
+            FROM exercise e
+            WHERE e.id IN :exerciseIds
+            AND e.date BETWEEN :startDate AND :endDate
+            """, nativeQuery = true)
+    List<Object[]> findExerciseParticipantCountsByExerciseIds(
+            @Param("exerciseIds") List<Long> exerciseIds,
+            @Param("startDate") LocalDate startDate,
+            @Param("endDate") LocalDate endDate);
 }

--- a/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseCommandService.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseCommandService.java
@@ -55,7 +55,7 @@ public class ExerciseCommandService {
 
         log.info("운동 생성 완료 - 운동ID: {}", savedExercise.getId());
 
-        return exerciseConverter.toCreateResponseDTO(savedExercise);
+        return exerciseConverter.toCreateResponse(savedExercise);
     }
 
     public ExerciseJoinDTO.Response joinExercise(Long exerciseId, Long memberId) {
@@ -76,7 +76,7 @@ public class ExerciseCommandService {
         log.info("운동 신청 종료 - memberExerciseId: {}, isPartyMember : {}"
                 , savedMemberExercise.getId(), isPartyMember);
 
-        return exerciseConverter.toJoinResponseDTO(savedMemberExercise, exercise);
+        return exerciseConverter.toJoinResponse(savedMemberExercise, exercise);
     }
 
     public ExerciseGuestInviteDTO.Response inviteGuest(Long exerciseId, Long inviterId, ExerciseGuestInviteDTO.Request request) {
@@ -97,7 +97,7 @@ public class ExerciseCommandService {
 
         log.info("게스트 초대 완료 - guestId: {}", savedGuest.getId());
 
-        return exerciseConverter.toGuestInviteResponseDTO(savedGuest, exercise);
+        return exerciseConverter.toGuestInviteResponse(savedGuest, exercise);
     }
 
     public ExerciseCancelDTO.Response cancelParticipation(Long exerciseId, Long memberId) {
@@ -119,7 +119,7 @@ public class ExerciseCommandService {
         log.info("운동 참여 취소 완료 - exerciseId: {}, memberId: {}, 현재 참여자 수: {}",
                 exerciseId, memberId, exercise.getNowCapacity());
 
-        return exerciseConverter.toCancelResponseDTO(exercise, member);
+        return exerciseConverter.toCancelResponse(exercise, member);
     }
 
     public ExerciseCancelDTO.Response cancelGuestInvitation(Long exerciseId, Long guestId, Long memberId) {
@@ -139,7 +139,7 @@ public class ExerciseCommandService {
 
         log.info("게스트 초대 취소 완료 - exerciseId: {}, guestId: {}, memberId: {}", exerciseId, guestId, memberId);
 
-        return exerciseConverter.toCancelResponseDTO(exercise, guest);
+        return exerciseConverter.toCancelResponse(exercise, guest);
     }
 
     public ExerciseCancelDTO.Response cancelParticipationByManager(
@@ -174,7 +174,7 @@ public class ExerciseCommandService {
 
         log.info("운동 삭제 종료 - exerciseId: {}, memberId: {}", exerciseId, memberId);
 
-        return exerciseConverter.toDeleteResponseDTO(exercise);
+        return exerciseConverter.toDeleteResponse(exercise);
     }
 
     public ExerciseUpdateDTO.Response updateExercise(Long exerciseId, Long memberId, ExerciseUpdateDTO.Request request) {
@@ -195,7 +195,7 @@ public class ExerciseCommandService {
 
         log.info("운동 수정 완료 - exerciseId: {}", savedExercise.getId());
 
-        return exerciseConverter.toUpdateResponseDTO(savedExercise);
+        return exerciseConverter.toUpdateResponse(savedExercise);
     }
 
 
@@ -386,7 +386,7 @@ public class ExerciseCommandService {
 
         exerciseRepository.save(exercise);
 
-        return exerciseConverter.toCancelResponseDTO(exercise, guest);
+        return exerciseConverter.toCancelResponse(exercise, guest);
     }
 
     private ExerciseCancelDTO.Response cancelMemberParticipation(Exercise exercise, Long participantId) {
@@ -400,7 +400,7 @@ public class ExerciseCommandService {
 
         exerciseRepository.save(exercise);
 
-        return exerciseConverter.toCancelResponseDTO(exercise, participant);
+        return exerciseConverter.toCancelResponse(exercise, participant);
     }
 
     // ========== 조회 메서드 ==========

--- a/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseQueryService.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseQueryService.java
@@ -68,7 +68,7 @@ public class ExerciseQueryService {
         ExerciseDetailDTO.ParticipantGroup participantGroup = createParticipantGroup(groups.participants(), exercise.getMaxCapacity());
         ExerciseDetailDTO.WaitingGroup waitingGroup = createWaitingGroup(groups.waiting());
 
-        return exerciseConverter.toDetailResponseDTO(isManager, exerciseInfo, participantGroup, waitingGroup);
+        return exerciseConverter.toDetailResponse(isManager, exerciseInfo, participantGroup, waitingGroup);
     }
 
     public ExerciseMyGuestListDTO.Response getMyInvitedGuests(Long exerciseId, Long memberId) {
@@ -116,7 +116,7 @@ public class ExerciseQueryService {
             log.info("해당 기간에 운동이 없어 빈 응답 반환 - partyId: {}, 기간: {} ~ {}",
                     partyId, dateRange.start(), dateRange.end());
 
-            return exerciseConverter.toEmptyPartyExerciseCalendar(
+            return exerciseConverter.toEmptyPartyCalendarResponse(
                     dateRange.start(), dateRange.end(), isMember, party);
         }
 
@@ -128,7 +128,7 @@ public class ExerciseQueryService {
 
         log.info("모임 운동 캘린더 조회 완료 - partyId: {}, 조회된 운동 수: {}", partyId, exercises.size());
 
-        return exerciseConverter.toCalendarResponse(
+        return exerciseConverter.toPartyCalendarResponse(
                 exercises, dateRange.start(), dateRange.end(), isMember, party, participantCounts, bookmarkStatus);
     }
 
@@ -152,7 +152,7 @@ public class ExerciseQueryService {
 
         log.info("내 운동 캘린더 조회 완료 - memberId: {}, 조회된 운동 수: {}", memberId, exercises.size());
 
-        return exerciseConverter.toCalendarResponse(exercises, dateRange.start(), dateRange.end());
+        return exerciseConverter.toMyCalendarResponse(exercises, dateRange.start(), dateRange.end());
     }
 
     public MyPartyExerciseDTO.Response getMyPartyExercise(Long memberId) {
@@ -165,7 +165,7 @@ public class ExerciseQueryService {
 
         if (myPartyIds.isEmpty()) {
             log.info("내가 속한 모임이 없음 - memberId = {}", memberId);
-            return exerciseConverter.toEmptyExerciseResponse();
+            return exerciseConverter.toEmptyMyPartyExerciseResponse();
         }
 
         Pageable pageable = PageRequest.of(0, 6);
@@ -389,9 +389,9 @@ public class ExerciseQueryService {
         return memberExercises.stream()
                 .map(me -> {
                     if (partyMemberRoles.containsKey(me.getMember().getId())) {
-                        return exerciseConverter.toParticipantInfo(me, partyMemberRoles);
+                        return exerciseConverter.toParticipantInfoFromMember(me, partyMemberRoles);
                     } else {
-                        return exerciseConverter.toExeternalParticipantInfo(me);
+                        return exerciseConverter.toParticipantInfoFromExternalMember(me);
                     }
                 })
                 .toList();
@@ -411,7 +411,7 @@ public class ExerciseQueryService {
         return guests.stream()
                 .map(guest -> {
                     String inviterName = inviterNames.getOrDefault(guest.getInviterId(), "알 수 없음");
-                    return exerciseConverter.toParticipantInfo(guest, inviterName);
+                    return exerciseConverter.toParticipantInfoFromGuest(guest, inviterName);
                 })
                 .toList();
     }

--- a/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseQueryService.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseQueryService.java
@@ -202,9 +202,12 @@ public class ExerciseQueryService {
         List<Long> exerciseIds = getExerciseIds(exercises);
         Map<Long, Boolean> bookmarkStatus = getExerciseBookmarkStatus(memberId, exerciseIds);
 
+        Map<Long, Integer> participantCounts = getParticipantCountsMap(exerciseIds, dateRange.start(), dateRange.end());
+
         log.info("내 운동 캘린더 조회 완료 - memberId: {}, 조회된 운동 수: {}", memberId, exercises.size());
 
-        return exerciseConverter.toMyPartyCalendarResponse(exercises, dateRange.start(), dateRange.end(), bookmarkStatus);
+        return exerciseConverter.toMyPartyCalendarResponse(
+                exercises, dateRange.start(), dateRange.end(), bookmarkStatus, orderType, participantCounts);
     }
 
     // ========== 검증 메서드들 ==========
@@ -530,6 +533,17 @@ public class ExerciseQueryService {
     private Map<Long, Integer> getParticipantCountsMap(Long partyId, LocalDate start, LocalDate end) {
         List<Object[]> countResults = exerciseRepository.findExerciseParticipantCounts(
                 partyId, start, end);
+
+        return countResults.stream()
+                .collect(Collectors.toMap(
+                        row -> ((Number) row[0]).longValue(),
+                        row -> ((Number) row[1]).intValue()
+                ));
+    }
+
+    private Map<Long, Integer> getParticipantCountsMap(List<Long> exerciseIds, LocalDate start, LocalDate end) {
+        List<Object[]> countResults = exerciseRepository.findExerciseParticipantCountsByExerciseIds(
+                exerciseIds, start, end);
 
         return countResults.stream()
                 .collect(Collectors.toMap(

--- a/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseQueryService.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseQueryService.java
@@ -189,7 +189,7 @@ public class ExerciseQueryService {
 
         if (myPartyIds.isEmpty()) {
             log.info("내가 속한 모임이 없음 - memberId = {}", memberId);
-            return exerciseConverter.toEmptyMyPartyExerciseCalendarResponse(dateRange.start(), dateRange.end());
+            return exerciseConverter.toEmptyMyPartyCalendarResponse(dateRange.start(), dateRange.end());
         }
 
         List<Exercise> exercises = switch (orderType) {
@@ -202,12 +202,15 @@ public class ExerciseQueryService {
         if (exercises.isEmpty()) {
             log.info("해당 기간에 내 모임의 운동이 없어 빈 응답 반환 - memberId: {}, 기간: {} ~ {}",
                     memberId, dateRange.start(), dateRange.end());
-            return exerciseConverter.toEmptyMyPartyExerciseCalendarResponse(dateRange.start(), dateRange.end());
+            return exerciseConverter.toEmptyMyPartyCalendarResponse(dateRange.start(), dateRange.end());
         }
+
+        List<Long> exerciseIds = getExerciseIds(exercises);
+        Map<Long, Boolean> bookmarkStatus = getExerciseBookmarkStatus(memberId, exerciseIds);
 
         log.info("내 운동 캘린더 조회 완료 - memberId: {}, 조회된 운동 수: {}", memberId, exercises.size());
 
-        return exerciseConverter.toMyPartyExerciseCalendarDTO(exercises, dateRange.start(), dateRange.end());
+        return exerciseConverter.toMyPartyCalendarResponse(exercises, dateRange.start(), dateRange.end(), bookmarkStatus);
     }
 
     // ========== 검증 메서드들 ==========

--- a/src/main/java/umc/cockple/demo/global/enums/MyPartyExerciseOrderType.java
+++ b/src/main/java/umc/cockple/demo/global/enums/MyPartyExerciseOrderType.java
@@ -1,0 +1,16 @@
+package umc.cockple.demo.global.enums;
+
+import lombok.Getter;
+
+public enum MyPartyExerciseOrderType {
+
+    LATEST("최신순"),
+    POPULARITY("인기순");
+
+    @Getter
+    private final String koreanName;
+
+    MyPartyExerciseOrderType(String koreanName) {
+        this.koreanName = koreanName;
+    }
+}


### PR DESCRIPTION
## ❤️ 기능 설명
내 모임 운동 캘린더 조회 API를 구현했습니다.

응답 -> 주별 -> 날짜별 -> 운동 아이템의 중첩 구조를 가지고 있으며,

멤버 id 값으로 내가 속한 모임의 id를 조회한 후,
운동 리스트를 조회합니다.

운동 찜 여부와 운동의 참여인원 수를 별개의 쿼리로 가져온 뒤에,
Converter에서 날짜별로 그룹핑하며 orderType에 따라 정렬을 진행합니다.

참여 인원 수는 피그마 화면에는 필요없지만 제대로 정렬된 걸 확인하기 위해 반환하도록 했습니다.

swagger 테스트 성공 결과 스크린샷 첨부
- 인기 많은순
<img width="2159" height="1156" alt="image" src="https://github.com/user-attachments/assets/7e0eeb0b-1991-4870-9891-038407a70e76" />

- 최신순
<img width="2140" height="1062" alt="image" src="https://github.com/user-attachments/assets/44ba33c2-2ad2-4ae8-95e8-5b491381cf5e" />


<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #165 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!


<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
