### PR TITLE
[feat/#137] 모임 멤버 삭제 API 구현

### DIFF
--- a/src/main/java/umc/cockple/demo/domain/party/controller/PartyController.java
+++ b/src/main/java/umc/cockple/demo/domain/party/controller/PartyController.java
@@ -145,6 +145,24 @@ public class PartyController {
         return BaseResponse.success(CommonSuccessCode.OK);
     }
 
+    @DeleteMapping("/parties/{partyId}/members/{memberId}")
+    @Operation(summary = "모임 멤버 삭제",
+            description = "모임장 또는 부모임장이 특정 멤버를 모임에서 삭제합니다.")
+    @ApiResponse(responseCode = "200", description = "모임 멤버 삭제 성공")
+    @ApiResponse(responseCode = "403", description = "모임 멤버 삭제 권한 없음")
+    @ApiResponse(responseCode = "404", description = "존재하지 않는 모임 또는 멤버")
+    public BaseResponse<Void> removeMember(
+            @PathVariable Long partyId,
+            @PathVariable("memberId") Long memberIdToRemove,
+            Authentication authentication
+    ) {
+        // TODO: JWT 인증 구현 후 교체 예정
+        Long currentMemberId = 1L; //현재 사용자 ID
+
+        partyCommandService.removeMember(partyId, memberIdToRemove, currentMemberId);
+        return BaseResponse.success(CommonSuccessCode.OK);
+    }
+
     @PostMapping("/parties/{partyId}/join-requests")
     @Operation(summary = "모임 가입 신청",
             description = "사용자가 특정 모임에 가입을 신청합니다")

--- a/src/main/java/umc/cockple/demo/domain/party/exception/PartyErrorCode.java
+++ b/src/main/java/umc/cockple/demo/domain/party/exception/PartyErrorCode.java
@@ -38,7 +38,8 @@ public enum PartyErrorCode implements BaseErrorCode {
     LEVEL_NOT_MATCH(HttpStatus.BAD_REQUEST, "PARTY404", "모임의 급수 조건에 맞지 않습니다."),
     GENDER_NOT_MATCH(HttpStatus.BAD_REQUEST, "PARTY405", "모임 유형에 맞지 않는 성별입니다."),
     AGE_NOT_MATCH(HttpStatus.BAD_REQUEST, "PARTY406", "모임의 나이 조건에 맞지 않습니다."),
-    PARTY_IS_DELETED(HttpStatus.BAD_REQUEST, "PARTY407", "이미 삭제된 모임입니다.");
+    PARTY_IS_DELETED(HttpStatus.BAD_REQUEST, "PARTY407", "이미 삭제된 모임입니다."),
+    CANNOT_REMOVE_SELF(HttpStatus.BAD_REQUEST, "PARTY408", "자기 자신을 모임에서 삭제할 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/umc/cockple/demo/domain/party/service/PartyCommandService.java
+++ b/src/main/java/umc/cockple/demo/domain/party/service/PartyCommandService.java
@@ -15,4 +15,6 @@ public interface PartyCommandService {
     void deleteParty(Long partyId, Long memberId);
 
     void leaveParty(Long partyId, Long memberId);
+
+    void removeMember(Long partyId, Long memberIdToRemove, Long currentMemberId);
 }


### PR DESCRIPTION
## ❤️ 기능 설명
모임장이 특정 멤버를 모임에서 삭제합니다.

swagger 테스트 성공 결과 스크린샷 첨부
<img width="546" height="365" alt="image" src="https://github.com/user-attachments/assets/cee63639-8dbe-433c-8833-5d6670707894" />
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #137
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 검증 메서드에 있는 자기 자신을 삭제하는 상황은 모임 탈퇴의 역할이기에 원래는 필요없으나, 혹시 몰라 부모임장만 자기 자신을 삭제할 수 있도록 구현해놨습니다. 추후에 프론트에서 정상적으로 수행될 경우 제거하겠습니다.

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
