### PR TITLE
[feat/#227] 모임 탈퇴 시, 자동으로 채팅방 퇴장 코드 구현

### DIFF
--- a/src/main/java/umc/cockple/demo/domain/chat/domain/ChatMessage.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/domain/ChatMessage.java
@@ -28,9 +28,6 @@ public class ChatMessage extends BaseEntity {
     @JoinColumn(name = "sender_id")
     private Member sender;
 
-    @Column(nullable = false)
-    private String senderName;
-
     @Column(columnDefinition = "TEXT")
     private String content;
 

--- a/src/main/java/umc/cockple/demo/domain/chat/domain/ChatMessage.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/domain/ChatMessage.java
@@ -25,12 +25,11 @@ public class ChatMessage extends BaseEntity {
     private ChatRoom chatRoom;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "chat_room_member_id")
-    private ChatRoomMember chatRoomMember;
-
-    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "sender_id")
     private Member sender;
+
+    @Column(nullable = false)
+    private String senderName;
 
     @Column(columnDefinition = "TEXT")
     private String content;

--- a/src/main/java/umc/cockple/demo/domain/chat/domain/ChatRoomMember.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/domain/ChatRoomMember.java
@@ -5,9 +5,6 @@ import lombok.*;
 import umc.cockple.demo.domain.member.domain.Member;
 import umc.cockple.demo.global.common.BaseEntity;
 
-import java.util.ArrayList;
-import java.util.List;
-
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -28,8 +25,4 @@ public class ChatRoomMember extends BaseEntity {
     private Member member;
 
     private Long lastReadMessageId;
-
-    @OneToMany(mappedBy = "chatRoomMember")
-    private List<ChatMessage> chatMessages = new ArrayList<>();
-
 }

--- a/src/main/java/umc/cockple/demo/domain/party/service/PartyCommandServiceImpl.java
+++ b/src/main/java/umc/cockple/demo/domain/party/service/PartyCommandServiceImpl.java
@@ -126,12 +126,7 @@ public class PartyCommandServiceImpl implements PartyCommandService{
         memberPartyRepository.delete(memberParty);
 
         //채팅방 퇴장 로직 수행
-        log.info("모임 채팅방 퇴장 시작 - memberId: {}", memberId);
-        ChatRoom chatRoom = chatRoomRepository.findByPartyId(partyId);
-        chatRoomMemberRepository
-                .findByChatRoomIdAndMemberId(chatRoom.getId(), memberId)
-                        .ifPresent(chatRoomMemberRepository::delete);
-        log.info("모임 채팅방 퇴장 완료 - chatRoomId: {}", chatRoom.getId());
+        leavePartyChatRoom(partyId, memberId);
         log.info("모임 탈퇴 완료 - partyId: {}, memberId: {}", partyId, memberId);
     }
 
@@ -199,7 +194,7 @@ public class PartyCommandServiceImpl implements PartyCommandService{
         //비즈니스 로직 수행 (승인/거절에 따른 처리)
         if(RequestAction.APPROVE.equals(request.action())){
             approveJoinRequest(partyJoinRequest);
-            JoinChatRoom(partyId, requestId, partyJoinRequest);
+            JoinPartyChatRoom(partyId, requestId, partyJoinRequest);
         }else{
             rejectJoinRequest(partyJoinRequest);
         }
@@ -414,8 +409,7 @@ public class PartyCommandServiceImpl implements PartyCommandService{
         party.addMember(newMemberParty);
     }
 
-
-    private void JoinChatRoom(Long partyId, Long requestId, PartyJoinRequest partyJoinRequest) {
+    private void JoinPartyChatRoom(Long partyId, Long requestId, PartyJoinRequest partyJoinRequest) {
         log.info("모임 채팅방 자동 참여 시작 - partyId: {}", partyId);
         ChatRoom chatRoom = chatRoomRepository.findByPartyId(partyId);
         ChatRoomMember chatRoomMember = ChatRoomMember.builder()
@@ -424,5 +418,14 @@ public class PartyCommandServiceImpl implements PartyCommandService{
                 .build();
         chatRoomMemberRepository.save(chatRoomMember);
         log.info("모임 채팅방 자동 참여 완료  - requestId: {}, chatRoomId: {}", requestId, chatRoom.getId());
+    }
+
+    private void leavePartyChatRoom(Long partyId, Long memberId) {
+        log.info("모임 채팅방 퇴장 시작 - memberId: {}", memberId);
+        ChatRoom chatRoom = chatRoomRepository.findByPartyId(partyId);
+        chatRoomMemberRepository
+                .findByChatRoomIdAndMemberId(chatRoom.getId(), memberId)
+                .ifPresent(chatRoomMemberRepository::delete);
+        log.info("모임 채팅방 퇴장 완료 - chatRoomId: {}", chatRoom.getId());
     }
 }

--- a/src/main/java/umc/cockple/demo/domain/party/service/PartyCommandServiceImpl.java
+++ b/src/main/java/umc/cockple/demo/domain/party/service/PartyCommandServiceImpl.java
@@ -125,6 +125,13 @@ public class PartyCommandServiceImpl implements PartyCommandService{
         //모임 탈퇴 로직 수행
         memberPartyRepository.delete(memberParty);
 
+        //채팅방 퇴장 로직 수행
+        log.info("모임 채팅방 퇴장 시작 - memberId: {}", memberId);
+        ChatRoom chatRoom = chatRoomRepository.findByPartyId(partyId);
+        chatRoomMemberRepository
+                .findByChatRoomIdAndMemberId(chatRoom.getId(), memberId)
+                        .ifPresent(chatRoomMemberRepository::delete);
+        log.info("모임 채팅방 퇴장 완료 - chatRoomId: {}", chatRoom.getId());
         log.info("모임 탈퇴 완료 - partyId: {}, memberId: {}", partyId, memberId);
     }
 


### PR DESCRIPTION
## ❤️ 기능 설명

swagger 테스트 성공 결과 스크린샷 첨부
<br>
<img width="495" height="146" alt="스크린샷 2025-08-01 16 29 16" src="https://github.com/user-attachments/assets/8314f4e8-3bb7-41c6-9ec2-4e2ad0ed3816" />

탈퇴는 잘되고요


<img width="530" height="513" alt="image" src="https://github.com/user-attachments/assets/21ad1cdf-2a7a-422e-ad2a-e487069f52e9" />

회원이 탈퇴 해도 메세지 내용이랑 이름은 유지하기 위해서 메세지 저장 방식을
chat_room_member와 chat_message 끼리 연관관계 삭제했습니다.

그래서 디비에

ALTER TABLE chat_message
    DROP FOREIGN KEY FKjtrl0cyo3rxu4bcg3f17fdpm5;

ALTER TABLE chat_message
    DROP COLUMN chat_room_member_id;

이거 해주셔야 돼요!

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #227 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [ ] 이슈넘버를 적었는가?
