### PR TITLE
[feat/#232] 신규 멤버 추천 API 구현

### DIFF
--- a/src/main/java/umc/cockple/demo/domain/member/repository/MemberRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/member/repository/MemberRepository.java
@@ -11,7 +11,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-public interface MemberRepository extends JpaRepository<Member, Long> {
+public interface MemberRepository extends JpaRepository<Member, Long>, MemberRepositoryCustom {
 
     default Map<Long, String> findMemberNamesByIds(Set<Long> memberIds) {
         if (memberIds.isEmpty()) {

--- a/src/main/java/umc/cockple/demo/domain/member/repository/MemberRepositoryCustom.java
+++ b/src/main/java/umc/cockple/demo/domain/member/repository/MemberRepositoryCustom.java
@@ -1,0 +1,10 @@
+package umc.cockple.demo.domain.member.repository;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import umc.cockple.demo.domain.member.domain.Member;
+import umc.cockple.demo.domain.party.domain.Party;
+
+public interface MemberRepositoryCustom {
+    Slice<Member> findRecommendedMembers(Party party, String levelSearch, Pageable pageable);
+}

--- a/src/main/java/umc/cockple/demo/domain/member/repository/MemberRepositoryCustomImpl.java
+++ b/src/main/java/umc/cockple/demo/domain/member/repository/MemberRepositoryCustomImpl.java
@@ -80,19 +80,20 @@ public class MemberRepositoryCustomImpl implements MemberRepositoryCustom{
     }
 
     private BooleanExpression levelMatch(Party party, String levelSearch) {
+        //모임의 급수 조건에 맞는 사용자 필터링
+        List<Level> femaleLevels = party.getLevels().stream()
+                .filter(pl -> pl.getGender() == Gender.FEMALE)
+                .map(PartyLevel::getLevel).toList();
+        List<Level> maleLevels = party.getLevels().stream()
+                .filter(pl -> pl.getGender() == Gender.MALE)
+                .map(PartyLevel::getLevel).toList();
+        BooleanExpression baseRequirement = member.gender.eq(Gender.FEMALE).and(member.level.in(femaleLevels))
+                .or(member.gender.eq(Gender.MALE).and(member.level.in(maleLevels)));
+
+        //검색 조건이 있는 경우 필터링에 추가
         if (StringUtils.hasText(levelSearch)) {
-            //쿼리 파라미터로 받은 검색 급수만 필터링
-            return member.level.eq(Level.fromKorean(levelSearch));
-        } else {
-            //모임의 급수 조건에 맞는 사용자 필터링
-            List<Level> femaleLevels = party.getLevels().stream()
-                    .filter(pl -> pl.getGender() == Gender.FEMALE)
-                    .map(PartyLevel::getLevel).toList();
-            List<Level> maleLevels = party.getLevels().stream()
-                    .filter(pl -> pl.getGender() == Gender.MALE)
-                    .map(PartyLevel::getLevel).toList();
-            return member.gender.eq(Gender.FEMALE).and(member.level.in(femaleLevels))
-                    .or(member.gender.eq(Gender.MALE).and(member.level.in(maleLevels)));
+            return baseRequirement.and(member.level.eq(Level.fromKorean(levelSearch)));
         }
+        return baseRequirement;
     }
 }

--- a/src/main/java/umc/cockple/demo/domain/member/repository/MemberRepositoryCustomImpl.java
+++ b/src/main/java/umc/cockple/demo/domain/member/repository/MemberRepositoryCustomImpl.java
@@ -1,0 +1,98 @@
+package umc.cockple.demo.domain.member.repository;
+
+import com.querydsl.core.types.Predicate;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.util.StringUtils;
+import umc.cockple.demo.domain.member.domain.Member;
+import umc.cockple.demo.domain.party.domain.Party;
+import umc.cockple.demo.domain.party.domain.PartyLevel;
+import umc.cockple.demo.domain.party.enums.RequestStatus;
+import umc.cockple.demo.global.enums.Gender;
+import umc.cockple.demo.global.enums.Level;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import static umc.cockple.demo.domain.member.domain.QMember.member;
+import static umc.cockple.demo.domain.member.domain.QMemberAddr.memberAddr;
+import static umc.cockple.demo.domain.member.domain.QMemberParty.memberParty;
+import static umc.cockple.demo.domain.party.domain.QPartyJoinRequest.partyJoinRequest;
+
+@RequiredArgsConstructor
+public class MemberRepositoryCustomImpl implements MemberRepositoryCustom{
+
+    public final JPAQueryFactory queryFactory;
+
+    @Override
+    public Slice<Member> findRecommendedMembers(Party party, String levelSearch, Pageable pageable) {
+        //추천에서 제외할 멤버를 찾는 로직
+        List<Long> excludedMemberIds = findExcludedMemberIds(party);
+
+        //동적 쿼리로 데이터 조회
+        List<Member> content = queryFactory
+                .selectFrom(member)
+                .join(member.addresses, memberAddr).fetchJoin()
+                .where(
+                        //제외할 멤버 목록에 포함되지 않는 사용자
+                        member.id.notIn(excludedMemberIds),
+                        //급수, 지역, 나이로 필터링
+                        levelMatch(party, levelSearch),
+                        member.birth.year().between(party.getMinBirthYear(), party.getMaxBirthYear()),
+                        memberAddr.isMain.isTrue().and(memberAddr.addr1.eq(party.getPartyAddr().getAddr1()))
+                )
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize() + 1)
+                .fetch();
+
+        boolean hasNext = false;
+        if (content.size() > pageable.getPageSize()) {
+            content.remove(pageable.getPageSize());
+            hasNext = true;
+        }
+
+        return new SliceImpl<>(content, pageable, hasNext);
+    }
+
+    private List<Long> findExcludedMemberIds(Party party) {
+        //이미 가입한 멤버 id 리스트
+        List<Long> existingMemberIds = queryFactory
+                .select(memberParty.member.id)
+                .from(memberParty)
+                .where(memberParty.party.eq(party))
+                .fetch();
+
+        //가입 신청 대기 중인 사용자 id 리스트
+        List<Long> pendingMemberIds = queryFactory
+                .select(partyJoinRequest.member.id)
+                .from(partyJoinRequest)
+                .where(
+                        partyJoinRequest.party.eq(party),
+                        partyJoinRequest.status.eq(RequestStatus.PENDING)
+                )
+                .fetch();
+
+        return Stream.concat(existingMemberIds.stream(), pendingMemberIds.stream()).distinct().toList();
+    }
+
+    private BooleanExpression levelMatch(Party party, String levelSearch) {
+        if (StringUtils.hasText(levelSearch)) {
+            //쿼리 파라미터로 받은 검색 급수만 필터링
+            return member.level.eq(Level.fromKorean(levelSearch));
+        } else {
+            //모임의 급수 조건에 맞는 사용자 필터링
+            List<Level> femaleLevels = party.getLevels().stream()
+                    .filter(pl -> pl.getGender() == Gender.FEMALE)
+                    .map(PartyLevel::getLevel).toList();
+            List<Level> maleLevels = party.getLevels().stream()
+                    .filter(pl -> pl.getGender() == Gender.MALE)
+                    .map(PartyLevel::getLevel).toList();
+            return member.gender.eq(Gender.FEMALE).and(member.level.in(femaleLevels))
+                    .or(member.gender.eq(Gender.MALE).and(member.level.in(maleLevels)));
+        }
+    }
+}

--- a/src/main/java/umc/cockple/demo/domain/party/controller/PartyController.java
+++ b/src/main/java/umc/cockple/demo/domain/party/controller/PartyController.java
@@ -84,7 +84,7 @@ public class PartyController {
             Authentication authentication
     ) {
         // TODO: JWT 인증 구현 후 교체 예정
-        Long memberId = 10L; // 임시값
+        Long memberId = 2L; // 임시값
 
         PartyFilterDTO.Request filter = PartyFilterDTO.Request.builder()
                 .addr1(addr1)
@@ -174,7 +174,7 @@ public class PartyController {
             Authentication authentication
     ){
         // TODO: JWT 인증 구현 후 교체 예정
-        Long memberId = 8L; // 임시값
+        Long memberId = 2L; // 임시값
 
         partyCommandService.leaveParty(partyId, memberId);
         return BaseResponse.success(CommonSuccessCode.OK);
@@ -209,7 +209,7 @@ public class PartyController {
             Authentication authentication
     ){
         // TODO: JWT 인증 구현 후 교체 예정
-        Long memberId = 8L; // 임시값
+        Long memberId = 2L; // 임시값
 
         PartyJoinCreateDTO.Response response = partyCommandService.createJoinRequest(partyId, memberId);
         return BaseResponse.success(CommonSuccessCode.CREATED, response);
@@ -252,6 +252,22 @@ public class PartyController {
 
         partyCommandService.actionJoinRequest(partyId, memberId, request, requestId);
         return BaseResponse.success(CommonSuccessCode.OK);
+    }
+
+    @GetMapping("/parties/{partyId}/members/suggestions")
+    @Operation(summary = "신규 멤버 추천받기",
+            description = "모임장이 자신의 모임에 초대할 만한 신규 멤버를 추천받습니다.")
+    public BaseResponse<Slice<PartyMemberSuggestionDTO.Response>> etRecommendedMembers(
+            @PathVariable Long partyId,
+            @RequestParam(required = false) String levelSearch,
+            @PageableDefault(page = 0, size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable,
+            Authentication authentication
+    ){
+        // TODO: JWT 인증 구현 후 교체 예정
+        Long memberId = 1L; // 임시값
+
+        Slice<PartyMemberSuggestionDTO.Response> response = partyQueryService.getRecommendedMembers(partyId, levelSearch, pageable);
+        return BaseResponse.success(CommonSuccessCode.OK, response);
     }
 
 }

--- a/src/main/java/umc/cockple/demo/domain/party/controller/PartyController.java
+++ b/src/main/java/umc/cockple/demo/domain/party/controller/PartyController.java
@@ -263,9 +263,6 @@ public class PartyController {
             @PageableDefault(page = 0, size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable,
             Authentication authentication
     ){
-        // TODO: JWT 인증 구현 후 교체 예정
-        Long memberId = 1L; // 임시값
-
         Slice<PartyMemberSuggestionDTO.Response> response = partyQueryService.getRecommendedMembers(partyId, levelSearch, pageable);
         return BaseResponse.success(CommonSuccessCode.OK, response);
     }

--- a/src/main/java/umc/cockple/demo/domain/party/converter/PartyConverter.java
+++ b/src/main/java/umc/cockple/demo/domain/party/converter/PartyConverter.java
@@ -179,6 +179,17 @@ public class PartyConverter {
         return new PartyMemberDTO.Response(summary, memberDetails);
     }
 
+    //추천 멤버 DTO로 변환
+    public PartyMemberSuggestionDTO.Response toPartyMemberSuggestionDTO(Member member, String imgUrl) {
+        return PartyMemberSuggestionDTO.Response.builder()
+                .userId(member.getId())
+                .nickname(member.getNickname())
+                .profileImageUrl(member.getProfileImg() != null ? imgUrl : null)
+                .gender(member.getGender().name())
+                .level(member.getLevel().getKoreanName())
+                .build();
+    }
+
     private int getRolePriority(String role) {
         return switch (role) {
             case "party_MANAGER" -> 0; // 모임장 역할

--- a/src/main/java/umc/cockple/demo/domain/party/dto/PartyMemberSuggestionDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/party/dto/PartyMemberSuggestionDTO.java
@@ -1,0 +1,14 @@
+package umc.cockple.demo.domain.party.dto;
+
+import lombok.Builder;
+
+public class PartyMemberSuggestionDTO {
+    @Builder
+    public record Response(
+            Long memberId,
+            String nickname,
+            String profileImageUrl,
+            String gender,
+            String level
+    ) {}
+}

--- a/src/main/java/umc/cockple/demo/domain/party/dto/PartyMemberSuggestionDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/party/dto/PartyMemberSuggestionDTO.java
@@ -5,7 +5,7 @@ import lombok.Builder;
 public class PartyMemberSuggestionDTO {
     @Builder
     public record Response(
-            Long memberId,
+            Long userId,
             String nickname,
             String profileImageUrl,
             String gender,

--- a/src/main/java/umc/cockple/demo/domain/party/service/PartyQueryService.java
+++ b/src/main/java/umc/cockple/demo/domain/party/service/PartyQueryService.java
@@ -11,5 +11,5 @@ public interface PartyQueryService {
     Slice<PartyDTO.Response> getMyParties(Long memberId, Boolean created, String sort, Pageable pageable);
     PartyMemberDTO.Response getPartyMembers(Long partyId, Long currentMemberId);
     Slice<PartyDTO.Response> getRecommendedParties(Long memberId, Boolean isCockpleRecommend, PartyFilterDTO.Request filter, String sort, Pageable pageable);
-    Slice<PartyMemberSuggestionDTO.Response> getRecommendedMembers(Long memberId, String levelSearch, Pageable pageable);
+    Slice<PartyMemberSuggestionDTO.Response> getRecommendedMembers(Long partyId, String levelSearch, Pageable pageable);
 }

--- a/src/main/java/umc/cockple/demo/domain/party/service/PartyQueryService.java
+++ b/src/main/java/umc/cockple/demo/domain/party/service/PartyQueryService.java
@@ -11,4 +11,5 @@ public interface PartyQueryService {
     Slice<PartyDTO.Response> getMyParties(Long memberId, Boolean created, String sort, Pageable pageable);
     PartyMemberDTO.Response getPartyMembers(Long partyId, Long currentMemberId);
     Slice<PartyDTO.Response> getRecommendedParties(Long memberId, Boolean isCockpleRecommend, PartyFilterDTO.Request filter, String sort, Pageable pageable);
+    Slice<PartyMemberSuggestionDTO.Response> getRecommendedMembers(Long memberId, String levelSearch, Pageable pageable);
 }

--- a/src/main/java/umc/cockple/demo/domain/party/service/PartyQueryServiceImpl.java
+++ b/src/main/java/umc/cockple/demo/domain/party/service/PartyQueryServiceImpl.java
@@ -175,6 +175,19 @@ public class PartyQueryServiceImpl implements PartyQueryService{
         return requestSlice.map(partyConverter::toPartyJoinResponseDTO);
     }
 
+    @Override
+    public Slice<PartyMemberSuggestionDTO.Response> getRecommendedMembers(Long partyId, String levelSearch, Pageable pageable) {
+        log.info("신규 멤버 추천 시작 - partyId: {}", partyId);
+        //모임 조회
+        Party party = findPartyOrThrow(partyId);
+
+        //멤버 추천 로직 수행
+        Slice<Member> recommendedMembersSlice = memberRepository.findRecommendedMembers(party, levelSearch, pageable);
+
+        log.info("신규 멤버 추천 완료. - 조회된 항목 수: {}", recommendedMembersSlice.getNumberOfElements());
+        return recommendedMembersSlice.map(partyConverter::toPartyMemberSuggestionDTO);
+    }
+
     // ========== 조회 메서드 ==========
     //사용자 조회
     private Party findPartyOrThrow(Long partyId) {

--- a/src/main/java/umc/cockple/demo/domain/party/service/PartyQueryServiceImpl.java
+++ b/src/main/java/umc/cockple/demo/domain/party/service/PartyQueryServiceImpl.java
@@ -8,10 +8,7 @@ import org.springframework.transaction.annotation.Transactional;
 import umc.cockple.demo.domain.exercise.domain.Exercise;
 import umc.cockple.demo.domain.exercise.repository.ExerciseRepository;
 import umc.cockple.demo.domain.image.service.ImageService;
-import umc.cockple.demo.domain.member.domain.Member;
-import umc.cockple.demo.domain.member.domain.MemberAddr;
-import umc.cockple.demo.domain.member.domain.MemberKeyword;
-import umc.cockple.demo.domain.member.domain.MemberParty;
+import umc.cockple.demo.domain.member.domain.*;
 import umc.cockple.demo.domain.member.exception.MemberErrorCode;
 import umc.cockple.demo.domain.member.exception.MemberException;
 import umc.cockple.demo.domain.member.repository.MemberAddrRepository;
@@ -185,7 +182,7 @@ public class PartyQueryServiceImpl implements PartyQueryService{
         Slice<Member> recommendedMembersSlice = memberRepository.findRecommendedMembers(party, levelSearch, pageable);
 
         log.info("신규 멤버 추천 완료. - 조회된 항목 수: {}", recommendedMembersSlice.getNumberOfElements());
-        return recommendedMembersSlice.map(partyConverter::toPartyMemberSuggestionDTO);
+        return recommendedMembersSlice.map(member -> partyConverter.toPartyMemberSuggestionDTO(member, getProfileUrl(member.getProfileImg())));
     }
 
     // ========== 조회 메서드 ==========
@@ -329,6 +326,13 @@ public class PartyQueryServiceImpl implements PartyQueryService{
     private String getImageUrl(PartyImg partyImg) {
         if (partyImg != null && partyImg.getImgKey() != null && !partyImg.getImgKey().isBlank()) {
             return imageService.getUrlFromKey(partyImg.getImgKey());
+        }
+        return null;
+    }
+
+    private String getProfileUrl(ProfileImg profileImg) {
+        if (profileImg != null && profileImg.getImgKey() != null && !profileImg.getImgKey().isBlank()) {
+            return imageService.getUrlFromKey(profileImg.getImgKey());
         }
         return null;
     }


### PR DESCRIPTION
## ❤️ 기능 설명
- 모임장이 자신의 모임에 초대할 만한 신규 멤버를 추천받습니다. (급수 / 나이 / 지역)
- 검색을 통해 해당하는 급수의 멤버만을 조회합니다.
- 이미 모임에 소속되어 있거나 가입 신청 대기 중인 유저는 추천 목록에서 자동으로 제외됩니다.

swagger 테스트 성공 결과 스크린샷 첨부
<img width="815" height="291" alt="image" src="https://github.com/user-attachments/assets/de022a8f-ef6e-43ee-a3ca-d05a4ea59e51" />
<img width="790" height="237" alt="image" src="https://github.com/user-attachments/assets/522fe851-56cc-423b-8881-b009f745cef0" />
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #232
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 가입 초대 대기인 경우, 제외하는 로직은 가입 초대를 구현하고 추가하겠습니다.

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
