### PR TITLE
[feat/#159] 특정 알림 읽음 처리

### DIFF
--- a/src/main/java/umc/cockple/demo/domain/notification/controller/NotificationController.java
+++ b/src/main/java/umc/cockple/demo/domain/notification/controller/NotificationController.java
@@ -42,7 +42,7 @@ public class NotificationController {
         // 추후 시큐리티를 통해 id 가져옴
         Long memberId = 1L;
 
-        notificationCommandService.markAsReadNotification(memberId, notificationId);
+        notificationCommandService.markAsReadNotification(notificationId);
         return BaseResponse.success(CommonSuccessCode.NO_CONTENT);
     }
 

--- a/src/main/java/umc/cockple/demo/domain/notification/controller/NotificationController.java
+++ b/src/main/java/umc/cockple/demo/domain/notification/controller/NotificationController.java
@@ -4,11 +4,10 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import umc.cockple.demo.domain.notification.domain.Notification;
 import umc.cockple.demo.domain.notification.dto.AllNotificationsResponseDTO;
+import umc.cockple.demo.domain.notification.service.NotificationCommandService;
 import umc.cockple.demo.domain.notification.service.NotificationQueryService;
 import umc.cockple.demo.global.response.BaseResponse;
 import umc.cockple.demo.global.response.code.status.CommonSuccessCode;
@@ -23,6 +22,7 @@ import java.util.List;
 public class NotificationController {
 
     private final NotificationQueryService notificationQueryService;
+    private final NotificationCommandService notificationCommandService;
 
     @GetMapping("/notifications")
     @Operation(summary = "내 알림 전체 조회",
@@ -34,6 +34,17 @@ public class NotificationController {
         return BaseResponse.success(CommonSuccessCode.OK, notificationQueryService.getAllNotifications(memberId));
     }
 
+
+    @PatchMapping("/notifications/{notificationId}")
+    @Operation(summary = "내 특정 알림 조회 및 읽음 처리",
+            description = "특정 알림을 조회하고 읽음 처리를 진행합니다. ")
+    public BaseResponse<String> markAsReadNotification(@PathVariable Long notificationId) {
+        // 추후 시큐리티를 통해 id 가져옴
+        Long memberId = 1L;
+
+        notificationCommandService.markAsReadNotification(memberId, notificationId);
+        return BaseResponse.success(CommonSuccessCode.NO_CONTENT);
+    }
 
 
 }

--- a/src/main/java/umc/cockple/demo/domain/notification/domain/Notification.java
+++ b/src/main/java/umc/cockple/demo/domain/notification/domain/Notification.java
@@ -32,4 +32,8 @@ public class Notification extends BaseEntity {
 
     @Column(nullable = false)
     private Boolean isRead;
+
+    public void read() {
+        this.isRead = true;
+    }
 }

--- a/src/main/java/umc/cockple/demo/domain/notification/exception/NotificationErrorCode.java
+++ b/src/main/java/umc/cockple/demo/domain/notification/exception/NotificationErrorCode.java
@@ -15,7 +15,11 @@ public enum NotificationErrorCode implements BaseErrorCode {
      * 2xx: 서버에서 리소스를 찾을 수 없는 문제
      * 3xx: 권한/인증 문제
      * 4xx: 비즈니스 로직 위반
-     */;
+     */
+
+    NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "NOTIFICATION201", "해당 알림이 존재하지 않습니다."),
+
+    ;
 
 
 

--- a/src/main/java/umc/cockple/demo/domain/notification/service/NotificationCommandService.java
+++ b/src/main/java/umc/cockple/demo/domain/notification/service/NotificationCommandService.java
@@ -4,11 +4,42 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import umc.cockple.demo.domain.member.domain.Member;
+import umc.cockple.demo.domain.member.exception.MemberErrorCode;
+import umc.cockple.demo.domain.member.exception.MemberException;
+import umc.cockple.demo.domain.member.repository.MemberRepository;
+import umc.cockple.demo.domain.notification.domain.Notification;
+import umc.cockple.demo.domain.notification.exception.NotificationErrorCode;
+import umc.cockple.demo.domain.notification.exception.NotificationException;
+import umc.cockple.demo.domain.notification.repository.NotificationRepository;
 
 @Service
 @Transactional
 @RequiredArgsConstructor
 @Slf4j
 public class NotificationCommandService {
+
+    private final NotificationRepository notificationRepository;
+    private final MemberRepository memberRepository;
+
+
+
+    public void markAsReadNotification(Long memberId, Long notificationId) {
+        Member member = findByMemberId(memberId);
+
+        Notification notification = findByNotificationId(notificationId);
+
+        notification.read();
+    }
+
+    private Member findByMemberId(Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
+    }
+
+    private Notification findByNotificationId(Long notification) {
+        return notificationRepository.findById(notification)
+                .orElseThrow(() -> new NotificationException(NotificationErrorCode.NOTIFICATION_NOT_FOUND));
+    }
 
 }

--- a/src/main/java/umc/cockple/demo/domain/notification/service/NotificationCommandService.java
+++ b/src/main/java/umc/cockple/demo/domain/notification/service/NotificationCommandService.java
@@ -24,18 +24,12 @@ public class NotificationCommandService {
 
 
 
-    public void markAsReadNotification(Long memberId, Long notificationId) {
-        Member member = findByMemberId(memberId);
-
+    public void markAsReadNotification(Long notificationId) {
         Notification notification = findByNotificationId(notificationId);
 
         notification.read();
     }
 
-    private Member findByMemberId(Long memberId) {
-        return memberRepository.findById(memberId)
-                .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
-    }
 
     private Notification findByNotificationId(Long notification) {
         return notificationRepository.findById(notification)


### PR DESCRIPTION
## ❤️ 기능 설명
알림을 눌렀을 때 상세 알림이 뜨는 구조가 아니라서 읽음 처리만 해주었음

스웨거 결과
<img width="816" height="1107" alt="스크린샷 2025-07-26 231949" src="https://github.com/user-attachments/assets/935c8128-8b56-46e0-8396-5360af059102" />

API 실행 전
<img width="1065" height="188" alt="스크린샷 2025-07-26 231707" src="https://github.com/user-attachments/assets/33cd4295-8e17-4cb6-aa89-88bf403af59b" />

실행 후
<img width="1054" height="175" alt="스크린샷 2025-07-26 231740" src="https://github.com/user-attachments/assets/53239c8a-8bf5-4792-a315-71472a7c7892" />

<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #159 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 너무 별 거 없어서 죄송함니다 ..


<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [ ] 이슈넘버를 적었는가?
