### PR TITLE
[feat/#248] 웹소켓 기본 설정 및 연결 관리 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,99 +1,99 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '3.5.3'
-	id 'io.spring.dependency-management' version '1.1.7'
+    id 'java'
+    id 'org.springframework.boot' version '3.5.3'
+    id 'io.spring.dependency-management' version '1.1.7'
 }
 
 group = 'umc'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	toolchain {
-		languageVersion = JavaLanguageVersion.of(17)
-	}
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
 }
 
 sourceSets {
-	main {
-		java {
-			srcDirs += "$buildDir/generated/sources/annotationProcessor/java/main"
-		}
-	}
+    main {
+        java {
+            srcDirs += "$buildDir/generated/sources/annotationProcessor/java/main"
+        }
+    }
 }
 
 configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
 
-	// springboot web
-	implementation 'org.springframework.boot:spring-boot-starter-web'
+    // springboot web
+    implementation 'org.springframework.boot:spring-boot-starter-web'
 
-	// validation
-	implementation 'org.springframework.boot:spring-boot-starter-validation'
+    // validation
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
 
-	// lombok
-	compileOnly 'org.projectlombok:lombok'
-	annotationProcessor 'org.projectlombok:lombok'
+    // lombok
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
 
-	// jpa
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    // jpa
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 
-	// h2
-	runtimeOnly 'com.h2database:h2'
+    // h2
+    runtimeOnly 'com.h2database:h2'
 
-	// mysql
-	runtimeOnly 'com.mysql:mysql-connector-j'
+    // mysql
+    runtimeOnly 'com.mysql:mysql-connector-j'
 
-	// security
-	implementation 'org.springframework.boot:spring-boot-starter-security'
-	testImplementation 'org.springframework.security:spring-security-test'
+    // security
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    testImplementation 'org.springframework.security:spring-security-test'
 
-	// springboot test
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    // springboot test
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
-	//swagger
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
+    // swagger
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
 
-	// s3
-	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+    // s3
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 
+    // jwt
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
-	// jwt
-	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
-	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
-	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+    // WebClient 사용 위해 추가
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
-	// WebClient 사용 위해 추가
-	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+    // QueryDSL
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 
-
-	//QueryDSL
-	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
-	annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
-	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
-	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
-
+    // WebSocket
+    implementation 'org.springframework.boot:spring-boot-starter-websocket'
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }
 
 // --- QueryDSL 설정 추가 ---
 tasks.withType(JavaCompile) {
-	options.getGeneratedSourceOutputDirectory().set(file("$buildDir/generated/sources/annotationProcessor/java/main"))
+    options.getGeneratedSourceOutputDirectory().set(file("$buildDir/generated/sources/annotationProcessor/java/main"))
 }
 
 // clean 작업 시 생성된 Q-Type 파일들도 삭제되도록 설정
 clean {
-	delete file("$buildDir/generated")
+    delete file("$buildDir/generated")
 }

--- a/src/main/java/umc/cockple/demo/domain/chat/dto/WebSocketMessageDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/dto/WebSocketMessageDTO.java
@@ -1,0 +1,17 @@
+package umc.cockple.demo.domain.chat.dto;
+
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+public class WebSocketMessageDTO {
+
+    @Builder
+    public record ConnectionInfo(
+            String type,
+            Long memberId,
+            String memberName,
+            LocalDateTime connectedAt,
+            String message) {
+    }
+}

--- a/src/main/java/umc/cockple/demo/domain/chat/enums/WebSocketMessageType.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/enums/WebSocketMessageType.java
@@ -1,0 +1,9 @@
+package umc.cockple.demo.domain.chat.enums;
+
+public enum WebSocketMessageType {
+    SEND,
+    READ,
+    SUBSCRIBE,
+    UNSUBSCRIBE,
+    ERROR
+}

--- a/src/main/java/umc/cockple/demo/domain/chat/handler/ChatWebSocketHandler.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/handler/ChatWebSocketHandler.java
@@ -1,0 +1,32 @@
+package umc.cockple.demo.domain.chat.handler;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.CloseStatus;
+import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketSession;
+import org.springframework.web.socket.handler.TextWebSocketHandler;
+
+@Component
+public class ChatWebSocketHandler extends TextWebSocketHandler {
+
+    @Override
+    public void afterConnectionEstablished(WebSocketSession session) throws Exception {
+
+    }
+
+    @Override
+    protected void handleTextMessage(WebSocketSession session, TextMessage message) throws Exception {
+
+    }
+
+    @Override
+    public void afterConnectionClosed(WebSocketSession session, CloseStatus status) throws Exception {
+
+    }
+
+    @Override
+    public void handleTransportError(WebSocketSession session, Throwable exception) throws Exception {
+
+    }
+
+}

--- a/src/main/java/umc/cockple/demo/domain/chat/handler/ChatWebSocketHandler.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/handler/ChatWebSocketHandler.java
@@ -1,17 +1,50 @@
 package umc.cockple.demo.domain.chat.handler;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.web.socket.CloseStatus;
 import org.springframework.web.socket.TextMessage;
 import org.springframework.web.socket.WebSocketSession;
 import org.springframework.web.socket.handler.TextWebSocketHandler;
