### PR TITLE
[feat/241] 찜 개수 제한 관련 로직 추가

### DIFF
--- a/src/main/java/umc/cockple/demo/domain/bookmark/repository/ExerciseBookmarkRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/bookmark/repository/ExerciseBookmarkRepository.java
@@ -29,4 +29,8 @@ public interface ExerciseBookmarkRepository extends JpaRepository<ExerciseBookma
             @Param("exerciseIds") List<Long> exerciseIds
     );
 
+
+    Optional<ExerciseBookmark> findFirstByMemberOrderByCreatedAtAsc(Member member);
+
+
 }

--- a/src/main/java/umc/cockple/demo/domain/bookmark/repository/PartyBookmarkRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/bookmark/repository/PartyBookmarkRepository.java
@@ -25,4 +25,8 @@ public interface PartyBookmarkRepository extends JpaRepository<PartyBookmark, Lo
         WHERE pb.member = :member
         """)
     List<PartyBookmark> findAllByMemberWithParty(@Param("member") Member member);
+
+    List<PartyBookmark> findAllByMember(Member member);
+
+    Optional<PartyBookmark> findFirstByMemberOrderByCreatedAtAsc(Member member);
 }

--- a/src/main/java/umc/cockple/demo/domain/bookmark/service/BookmarkCommandService.java
+++ b/src/main/java/umc/cockple/demo/domain/bookmark/service/BookmarkCommandService.java
@@ -25,6 +25,8 @@ import umc.cockple.demo.domain.party.repository.PartyRepository;
 import umc.cockple.demo.domain.party.enums.PartyOrderType;
 import umc.cockple.demo.domain.party.enums.PartyStatus;
 
+import java.util.List;
+
 @Service
 @Transactional
 @RequiredArgsConstructor
@@ -59,6 +61,15 @@ public class BookmarkCommandService {
                 .orderType(PartyOrderType.LATEST)
                 .build()
         ;
+
+        // 찜 개수 확인
+        List<PartyBookmark> bookmarks = partyBookmarkRepository.findAllByMember(member);
+        if (bookmarks.size() >= 15) {
+            // 가장 오래된 북마크 삭제
+            partyBookmarkRepository.findFirstByMemberOrderByCreatedAtAsc(member)
+                    .ifPresent(partyBookmarkRepository::delete);
+
+        }
 
         // 찜하기
         PartyBookmark saveBookmark = partyBookmarkRepository.save(bookmark);
@@ -102,6 +113,14 @@ public class BookmarkCommandService {
                 .exercise(exercise)
                 .build()
         ;
+
+        // 찜 개수 확인
+        List<ExerciseBookmark> bookmarks = exerciseBookmarkRepository.findAllByMember(member);
+        if (bookmarks.size() >= 50) {
+            // 가장 오래된 거 삭제
+            exerciseBookmarkRepository.findFirstByMemberOrderByCreatedAtAsc(member)
+                    .ifPresent(exerciseBookmarkRepository::delete);
+        }
 
         // 찜하기
         ExerciseBookmark saveBookmark = exerciseBookmarkRepository.save(bookmark);


### PR DESCRIPTION
## ❤️ 기능 설명
운동 50개, 모임 15개 제한 로직 추가
-> 넘길경우 가장 오래된 찜을 삭제 후 추가

swagger 테스트 성공 결과 스크린샷 첨부
<img width="798" height="919" alt="image" src="https://github.com/user-attachments/assets/0d832eab-e530-4f9c-9c3a-70151533f285" />

모임 15개 찜 된 상태
<img width="805" height="667" alt="스크린샷 2025-08-03 003218" src="https://github.com/user-attachments/assets/98e19268-3d18-4eb2-96ea-20a0be3ef013" />

모임을 또 찜하면 가장 오래된 찜 삭제
<img width="816" height="659" alt="스크린샷 2025-08-03 003227" src="https://github.com/user-attachments/assets/ebc00469-ad22-4ea0-893a-a9fd7abf22e6" />


<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #241 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [ ] 이슈넘버를 적었는가?
