### PR TITLE
[fix/#236] 대회 이미지 저장 방식 변경

### DIFF
--- a/src/main/java/umc/cockple/demo/domain/contest/controller/ContestController.java
+++ b/src/main/java/umc/cockple/demo/domain/contest/controller/ContestController.java
@@ -1,6 +1,8 @@
 package umc.cockple.demo.domain.contest.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -101,6 +103,11 @@ public class ContestController {
     @ApiResponse(responseCode = "200", description = "조회 성공")
     public BaseResponse<List<ContestRecordSimpleDTO.Response>> getMyContestRecord(
             //@AuthenticationPrincipal Long memberId
+            @Parameter(
+                    name = "medalType",
+                    description = "전체 or NONE",
+                    schema = @Schema(allowableValues = {"NONE"})
+            )
             @RequestParam(required = false) MedalType medalType
     ) {
         // TODO: JWT 인증 구현 후 교체 예정
@@ -144,6 +151,11 @@ public class ContestController {
     @ApiResponse(responseCode = "200", description = "조회 성공")
     public BaseResponse<List<ContestRecordSimpleDTO.Response>> getOtherMemberContestRecord(
             @RequestParam Long memberId,
+            @Parameter(
+                    name = "medalType",
+                    description = "전체 or NONE",
+                    schema = @Schema(allowableValues = {"NONE"})
+            )
             @RequestParam(required = false) MedalType medalType
     ) {
         List<ContestRecordSimpleDTO.Response> response = contestQueryService.getMyContestRecordsByMedalType(memberId, medalType);

--- a/src/main/java/umc/cockple/demo/domain/contest/converter/ContestConverter.java
+++ b/src/main/java/umc/cockple/demo/domain/contest/converter/ContestConverter.java
@@ -3,11 +3,8 @@ package umc.cockple.demo.domain.contest.converter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import umc.cockple.demo.domain.contest.domain.Contest;
-import umc.cockple.demo.domain.contest.domain.ContestImg;
-import umc.cockple.demo.domain.contest.domain.ContestVideo;
 import umc.cockple.demo.domain.contest.dto.*;
 
-import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -55,25 +52,7 @@ public class ContestConverter {
     }
 
     // 대회 기록 상세 조회
-    public ContestRecordDetailDTO.Response toDetailResponseDTO(Contest contest, Boolean isOwner) {
-        List<String> imgUrls = contest.getContestImgs().stream()
-                .sorted(Comparator.comparing(ContestImg::getImgOrder))
-                .map(ContestImg::getImgUrl)
-                .collect(Collectors.toList());
-
-        // video 링크 공개여부 처리
-        List<String> videoUrls = (contest.getVideoIsOpen() || isOwner)
-                ? contest.getContestVideos().stream()
-                .sorted(Comparator.comparingInt(ContestVideo::getVideoOrder))
-                .map(ContestVideo::getVideoUrl)
-                .collect(Collectors.toList())
-                : List.of();
-
-        // 기록 공개여부 처리
-        String content = (contest.getContentIsOpen() || isOwner)
-                ? contest.getContent()
-                : "";
-
+    public ContestRecordDetailDTO.Response toDetailResponseDTO(Contest contest, List<String> imgUrls, List<String> videoUrls, String content) {
         return ContestRecordDetailDTO.Response.builder()
                 .contestId(contest.getId())
                 .contestName(contest.getContestName())

--- a/src/main/java/umc/cockple/demo/domain/contest/domain/ContestImg.java
+++ b/src/main/java/umc/cockple/demo/domain/contest/domain/ContestImg.java
@@ -20,9 +20,6 @@ public class ContestImg {
     private Contest contest;
 
     @Column(nullable = false)
-    private String imgUrl;
-
-    @Column(nullable = false)
     private String imgKey;
 
     @Setter
@@ -38,10 +35,9 @@ public class ContestImg {
         }
     }
 
-    public static ContestImg of(Contest contest, String imgUrl, String imgKey, int imgOrder) {
+    public static ContestImg of(Contest contest, String imgKey, int imgOrder) {
         return ContestImg.builder()
                 .contest(contest)
-                .imgUrl(imgUrl)
                 .imgKey(imgKey)
                 .imgOrder(imgOrder)
                 .build();

--- a/src/main/java/umc/cockple/demo/domain/contest/dto/ContestRecordCreateDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/contest/dto/ContestRecordCreateDTO.java
@@ -4,7 +4,6 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.Builder;
-import umc.cockple.demo.domain.image.dto.ImageUploadRequestDTO;
 import umc.cockple.demo.global.enums.Level;
 import umc.cockple.demo.domain.contest.enums.MedalType;
 import umc.cockple.demo.domain.party.enums.ParticipationType;
@@ -42,7 +41,7 @@ public class ContestRecordCreateDTO {
             List<String> contestVideos,
 
             @Size(max = 3, message = "이미지는 3개까지 업로드 가능합니다.")
-            List<ImageUploadRequestDTO> contestImgs
+            List<String> contestImgs
 
     ) {
     }
@@ -59,7 +58,7 @@ public class ContestRecordCreateDTO {
             Boolean contentIsOpen,
             Boolean videoIsOpen,
             List<String> contestVideos,
-            List<ImageUploadRequestDTO> contestImgs
+            List<String> contestImgs
     ) {
     }
 

--- a/src/main/java/umc/cockple/demo/domain/contest/dto/ContestRecordCreateDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/contest/dto/ContestRecordCreateDTO.java
@@ -4,7 +4,7 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.Builder;
-import umc.cockple.demo.domain.image.dto.ImageUploadResponseDTO;
+import umc.cockple.demo.domain.image.dto.ImageUploadRequestDTO;
 import umc.cockple.demo.global.enums.Level;
 import umc.cockple.demo.domain.contest.enums.MedalType;
 import umc.cockple.demo.domain.party.enums.ParticipationType;
@@ -42,7 +42,7 @@ public class ContestRecordCreateDTO {
             List<String> contestVideos,
 
             @Size(max = 3, message = "이미지는 3개까지 업로드 가능합니다.")
-            List<ImageUploadResponseDTO> contestImgs
+            List<ImageUploadRequestDTO> contestImgs
 
     ) {
     }
@@ -59,7 +59,7 @@ public class ContestRecordCreateDTO {
             Boolean contentIsOpen,
             Boolean videoIsOpen,
             List<String> contestVideos,
-            List<ImageUploadResponseDTO> contestImgs
+            List<ImageUploadRequestDTO> contestImgs
     ) {
     }
 

--- a/src/main/java/umc/cockple/demo/domain/contest/dto/ContestRecordUpdateDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/contest/dto/ContestRecordUpdateDTO.java
@@ -4,7 +4,7 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.Builder;
-import umc.cockple.demo.domain.image.dto.ImageUploadResponseDTO;
+import umc.cockple.demo.domain.image.dto.ImageUploadRequestDTO;
 import umc.cockple.demo.global.enums.Level;
 import umc.cockple.demo.domain.contest.enums.MedalType;
 import umc.cockple.demo.domain.party.enums.ParticipationType;
@@ -42,7 +42,7 @@ public class ContestRecordUpdateDTO {
             List<String> contestVideos,
 
             // 새로 추가할 이미지
-            List<ImageUploadResponseDTO> contestImgs,
+            List<ImageUploadRequestDTO> contestImgs,
 
             // 삭제할 이미지 imgKey (프론트에서 관리)
             List<String> contestImgsToDelete,

--- a/src/main/java/umc/cockple/demo/domain/contest/dto/ContestRecordUpdateDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/contest/dto/ContestRecordUpdateDTO.java
@@ -4,7 +4,6 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.Builder;
-import umc.cockple.demo.domain.image.dto.ImageUploadRequestDTO;
 import umc.cockple.demo.global.enums.Level;
 import umc.cockple.demo.domain.contest.enums.MedalType;
 import umc.cockple.demo.domain.party.enums.ParticipationType;
@@ -42,7 +41,7 @@ public class ContestRecordUpdateDTO {
             List<String> contestVideos,
 
             // 새로 추가할 이미지
-            List<ImageUploadRequestDTO> contestImgs,
+            List<String> contestImgs,
 
             // 삭제할 이미지 imgKey (프론트에서 관리)
             List<String> contestImgsToDelete,

--- a/src/main/java/umc/cockple/demo/domain/contest/service/ContestCommandServiceImpl.java
+++ b/src/main/java/umc/cockple/demo/domain/contest/service/ContestCommandServiceImpl.java
@@ -12,7 +12,7 @@ import umc.cockple.demo.domain.contest.dto.*;
 import umc.cockple.demo.domain.contest.exception.ContestErrorCode;
 import umc.cockple.demo.domain.contest.exception.ContestException;
 import umc.cockple.demo.domain.contest.repository.ContestRepository;
-import umc.cockple.demo.domain.image.dto.ImageUploadResponseDTO;
+import umc.cockple.demo.domain.image.dto.ImageUploadRequestDTO;
 import umc.cockple.demo.domain.member.domain.Member;
 import umc.cockple.demo.domain.member.repository.MemberRepository;
 import umc.cockple.demo.domain.image.service.ImageService;
@@ -27,7 +27,7 @@ public class ContestCommandServiceImpl implements ContestCommandService {
     private final ContestRepository contestRepository;
     private final MemberRepository memberRepository;
     private final ContestConverter contestConverter;
-    private final ImageService imageService; //이미지 업로드 담당
+    private final ImageService imageService;
 
             /*
         1.	memberId로 Member 조회
@@ -174,7 +174,7 @@ public class ContestCommandServiceImpl implements ContestCommandService {
         return contestConverter.toDeleteResponseDTO(contest);
     }
 
-    private void extractedImgs(List<ImageUploadResponseDTO> imgs, Contest contest) {
+    private void extractedImgs(List<ImageUploadRequestDTO> imgs, Contest contest) {
         int startIndex = contest.getContestImgs().size();
         int total = startIndex + imgs.size();
         if (total > 3) {
@@ -182,8 +182,8 @@ public class ContestCommandServiceImpl implements ContestCommandService {
             throw new ContestException(ContestErrorCode.IMAGE_UPLOAD_LIMIT_EXCEEDED);
         }
         for (int i = 0; i < imgs.size(); i++) {
-            ImageUploadResponseDTO dto = imgs.get(i);
-            ContestImg contestImg = ContestImg.of(contest, dto.imgUrl(), dto.imgKey(), startIndex + i);
+            ImageUploadRequestDTO dto = imgs.get(i);
+            ContestImg contestImg = ContestImg.of(contest, dto.imgKey(), startIndex + i);
             contest.addContestImg(contestImg);
         }
     }

--- a/src/main/java/umc/cockple/demo/domain/contest/service/ContestCommandServiceImpl.java
+++ b/src/main/java/umc/cockple/demo/domain/contest/service/ContestCommandServiceImpl.java
@@ -12,7 +12,6 @@ import umc.cockple.demo.domain.contest.dto.*;
 import umc.cockple.demo.domain.contest.exception.ContestErrorCode;
 import umc.cockple.demo.domain.contest.exception.ContestException;
 import umc.cockple.demo.domain.contest.repository.ContestRepository;
-import umc.cockple.demo.domain.image.dto.ImageUploadRequestDTO;
 import umc.cockple.demo.domain.member.domain.Member;
 import umc.cockple.demo.domain.member.repository.MemberRepository;
 import umc.cockple.demo.domain.image.service.ImageService;
@@ -174,7 +173,7 @@ public class ContestCommandServiceImpl implements ContestCommandService {
         return contestConverter.toDeleteResponseDTO(contest);
     }
 
-    private void extractedImgs(List<ImageUploadRequestDTO> imgs, Contest contest) {
+    private void extractedImgs(List<String> imgs, Contest contest) {
         int startIndex = contest.getContestImgs().size();
         int total = startIndex + imgs.size();
         if (total > 3) {
@@ -182,8 +181,8 @@ public class ContestCommandServiceImpl implements ContestCommandService {
             throw new ContestException(ContestErrorCode.IMAGE_UPLOAD_LIMIT_EXCEEDED);
         }
         for (int i = 0; i < imgs.size(); i++) {
-            ImageUploadRequestDTO dto = imgs.get(i);
-            ContestImg contestImg = ContestImg.of(contest, dto.imgKey(), startIndex + i);
+            String key = imgs.get(i);
+            ContestImg contestImg = ContestImg.of(contest, key, startIndex + i);
             contest.addContestImg(contestImg);
         }
     }

--- a/src/main/java/umc/cockple/demo/domain/image/dto/ImageUploadRequestDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/image/dto/ImageUploadRequestDTO.java
@@ -1,5 +1,0 @@
-package umc.cockple.demo.domain.image.dto;
-
-public record ImageUploadRequestDTO(
-        String imgKey
-) {}

--- a/src/main/java/umc/cockple/demo/domain/image/dto/ImageUploadRequestDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/image/dto/ImageUploadRequestDTO.java
@@ -1,0 +1,5 @@
+package umc.cockple.demo.domain.image.dto;
+
+public record ImageUploadRequestDTO(
+        String imgKey
+) {}


### PR DESCRIPTION
## ❤️ 기능 설명

swagger 테스트 성공 결과 스크린샷 첨부
<br>
<img width="660" height="482" alt="스크린샷 2025-08-02 21 23 31" src="https://github.com/user-attachments/assets/b9998f81-7f00-4be0-bd04-bab150633af5" />

이미지 저장할때 key만 보내는 걸로

<img width="1040" height="579" alt="스크린샷 2025-08-02 21 24 02" src="https://github.com/user-attachments/assets/63bcd58a-b727-47c0-b202-9423fddd7075" />

응답은 url로

<img width="542" height="403" alt="image" src="https://github.com/user-attachments/assets/96c003aa-795d-4c84-b5fd-44fcd2cf2fd1" />


## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #236 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ] 기존에 ImageUploadResponseDTO이거 쓰던걸 
<img width="1492" height="948" alt="image" src="https://github.com/user-attachments/assets/1d694b77-04f2-4872-919b-a3e394cce0fe" />

이걸로 교체 했는데 괜찮을까요?
아니면 그냥 String으로 할까요? 지피티는 확장에는 DTO가 낫다고 하긴 하는데욤..

<img width="449" height="560" alt="image" src="https://github.com/user-attachments/assets/0537f130-a606-47a0-ad08-69fe6c5d7bc7" />

--> String으로 결정

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