+import umc.cockple.demo.domain.chat.dto.WebSocketMessageDTO;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 @Component
+@Slf4j
+@RequiredArgsConstructor
 public class ChatWebSocketHandler extends TextWebSocketHandler {
+
+    private final ObjectMapper objectMapper;
+
+    private final Map<Long, WebSocketSession> memberSessions = new ConcurrentHashMap<>();
 
     @Override
     public void afterConnectionEstablished(WebSocketSession session) throws Exception {
+        log.info("웹소켓 연결 성공");
 
+        try {
+            Long memberId = extractMemberIdFromURL(session);
+
+            if (memberId != null) {
+                session.getAttributes().put("memberId", memberId);
+                memberSessions.put(memberId, session);
+
+                log.info("사용자 연결 완료 - memberId: {}, 세션 ID: {}", memberId, session.getId());
+
+                sendConnectionSuccessMessage(session, memberId);
+            } else {
+                log.warn("memberId를 찾을 수 없습니다. 세션을 종료합니다.");
+                session.close();
+            }
+        } catch (Exception e) {
+            log.error("WebSocket 연결 처리 중 오류 발생", e);
+            session.close();
+        }
     }
 
     @Override
@@ -27,6 +60,39 @@ public class ChatWebSocketHandler extends TextWebSocketHandler {
     @Override
     public void handleTransportError(WebSocketSession session, Throwable exception) throws Exception {
 
+    }
+
+    // ========== 내부 메서드들 ==========
+
+    private Long extractMemberIdFromURL(WebSocketSession session) {
+        String query = session.getUri().getQuery();
+        if (query != null && query.contains("memberId=")) {
+            try {
+                String memberIdStr = query.split("memberId=")[1].split("&")[0]; // Id값 뽑아내기.
+                return Long.parseLong(memberIdStr);
+            } catch (Exception e) {
+                log.error("memberId 추출 실패", e);
+            }
+        }
+        return null;
+    }
+
+    private void sendConnectionSuccessMessage(WebSocketSession session, Long memberId) {
+        try {
+            WebSocketMessageDTO.ConnectionInfo connectionInfo = WebSocketMessageDTO.ConnectionInfo.builder()
+                    .type("CONNECTION")
+                    .memberId(memberId)
+                    .connectedAt(LocalDateTime.now())
+                    .message("WebSocket 연결이 성공했습니다.")
+                    .build();
+
+            String messageJson = objectMapper.writeValueAsString(connectionInfo);
+            session.sendMessage(new TextMessage(messageJson));
+
+            log.info("연결 성공 메시지 전송 완료 - memberId: {}", memberId);
+        } catch (Exception e) {
+            log.error("연결 성공 메시지 전송 실패", e);
+        }
     }
 
 }

--- a/src/main/java/umc/cockple/demo/domain/chat/handler/ChatWebSocketHandler.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/handler/ChatWebSocketHandler.java
@@ -76,7 +76,8 @@ public class ChatWebSocketHandler extends TextWebSocketHandler {
 
     @Override
     public void handleTransportError(WebSocketSession session, Throwable exception) throws Exception {
-
+        Long memberId = (Long) session.getAttributes().get("memberId");
+        log.error("WebSocket 전송 오류 발생 - 세션 ID: {}, 사용자 ID: {}", session.getId(), memberId, exception);
     }
 
     // ========== 내부 메서드들 ==========

--- a/src/main/java/umc/cockple/demo/global/config/WebSocketConfig.java
+++ b/src/main/java/umc/cockple/demo/global/config/WebSocketConfig.java
@@ -1,0 +1,23 @@
+package umc.cockple.demo.global.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.socket.config.annotation.EnableWebSocket;
+import org.springframework.web.socket.config.annotation.WebSocketConfigurer;
+import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry;
+
+@Configuration
+@EnableWebSocket
+@RequiredArgsConstructor
+public class WebSocketConfig implements WebSocketConfigurer {
+
+    private final ChatWebSocketHandler chatWebSocketHandler;
+
+    @Override
+    public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
+        registry
+                .addHandler(chatWebSocketHandler, "/ws/chats")
+                .setAllowedOrigins("*") // TODO: 운영 환경에서는 변경 필요. CORS 방지
+                .withSockJS(); // 브라우저 호환성
+    }
+}

--- a/src/main/java/umc/cockple/demo/global/config/WebSocketConfig.java
+++ b/src/main/java/umc/cockple/demo/global/config/WebSocketConfig.java
@@ -5,6 +5,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.web.socket.config.annotation.EnableWebSocket;
 import org.springframework.web.socket.config.annotation.WebSocketConfigurer;
 import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry;
+import umc.cockple.demo.domain.chat.handler.ChatWebSocketHandler;
 
 @Configuration
 @EnableWebSocket


### PR DESCRIPTION
## ❤️ 기능 설명
클라이언트는 /ws/chats 경로로 웹소켓 연결을 진행할 수 있습니다.

swagger 테스트 성공 결과 스크린샷 첨부
<img width="1292" height="1002" alt="image" src="https://github.com/user-attachments/assets/3fe502a0-cdbf-4714-aba7-7a3a85d2ceb4" />
포스트맨에서 테스트를 할 때는 SockJS 설정 때문에 끝에 /websocket url을 붙였습니다.

<img width="1396" height="152" alt="image" src="https://github.com/user-attachments/assets/921b7633-0966-4f1c-834b-6216d383e0c9" />

<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #248 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 클라이언트 경로를 잘 모르기에 일단 모든 경로를 허용으로 해뒀습니다.
- [ ] 실시간 읽음 처리 로직의 경우 STOMP를 쓰지 않는 쪽이 구현이 편하다고 들어서 순수 웹소켓으로 구현해볼 생각입니다.
- [ ] 일단 Reddis 없이 기능 개발을 마친 후 Reddis를 도입하겠습니다.

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
