### PR TITLE
[feat/#120] 카카오 소셜로그인 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,15 @@ dependencies {
 
 	// s3
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+
+	// jwt
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+	// WebClient 사용 위해 추가
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/umc/cockple/demo/domain/bookmark/controller/BookmarkController.java
+++ b/src/main/java/umc/cockple/demo/domain/bookmark/controller/BookmarkController.java
@@ -13,6 +13,7 @@ import umc.cockple.demo.global.enums.ExerciseOrderType;
 import umc.cockple.demo.global.enums.PartyOrderType;
 import umc.cockple.demo.global.response.BaseResponse;
 import umc.cockple.demo.global.response.code.status.CommonSuccessCode;
+import umc.cockple.demo.global.security.utils.SecurityUtil;
 
 import java.util.List;
 
@@ -30,8 +31,8 @@ public class BookmarkController {
     @Operation(summary = "모임 찜 API",
             description = "사용자가 원하는 모임을 찜해둘 수 있음")
     public BaseResponse<Long> partyBookmark(@PathVariable Long partyId) {
-        // 추후 시큐리티를 통해 id 가져옴
-        Long memberId = 1L;
+
+        Long memberId = SecurityUtil.getCurrentMemberId();
 
         return BaseResponse.success(CommonSuccessCode.CREATED, bookmarkCommandService.partyBookmark(memberId, partyId));
     }
@@ -40,8 +41,8 @@ public class BookmarkController {
     @Operation(summary = "모임 찜 해제 API",
             description = "사용자가 찜한 모임을 해제할 수 있음")
     public BaseResponse<Object> releasePartyBookmark(@PathVariable Long partyId) {
-        // 추후 시큐리티를 통해 id 가져옴
-        Long memberId = 1L;
+
+        Long memberId = SecurityUtil.getCurrentMemberId();
 
         bookmarkCommandService.releasePartyBookmark(memberId, partyId);
         return BaseResponse.success(CommonSuccessCode.NO_CONTENT);
@@ -51,8 +52,8 @@ public class BookmarkController {
     @Operation(summary = "운동 찜 API",
             description = "사용자가 원하는 운동을 찜해둘 수 있음")
     public BaseResponse<Long> exerciseBookmark(@PathVariable Long exerciseId) {
-        // 추후 시큐리티를 통해 id 가져옴
-        Long memberId = 1L;
+
+        Long memberId = SecurityUtil.getCurrentMemberId();
 
         return BaseResponse.success(CommonSuccessCode.CREATED, bookmarkCommandService.exerciseBookmark(memberId, exerciseId));
     }
@@ -61,8 +62,8 @@ public class BookmarkController {
     @Operation(summary = "운동 찜 해제 API",
             description = "사용자가 찜한 운동 해제할 수 있음")
     public BaseResponse<Object> releaseExerciseBookmark(@PathVariable Long exerciseId) {
-        // 추후 시큐리티를 통해 id 가져옴
-        Long memberId = 1L;
+
+        Long memberId = SecurityUtil.getCurrentMemberId();
 
         bookmarkCommandService.releaseExerciseBookmark(memberId, exerciseId);
         return BaseResponse.success(CommonSuccessCode.NO_CONTENT);
@@ -73,8 +74,8 @@ public class BookmarkController {
     @Operation(summary = "찜한 운동 전체 조회 API",
             description = "사용자가 찜한 운동을 모두 조회")
     public BaseResponse<List<GetAllExerciseBookmarksResponseDTO>> getAllExerciseBookmarks(@RequestParam ExerciseOrderType orderType) {
-        // 추후 시큐리티를 통해 id 가져옴
-        Long memberId = 1L;
+
+        Long memberId = SecurityUtil.getCurrentMemberId();
 
         return BaseResponse.success(CommonSuccessCode.OK, bookmarkQueryService.getAllExerciseBookmarks(memberId, orderType));
     }
@@ -83,8 +84,8 @@ public class BookmarkController {
     @Operation(summary = "찜한 모임 전체 조회 API",
             description = "사용자가 찜한 모임을 모두 조회")
     public BaseResponse<List<GetAllPartyBookmarkResponseDTO>> getAllPartyBookmarks(@RequestParam PartyOrderType orderType) {
-        // 추후 시큐리티를 통해 id 가져옴
-        Long memberId = 1L;
+
+        Long memberId = SecurityUtil.getCurrentMemberId();
 
         return BaseResponse.success(CommonSuccessCode.OK, bookmarkQueryService.getAllPartyBookmarks(memberId, orderType));
     }

--- a/src/main/java/umc/cockple/demo/domain/member/controller/MemberController.java
+++ b/src/main/java/umc/cockple/demo/domain/member/controller/MemberController.java
@@ -17,6 +17,7 @@ import umc.cockple.demo.global.jwt.domain.TokenRefreshResponse;
 import umc.cockple.demo.global.oauth2.service.KakaoOauthService;
 import umc.cockple.demo.global.response.BaseResponse;
 import umc.cockple.demo.global.response.code.status.CommonSuccessCode;
+import umc.cockple.demo.global.security.utils.SecurityUtil;
 
 import java.io.IOException;
 import java.time.Duration;
@@ -123,7 +124,7 @@ public class MemberController {
             description = "사용자가 자신의 프로필 수정")
     public BaseResponse<Object> updateProfile(@RequestBody @Valid UpdateProfileRequestDTO requestDTO) throws IOException {
         // 추후 시큐리티를 통해 id 가져옴
-        Long memberId = 1L;
+        Long memberId = SecurityUtil.getCurrentMemberId();
 
         memberCommandService.updateProfile(requestDTO, memberId);
         return BaseResponse.success(CommonSuccessCode.OK);
@@ -138,7 +139,7 @@ public class MemberController {
             description = "사용자가 자신의 주소 추가")
     public BaseResponse<CreateMemberAddrResponseDTO> createMemberAddress(@RequestBody @Valid CreateMemberAddrRequestDTO requestDto) {
         // 추후 시큐리티를 통해 id 가져옴
-        Long memberId = 1L;
+        Long memberId = SecurityUtil.getCurrentMemberId();
 
         return BaseResponse.success(CommonSuccessCode.CREATED, memberCommandService.addMemberNewAddr(requestDto, memberId));
     }

--- a/src/main/java/umc/cockple/demo/domain/member/controller/MemberController.java
+++ b/src/main/java/umc/cockple/demo/domain/member/controller/MemberController.java
@@ -89,8 +89,8 @@ public class MemberController {
     @Operation(summary = "회원 탈퇴 API",
             description = "사용자 회원 탈퇴")
     public BaseResponse<String> withdraw() {
-        // 추후 시큐리티를 통해 id 가져옴
-        Long memberId = 1L;
+
+        Long memberId = SecurityUtil.getCurrentMemberId();
 
         memberCommandService.withdrawMember(memberId);
         return BaseResponse.success(CommonSuccessCode.NO_CONTENT);
@@ -112,8 +112,8 @@ public class MemberController {
     @Operation(summary = "내 프로필 조회 API",
             description = "사용자가 자신의 프로필을 조회")
     public BaseResponse<GetMyProfileResponseDTO> getMyProfile() {
-        // 추후 시큐리티를 통해 id 가져옴
-        Long memberId = 1L;
+
+        Long memberId = SecurityUtil.getCurrentMemberId();
 
         return BaseResponse.success(CommonSuccessCode.OK, memberQueryService.getMyProfile(memberId));
     }
@@ -123,7 +123,7 @@ public class MemberController {
     @Operation(summary = "프로필 수정 API",
             description = "사용자가 자신의 프로필 수정")
     public BaseResponse<Object> updateProfile(@RequestBody @Valid UpdateProfileRequestDTO requestDTO) throws IOException {
-        // 추후 시큐리티를 통해 id 가져옴
+
         Long memberId = SecurityUtil.getCurrentMemberId();
 
         memberCommandService.updateProfile(requestDTO, memberId);
@@ -138,7 +138,7 @@ public class MemberController {
     @Operation(summary = "회원 주소 추가 API",
             description = "사용자가 자신의 주소 추가")
     public BaseResponse<CreateMemberAddrResponseDTO> createMemberAddress(@RequestBody @Valid CreateMemberAddrRequestDTO requestDto) {
-        // 추후 시큐리티를 통해 id 가져옴
+
         Long memberId = SecurityUtil.getCurrentMemberId();
 
         return BaseResponse.success(CommonSuccessCode.CREATED, memberCommandService.addMemberNewAddr(requestDto, memberId));
@@ -148,8 +148,8 @@ public class MemberController {
     @Operation(summary = "대표 주소 변경 API",
             description = "사용자가 자신의 대표주소 변경")
     public BaseResponse<String> updateMainAddr(@PathVariable Long memberAddrId) {
-        // 추후 시큐리티를 통해 id 가져옴
-        Long memberId = 1L;
+
+        Long memberId = SecurityUtil.getCurrentMemberId();
 
         memberCommandService.updateMainAddr(memberId, memberAddrId);
         return BaseResponse.success(CommonSuccessCode.OK);
@@ -159,8 +159,8 @@ public class MemberController {
     @Operation(summary = "회원 주소 삭제 API",
             description = "사용자가 자신의 주소 중 원하는 주소를 삭제")
     public BaseResponse<String> deleteMemberAddr(@PathVariable Long memberAddrId) {
-        // 추후 시큐리티를 통해 id 가져옴
-        Long memberId = 1L;
+
+        Long memberId = SecurityUtil.getCurrentMemberId();
 
         memberCommandService.deleteMemberAddr(memberId, memberAddrId);
         return BaseResponse.success(CommonSuccessCode.OK);
@@ -170,8 +170,8 @@ public class MemberController {
     @Operation(summary = "회원 현재 위치 조회 API",
             description = "사용자의 현재 위치를 조회 (홈 화면 상단에 해당 위치의 동을 띄울 때 사용)")
     public BaseResponse<GetNowAddressResponseDTO> getNowAddress() {
-        // 추후 시큐리티를 통해 id 가져옴
-        Long memberId = 1L;
+
+        Long memberId = SecurityUtil.getCurrentMemberId();
 
         return BaseResponse.success(CommonSuccessCode.OK, memberQueryService.getNowAddress(memberId));
 
@@ -181,8 +181,8 @@ public class MemberController {
     @Operation(summary = "회원 주소 전체 조회 API",
             description = "사용자가 등록한 모든 주소를 조회")
     public BaseResponse<List<GetAllAddressResponseDTO>> getAllAddress() {
-        // 추후 시큐리티를 통해 id 가져옴
-        Long memberId = 1L;
+
+        Long memberId = SecurityUtil.getCurrentMemberId();
 
         List<GetAllAddressResponseDTO> addresses = memberQueryService.getAllAddress(memberId);
         return BaseResponse.success(CommonSuccessCode.OK, addresses);

--- a/src/main/java/umc/cockple/demo/domain/member/controller/MemberController.java
+++ b/src/main/java/umc/cockple/demo/domain/member/controller/MemberController.java
@@ -7,8 +7,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import umc.cockple.demo.domain.member.dto.*;
+import umc.cockple.demo.domain.member.dto.kakao.KakaoLoginDTO;
 import umc.cockple.demo.domain.member.service.MemberCommandService;
 import umc.cockple.demo.domain.member.service.MemberQueryService;
+import umc.cockple.demo.global.oauth2.service.KakaoOauthService;
 import umc.cockple.demo.global.response.BaseResponse;
 import umc.cockple.demo.global.response.code.status.CommonSuccessCode;
 
@@ -16,6 +18,7 @@ import java.io.IOException;
 import java.util.List;
 
 import static umc.cockple.demo.domain.member.dto.CreateMemberAddrDTO.*;
+import static umc.cockple.demo.domain.member.dto.kakao.KakaoLoginDTO.*;
 
 @RestController
 @RequestMapping("/api")
@@ -26,6 +29,14 @@ public class MemberController {
 
     private final MemberCommandService memberCommandService;
     private final MemberQueryService memberQueryService;
+    private final KakaoOauthService kakaoOauthService;
+
+    @PostMapping("/oauth/login")
+    @Operation(summary = "카카오 소셜 로그인 API",
+            description = "카카오에서 인가코드를 발급받아 요청으로 넣어주세요. 기존 회원의 경우 로그인, 신규 회원의 경우 회원가입을 합니다.")
+    public BaseResponse<KakaoLoginResponseDTO> login(@RequestBody @Valid KakaoLoginRequestDTO requestDTO) {
+        return BaseResponse.success(CommonSuccessCode.ACCEPTED, kakaoOauthService.signup(requestDTO.code()));
+    }
 
 
     @PatchMapping(value = "/member")

--- a/src/main/java/umc/cockple/demo/domain/member/domain/Member.java
+++ b/src/main/java/umc/cockple/demo/domain/member/domain/Member.java
@@ -48,6 +48,7 @@ public class Member extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private MemberStatus isActive;
 
+    @Column(nullable = false)
     private String refreshToken;
 
     @Column(nullable = false)
@@ -141,5 +142,9 @@ public class Member extends BaseEntity {
 
     public int getAge(){
         return Period.between(birth, LocalDate.now()).getYears();
+    }
+
+    public void setRefreshToken(String refreshToken) {
+        this.refreshToken = refreshToken;
     }
 }

--- a/src/main/java/umc/cockple/demo/domain/member/domain/Member.java
+++ b/src/main/java/umc/cockple/demo/domain/member/domain/Member.java
@@ -32,17 +32,13 @@ public class Member extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false)
     private String memberName;
 
-    @Column(nullable = false)
     @Enumerated(EnumType.STRING)
     private Gender gender;
 
-    @Column(nullable = false)
     private LocalDate birth;
 
-    @Column(nullable = false)
     @Enumerated(EnumType.STRING)
     private Level level;
 
@@ -53,6 +49,9 @@ public class Member extends BaseEntity {
     private MemberStatus isActive;
 
     private String refreshToken;
+
+    @Column(nullable = false)
+    private Long socialId; // 카카오에서 받아온 고유id
 
 
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)

--- a/src/main/java/umc/cockple/demo/domain/member/dto/kakao/KakaoLoginDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/member/dto/kakao/KakaoLoginDTO.java
@@ -1,0 +1,19 @@
+package umc.cockple.demo.domain.member.dto.kakao;
+
+import lombok.Builder;
+
+public class KakaoLoginDTO {
+
+    @Builder
+    public record KakaoLoginRequestDTO(
+            String code
+    ){}
+
+    @Builder
+    public record KakaoLoginResponseDTO(
+            String accessToken,
+            Long memberId,
+            String nickname,
+            Boolean isNewMember
+    ){}
+}

--- a/src/main/java/umc/cockple/demo/domain/member/dto/kakao/KakaoLoginDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/member/dto/kakao/KakaoLoginDTO.java
@@ -12,6 +12,7 @@ public class KakaoLoginDTO {
     @Builder
     public record KakaoLoginResponseDTO(
             String accessToken,
+            String refreshToken,
             Long memberId,
             String nickname,
             Boolean isNewMember

--- a/src/main/java/umc/cockple/demo/domain/member/exception/MemberErrorCode.java
+++ b/src/main/java/umc/cockple/demo/domain/member/exception/MemberErrorCode.java
@@ -33,6 +33,14 @@ public enum MemberErrorCode implements BaseErrorCode {
     MEMBER_ADDRESS_MINIMUM_REQUIRED(HttpStatus.BAD_REQUEST, "MEM_ADDR404", "주소가 적어도 1개 이상 필요합니다."),
     MAIN_ADDRESS_NULL(HttpStatus.BAD_REQUEST, "MEM_ADDR405", "대표 주소가 존재하지 않습니다."),
 
+
+    // jwt
+
+    INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "MEM_AUTH_301", "리프레시토큰이 유효하지 않습니다. 다시 로그인을 진행해주세요."),
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "MEM_AUTH_302", "잘못된 토큰입니다. (session지원 실패)"),
+
+    NICKNAME_IS_NULL(HttpStatus.BAD_REQUEST, "MEM_AUTH_401", "토큰 생성 중 닉네임이 존재하지 않습니다."),
+
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/umc/cockple/demo/domain/member/repository/MemberRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/member/repository/MemberRepository.java
@@ -32,4 +32,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     List<Map<String, Object>> findMemberNameMapsByIds(@Param("memberIds") Set<Long> memberIds);
 
     Optional<Member> findBySocialId(Long socialId);
+
+    Optional<Member> findByRefreshToken(String refreshToken);
 }

--- a/src/main/java/umc/cockple/demo/domain/member/repository/MemberRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/member/repository/MemberRepository.java
@@ -7,6 +7,7 @@ import umc.cockple.demo.domain.member.domain.Member;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -29,4 +30,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
             WHERE m.id IN :memberIds
             """)
     List<Map<String, Object>> findMemberNameMapsByIds(@Param("memberIds") Set<Long> memberIds);
+
+    Optional<Member> findBySocialId(Long socialId);
 }

--- a/src/main/java/umc/cockple/demo/domain/notification/controller/NotificationController.java
+++ b/src/main/java/umc/cockple/demo/domain/notification/controller/NotificationController.java
@@ -14,6 +14,7 @@ import umc.cockple.demo.domain.notification.service.NotificationQueryService;
 import umc.cockple.demo.global.enums.NotificationType;
 import umc.cockple.demo.global.response.BaseResponse;
 import umc.cockple.demo.global.response.code.status.CommonSuccessCode;
+import umc.cockple.demo.global.security.utils.SecurityUtil;
 
 import java.util.List;
 
@@ -33,8 +34,8 @@ public class NotificationController {
     @Operation(summary = "내 알림 전체 조회",
             description = "사용자에게 온 알림 전체를 조회합니다. ")
     public BaseResponse<List<AllNotificationsResponseDTO>> getAllNotifications() {
-        // 추후 시큐리티를 통해 id 가져옴
-        Long memberId = 1L;
+
+        Long memberId = SecurityUtil.getCurrentMemberId();
 
         return BaseResponse.success(CommonSuccessCode.OK, notificationQueryService.getAllNotifications(memberId));
     }
@@ -45,8 +46,8 @@ public class NotificationController {
     @Operation(summary = "안 읽은 알림 존재여부 조회",
             description = "사용자가 읽지 않은 알림이 있는지 확인합니다. 존재 시 알림 아이콘에 빨간 점이 표시됩니다 ")
     public BaseResponse<ExistNewNotificationResponseDTO> checkUnReadNotification() {
-        // 추후 시큐리티를 통해 id 가져옴
-        Long memberId = 1L;
+
+        Long memberId = SecurityUtil.getCurrentMemberId();
 
         return BaseResponse.success(CommonSuccessCode.OK,notificationQueryService.checkUnreadNotification(memberId));
     }
@@ -58,8 +59,7 @@ public class NotificationController {
             description = "특정 알림을 조회하고 읽음 처리를 진행합니다. ")
     public BaseResponse<Response> markAsReadNotification(@PathVariable Long notificationId,
                                                          Request type) {
-        // 추후 시큐리티를 통해 id 가져옴
-        Long memberId = 1L;
+        Long memberId = SecurityUtil.getCurrentMemberId();
 
         return BaseResponse.success(CommonSuccessCode.OK, notificationCommandService.markAsReadNotification(memberId, notificationId, type.type()));
     }

--- a/src/main/java/umc/cockple/demo/global/config/SecurityConfig.java
+++ b/src/main/java/umc/cockple/demo/global/config/SecurityConfig.java
@@ -34,19 +34,15 @@ public class SecurityConfig {
         http
                 .csrf(AbstractHttpConfigurer::disable)
                 .httpBasic(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
                 .sessionManagement(session ->
                         session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                        .anyRequest().permitAll()
-
-                        //TODO 로그인 로직 구현 전까지 모든 경로 허용
-//                        .requestMatchers(
-//                                "/api/member/**", "/",
-//                                "/api/terms", "/api/nickname"
-//                        ).permitAll()
-//                        .anyRequest().authenticated()
+                        .requestMatchers("/api/oauth/kakao").permitAll()
+                        .anyRequest().authenticated()
                 )
-                .formLogin(AbstractHttpConfigurer::disable)
+                .sessionManagement(session -> session
+                                .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
 //                .addFilterBefore() // 추후 jwt 개발시 사용
         ;
 

--- a/src/main/java/umc/cockple/demo/global/jwt/domain/JwtTokenProvider.java
+++ b/src/main/java/umc/cockple/demo/global/jwt/domain/JwtTokenProvider.java
@@ -1,27 +1,33 @@
 package umc.cockple.demo.global.jwt.domain;
 
-import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.JwtException;
-import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.*;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
+import umc.cockple.demo.domain.member.domain.Member;
 import umc.cockple.demo.domain.member.exception.MemberErrorCode;
 import umc.cockple.demo.domain.member.exception.MemberException;
+import umc.cockple.demo.domain.member.repository.MemberRepository;
 import umc.cockple.demo.global.jwt.properties.JwtProperties;
+import umc.cockple.demo.global.security.domain.CustomUserDetails;
 
 import java.security.Key;
 import java.util.Date;
 
 @Component
+@Slf4j
 @RequiredArgsConstructor
 public class JwtTokenProvider {
 
     private Key key;
     private final JwtProperties jwtProperties;
+    private final MemberRepository memberRepository;
 
     @PostConstruct
     public void init() {
@@ -57,6 +63,32 @@ public class JwtTokenProvider {
                 .compact();
     }
 
+    // 토큰 유효성 검사
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder()
+                    .setSigningKey(key)
+                    .build()
+                    .parseClaimsJws(token);
+
+            return true;
+        } catch (SecurityException | MalformedJwtException e) {
+            log.info("Invalid JWT Token", e);
+        } catch (io.jsonwebtoken.security.SignatureException exception) {
+            log.error("JWT signature validation fails");
+        } catch (ExpiredJwtException e) {
+            log.info("Expired JWT Token", e);
+        } catch (UnsupportedJwtException e) {
+            log.info("Unsupported JWT Token", e);
+        } catch (IllegalArgumentException e) {
+            log.info("JWT claims string is empty.", e);
+        } catch (Exception exception) {
+            log.error("JWT validation fails", exception);
+        }
+        return false;
+    }
+
+
     public boolean isTokenExpiringSoon(String refreshToken, long thresholdMillis) {
         try {
             Claims claims = Jwts.parserBuilder()
@@ -72,5 +104,24 @@ public class JwtTokenProvider {
         } catch (JwtException e) {
             throw new MemberException(MemberErrorCode.INVALID_TOKEN);
         }
+    }
+
+    public Long getUserId(String token) {
+        Claims claims = Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+
+        return Long.valueOf(claims.getSubject());
+    }
+
+    public Authentication getAuthentication(String token) {
+        Long memberId = getUserId(token);
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
+
+        UserDetails userDetails = new CustomUserDetails(member.getId(), member.getNickname());
+        return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
     }
 }

--- a/src/main/java/umc/cockple/demo/global/jwt/domain/JwtTokenProvider.java
+++ b/src/main/java/umc/cockple/demo/global/jwt/domain/JwtTokenProvider.java
@@ -1,0 +1,76 @@
+package umc.cockple.demo.global.jwt.domain;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import umc.cockple.demo.domain.member.exception.MemberErrorCode;
+import umc.cockple.demo.domain.member.exception.MemberException;
+import umc.cockple.demo.global.jwt.properties.JwtProperties;
+
+import java.security.Key;
+import java.util.Date;
+
+@Component
+@RequiredArgsConstructor
+public class JwtTokenProvider {
+
+    private Key key;
+    private final JwtProperties jwtProperties;
+
+    @PostConstruct
+    public void init() {
+        byte[] keyBytes = Decoders.BASE64URL.decode(jwtProperties.getSecret());
+        this.key = Keys.hmacShaKeyFor(keyBytes);
+    }
+
+    public String createAccessToken(Long memberId, String nickname) {
+        return createToken(memberId, nickname, jwtProperties.getAccessTokenValidity());
+    }
+
+    public String createRefreshToken(Long memberId, String nickname) {
+        return createToken(memberId, nickname, jwtProperties.getRefreshTokenValidity());
+    }
+
+    private String createToken(Long memberId, String nickname, long validity) {
+        Claims claims = Jwts.claims().setSubject(String.valueOf(memberId));
+
+        if (nickname == null) {
+            throw new MemberException(MemberErrorCode.NICKNAME_IS_NULL);
+        }
+
+        claims.put("nickname", nickname);
+
+        Date now = new Date();
+        Date expiration = new Date(now.getTime() + validity);
+
+        return Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(now)
+                .setExpiration(expiration)
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    public boolean isTokenExpiringSoon(String refreshToken, long thresholdMillis) {
+        try {
+            Claims claims = Jwts.parserBuilder()
+                    .setSigningKey(key)
+                    .build()
+                    .parseClaimsJws(refreshToken)
+                    .getBody();
+
+            Date expiration = claims.getExpiration();
+            long now = System.currentTimeMillis();
+
+            return expiration.getTime() - now < thresholdMillis;
+        } catch (JwtException e) {
+            throw new MemberException(MemberErrorCode.INVALID_TOKEN);
+        }
+    }
+}

--- a/src/main/java/umc/cockple/demo/global/jwt/domain/TokenRefreshResponse.java
+++ b/src/main/java/umc/cockple/demo/global/jwt/domain/TokenRefreshResponse.java
@@ -1,0 +1,7 @@
+package umc.cockple.demo.global.jwt.domain;
+
+public record TokenRefreshResponse(
+        String accessToken,
+        String refreshToken
+) {
+}

--- a/src/main/java/umc/cockple/demo/global/jwt/properties/JwtProperties.java
+++ b/src/main/java/umc/cockple/demo/global/jwt/properties/JwtProperties.java
@@ -1,0 +1,14 @@
+package umc.cockple.demo.global.jwt.properties;
+
+import lombok.Getter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Getter
+@Configuration
+@ConfigurationProperties(prefix = "jwt")
+public class JwtProperties {
+    private String secret;
+    private long accessTokenValidity;
+    private long refreshTokenValidity;
+}

--- a/src/main/java/umc/cockple/demo/global/jwt/properties/JwtProperties.java
+++ b/src/main/java/umc/cockple/demo/global/jwt/properties/JwtProperties.java
@@ -1,10 +1,12 @@
 package umc.cockple.demo.global.jwt.properties;
 
 import lombok.Getter;
+import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 
 @Getter
+@Setter
 @Configuration
 @ConfigurationProperties(prefix = "jwt")
 public class JwtProperties {

--- a/src/main/java/umc/cockple/demo/global/oauth2/domain/KakaoClient.java
+++ b/src/main/java/umc/cockple/demo/global/oauth2/domain/KakaoClient.java
@@ -1,0 +1,74 @@
+package umc.cockple.demo.global.oauth2.domain;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.BodyInserter;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.client.WebClient;
+import umc.cockple.demo.global.oauth2.domain.info.KakaoClientInfo;
+
+@Component
+@RequiredArgsConstructor
+public class KakaoClient {
+
+    private final WebClient webClient = WebClient.create();
+
+    @Value("${kakao.client-id}")
+    private String clientId;
+
+    @Value("${kakao.client-secret:}")
+    private String clientSecret;
+
+    @Value("${kakao.redirect-uri}")
+    private String redirectUri;
+
+    @Value("${kakao.token-uri}")
+    private String tokenUri;
+
+    @Value("${kakao.user-info-uri}")
+    private String userInfoUri;
+
+
+    // 인가코드로 AccessToken 요청하기
+    public String getAccessToken(String code) {
+        BodyInserters.FormInserter<String> formData = BodyInserters.fromFormData("grant-type", "authorization_code")
+                .with("client_id", clientId)
+                .with("redirect_uri", redirectUri)
+                .with("code", code);
+
+        if (clientSecret != null && !clientSecret.isBlank()) {
+            formData.with("client_secret", clientSecret);
+        }
+
+        JsonNode response = webClient.post()
+                .uri(tokenUri)
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .body(formData)
+                .retrieve()
+                .bodyToMono(JsonNode.class)
+                .block();
+
+        return response.get("access_token").asText();
+    }
+
+    // access 토큰으로 사용자 정보 요청
+    public KakaoClientInfo getClientInfo(String accessToken) {
+        JsonNode response = webClient.get()
+                .uri(userInfoUri)
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                .retrieve()
+                .bodyToMono(JsonNode.class)
+                .block();
+
+        Long kakaoId = response.get("id").asLong();
+        String nickname = response.path("properties").path("nickname").asText();
+
+        return new KakaoClientInfo(kakaoId, nickname);
+    }
+
+
+}

--- a/src/main/java/umc/cockple/demo/global/oauth2/domain/KakaoClient.java
+++ b/src/main/java/umc/cockple/demo/global/oauth2/domain/KakaoClient.java
@@ -2,6 +2,7 @@ package umc.cockple.demo.global.oauth2.domain;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -12,6 +13,7 @@ import org.springframework.web.reactive.function.client.WebClient;
 import umc.cockple.demo.global.oauth2.domain.info.KakaoClientInfo;
 
 @Component
+@Slf4j
 @RequiredArgsConstructor
 public class KakaoClient {
 
@@ -35,7 +37,7 @@ public class KakaoClient {
 
     // 인가코드로 AccessToken 요청하기
     public String getAccessToken(String code) {
-        BodyInserters.FormInserter<String> formData = BodyInserters.fromFormData("grant-type", "authorization_code")
+        BodyInserters.FormInserter<String> formData = BodyInserters.fromFormData("grant_type", "authorization_code")
                 .with("client_id", clientId)
                 .with("redirect_uri", redirectUri)
                 .with("code", code);
@@ -44,6 +46,8 @@ public class KakaoClient {
             formData.with("client_secret", clientSecret);
         }
 
+        log.info("Redirect URI used: {}", redirectUri);
+        log.info("Auth Code: {}", code);
         JsonNode response = webClient.post()
                 .uri(tokenUri)
                 .contentType(MediaType.APPLICATION_FORM_URLENCODED)

--- a/src/main/java/umc/cockple/demo/global/oauth2/domain/info/KakaoClientInfo.java
+++ b/src/main/java/umc/cockple/demo/global/oauth2/domain/info/KakaoClientInfo.java
@@ -1,0 +1,9 @@
+package umc.cockple.demo.global.oauth2.domain.info;
+
+public record KakaoClientInfo(
+        Long kakaoId,
+        String nickname
+) {
+
+}
+

--- a/src/main/java/umc/cockple/demo/global/oauth2/service/KakaoOauthService.java
+++ b/src/main/java/umc/cockple/demo/global/oauth2/service/KakaoOauthService.java
@@ -1,14 +1,20 @@
 package umc.cockple.demo.global.oauth2.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import umc.cockple.demo.domain.member.domain.Member;
 import umc.cockple.demo.domain.member.dto.kakao.KakaoLoginDTO;
+import umc.cockple.demo.domain.member.exception.MemberErrorCode;
+import umc.cockple.demo.domain.member.exception.MemberException;
 import umc.cockple.demo.domain.member.repository.MemberRepository;
+import umc.cockple.demo.global.jwt.domain.JwtTokenProvider;
+import umc.cockple.demo.global.jwt.domain.TokenRefreshResponse;
 import umc.cockple.demo.global.oauth2.domain.KakaoClient;
 import umc.cockple.demo.global.oauth2.domain.info.KakaoClientInfo;
 
+import java.time.Duration;
 import java.util.Optional;
 
 import static umc.cockple.demo.domain.member.dto.kakao.KakaoLoginDTO.*;
@@ -19,14 +25,15 @@ public class KakaoOauthService {
 
     private final KakaoClient kakaoClient;
     private final MemberRepository memberRepository;
+    private final JwtTokenProvider jwtTokenProvider;
 
     @Transactional
     public KakaoLoginResponseDTO signup(String code) {
         // 1. accessToken 발급
-        String accessToken = kakaoClient.getAccessToken(code);
+        String kakaoAccessToken = kakaoClient.getAccessToken(code);
 
         // 2. 카카오에 사용자 정보 요청
-        KakaoClientInfo info = kakaoClient.getClientInfo(accessToken);
+        KakaoClientInfo info = kakaoClient.getClientInfo(kakaoAccessToken);
 
         // 3. 기존 유저 여부 확인
         Optional<Member> optionalMember = memberRepository.findBySocialId(info.kakaoId());
@@ -39,8 +46,33 @@ public class KakaoOauthService {
                         .build())
         );
 
+        // 4. jwt 발급
+        String accessToken = jwtTokenProvider.createAccessToken(member.getId(), member.getNickname());
+        String refreshToken = jwtTokenProvider.createRefreshToken(member.getId(), member.getNickname());
+
+        // 5. refresh는 db에 저장
+        member.setRefreshToken(refreshToken);
+
         // jwt개발할 때 넣기
-        return new KakaoLoginResponseDTO(null, member.getId(), member.getNickname(), newMember);
+        return new KakaoLoginResponseDTO(accessToken, refreshToken, member.getId(), member.getNickname(), newMember);
     }
 
+    public TokenRefreshResponse validateMember(String refreshToken) {
+        Member member = memberRepository.findByRefreshToken(refreshToken)
+                .orElseThrow(() -> new MemberException(MemberErrorCode.INVALID_REFRESH_TOKEN));
+
+        // 액세스 토큰 재발급
+        String newAccessToken = jwtTokenProvider.createAccessToken(member.getId(), member.getNickname());
+
+        // 리프레시 토큰 만료가 3일 이하로 남은 경우 갱신 (sliding session)
+        long expired = 3 * 24 * 60 * 60 * 1000L;
+        if (jwtTokenProvider.isTokenExpiringSoon(refreshToken, expired)) {
+            String newRefreshToken = jwtTokenProvider.createRefreshToken(member.getId(), member.getNickname());
+            member.setRefreshToken(newRefreshToken);
+
+            return new TokenRefreshResponse(newAccessToken, newRefreshToken);
+        }
+
+        return new TokenRefreshResponse(newAccessToken, refreshToken);
+    }
 }

--- a/src/main/java/umc/cockple/demo/global/oauth2/service/KakaoOauthService.java
+++ b/src/main/java/umc/cockple/demo/global/oauth2/service/KakaoOauthService.java
@@ -1,0 +1,46 @@
+package umc.cockple.demo.global.oauth2.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import umc.cockple.demo.domain.member.domain.Member;
+import umc.cockple.demo.domain.member.dto.kakao.KakaoLoginDTO;
+import umc.cockple.demo.domain.member.repository.MemberRepository;
+import umc.cockple.demo.global.oauth2.domain.KakaoClient;
+import umc.cockple.demo.global.oauth2.domain.info.KakaoClientInfo;
+
+import java.util.Optional;
+
+import static umc.cockple.demo.domain.member.dto.kakao.KakaoLoginDTO.*;
+
+@Service
+@RequiredArgsConstructor
+public class KakaoOauthService {
+
+    private final KakaoClient kakaoClient;
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public KakaoLoginResponseDTO signup(String code) {
+        // 1. accessToken 발급
+        String accessToken = kakaoClient.getAccessToken(code);
+
+        // 2. 카카오에 사용자 정보 요청
+        KakaoClientInfo info = kakaoClient.getClientInfo(accessToken);
+
+        // 3. 기존 유저 여부 확인
+        Optional<Member> optionalMember = memberRepository.findBySocialId(info.kakaoId());
+        boolean newMember = optionalMember.isEmpty();
+
+        Member member = optionalMember.orElseGet(() ->
+                memberRepository.save(Member.builder()
+                        .socialId(info.kakaoId())
+                        .nickname(info.nickname())
+                        .build())
+        );
+
+        // jwt개발할 때 넣기
+        return new KakaoLoginResponseDTO(null, member.getId(), member.getNickname(), newMember);
+    }
+
+}

--- a/src/main/java/umc/cockple/demo/global/security/domain/CustomUserDetails.java
+++ b/src/main/java/umc/cockple/demo/global/security/domain/CustomUserDetails.java
@@ -1,0 +1,58 @@
+package umc.cockple.demo.global.security.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.Collections;
+
+@Builder
+@AllArgsConstructor
+public class CustomUserDetails implements UserDetails {
+
+    @Getter
+    private final Long memberId;
+
+    @Getter
+    private final String nickname;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        // 아직 role 사용 안 함
+        return Collections.emptyList();
+    }
+
+    @Override
+    public String getPassword() {
+        return null;
+    }
+
+    @Override
+    public String getUsername() {
+        return String.valueOf(memberId);
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+
+}

--- a/src/main/java/umc/cockple/demo/global/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/umc/cockple/demo/global/security/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,53 @@
+package umc.cockple.demo.global.security.filter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+import umc.cockple.demo.domain.member.repository.MemberRepository;
+import umc.cockple.demo.global.jwt.domain.JwtTokenProvider;
+import umc.cockple.demo.global.security.domain.CustomUserDetails;
+
+import java.io.IOException;
+
+@RequiredArgsConstructor
+@Slf4j
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+
+        String token = resolveToken(request);
+
+        if (token != null && jwtTokenProvider.validateToken(token)) {
+            Authentication auth = jwtTokenProvider.getAuthentication(token);
+            SecurityContextHolder.getContext().setAuthentication(auth);
+            log.debug("인증 정보 SecurityContext에 저장 완료: {}", auth.getName());
+        }else {
+            log.trace("Authorization 헤더에 토큰 없음 혹은 유효하지 않음");
+        }
+
+        filterChain.doFilter(request, response);
+
+    }
+
+
+
+    private String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (bearerToken != null && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/umc/cockple/demo/global/security/utils/SecurityUtil.java
+++ b/src/main/java/umc/cockple/demo/global/security/utils/SecurityUtil.java
@@ -1,0 +1,32 @@
+package umc.cockple.demo.global.security.utils;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import umc.cockple.demo.domain.member.exception.MemberErrorCode;
+import umc.cockple.demo.domain.member.exception.MemberException;
+import umc.cockple.demo.global.security.domain.CustomUserDetails;
+
+import java.util.Optional;
+
+public class SecurityUtil {
+
+    /**
+     * 현재 로그인한 사용자의 memberId를 반환
+     */
+    public static Long getCurrentMemberId() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication == null || !authentication.isAuthenticated()) {
+            throw new MemberException(MemberErrorCode.MEMBER_NOT_FOUND);
+        }
+
+        Object principal = authentication.getPrincipal();
+        if (!(principal instanceof CustomUserDetails)) {
+            throw new MemberException(MemberErrorCode.MEMBER_NOT_FOUND);
+        }
+
+        return ((CustomUserDetails) principal).getMemberId();
+    }
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -49,7 +49,7 @@ kakao:
   token-uri: https://kauth.kakao.com/oauth/token
   user-info-uri: https://kapi.kakao.com/v2/user/me
 
-#jwt:
-#  secret: ${JWT_SECRET_KEY}
-#  access-token-validity: 3600000
-#  refresh-token-validity: 1209600000
+jwt:
+  secret: ${JWT_SECRET_KEY}
+  access-token-validity: 3600000
+  refresh-token-validity: 1209600000

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -48,6 +48,7 @@ kakao:
   client-secret: ${KAKAO_CLIENT_SECRET}
   token-uri: https://kauth.kakao.com/oauth/token
   user-info-uri: https://kapi.kakao.com/v2/user/me
+  redirect-uri: http://localhost:8080/api/oauth/login
 
 jwt:
   secret: ${JWT_SECRET_KEY}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -42,3 +42,14 @@ cloud:
       auto: false
     stack:
       auto: false
+
+kakao:
+  client-id: ${KAKAO_CLIENT_ID}
+  client-secret: ${KAKAO_CLIENT_SECRET}
+  token-uri: https://kauth.kakao.com/oauth/token
+  user-info-uri: https://kapi.kakao.com/v2/user/me
+
+#jwt:
+#  secret: ${JWT_SECRET_KEY}
+#  access-token-validity: 3600000
+#  refresh-token-validity: 1209600000


### PR DESCRIPTION
## ❤️ 기능 설명
1. 순수 소셜로그인 구현
2. JWT 발급 및 도입
3. Spring Security 도입
+) 리프레시토큰 재발급 로직 구현

swagger 테스트 성공 결과 스크린샷 첨부

인가코드 넣으면 jwt (액세스토큰) 발급, refreshToken은 body로는 안 넘기고 헤더 속 쿠키에 넣어 보냅니다
<img width="1479" height="1329" alt="스크린샷 2025-07-30 221814" src="https://github.com/user-attachments/assets/8d8a5245-cc3c-49bd-8d45-26fac9954b1b" />

쿠키 확인
<img width="1900" height="137" alt="스크린샷 2025-07-30 221832" src="https://github.com/user-attachments/assets/8d478ccd-8069-4b3c-8e21-a4c6d334c30c" />


<br>

## 연결된 issue



연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #120 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 로그인 한 사람의 memberId는 global.security.utils.SecurityUtil 에 메소드로 구현해두었습니다! 이 브랜치를 판지 너무 오래돼서 다른분들 컨트롤러를 수정하면 충돌이 생길까봐 수정 따로 안 했습니다 ! 
- [ ] 저는 인가코드를 제가 받을 수 있게 yml이랑 kakao developer를 수정해서 테스트를 했는데 다른 분들이 테스트하게 하려면 어떻게 해야 좋을지 모르겠네요 ㅠㅡㅠ url 한개를 정해놓고 임시로 바꿔두는게 나을까요?

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [ ] 이슈넘버를 적었는가?
