### PR TITLE
[feat/#188] 모임 추천 조회 API 구현

### DIFF
--- a/src/main/java/umc/cockple/demo/domain/member/repository/MemberAddrRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/member/repository/MemberAddrRepository.java
@@ -1,7 +1,11 @@
 package umc.cockple.demo.domain.member.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import umc.cockple.demo.domain.member.domain.Member;
 import umc.cockple.demo.domain.member.domain.MemberAddr;
 
+import java.util.Optional;
+
 public interface MemberAddrRepository extends JpaRepository<MemberAddr, Long> {
+    Optional<MemberAddr> findByMemberAndIsMain(Member member, Boolean isMain);
 }

--- a/src/main/java/umc/cockple/demo/domain/party/controller/PartyController.java
+++ b/src/main/java/umc/cockple/demo/domain/party/controller/PartyController.java
@@ -65,6 +65,22 @@ public class PartyController {
         return BaseResponse.success(CommonSuccessCode.OK, response);
     }
 
+    @GetMapping("/my/parties/suggestions")
+    @Operation(summary = "추천 모임 목록 조회",
+            description = "사용자에게 추천되는 모임 목록을 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "모임 조회 성공")
+    @ApiResponse(responseCode = "404", description = "존재하지 않는 사용자")
+    public BaseResponse<Slice<PartyDTO.Response>> getRecommendedParties(
+            @PageableDefault(size = 10) Pageable pageable,
+            Authentication authentication
+    ) {
+        // TODO: JWT 인증 구현 후 교체 예정
+        Long memberId = 1L; // 임시값
+
+        Slice<PartyDTO.Response> response = partyQueryService.getRecommendedParties(memberId, pageable);
+        return BaseResponse.success(CommonSuccessCode.OK, response);
+    }
+
     @GetMapping("/parties/{partyId}")
     @Operation(summary = "모임 상세 정보 조회",
             description = "특정 모임의 상세 정보를 조회합니다.")

--- a/src/main/java/umc/cockple/demo/domain/party/repository/PartyRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/party/repository/PartyRepository.java
@@ -6,7 +6,10 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import umc.cockple.demo.domain.party.domain.Party;
+import umc.cockple.demo.global.enums.Gender;
+import umc.cockple.demo.global.enums.Level;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface PartyRepository extends JpaRepository<Party, Long> {
@@ -24,4 +27,21 @@ public interface PartyRepository extends JpaRepository<Party, Long> {
             WHERE p.id = :partyId
             """)
     Optional<Party> findByIdWithLevels(@Param("partyId") Long partyId);
+
+    @Query("""
+        SELECT p FROM Party p
+        WHERE p.partyAddr.addr1 = :addr1
+        AND p.minAge <= :birthYear AND p.maxAge >= :birthYear
+        AND EXISTS (
+            SELECT pl FROM p.levels pl
+            WHERE pl.gender = :gender AND pl.level = :level
+        )
+        ORDER BY p.createdAt DESC
+    """)
+    List<Party> findRecommendedParties(
+            @Param("addr1") String addr1,
+            @Param("birthYear") int birthYear,
+            @Param("gender") Gender gender,
+            @Param("level") Level level
+    );
 }

--- a/src/main/java/umc/cockple/demo/domain/party/repository/PartyRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/party/repository/PartyRepository.java
@@ -36,12 +36,17 @@ public interface PartyRepository extends JpaRepository<Party, Long> {
             SELECT pl FROM p.levels pl
             WHERE pl.gender = :gender AND pl.level = :level
         )
+        AND NOT EXISTS (
+            SELECT mp FROM MemberParty mp
+            WHERE mp.member.id = :memberId AND mp.party.id = p.id
+        ) 
         ORDER BY p.createdAt DESC
     """)
     List<Party> findRecommendedParties(
             @Param("addr1") String addr1,
             @Param("birthYear") int birthYear,
             @Param("gender") Gender gender,
-            @Param("level") Level level
+            @Param("level") Level level,
+            @Param("memberId") Long memberId
     );
 }

--- a/src/main/java/umc/cockple/demo/domain/party/service/PartyQueryService.java
+++ b/src/main/java/umc/cockple/demo/domain/party/service/PartyQueryService.java
@@ -10,4 +10,5 @@ public interface PartyQueryService {
     Slice<PartySimpleDTO.Response> getSimpleMyParties(Long memberId, Pageable pageable);
     Slice<PartyDTO.Response> getMyParties(Long memberId, Boolean created, String sort, Pageable pageable);
     PartyMemberDTO.Response getPartyMembers(Long partyId, Long currentMemberId);
+    Slice<PartyDTO.Response> getRecommendedParties(Long memberId, Pageable pageable);
 }

--- a/src/main/java/umc/cockple/demo/domain/party/service/PartyQueryServiceImpl.java
+++ b/src/main/java/umc/cockple/demo/domain/party/service/PartyQueryServiceImpl.java
@@ -215,7 +215,8 @@ public class PartyQueryServiceImpl implements PartyQueryService{
                 member.getBirth().getYear(),
                 member.getGender(),
                 member.getLevel(),
-                memberKeywords
+                memberKeywords,
+                memberId
         );
     }
 
@@ -225,7 +226,8 @@ public class PartyQueryServiceImpl implements PartyQueryService{
                 partiesInfo.addr1(),
                 partiesInfo.birthYear(),
                 partiesInfo.gender(),
-                partiesInfo.level()
+                partiesInfo.level(),
+                partiesInfo.memberId()
         );
     }
 
@@ -316,6 +318,6 @@ public class PartyQueryServiceImpl implements PartyQueryService{
     // ========== record ==========
     //임시로 사용할 데이터 묶음을 record로 구현
     private record ExerciseInfo(Map<Long, Integer> countMap, Map<Long, String> nextInfoMap) {} //운동 정보
-    private record RecommendedPartiesInfo(String addr1, int birthYear, Gender gender, Level level, Set<Keyword> keywords) {} //추천 정보
+    private record RecommendedPartiesInfo(String addr1, int birthYear, Gender gender, Level level, Set<Keyword> keywords, Long memberId) {} //추천 정보
 
 }


### PR DESCRIPTION
## ❤️ 기능 설명
사용자에게 추천되는 모임 목록을 조회합니다.
- 추천 기준 1) 사용자의 급수, 지역, 나이대를 기반으로 필터링을 걸어 맞춤형 모임을 추천합니다. ex) 경기도/파주시라면 경기도인 사람에게만 추천 목록으로 조회됨
- 추천 기준 2) 키워드 맞는거 있는 순으로 상위 노출
- 이미 가입한 모임은 추천되지 않도록 구현했습니다.

swagger 테스트 성공 결과 스크린샷 첨부
<img width="714" height="320" alt="image" src="https://github.com/user-attachments/assets/b7914ac6-5777-4ccd-9568-eca70260cdf0" />
<img width="709" height="236" alt="image" src="https://github.com/user-attachments/assets/5653087d-6f49-4a9e-840f-824835ef9c94" />
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #188
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 급수, 지역, 나이대가 일치하는 모임만 추천되는 것을 확인했습니다.
- [ ] 키워드가 일치하는 모임부터 상단에 추천되는 것을 확인했습니다. (현재 모임에 키워드를 추가하는 api가 없어 직접 데이터베이스에서 키워드를 삽입하여 테스트했습니다.)

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
