### PR TITLE
[debug#224] 나이 검증 출생년도 비교로 변경 및 관련 필드명 변경

### DIFF
--- a/src/main/java/umc/cockple/demo/domain/exercise/repository/ExerciseRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/repository/ExerciseRepository.java
@@ -158,14 +158,14 @@ public interface ExerciseRepository extends JpaRepository<Exercise, Long> {
                 AND me.member.id = :memberId
             )
             AND (pl.gender = :gender AND pl.level = :level)
-            AND (:age >= p.minBirthYear AND :age <= p.maxBirthYear)
+            AND (:birthYear >= p.minBirthYear AND :birthYear <= p.maxBirthYear)
             AND e.outsideGuestAccept = true
             """)
-    List<Exercise> findExercisesByMemberIdAndLevelAndAge(
+    List<Exercise> findExercisesByMemberIdAndLevelAndBirthYear(
             @Param("memberId") Long memberId,
             @Param("gender") Gender gender,
             @Param("level") Level level,
-            @Param("age") int age);
+            @Param("birthYear") int birthYear);
            
     @Query("""
             SELECT e FROM Exercise e 

--- a/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseQueryService.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseQueryService.java
@@ -227,7 +227,7 @@ public class ExerciseQueryService {
         MemberAddr mainAddr = findMainAddrOrThrow(member);
 
         List<Exercise> candidateExercises = findRecommendedExercises(
-                memberId, member.getGender(), member.getLevel(), member.getAge());
+                memberId, member.getGender(), member.getLevel(), member.getBirth().getYear());
 
         List<ExerciseWithDistance> finalExercisesWithDistance = getFinalSortedExercises(candidateExercises, mainAddr);
         List<Exercise> finalExercises = extractExercises(finalExercisesWithDistance);
@@ -755,8 +755,8 @@ public class ExerciseQueryService {
         return exerciseRepository.findRecentExercisesByPartyIds(myPartyIds, pageable);
     }
 
-    private List<Exercise> findRecommendedExercises(Long memberId, Gender gender, Level level, int age) {
-        return exerciseRepository.findExercisesByMemberIdAndLevelAndAge(memberId, gender, level, age);
+    private List<Exercise> findRecommendedExercises(Long memberId, Gender gender, Level level, int birthYear) {
+        return exerciseRepository.findExercisesByMemberIdAndLevelAndBirthYear(memberId, gender, level, birthYear);
     }
 
     private List<Exercise> findByPartyIdsAndDateRange(

--- a/src/main/java/umc/cockple/demo/domain/member/domain/Member.java
+++ b/src/main/java/umc/cockple/demo/domain/member/domain/Member.java
@@ -149,10 +149,6 @@ public class Member extends BaseEntity {
         this.isActive = MemberStatus.INACTIVE;
     }
 
-    public int getAge(){
-        return Period.between(birth, LocalDate.now()).getYears();
-    }
-
     public void setRefreshToken(String refreshToken) {
         this.refreshToken = refreshToken;
     }

--- a/src/main/java/umc/cockple/demo/domain/party/domain/Party.java
+++ b/src/main/java/umc/cockple/demo/domain/party/domain/Party.java
@@ -147,11 +147,11 @@ public class Party extends BaseEntity {
     }
 
     public boolean isAgeValid(Member member){
-        int age = member.getAge();
+        int birthYear = member.getBirth().getYear();
 
-        if(minBirthYear != null && age < minBirthYear){
+        if(minBirthYear != null && birthYear < minBirthYear){
             return false;
-        }if(maxBirthYear != null && age > maxBirthYear){
+        }if(maxBirthYear != null && birthYear > maxBirthYear){
             return false;
         }
         return true;


### PR DESCRIPTION
## ❤️ 기능 설명
멤버의 나이와 모임의 나이 조건을 검증할 때, 멤버는 나이, 모임은 출생년도의 값을 비교하여 에러가 생겼습니다.
이를 출생년도로 통일하여 해결했습니다.

swagger 테스트 성공 결과 스크린샷 첨부
DB 멤버 칼럼값
<img width="654" height="86" alt="image" src="https://github.com/user-attachments/assets/31b98b43-7622-466d-94f0-a4693d84e478" />

DB 파티 칼럼값
<img width="1040" height="95" alt="image" src="https://github.com/user-attachments/assets/35ceb57e-e06f-409b-8db1-7fe868099e33" />

운동 참여 신청 API
<img width="2139" height="803" alt="image" src="https://github.com/user-attachments/assets/e573527d-3298-4f77-be17-c7c795521fe8" />

새로운 운동 추천 API
<img width="915" height="135" alt="image" src="https://github.com/user-attachments/assets/58137662-9762-4d70-862d-c8c1c3afff30" />
2번 멤버 사용

<img width="2151" height="1150" alt="image" src="https://github.com/user-attachments/assets/762f5fed-3382-43ce-9477-522eafe8ed3d" />


<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #224 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
