### PR TITLE
[refactor/#199] 대회 기록 수정 API에서 이미지 업로드 분리

### DIFF
--- a/src/main/java/umc/cockple/demo/domain/contest/controller/ContestController.java
+++ b/src/main/java/umc/cockple/demo/domain/contest/controller/ContestController.java
@@ -5,15 +5,12 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.MediaType;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.multipart.MultipartFile;
 import umc.cockple.demo.domain.contest.dto.*;
 import umc.cockple.demo.domain.contest.service.ContestCommandService;
 import umc.cockple.demo.domain.contest.service.ContestQueryService;
-import umc.cockple.demo.domain.image.service.ImageService;
 import umc.cockple.demo.domain.contest.enums.MedalType;
 import umc.cockple.demo.global.response.BaseResponse;
 import umc.cockple.demo.global.response.code.status.CommonSuccessCode;
@@ -29,7 +26,6 @@ public class ContestController {
 
     private final ContestCommandService contestCommandService;
     private final ContestQueryService contestQueryService;
-    private final ImageService imageService;
 
     @PostMapping(value = "/contests/my")
     @Operation(summary = "대회 기록 등록", description = "회원이 자신의 대회 기록을 등록합니다.")

--- a/src/main/java/umc/cockple/demo/domain/contest/controller/ContestController.java
+++ b/src/main/java/umc/cockple/demo/domain/contest/controller/ContestController.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
@@ -48,7 +49,7 @@ public class ContestController {
         return BaseResponse.success(CommonSuccessCode.CREATED, response);
     }
 
-    @PatchMapping(value = "/contests/my/{contestId}", consumes = {"multipart/form-data"})
+    @PatchMapping(value = "/contests/my/{contestId}")
     @Operation(summary = "대회 기록 수정", description = "회원이 자신의 대회 기록을 수정합니다.")
     @ApiResponse(responseCode = "201", description = "대회 기록 수정 성공")
     @ApiResponse(responseCode = "400", description = "입력값 오류")
@@ -56,14 +57,13 @@ public class ContestController {
     public BaseResponse<ContestRecordUpdateDTO.Response> updateContestRecord(
             //@AuthenticationPrincipal Long memberId
             @PathVariable Long contestId,
-            @RequestPart("updateRequest") @Valid ContestRecordUpdateDTO.Request request,
-            @RequestPart(value = "contestImg", required = false) List<MultipartFile> contestImgsToAdd
+            @RequestBody @Valid ContestRecordUpdateDTO.Request request
     ) {
         // TODO: JWT 인증 구현 후 교체 예정
         Long memberId = 1L; // 임시값
 
         //서비스 호출
-        ContestRecordUpdateDTO.Response response = contestCommandService.updateContestRecord(memberId, contestId, contestImgsToAdd, request);
+        ContestRecordUpdateDTO.Response response = contestCommandService.updateContestRecord(memberId, contestId, request);
 
         return BaseResponse.success(CommonSuccessCode.CREATED, response);
     }

--- a/src/main/java/umc/cockple/demo/domain/contest/dto/ContestRecordUpdateDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/contest/dto/ContestRecordUpdateDTO.java
@@ -1,11 +1,10 @@
 package umc.cockple.demo.domain.contest.dto;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.Builder;
-import org.springframework.web.multipart.MultipartFile;
+import umc.cockple.demo.domain.image.dto.ImageUploadResponseDTO;
 import umc.cockple.demo.global.enums.Level;
 import umc.cockple.demo.domain.contest.enums.MedalType;
 import umc.cockple.demo.domain.party.enums.ParticipationType;
@@ -22,7 +21,6 @@ public class ContestRecordUpdateDTO {
             @Size(max = 60, message = "대회 이름은 최대 60자 입니다")
             String contestName,
 
-            @JsonFormat(pattern = "yyyy.MM.dd")
             LocalDate date,
 
             MedalType medalType,
@@ -44,12 +42,12 @@ public class ContestRecordUpdateDTO {
             List<String> contestVideos,
 
             // 새로 추가할 이미지
-            List<MultipartFile> contestImgs,
+            List<ImageUploadResponseDTO> contestImgs,
 
             // 삭제할 이미지 imgKey (프론트에서 관리)
             List<String> contestImgsToDelete,
 
-            // 삭제할 영상의 videoOrder (URL 기반)
+            // 삭제할 영상의 비디오 아이디
             List<Long> contestVideoIdsToDelete
 
     ) {

--- a/src/main/java/umc/cockple/demo/domain/contest/service/ContestCommandService.java
+++ b/src/main/java/umc/cockple/demo/domain/contest/service/ContestCommandService.java
@@ -1,9 +1,6 @@
 package umc.cockple.demo.domain.contest.service;
 
-import org.springframework.web.multipart.MultipartFile;
 import umc.cockple.demo.domain.contest.dto.*;
-
-import java.util.List;
 
 public interface ContestCommandService {
     ContestRecordCreateDTO.Response createContestRecord(

--- a/src/main/java/umc/cockple/demo/domain/contest/service/ContestCommandService.java
+++ b/src/main/java/umc/cockple/demo/domain/contest/service/ContestCommandService.java
@@ -11,7 +11,7 @@ public interface ContestCommandService {
     );
 
     ContestRecordUpdateDTO.Response updateContestRecord(
-            Long memberId, Long contestId, List<MultipartFile> ContestImage, ContestRecordUpdateDTO.Request request
+            Long memberId, Long contestId, ContestRecordUpdateDTO.Request request
     );
 
     ContestRecordDeleteDTO.Response deleteContestRecord(

--- a/src/main/java/umc/cockple/demo/domain/contest/service/ContestCommandServiceImpl.java
+++ b/src/main/java/umc/cockple/demo/domain/contest/service/ContestCommandServiceImpl.java
@@ -4,7 +4,6 @@ import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-import org.springframework.web.multipart.MultipartFile;
 import umc.cockple.demo.domain.contest.converter.ContestConverter;
 import umc.cockple.demo.domain.contest.domain.Contest;
 import umc.cockple.demo.domain.contest.domain.ContestImg;
@@ -17,8 +16,6 @@ import umc.cockple.demo.domain.image.dto.ImageUploadResponseDTO;
 import umc.cockple.demo.domain.member.domain.Member;
 import umc.cockple.demo.domain.member.repository.MemberRepository;
 import umc.cockple.demo.domain.image.service.ImageService;
-import umc.cockple.demo.global.enums.ImgType;
-
 import java.util.List;
 
 @Slf4j

--- a/src/main/java/umc/cockple/demo/domain/contest/service/ContestCommandServiceImpl.java
+++ b/src/main/java/umc/cockple/demo/domain/contest/service/ContestCommandServiceImpl.java
@@ -60,16 +60,12 @@ public class ContestCommandServiceImpl implements ContestCommandService {
 
         // 4. 이미지 → ContestImg로 매핑
         if (command.contestImgs() != null) {
-            for (int i = 0; i < command.contestImgs().size(); i++) {
-                ImageUploadResponseDTO imgDTO = command.contestImgs().get(i);
-                ContestImg contestImg = ContestImg.of(contest, imgDTO.imgUrl(), imgDTO.imgKey(), i);
-                contest.addContestImg(contestImg);
-            }
+            extractedImgs(command.contestImgs(), contest);
         }
 
         // 5. 영상 URL -> ContestVideo로 변환
         try {
-            extractedVideo(command, contest);
+            extractedVideo(command.contestVideos(), contest, 0);
         } catch (Exception e) {
             log.error("영상 URL 처리 중 예외 발생", e);
             throw new ContestException(ContestErrorCode.VIDEO_URL_SAVE_FAIL);
@@ -93,7 +89,7 @@ public class ContestCommandServiceImpl implements ContestCommandService {
     // 수정
     @Override
     public ContestRecordUpdateDTO.Response updateContestRecord(
-            Long memberId, Long contestId, List<MultipartFile> contestImgs, ContestRecordUpdateDTO.Request request
+            Long memberId, Long contestId, ContestRecordUpdateDTO.Request request
     ) {
 
         log.info("[대회 기록 수정 시작] - memberId: {}, contestId: {}", memberId, contestId);
@@ -119,11 +115,8 @@ public class ContestCommandServiceImpl implements ContestCommandService {
         }
 
         // 5. 이미지 추가
-        try {
-            extractedImg(contestImgs, contest);
-        } catch (Exception e) {
-            log.error("이미지 업로드 중 예외 발생", e);
-            throw new ContestException(ContestErrorCode.IMAGE_UPLOAD_FAIL);
+        if (request.contestImgs() != null) {
+            extractedImgs(request.contestImgs(), contest);
         }
 
         // 6. 영상 삭제
@@ -140,8 +133,11 @@ public class ContestCommandServiceImpl implements ContestCommandService {
         }
 
         // 8. 영상 추가
+        int maxOrder = contest.getContestVideos().stream()
+                .mapToInt(ContestVideo::getVideoOrder)
+                .max().orElse(-1);
         try {
-            extractedVideo(request, contest);
+            extractedVideo(request.contestVideos(), contest, maxOrder + 1);
         } catch (Exception e) {
             log.error("영상 수정 중 오류 발생", e);
             throw new ContestException(ContestErrorCode.VIDEO_URL_SAVE_FAIL);
@@ -181,52 +177,26 @@ public class ContestCommandServiceImpl implements ContestCommandService {
         return contestConverter.toDeleteResponseDTO(contest);
     }
 
-    private static void extractedVideo(ContestRecordUpdateDTO.Request request, Contest contest) {
-        if (request.contestVideos() != null) {
-            int maxOrder = contest.getContestVideos().stream()
-                    .mapToInt(ContestVideo::getVideoOrder)
-                    .max().orElse(-1);
+    private void extractedImgs(List<ImageUploadResponseDTO> imgs, Contest contest) {
+        int startIndex = contest.getContestImgs().size();
+        int total = startIndex + imgs.size();
+        if (total > 3) {
+            log.error("이미지 개수 초과: 기존 {}, 추가 {}", startIndex, imgs.size());
+            throw new ContestException(ContestErrorCode.IMAGE_UPLOAD_LIMIT_EXCEEDED);
+        }
+        for (int i = 0; i < imgs.size(); i++) {
+            ImageUploadResponseDTO dto = imgs.get(i);
+            ContestImg contestImg = ContestImg.of(contest, dto.imgUrl(), dto.imgKey(), startIndex + i);
+            contest.addContestImg(contestImg);
+        }
+    }
 
-            for (int i = 0; i < request.contestVideos().size(); i++) {
-                String videoUrl = request.contestVideos().get(i);
-                ContestVideo video = ContestVideo.of(contest, videoUrl, maxOrder + i + 1);
+    private void extractedVideo(List<String> videoUrls, Contest contest, int startOrder) {
+        if (videoUrls != null && !videoUrls.isEmpty()) {
+            for (int i = 0; i < videoUrls.size(); i++) {
+                String url = videoUrls.get(i);
+                ContestVideo video = ContestVideo.of(contest, url, startOrder + i);
                 contest.getContestVideos().add(video);
-            }
-        }
-    }
-
-    private void extractedImg(List<MultipartFile> contestImgs, Contest contest) {
-        if (contestImgs != null && !contestImgs.isEmpty()) {
-            int baseOrder = contest.getContestImgs().size();
-
-            // 실제 업로드된 URL들 (null 아닌 값만 들어옴)
-            List<ImageUploadResponseDTO> imgUrls = imageService.uploadImages(contestImgs, ImgType.CONTEST);
-
-            int totalImages = contest.getContestImgs().size() + contestImgs.size();
-            if (totalImages > 3) {
-                log.error("이미지 최대 개수 초과 예외");
-                throw new ContestException(ContestErrorCode.IMAGE_UPLOAD_LIMIT_EXCEEDED);
-            }
-
-            for (int i = 0; i < imgUrls.size(); i++) {
-                String imgUrl = imgUrls.get(i).imgUrl();
-                String imgKey = imageService.extractKeyFromUrl(imgUrl, ImgType.CONTEST); // 나중에 실제 키로 대체하면 됨
-
-                ContestImg img = ContestImg.of(contest, imgUrl, imgKey, baseOrder + i);
-                contest.addContestImg(img);
-            }
-        }
-    }
-
-
-    private static void extractedVideo(ContestRecordCreateDTO.Command contestRecordCommand, Contest contest) {
-        if (contestRecordCommand.contestVideos() != null) {
-            for (int i = 0; i < contestRecordCommand.contestVideos().size(); i++) {
-                String videoUrl = contestRecordCommand.contestVideos().get(i);
-
-                ContestVideo contestVideo = ContestVideo.of(contest, videoUrl, i);
-
-                contest.getContestVideos().add(contestVideo);
             }
         }
     }


### PR DESCRIPTION
## ❤️ 기능 설명

swagger 테스트 성공 결과 스크린샷 첨부
<br>
<img width="740" height="718" alt="스크린샷 2025-07-29 13 41 35" src="https://github.com/user-attachments/assets/5b16ac20-82a1-420a-90f8-684b557dec37" />

이미지, 동영상 삭제

<img width="1470" height="956" alt="스크린샷 2025-07-29 13 44 30" src="https://github.com/user-attachments/assets/2f203124-691f-4b83-85e8-ea44b690c229" />

이미지, 동영상 추가

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #199 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
