### PR TITLE
[feat/#177] 캘린더 조회 API에서 날짜별로 아이템 묶기

### DIFF
--- a/src/main/java/umc/cockple/demo/domain/exercise/dto/MyExerciseCalendarDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/dto/MyExerciseCalendarDTO.java
@@ -20,7 +20,7 @@ public class MyExerciseCalendarDTO {
     public record WeeklyExercises(
             LocalDate weekStartDate,
             LocalDate weekEndDate,
-            List<MyExerciseCalendarDTO.DailyExercises> exercises
+            List<MyExerciseCalendarDTO.DailyExercises> days
     ) {
     }
 

--- a/src/main/java/umc/cockple/demo/domain/exercise/dto/MyExerciseCalendarDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/dto/MyExerciseCalendarDTO.java
@@ -20,6 +20,14 @@ public class MyExerciseCalendarDTO {
     public record WeeklyExercises(
             LocalDate weekStartDate,
             LocalDate weekEndDate,
+            List<MyExerciseCalendarDTO.DailyExercises> exercises
+    ) {
+    }
+
+    @Builder
+    public record DailyExercises(
+            LocalDate date,
+            String dayOfWeek,
             List<MyExerciseCalendarDTO.ExerciseCalendarItem> exercises
     ) {
     }
@@ -27,8 +35,6 @@ public class MyExerciseCalendarDTO {
     @Builder
     public record ExerciseCalendarItem(
             Long exerciseId,
-            LocalDate date,
-            String dayOfWeek,
             Long partyId,
             String partyName,
             String buildingName,

--- a/src/main/java/umc/cockple/demo/domain/exercise/dto/MyExerciseCalendarDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/dto/MyExerciseCalendarDTO.java
@@ -12,7 +12,7 @@ public class MyExerciseCalendarDTO {
     public record Response(
             LocalDate startDate,
             LocalDate endDate,
-            List<MyExerciseCalendarDTO.WeeklyExercises> weeks
+            List<WeeklyExercises> weeks
     ) {
     }
 
@@ -20,7 +20,7 @@ public class MyExerciseCalendarDTO {
     public record WeeklyExercises(
             LocalDate weekStartDate,
             LocalDate weekEndDate,
-            List<MyExerciseCalendarDTO.DailyExercises> days
+            List<DailyExercises> days
     ) {
     }
 
@@ -28,7 +28,7 @@ public class MyExerciseCalendarDTO {
     public record DailyExercises(
             LocalDate date,
             String dayOfWeek,
-            List<MyExerciseCalendarDTO.ExerciseCalendarItem> exercises
+            List<ExerciseCalendarItem> exercises
     ) {
     }
 

--- a/src/main/java/umc/cockple/demo/domain/exercise/dto/PartyExerciseCalendarDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/dto/PartyExerciseCalendarDTO.java
@@ -22,6 +22,14 @@ public class PartyExerciseCalendarDTO {
     public record WeeklyExercises(
             LocalDate weekStartDate,
             LocalDate weekEndDate,
+            List<DailyExercises> days
+    ) {
+    }
+
+    @Builder
+    public record DailyExercises(
+            LocalDate date,
+            String dayOfWeek,
             List<ExerciseCalendarItem> exercises
     ) {
     }
@@ -30,8 +38,6 @@ public class PartyExerciseCalendarDTO {
     public record ExerciseCalendarItem(
             Long exerciseId,
             Boolean isBookmarked,
-            LocalDate date,
-            String dayOfWeek,
             LocalTime startTime,
             LocalTime endTime,
             String buildingName,


### PR DESCRIPTION
## ❤️ 기능 설명
응답 -> 주별 -> 날짜별 -> 운동 아이템 순의 DTO 계층 구조를

- 내 운동 캘린더 조회 API
- 모임 운동 캘린더 조회 API

에 적용했습니다.

swagger 테스트 성공 결과 스크린샷 첨부
- 내 운동 캘린더 조회 API
<img width="1739" height="599" alt="image" src="https://github.com/user-attachments/assets/ddc0dfdd-5e44-4e58-9967-b7b8b0507165" />

<img width="1253" height="606" alt="image" src="https://github.com/user-attachments/assets/86279dc6-9db2-4712-9a2c-5fde3d2bb424" />

- 모임 운동 캘린더 조회 API
<img width="1882" height="726" alt="image" src="https://github.com/user-attachments/assets/b7f922f5-0603-4716-9c33-6006f0c8647c" />

<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #177 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
