### PR TITLE
[feat/#178] 모임 멤버 조회 API 구현

### DIFF
--- a/src/main/java/umc/cockple/demo/domain/member/repository/MemberPartyRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/member/repository/MemberPartyRepository.java
@@ -45,4 +45,11 @@ public interface MemberPartyRepository extends JpaRepository<MemberParty, Long> 
             WHERE mp.member.id = :memberId
             """)
     List<Long> findPartyIdsByMemberId(@Param("memberId") Long memberId);
+
+    @Query("""
+       SELECT mp FROM MemberParty mp
+       JOIN FETCH mp.member
+       WHERE mp.party.id = :partyId
+       """)
+    List<MemberParty> findAllByPartyIdWithMember(@Param("partyId") Long partyId);
 }

--- a/src/main/java/umc/cockple/demo/domain/party/controller/PartyController.java
+++ b/src/main/java/umc/cockple/demo/domain/party/controller/PartyController.java
@@ -112,6 +112,21 @@ public class PartyController {
         return BaseResponse.success(CommonSuccessCode.OK);
     }
 
+    @GetMapping("/{partyId}/members")
+    @Operation(summary = "모임 멤버 조회",
+                description = "특정 모임의 멤버 목록을 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "모임 멤버 조회 성공")
+    @ApiResponse(responseCode = "404", description = "존재하지 않는 모임")
+    public BaseResponse<PartyMemberDTO.Response> getPartyMembers(
+            @PathVariable Long partyId,
+            Authentication authentication
+    ){
+        // TODO: JWT 인증 구현 후 교체 예정
+        Long memberId = 1L; // 임시값
+
+        PartyMemberDTO.Response response = partyQueryService.getPartyMembers(partyId, memberId);
+        return BaseResponse.success(CommonSuccessCode.OK, response);
+    }
 
 
     @PostMapping("/parties/{partyId}/join-requests")

--- a/src/main/java/umc/cockple/demo/domain/party/converter/PartyConverter.java
+++ b/src/main/java/umc/cockple/demo/domain/party/converter/PartyConverter.java
@@ -145,4 +145,32 @@ public class PartyConverter {
         return levelList.isEmpty() ? null : levelList;
     }
 
+    public PartyMemberDTO.Response toPartyMemberDTO(List<MemberParty> memberParties, Long currentMemberId) {
+        //멤버 리스트 생성
+        List<PartyMemberDTO.MemberDetail> memberDetails = memberParties.stream()
+                .map(mp -> {
+                    Member member = mp.getMember();
+                    return PartyMemberDTO.MemberDetail.builder()
+                            .memberId(member.getId())
+                            .nickname(member.getNickname())
+                            .profileImageUrl(member.getProfileImg() != null ? member.getProfileImg().getImgUrl() : null)
+                            .role(mp.getRole().name())
+                            .gender(member.getGender().name())
+                            .level(member.getLevel().getKoreanName())
+                            .isMe(member.getId().equals(currentMemberId))
+                            .build();
+                })
+                .toList();
+
+        //모임의 멤버 관련 정보 리스트 생성
+        long femaleCount = memberDetails.stream().filter(md -> "FEMALE".equals(md.gender())).count();
+        long maleCount = memberDetails.stream().filter(md -> "MALE".equals(md.gender())).count();
+        PartyMemberDTO.Summary summary = PartyMemberDTO.Summary.builder()
+                .totalCount(memberDetails.size())
+                .femaleCount((int) femaleCount)
+                .maleCount((int) maleCount)
+                .build();
+
+        return new PartyMemberDTO.Response(summary, memberDetails);
+    }
 }

--- a/src/main/java/umc/cockple/demo/domain/party/converter/PartyConverter.java
+++ b/src/main/java/umc/cockple/demo/domain/party/converter/PartyConverter.java
@@ -11,6 +11,7 @@ import umc.cockple.demo.global.enums.ParticipationType;
 import umc.cockple.demo.global.enums.RequestStatus;
 
 import java.time.LocalDateTime;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -160,6 +161,8 @@ public class PartyConverter {
                             .isMe(member.getId().equals(currentMemberId))
                             .build();
                 })
+                //Role에 따라 정렬 (모임장, 부모임장이 위로 가도록 정렬)
+                .sorted(Comparator.comparing(detail -> getRolePriority(detail.role()))) // .sort() 대신 .sorted() 사용
                 .toList();
 
         //모임의 멤버 관련 정보 리스트 생성
@@ -172,5 +175,14 @@ public class PartyConverter {
                 .build();
 
         return new PartyMemberDTO.Response(summary, memberDetails);
+    }
+
+    private int getRolePriority(String role) {
+        return switch (role) {
+            case "party_MANAGER" -> 0; // 모임장 역할
+            case "party_SUBMANAGER" -> 1; // 부모임장
+            case "party_MEMBER" -> 2; // 일반 멤버
+            default -> 99;
+        };
     }
 }

--- a/src/main/java/umc/cockple/demo/domain/party/dto/PartyMemberDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/party/dto/PartyMemberDTO.java
@@ -1,0 +1,31 @@
+package umc.cockple.demo.domain.party.dto;
+
+import lombok.Builder;
+
+import java.util.List;
+
+public class PartyMemberDTO {
+    @Builder
+    public record Response(
+            Summary summary,
+            List<MemberDetail> members
+    ) {}
+
+    @Builder
+    public record Summary(
+            Integer totalCount,
+            Integer femaleCount,
+            Integer maleCount
+    ) {}
+
+    @Builder
+    public record MemberDetail(
+            Long memberId,
+            String nickname,
+            String profileImageUrl,
+            String role,
+            String gender,
+            String level,
+            Boolean isMe
+    ) {}
+}

--- a/src/main/java/umc/cockple/demo/domain/party/service/PartyQueryService.java
+++ b/src/main/java/umc/cockple/demo/domain/party/service/PartyQueryService.java
@@ -2,14 +2,12 @@ package umc.cockple.demo.domain.party.service;
 
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
-import umc.cockple.demo.domain.party.dto.PartyDTO;
-import umc.cockple.demo.domain.party.dto.PartyDetailDTO;
-import umc.cockple.demo.domain.party.dto.PartyJoinDTO;
-import umc.cockple.demo.domain.party.dto.PartySimpleDTO;
+import umc.cockple.demo.domain.party.dto.*;
 
 public interface PartyQueryService {
     Slice<PartyJoinDTO.Response> getJoinRequests(Long partyId, Long memberId, String status, Pageable pageable);
     PartyDetailDTO.Response getPartyDetails(Long partyId, Long memberId);
     Slice<PartySimpleDTO.Response> getSimpleMyParties(Long memberId, Pageable pageable);
     Slice<PartyDTO.Response> getMyParties(Long memberId, Boolean created, String sort, Pageable pageable);
+    PartyMemberDTO.Response getPartyMembers(Long partyId, Long currentMemberId);
 }

--- a/src/main/java/umc/cockple/demo/domain/party/service/PartyQueryServiceImpl.java
+++ b/src/main/java/umc/cockple/demo/domain/party/service/PartyQueryServiceImpl.java
@@ -89,7 +89,8 @@ public class PartyQueryServiceImpl implements PartyQueryService{
         log.info("모임 멤버 조회 시작 - partyId: {}", partyId);
         //모임 조회
         Party party = findPartyOrThrow(partyId);
-
+        //모임 활성화 확인
+        validatePartyIsActive(party);
         //모임 멤버 목록 조회
         List<MemberParty> memberParties = memberPartyRepository.findAllByPartyIdWithMember(partyId);
 

--- a/src/main/java/umc/cockple/demo/domain/party/service/PartyQueryServiceImpl.java
+++ b/src/main/java/umc/cockple/demo/domain/party/service/PartyQueryServiceImpl.java
@@ -50,7 +50,7 @@ public class PartyQueryServiceImpl implements PartyQueryService{
 
     @Override
     public Slice<PartySimpleDTO.Response> getSimpleMyParties(Long memberId, Pageable pageable) {
-        log.info("내 모임 간략화 조회 시작 - partyId: {}", memberId);
+        log.info("내 모임 간략화 조회 시작 - memberId: {}", memberId);
         //사용자 조회
         Member member = findMemberOrThrow(memberId);
 
@@ -63,6 +63,8 @@ public class PartyQueryServiceImpl implements PartyQueryService{
 
     @Override
     public Slice<PartyDTO.Response> getMyParties(Long memberId, Boolean created, String sort, Pageable pageable) {
+        log.info("내 모임 조회 시작 - memberId: {}", memberId);
+
         //정렬 기준 문자 검증, Pageable 객체 생성
         Pageable sortedPageable = createSortedPageable(pageable, sort);
 
@@ -73,6 +75,7 @@ public class PartyQueryServiceImpl implements PartyQueryService{
         //운동 정보 조회
         ExerciseInfo exerciseInfo = getExerciseInfo(partyIds);
 
+        log.info("내 모임 목록 조회 완료. 조회된 항목 수: {}", partySlice.getNumberOfElements());
         //기본 정보와 추가 정보를 조합하여 최종 DTO 생성
         return partySlice.map(party -> {
             Integer totalExerciseCount = exerciseInfo.countMap().getOrDefault(party.getId(), 0);

--- a/src/main/java/umc/cockple/demo/domain/party/service/PartyQueryServiceImpl.java
+++ b/src/main/java/umc/cockple/demo/domain/party/service/PartyQueryServiceImpl.java
@@ -85,6 +85,19 @@ public class PartyQueryServiceImpl implements PartyQueryService{
     }
 
     @Override
+    public PartyMemberDTO.Response getPartyMembers(Long partyId, Long currentMemberId) {
+        log.info("모임 멤버 조회 시작 - partyId: {}", partyId);
+        //모임 조회
+        Party party = findPartyOrThrow(partyId);
+
+        //모임 멤버 목록 조회
+        List<MemberParty> memberParties = memberPartyRepository.findAllByPartyIdWithMember(partyId);
+
+        log.info("모임 멤버 목록 조회 완료 - partyId: {}", partyId);
+        return partyConverter.toPartyMemberDTO(memberParties, currentMemberId);
+    }
+
+    @Override
     public PartyDetailDTO.Response getPartyDetails(Long partyId, Long memberId) {
         log.info("모임 상세 정보 조회 시작 - partyId: {}, memberId: {}", partyId, memberId);
 

--- a/src/main/java/umc/cockple/demo/global/enums/Role.java
+++ b/src/main/java/umc/cockple/demo/global/enums/Role.java
@@ -2,7 +2,9 @@ package umc.cockple.demo.global.enums;
 
 public enum Role {
 
-    party_MEMBER,
+    party_MEMBER, //일반 멤버
 
-    party_MANAGER
+    party_MANAGER, //모임장
+
+    party_SUBMANAGER //부모임장
 }


### PR DESCRIPTION
## ❤️ 기능 설명
특정 모임의 멤버 목록을 조회합니다.
- 모임장, 부모임장이 가장 상단에 오도록 정렬했습니다
- 사용자 본인 여부를 파악할 수 있도록 하여 모임 탈퇴 시 사용하도록 구현했습니다. 

swagger 테스트 성공 결과 스크린샷 첨부
<img width="711" height="203" alt="image" src="https://github.com/user-attachments/assets/c897e65c-266e-4cb6-9a16-671bc87e6a8d" />
<img width="703" height="244" alt="image" src="https://github.com/user-attachments/assets/609867b7-7eb0-4ab0-9e58-abcb4146318c" />
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #178
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- 없습니다.

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
