### PR TITLE
[feat/#250] 메시지 전송 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,6 +59,9 @@ dependencies {
     // springboot test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    testImplementation 'org.mockito:mockito-core'
+    testImplementation 'org.mockito:mockito-junit-jupiter'
+    testImplementation 'org.assertj:assertj-core'
 
     // swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'

--- a/src/main/java/umc/cockple/demo/domain/chat/converter/ChatConverter.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/converter/ChatConverter.java
@@ -103,7 +103,8 @@ public class ChatConverter {
                 ).collect(Collectors.toList());
     }
 
-    public WebSocketMessageDTO.Response toSendMessageResponse(Long chatRoomId, String content, ChatMessage savedMessage, Member sender) {
+    public WebSocketMessageDTO.Response toSendMessageResponse(
+            Long chatRoomId, String content, ChatMessage savedMessage, Member sender, String senderProfileImageUrl) {
         return WebSocketMessageDTO.Response.builder()
                 .type(WebSocketMessageType.SEND)
                 .chatRoomId(chatRoomId)
@@ -111,6 +112,7 @@ public class ChatConverter {
                 .content(content)
                 .senderId(sender.getId())
                 .senderName(sender.getMemberName())
+                .senderProfileImageUrl(senderProfileImageUrl)
                 .createdAt(savedMessage.getCreatedAt())
                 .build();
     }

--- a/src/main/java/umc/cockple/demo/domain/chat/converter/ChatConverter.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/converter/ChatConverter.java
@@ -5,8 +5,9 @@ import org.springframework.stereotype.Component;
 import umc.cockple.demo.domain.chat.domain.ChatMessage;
 import umc.cockple.demo.domain.chat.domain.ChatRoom;
 import umc.cockple.demo.domain.chat.domain.ChatRoomMember;
-import umc.cockple.demo.domain.chat.dto.*;
+import umc.cockple.demo.domain.chat.enums.WebSocketMessageType;
 import umc.cockple.demo.domain.member.domain.Member;
+import umc.cockple.demo.domain.chat.dto.*;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -181,6 +182,18 @@ public class ChatConverter {
                 .messages(messages)
                 .hasNext(hasNext)
                 .nextCursor(nextCursor)
+                .build();
+    }
+
+    public WebSocketMessageDTO.Response toSendMessageResponse(WebSocketMessageDTO.Request request, ChatMessage savedMessage, Member sender) {
+        return WebSocketMessageDTO.Response.builder()
+                .type(WebSocketMessageType.SEND)
+                .chatRoomId(request.chatRoomId())
+                .messageId(savedMessage.getId())
+                .content(request.content())
+                .senderId(sender.getId())
+                .senderName(sender.getMemberName())
+                .createdAt(savedMessage.getCreatedAt())
                 .build();
     }
 }

--- a/src/main/java/umc/cockple/demo/domain/chat/converter/ChatConverter.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/converter/ChatConverter.java
@@ -103,6 +103,18 @@ public class ChatConverter {
                 ).collect(Collectors.toList());
     }
 
+    public WebSocketMessageDTO.Response toSendMessageResponse(Long chatRoomId, String content, ChatMessage savedMessage, Member sender) {
+        return WebSocketMessageDTO.Response.builder()
+                .type(WebSocketMessageType.SEND)
+                .chatRoomId(chatRoomId)
+                .messageId(savedMessage.getId())
+                .content(content)
+                .senderId(sender.getId())
+                .senderName(sender.getMemberName())
+                .createdAt(savedMessage.getCreatedAt())
+                .build();
+    }
+
     public ChatRoomDetailDTO.ChatRoomInfo toChatRoomDetailChatRoomInfo(
             ChatRoom chatRoom,
             String displayName,
@@ -182,18 +194,6 @@ public class ChatConverter {
                 .messages(messages)
                 .hasNext(hasNext)
                 .nextCursor(nextCursor)
-                .build();
-    }
-
-    public WebSocketMessageDTO.Response toSendMessageResponse(WebSocketMessageDTO.Request request, ChatMessage savedMessage, Member sender) {
-        return WebSocketMessageDTO.Response.builder()
-                .type(WebSocketMessageType.SEND)
-                .chatRoomId(request.chatRoomId())
-                .messageId(savedMessage.getId())
-                .content(request.content())
-                .senderId(sender.getId())
-                .senderName(sender.getMemberName())
-                .createdAt(savedMessage.getCreatedAt())
                 .build();
     }
 }

--- a/src/main/java/umc/cockple/demo/domain/chat/domain/ChatMessage.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/domain/ChatMessage.java
@@ -40,4 +40,14 @@ public class ChatMessage extends BaseEntity {
 
     @OneToMany(mappedBy = "chatMessage", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ChatMessageImg> chatMessageImgs = new ArrayList<>();
+
+    public static ChatMessage create(ChatRoom chatRoom, Member sender, String content, MessageType type) {
+        return ChatMessage.builder()
+                .chatRoom(chatRoom)
+                .sender(sender)
+                .content(content)
+                .type(type)
+                .isDeleted(false)
+                .build();
+    }
 }

--- a/src/main/java/umc/cockple/demo/domain/chat/dto/WebSocketMessageDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/dto/WebSocketMessageDTO.java
@@ -28,7 +28,7 @@ public class WebSocketMessageDTO {
             WebSocketMessageType type,
             Long chatRoomId,
             Long messageId,
-            String contentId,
+            String content,
             Long senderId,
             String senderName,
             LocalDateTime createdAt,

--- a/src/main/java/umc/cockple/demo/domain/chat/dto/WebSocketMessageDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/dto/WebSocketMessageDTO.java
@@ -31,8 +31,7 @@ public class WebSocketMessageDTO {
             String content,
             Long senderId,
             String senderName,
-            LocalDateTime createdAt,
-            int unreadCount
+            LocalDateTime createdAt
     ) {
     }
 

--- a/src/main/java/umc/cockple/demo/domain/chat/dto/WebSocketMessageDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/dto/WebSocketMessageDTO.java
@@ -31,6 +31,7 @@ public class WebSocketMessageDTO {
             String content,
             Long senderId,
             String senderName,
+            String senderProfileImageUrl,
             LocalDateTime createdAt
     ) {
     }

--- a/src/main/java/umc/cockple/demo/domain/chat/dto/WebSocketMessageDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/dto/WebSocketMessageDTO.java
@@ -22,4 +22,13 @@ public class WebSocketMessageDTO {
             String content
     ) {
     }
+
+    @Builder
+    public record ErrorResponse(
+            WebSocketMessageType type,
+            String errorCode,
+            String message,
+            Long chatRoomId
+    ) {
+    }
 }

--- a/src/main/java/umc/cockple/demo/domain/chat/dto/WebSocketMessageDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/dto/WebSocketMessageDTO.java
@@ -1,6 +1,7 @@
 package umc.cockple.demo.domain.chat.dto;
 
 import lombok.Builder;
+import umc.cockple.demo.domain.chat.enums.WebSocketMessageType;
 
 import java.time.LocalDateTime;
 
@@ -13,5 +14,12 @@ public class WebSocketMessageDTO {
             String memberName,
             LocalDateTime connectedAt,
             String message) {
+    }
+
+    public record Request(
+            WebSocketMessageType type,
+            Long chatRoomId,
+            String content
+    ) {
     }
 }

--- a/src/main/java/umc/cockple/demo/domain/chat/dto/WebSocketMessageDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/dto/WebSocketMessageDTO.java
@@ -24,6 +24,19 @@ public class WebSocketMessageDTO {
     }
 
     @Builder
+    public record Response(
+            WebSocketMessageType type,
+            Long chatRoomId,
+            Long messageId,
+            String contentId,
+            Long senderId,
+            String senderName,
+            LocalDateTime createdAt,
+            int unreadCount
+    ) {
+    }
+
+    @Builder
     public record ErrorResponse(
             WebSocketMessageType type,
             String errorCode,
@@ -31,4 +44,5 @@ public class WebSocketMessageDTO {
             Long chatRoomId
     ) {
     }
+
 }

--- a/src/main/java/umc/cockple/demo/domain/chat/exception/ChatErrorCode.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/exception/ChatErrorCode.java
@@ -12,6 +12,8 @@ public enum ChatErrorCode implements BaseErrorCode {
 
     //1xx: 클라이언트가 수정해야 할 입력값 문제
     CANNOT_CHAT_WITH_SELF(HttpStatus.BAD_REQUEST, "CHAT101", "나와의 채팅방 생성은 불가합니다"),
+    CHATROOM_ID_NECESSARY(HttpStatus.BAD_REQUEST, "CHAT102", "채팅방 ID가 필요합니다."),
+    CONTENT_NECESSARY(HttpStatus.BAD_REQUEST, "CHAT103", "메시지 내용이 필요합니다"),
 
     // 2xx: 리소스 없음
     CHAT_ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "CHAT201", "채팅방을 찾을 수 없습니다."),

--- a/src/main/java/umc/cockple/demo/domain/chat/exception/ChatErrorCode.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/exception/ChatErrorCode.java
@@ -11,9 +11,10 @@ import umc.cockple.demo.global.response.dto.ErrorReasonDTO;
 public enum ChatErrorCode implements BaseErrorCode {
 
     //1xx: 클라이언트가 수정해야 할 입력값 문제
-    CANNOT_CHAT_WITH_SELF(HttpStatus.BAD_REQUEST, "CHAT101", "나와의 채팅방 생성은 불가합니다"),
+    CANNOT_CHAT_WITH_SELF(HttpStatus.BAD_REQUEST, "CHAT101", "나와의 채팅방 생성은 불가합니다."),
     CHATROOM_ID_NECESSARY(HttpStatus.BAD_REQUEST, "CHAT102", "채팅방 ID가 필요합니다."),
-    CONTENT_NECESSARY(HttpStatus.BAD_REQUEST, "CHAT103", "메시지 내용이 필요합니다"),
+    CONTENT_NECESSARY(HttpStatus.BAD_REQUEST, "CHAT103", "메시지 내용이 필요합니다."),
+    MESSAGE_TO_LONG(HttpStatus.BAD_REQUEST, "CHAT104", "메시지는 1000자를 초과할 수 없습니다."),
 
     // 2xx: 리소스 없음
     CHAT_ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "CHAT201", "채팅방을 찾을 수 없습니다."),

--- a/src/main/java/umc/cockple/demo/domain/chat/exception/ChatErrorCode.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/exception/ChatErrorCode.java
@@ -18,10 +18,10 @@ public enum ChatErrorCode implements BaseErrorCode {
 
     // 2xx: 리소스 없음
     CHAT_ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "CHAT201", "채팅방을 찾을 수 없습니다."),
-    CHAT_ROOM_MEMBER_NOT_FOUND(HttpStatus.BAD_REQUEST, "CHAT202", "채팅방 멤버가 존재하지 않습니다."),
+    CHAT_ROOM_MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "CHAT202", "채팅방 멤버가 존재하지 않습니다."),
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "CHAT203", "멤버가 존재하지 않습니다."),
 
     // 3xx: 인증/인가 문제
-    NOT_CHAT_ROOM_MEMBER(HttpStatus.BAD_REQUEST, "CHAT301", "채팅방에 참여한 멤버가 아닙니다."),
     PARTY_MEMBER_NOT_FOUND(HttpStatus.BAD_REQUEST, "CHAT302", "모임에 참여한 회원이 아닙니다.");
 
     private final HttpStatus httpStatus;

--- a/src/main/java/umc/cockple/demo/domain/chat/exception/ChatErrorCode.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/exception/ChatErrorCode.java
@@ -15,9 +15,10 @@ public enum ChatErrorCode implements BaseErrorCode {
 
     // 2xx: 리소스 없음
     CHAT_ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "CHAT201", "채팅방을 찾을 수 없습니다."),
-    CHAT_ROOM_MEMBER_NOT_FOUND(HttpStatus.BAD_REQUEST, "CHAT202", "채팅방에 참여한 멤버가 아닙니다."),
+    CHAT_ROOM_MEMBER_NOT_FOUND(HttpStatus.BAD_REQUEST, "CHAT202", "채팅방 멤버가 존재하지 않습니다."),
 
     // 3xx: 인증/인가 문제
+    NOT_CHAT_ROOM_MEMBER(HttpStatus.BAD_REQUEST, "CHAT301", "채팅방에 참여한 멤버가 아닙니다."),
     PARTY_MEMBER_NOT_FOUND(HttpStatus.BAD_REQUEST, "CHAT302", "모임에 참여한 회원이 아닙니다.");
 
     private final HttpStatus httpStatus;

--- a/src/main/java/umc/cockple/demo/domain/chat/handler/ChatWebSocketHandler.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/handler/ChatWebSocketHandler.java
@@ -63,7 +63,7 @@ public class ChatWebSocketHandler extends TextWebSocketHandler {
             );
 
             Long memberId = (Long) session.getAttributes().get("memberId");
-            if(memberId == null){
+            if (memberId == null) {
                 sendErrorMessage(session, "UNAUTHORIZED", "인증되지 않은 사용자입니다.");
                 return;
             }
@@ -172,15 +172,21 @@ public class ChatWebSocketHandler extends TextWebSocketHandler {
         log.info("메시지 전송 처리 - 채팅방 ID: {}, 사용자 ID: {}, 내용: {}",
                 request.chatRoomId(), memberId, request.content());
 
-        try{
+        try {
             WebSocketMessageDTO.Response response = chatWebSocketService.sendMessage(request, memberId);
-        }catch (Exception e){
+        } catch (Exception e) {
             log.error("메시지 전송 중 오류 발생", e);
 
             String errorMessage = "";
             String errorCode = "";
 
-            if (e.getMessage().contains("채팅방을 찾을 수 없습니다.")) {
+            if (e.getMessage().contains("채팅방 ID가 필요합니다.")) {
+                errorCode = "CHATROOM_ID_NECESSARY";
+                errorMessage = "채팅방 ID가 필요합니다.";
+            } else if (e.getMessage().contains("메시지 내용이 필요합니다.")) {
+                errorCode = "CONTENT_NECESSARY";
+                errorMessage = "메시지 내용이 필요합니다.";
+            } else if (e.getMessage().contains("채팅방을 찾을 수 없습니다.")) {
                 errorCode = "CHAT_ROOM_NOT_FOUND";
                 errorMessage = "존재하지 않는 채팅방입니다.";
             } else if (e.getMessage().contains("사용자를 찾을 수 없습니다.")) {
@@ -189,12 +195,6 @@ public class ChatWebSocketHandler extends TextWebSocketHandler {
             } else if (e.getMessage().contains("채팅방에 참여한 멤버가 아닙니다.")) {
                 errorCode = "NOT_CHAT_ROOM_MEMBER";
                 errorMessage = "채팅방에 참여한 멤버가 아닙니다.";
-            } else if(e.getMessage().contains("채팅방 ID가 필요합니다.")){
-                errorCode = "CHATROOM_ID_NECESSARY";
-                errorMessage = "채팅방 ID가 필요합니다.";
-            } else if (e.getMessage().contains("메시지 내용이 필요합니다.")) {
-                errorCode = "CONTENT_NECESSARY";
-                errorMessage = "메시지 내용이 필요합니다.";
             }
 
             sendErrorMessage(session, errorCode, errorMessage);

--- a/src/main/java/umc/cockple/demo/domain/chat/handler/ChatWebSocketHandler.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/handler/ChatWebSocketHandler.java
@@ -55,7 +55,7 @@ public class ChatWebSocketHandler extends TextWebSocketHandler {
     }
 
     @Override
-    protected void handleTextMessage(WebSocketSession session, TextMessage message) throws Exception {
+    public void handleTextMessage(WebSocketSession session, TextMessage message) throws Exception {
         log.info("메시지 수신");
         log.info("메시지: {}", message.getPayload());
 

--- a/src/main/java/umc/cockple/demo/domain/chat/handler/ChatWebSocketHandler.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/handler/ChatWebSocketHandler.java
@@ -246,4 +246,10 @@ public class ChatWebSocketHandler extends TextWebSocketHandler {
             }
         }
     }
+
+    // ========== 테스트용 ==========
+    public void clearAllSessionsForTest() {
+        memberSessions.clear();
+        chatRoomSessions.clear();
+    }
 }

--- a/src/main/java/umc/cockple/demo/domain/chat/handler/ChatWebSocketHandler.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/handler/ChatWebSocketHandler.java
@@ -248,7 +248,7 @@ public class ChatWebSocketHandler extends TextWebSocketHandler {
     }
 
     // ========== 테스트용 ==========
-    public void clearAllSessionsForTest() {
+    void clearAllSessionsForTest() {
         memberSessions.clear();
         chatRoomSessions.clear();
     }

--- a/src/main/java/umc/cockple/demo/domain/chat/handler/ChatWebSocketHandler.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/handler/ChatWebSocketHandler.java
@@ -252,4 +252,18 @@ public class ChatWebSocketHandler extends TextWebSocketHandler {
         memberSessions.clear();
         chatRoomSessions.clear();
     }
+
+    void addChatRoomSessionForTest(Long chatRoomId, Long memberId, WebSocketSession session) {
+        chatRoomSessions.computeIfAbsent(chatRoomId, k -> new ConcurrentHashMap<>())
+                .put(memberId, session);
+    }
+
+    void broadcastToChatRoomForTest(Long chatRoomId, WebSocketMessageDTO.Response message) {
+        broadcastToChatRoom(chatRoomId, message);
+    }
+
+    boolean isMemberInChatRoomForTest(Long chatRoomId, Long memberId) {
+        Map<Long, WebSocketSession> sessions = chatRoomSessions.get(chatRoomId);
+        return sessions != null && sessions.containsKey(memberId);
+    }
 }

--- a/src/main/java/umc/cockple/demo/domain/chat/handler/ChatWebSocketHandler.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/handler/ChatWebSocketHandler.java
@@ -10,7 +10,6 @@ import org.springframework.web.socket.WebSocketSession;
 import org.springframework.web.socket.handler.TextWebSocketHandler;
 import umc.cockple.demo.domain.chat.dto.WebSocketMessageDTO;
 import umc.cockple.demo.domain.chat.enums.WebSocketMessageType;
-import umc.cockple.demo.domain.chat.exception.ChatErrorCode;
 import umc.cockple.demo.domain.chat.exception.ChatException;
 import umc.cockple.demo.domain.chat.service.ChatWebSocketService;
 
@@ -195,7 +194,7 @@ public class ChatWebSocketHandler extends TextWebSocketHandler {
             log.info("채팅방 {}에 구독 중인 세션이 없습니다.", chatRoomId);
             return;
         }
-        
+
         String messageJson;
         try {
             messageJson = objectMapper.writeValueAsString(message);

--- a/src/main/java/umc/cockple/demo/domain/chat/handler/ChatWebSocketHandler.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/handler/ChatWebSocketHandler.java
@@ -180,15 +180,21 @@ public class ChatWebSocketHandler extends TextWebSocketHandler {
             String errorMessage = "";
             String errorCode = "";
 
-            if (e.getMessage().contains("채팅방을 찾을 수 없습니다")) {
+            if (e.getMessage().contains("채팅방을 찾을 수 없습니다.")) {
                 errorCode = "CHAT_ROOM_NOT_FOUND";
                 errorMessage = "존재하지 않는 채팅방입니다.";
-            } else if (e.getMessage().contains("사용자를 찾을 수 없습니다")) {
+            } else if (e.getMessage().contains("사용자를 찾을 수 없습니다.")) {
                 errorCode = "USER_NOT_FOUND";
                 errorMessage = "사용자 정보를 찾을 수 없습니다.";
-            } else if (e.getMessage().contains("채팅방에 참여한 멤버가 아닙니다")) {
+            } else if (e.getMessage().contains("채팅방에 참여한 멤버가 아닙니다.")) {
                 errorCode = "NOT_CHAT_ROOM_MEMBER";
                 errorMessage = "채팅방에 참여한 멤버가 아닙니다.";
+            } else if(e.getMessage().contains("채팅방 ID가 필요합니다.")){
+                errorCode = "CHATROOM_ID_NECESSARY";
+                errorMessage = "채팅방 ID가 필요합니다.";
+            } else if (e.getMessage().contains("메시지 내용이 필요합니다.")) {
+                errorCode = "CONTENT_NECESSARY";
+                errorMessage = "메시지 내용이 필요합니다.";
             }
 
             sendErrorMessage(session, errorCode, errorMessage);

--- a/src/main/java/umc/cockple/demo/domain/chat/handler/ChatWebSocketHandler.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/handler/ChatWebSocketHandler.java
@@ -175,46 +175,16 @@ public class ChatWebSocketHandler extends TextWebSocketHandler {
                 request.chatRoomId(), memberId, request.content());
 
         try {
-            validateRequest(request);
-
             WebSocketMessageDTO.Response response
                     = chatWebSocketService.sendMessage(request.chatRoomId(), request.content(), memberId);
 
             broadcastToChatRoom(request.chatRoomId(), response);
-        } catch (Exception e) {
+        } catch (ChatException e) {
             log.error("메시지 전송 중 오류 발생", e);
-
-            String errorMessage = "";
-            String errorCode = "";
-
-            if (e.getMessage().contains("채팅방 ID가 필요합니다.")) {
-                errorCode = "CHATROOM_ID_NECESSARY";
-                errorMessage = "채팅방 ID가 필요합니다.";
-            } else if (e.getMessage().contains("메시지 내용이 필요합니다.")) {
-                errorCode = "CONTENT_NECESSARY";
-                errorMessage = "메시지 내용이 필요합니다.";
-            } else if (e.getMessage().contains("채팅방을 찾을 수 없습니다.")) {
-                errorCode = "CHAT_ROOM_NOT_FOUND";
-                errorMessage = "존재하지 않는 채팅방입니다.";
-            } else if (e.getMessage().contains("사용자를 찾을 수 없습니다.")) {
-                errorCode = "USER_NOT_FOUND";
-                errorMessage = "사용자 정보를 찾을 수 없습니다.";
-            } else if (e.getMessage().contains("채팅방에 참여한 멤버가 아닙니다.")) {
-                errorCode = "NOT_CHAT_ROOM_MEMBER";
-                errorMessage = "채팅방에 참여한 멤버가 아닙니다.";
-            }
-
-            sendErrorMessage(session, errorCode, errorMessage);
-        }
-    }
-
-    private void validateRequest(WebSocketMessageDTO.Request request) {
-        if(request.chatRoomId() == null) {
-            throw new ChatException(ChatErrorCode.CHATROOM_ID_NECESSARY);
-        }
-
-        if(request.content() == null || request.content().trim().isEmpty()) {
-            throw new ChatException(ChatErrorCode.CONTENT_NECESSARY);
+            sendErrorMessage(session, e.getCode().toString(), e.getMessage());
+        } catch (Exception e) {
+            log.error("메시지 전송 중 예상치 못한 오류 발생", e);
+            sendErrorMessage(session, "INTERNAL_ERROR", "예상치 못한 에러가 발생했습니다.");
         }
     }
 

--- a/src/main/java/umc/cockple/demo/domain/chat/handler/ChatWebSocketHandler.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/handler/ChatWebSocketHandler.java
@@ -50,6 +50,26 @@ public class ChatWebSocketHandler extends TextWebSocketHandler {
 
     @Override
     protected void handleTextMessage(WebSocketSession session, TextMessage message) throws Exception {
+        log.info("메시지 수신");
+        log.info("메시지: {}", message.getPayload());
+
+        try {
+            WebSocketMessageDTO.Request request = objectMapper.readValue(
+                    message.getPayload(), WebSocketMessageDTO.Request.class
+            );
+
+            Long memberId = (Long) session.getAttributes().get("memberId");
+            log.info("메시지 타입: {}, 채팅방 ID: {}, 사용자 ID: {}", memberId, session.getId(), memberId);
+
+            switch (request.type()) {
+                case SEND:
+                    handleSendMessage(session, request, memberId);
+                    break;
+            }
+
+        } catch (Exception e) {
+
+        }
 
     }
 

--- a/src/main/java/umc/cockple/demo/domain/chat/handler/ChatWebSocketHandler.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/handler/ChatWebSocketHandler.java
@@ -10,6 +10,8 @@ import org.springframework.web.socket.WebSocketSession;
 import org.springframework.web.socket.handler.TextWebSocketHandler;
 import umc.cockple.demo.domain.chat.dto.WebSocketMessageDTO;
 import umc.cockple.demo.domain.chat.enums.WebSocketMessageType;
+import umc.cockple.demo.domain.chat.exception.ChatErrorCode;
+import umc.cockple.demo.domain.chat.exception.ChatException;
 import umc.cockple.demo.domain.chat.service.ChatWebSocketService;
 
 import java.time.LocalDateTime;
@@ -173,7 +175,10 @@ public class ChatWebSocketHandler extends TextWebSocketHandler {
                 request.chatRoomId(), memberId, request.content());
 
         try {
-            WebSocketMessageDTO.Response response = chatWebSocketService.sendMessage(request, memberId);
+            validateRequest(request);
+
+            WebSocketMessageDTO.Response response
+                    = chatWebSocketService.sendMessage(request.chatRoomId(), request.content(), memberId);
         } catch (Exception e) {
             log.error("메시지 전송 중 오류 발생", e);
 
@@ -198,6 +203,16 @@ public class ChatWebSocketHandler extends TextWebSocketHandler {
             }
 
             sendErrorMessage(session, errorCode, errorMessage);
+        }
+    }
+
+    private void validateRequest(WebSocketMessageDTO.Request request) {
+        if(request.chatRoomId() == null) {
+            throw new ChatException(ChatErrorCode.CHATROOM_ID_NECESSARY);
+        }
+
+        if(request.content() == null || request.content().trim().isEmpty()) {
+            throw new ChatException(ChatErrorCode.CONTENT_NECESSARY);
         }
     }
 }

--- a/src/main/java/umc/cockple/demo/domain/chat/repository/ChatRoomMemberRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/repository/ChatRoomMemberRepository.java
@@ -3,7 +3,9 @@ package umc.cockple.demo.domain.chat.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import umc.cockple.demo.domain.chat.domain.ChatRoom;
 import umc.cockple.demo.domain.chat.domain.ChatRoomMember;
+import umc.cockple.demo.domain.member.domain.Member;
 
 import java.util.List;
 import java.util.Optional;
@@ -27,6 +29,8 @@ public interface ChatRoomMemberRepository extends JpaRepository<ChatRoomMember, 
     List<ChatRoomMember> findByChatRoomId(Long id);
 
     List<ChatRoomMember> findAllByMemberId(Long id);
+
+    boolean existsByChatRoomAndMember(ChatRoom chatRoom, Member member);
 
     @Query("""
             SELECT crm FROM ChatRoomMember crm

--- a/src/main/java/umc/cockple/demo/domain/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/repository/ChatRoomRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import umc.cockple.demo.domain.chat.domain.ChatRoom;
+import umc.cockple.demo.domain.member.domain.Member;
 
 import java.util.List;
 import java.util.Optional;
@@ -47,6 +48,8 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
 
 
     ChatRoom findByPartyId(Long partyId);
+
+    boolean existsByChatRoomAndMember(ChatRoom chatRoom, Member member);
 
     @Query("""
             SELECT cr

--- a/src/main/java/umc/cockple/demo/domain/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/repository/ChatRoomRepository.java
@@ -6,7 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import umc.cockple.demo.domain.chat.domain.ChatRoom;
-import umc.cockple.demo.domain.member.domain.Member;
 
 import java.util.List;
 import java.util.Optional;
@@ -50,8 +49,6 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
 
 
     ChatRoom findByPartyId(Long partyId);
-
-    boolean existsByChatRoomAndMember(ChatRoom chatRoom, Member member);
 
     @Query("""
             SELECT cr

--- a/src/main/java/umc/cockple/demo/domain/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/repository/ChatRoomRepository.java
@@ -43,6 +43,8 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
     Slice<ChatRoom> searchPartyChatRoomsByName(
             @Param("memberId") Long memberId,
             @Param("name") String name,
+            @Param("cursor") Long cursor,
+            @Param("direction") String direction,
             Pageable pageable
     );
 

--- a/src/main/java/umc/cockple/demo/domain/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/repository/ChatRoomRepository.java
@@ -27,7 +27,6 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
             Pageable pageable
     );
 
-
     @Query("""
             SELECT cr FROM ChatRoom cr
             JOIN cr.chatRoomMembers crm
@@ -42,11 +41,8 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
     Slice<ChatRoom> searchPartyChatRoomsByName(
             @Param("memberId") Long memberId,
             @Param("name") String name,
-            @Param("cursor") Long cursor,
-            @Param("direction") String direction,
             Pageable pageable
     );
-
 
     ChatRoom findByPartyId(Long partyId);
 

--- a/src/main/java/umc/cockple/demo/domain/chat/service/ChatWebSocketService.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/ChatWebSocketService.java
@@ -12,6 +12,7 @@ import umc.cockple.demo.domain.chat.enums.MessageType;
 import umc.cockple.demo.domain.chat.exception.ChatErrorCode;
 import umc.cockple.demo.domain.chat.exception.ChatException;
 import umc.cockple.demo.domain.chat.repository.ChatMessageRepository;
+import umc.cockple.demo.domain.chat.repository.ChatRoomMemberRepository;
 import umc.cockple.demo.domain.chat.repository.ChatRoomRepository;
 import umc.cockple.demo.domain.member.domain.Member;
 import umc.cockple.demo.domain.member.repository.MemberRepository;
@@ -25,6 +26,7 @@ public class ChatWebSocketService {
     private final ChatRoomRepository chatRoomRepository;
     private final MemberRepository memberRepository;
     private final ChatMessageRepository chatMessageRepository;
+    private final ChatRoomMemberRepository chatRoomMemberRepository;
 
     private final ChatConverter chatConverter;
 
@@ -32,8 +34,10 @@ public class ChatWebSocketService {
         log.info("메시지 전송 시작 - 채팅방: {}, 발신자: {}", chatRoomId, senderId);
 
         validateInput(chatRoomId, content);
+
         ChatRoom chatRoom = findChatRoomOrThrow(chatRoomId);
         Member sender = findMemberOrThrow(senderId);
+
         validateChatRoomMember(chatRoom, sender);
 
         // TODO: 다양한 타입의 텍스트 전송가능하도록 변경해야 함
@@ -60,7 +64,7 @@ public class ChatWebSocketService {
     }
 
     private void validateChatRoomMember(ChatRoom chatRoom, Member member) {
-        if (!chatRoomRepository.existsByChatRoomAndMember(chatRoom, member))
+        if (!chatRoomMemberRepository.existsByChatRoomAndMember(chatRoom, member))
             throw new ChatException(ChatErrorCode.NOT_CHAT_ROOM_MEMBER);
     }
 

--- a/src/main/java/umc/cockple/demo/domain/chat/service/ChatWebSocketService.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/ChatWebSocketService.java
@@ -4,10 +4,13 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import umc.cockple.demo.domain.chat.domain.ChatMessage;
 import umc.cockple.demo.domain.chat.domain.ChatRoom;
 import umc.cockple.demo.domain.chat.dto.WebSocketMessageDTO;
+import umc.cockple.demo.domain.chat.enums.MessageType;
 import umc.cockple.demo.domain.chat.exception.ChatErrorCode;
 import umc.cockple.demo.domain.chat.exception.ChatException;
+import umc.cockple.demo.domain.chat.repository.ChatMessageRepository;
 import umc.cockple.demo.domain.chat.repository.ChatRoomRepository;
 import umc.cockple.demo.domain.member.domain.Member;
 import umc.cockple.demo.domain.member.repository.MemberRepository;
@@ -20,6 +23,7 @@ public class ChatWebSocketService {
 
     private final ChatRoomRepository chatRoomRepository;
     private final MemberRepository memberRepository;
+    private final ChatMessageRepository chatMessageRepository;
 
     public WebSocketMessageDTO.Response sendMessage(Long chatRoomId, String content, Long senderId) {
         log.info("메시지 전송 시작 - 채팅방: {}, 발신자: {}", chatRoomId, senderId);
@@ -28,6 +32,12 @@ public class ChatWebSocketService {
         Member sender = findMemberOrThrow(senderId);
 
         validateChatRoomMember(chatRoom, sender);
+
+        // TODO: 다양한 타입의 텍스트 전송가능하도록 변경해야 함
+        ChatMessage chatMessage = ChatMessage.create(chatRoom, sender, content, MessageType.TEXT);
+        ChatMessage savedMessage = chatMessageRepository.save(chatMessage);
+        log.info("메시지 저장 완료 - 메시지 ID: {}", savedMessage.getId());
+
     }
 
     private void validateChatRoomMember(ChatRoom chatRoom, Member member) {

--- a/src/main/java/umc/cockple/demo/domain/chat/service/ChatWebSocketService.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/ChatWebSocketService.java
@@ -1,0 +1,4 @@
+package umc.cockple.demo.domain.chat.service;
+
+public class ChatWebSocketService {
+}

--- a/src/main/java/umc/cockple/demo/domain/chat/service/ChatWebSocketService.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/ChatWebSocketService.java
@@ -31,9 +31,9 @@ public class ChatWebSocketService {
     public WebSocketMessageDTO.Response sendMessage(Long chatRoomId, String content, Long senderId) {
         log.info("메시지 전송 시작 - 채팅방: {}, 발신자: {}", chatRoomId, senderId);
 
+        validateInput(chatRoomId, content);
         ChatRoom chatRoom = findChatRoomOrThrow(chatRoomId);
         Member sender = findMemberOrThrow(senderId);
-
         validateChatRoomMember(chatRoom, sender);
 
         // TODO: 다양한 타입의 텍스트 전송가능하도록 변경해야 함
@@ -43,6 +43,20 @@ public class ChatWebSocketService {
         log.info("메시지 저장 완료 - 메시지 ID: {}", savedMessage.getId());
 
         return chatConverter.toSendMessageResponse(chatRoomId, content, savedMessage, sender);
+    }
+
+    private void validateInput(Long chatRoomId, String content) {
+        if (chatRoomId == null) {
+            throw new ChatException(ChatErrorCode.CHATROOM_ID_NECESSARY);
+        }
+
+        if (content == null || content.trim().isEmpty()) {
+            throw new ChatException(ChatErrorCode.CONTENT_NECESSARY);
+        }
+
+        if(content.length() > 1000){
+            throw new ChatException(ChatErrorCode.MESSAGE_TO_LONG);
+        }
     }
 
     private void validateChatRoomMember(ChatRoom chatRoom, Member member) {

--- a/src/main/java/umc/cockple/demo/domain/chat/service/ChatWebSocketService.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/ChatWebSocketService.java
@@ -54,7 +54,7 @@ public class ChatWebSocketService {
             throw new ChatException(ChatErrorCode.CONTENT_NECESSARY);
         }
 
-        if(content.length() > 1000){
+        if (content.length() > 1000) {
             throw new ChatException(ChatErrorCode.MESSAGE_TO_LONG);
         }
     }

--- a/src/main/java/umc/cockple/demo/domain/chat/service/ChatWebSocketService.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/ChatWebSocketService.java
@@ -14,7 +14,9 @@ import umc.cockple.demo.domain.chat.exception.ChatException;
 import umc.cockple.demo.domain.chat.repository.ChatMessageRepository;
 import umc.cockple.demo.domain.chat.repository.ChatRoomMemberRepository;
 import umc.cockple.demo.domain.chat.repository.ChatRoomRepository;
+import umc.cockple.demo.domain.image.service.ImageService;
 import umc.cockple.demo.domain.member.domain.Member;
+import umc.cockple.demo.domain.member.domain.ProfileImg;
 import umc.cockple.demo.domain.member.repository.MemberRepository;
 
 @Service
@@ -36,7 +38,7 @@ public class ChatWebSocketService {
         validateInput(chatRoomId, content);
 
         ChatRoom chatRoom = findChatRoomOrThrow(chatRoomId);
-        Member sender = findMemberOrThrow(senderId);
+        Member sender = findMemberWithProfileOrThrow(senderId);
 
         validateChatRoomMember(chatRoom, sender);
 
@@ -73,8 +75,8 @@ public class ChatWebSocketService {
                 .orElseThrow(() -> new ChatException(ChatErrorCode.CHAT_ROOM_NOT_FOUND));
     }
 
-    private Member findMemberOrThrow(Long senderId) {
-        return memberRepository.findById(senderId)
+    private Member findMemberWithProfileOrThrow(Long senderId) {
+        return memberRepository.findMemberWithProfileById(senderId)
                 .orElseThrow(() -> new ChatException(ChatErrorCode.MEMBER_NOT_FOUND));
     }
 }

--- a/src/main/java/umc/cockple/demo/domain/chat/service/ChatWebSocketService.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/ChatWebSocketService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import umc.cockple.demo.domain.chat.converter.ChatConverter;
 import umc.cockple.demo.domain.chat.domain.ChatMessage;
 import umc.cockple.demo.domain.chat.domain.ChatRoom;
 import umc.cockple.demo.domain.chat.dto.WebSocketMessageDTO;
@@ -25,6 +26,8 @@ public class ChatWebSocketService {
     private final MemberRepository memberRepository;
     private final ChatMessageRepository chatMessageRepository;
 
+    private final ChatConverter chatConverter;
+
     public WebSocketMessageDTO.Response sendMessage(WebSocketMessageDTO.Request request, Long senderId) {
 
         log.info("메시지 전송 시작 - 채팅방: {}, 발신자: {}", request.chatRoomId(), senderId);
@@ -37,8 +40,10 @@ public class ChatWebSocketService {
         // TODO: 다양한 타입의 텍스트 전송가능하도록 변경해야 함
         ChatMessage chatMessage = ChatMessage.create(chatRoom, sender, request.content(), MessageType.TEXT);
         ChatMessage savedMessage = chatMessageRepository.save(chatMessage);
+
         log.info("메시지 저장 완료 - 메시지 ID: {}", savedMessage.getId());
 
+        return chatConverter.toSendMessageResponse(request, savedMessage, sender);
     }
 
     private void validateChatRoomMember(ChatRoom chatRoom, Member member) {

--- a/src/main/java/umc/cockple/demo/domain/chat/service/ChatWebSocketService.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/ChatWebSocketService.java
@@ -1,4 +1,47 @@
 package umc.cockple.demo.domain.chat.service;
 
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import umc.cockple.demo.domain.chat.domain.ChatRoom;
+import umc.cockple.demo.domain.chat.dto.WebSocketMessageDTO;
+import umc.cockple.demo.domain.chat.exception.ChatErrorCode;
+import umc.cockple.demo.domain.chat.exception.ChatException;
+import umc.cockple.demo.domain.chat.repository.ChatRoomRepository;
+import umc.cockple.demo.domain.member.domain.Member;
+import umc.cockple.demo.domain.member.repository.MemberRepository;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+@Slf4j
 public class ChatWebSocketService {
+
+    private final ChatRoomRepository chatRoomRepository;
+    private final MemberRepository memberRepository;
+
+    public WebSocketMessageDTO.Response sendMessage(Long chatRoomId, String content, Long senderId) {
+        log.info("메시지 전송 시작 - 채팅방: {}, 발신자: {}", chatRoomId, senderId);
+
+        ChatRoom chatRoom = findChatRoomOrThrow(chatRoomId);
+        Member sender = findMemberOrThrow(senderId);
+
+        validateChatRoomMember(chatRoom, sender);
+    }
+
+    private void validateChatRoomMember(ChatRoom chatRoom, Member member) {
+        if (!chatRoomRepository.existsByChatRoomAndMember(chatRoom, member))
+            throw new ChatException(ChatErrorCode.NOT_CHAT_ROOM_MEMBER);
+    }
+
+    private ChatRoom findChatRoomOrThrow(Long chatRoomId) {
+        return chatRoomRepository.findById(chatRoomId)
+                .orElseThrow(() -> new ChatException(ChatErrorCode.CHAT_ROOM_NOT_FOUND));
+    }
+
+    private Member findMemberOrThrow(Long senderId) {
+        return memberRepository.findById(senderId)
+                .orElseThrow(() -> new ChatException(ChatErrorCode.MEMBER_NOT_FOUND));
+    }
 }

--- a/src/main/java/umc/cockple/demo/domain/chat/service/ChatWebSocketService.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/ChatWebSocketService.java
@@ -70,7 +70,7 @@ public class ChatWebSocketService {
 
     private void validateChatRoomMember(ChatRoom chatRoom, Member member) {
         if (!chatRoomMemberRepository.existsByChatRoomAndMember(chatRoom, member))
-            throw new ChatException(ChatErrorCode.NOT_CHAT_ROOM_MEMBER);
+            throw new ChatException(ChatErrorCode.CHAT_ROOM_MEMBER_NOT_FOUND);
     }
 
     private String getImageUrl(ProfileImg profileImg) {

--- a/src/main/java/umc/cockple/demo/domain/chat/service/ChatWebSocketService.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/ChatWebSocketService.java
@@ -25,16 +25,17 @@ public class ChatWebSocketService {
     private final MemberRepository memberRepository;
     private final ChatMessageRepository chatMessageRepository;
 
-    public WebSocketMessageDTO.Response sendMessage(Long chatRoomId, String content, Long senderId) {
-        log.info("메시지 전송 시작 - 채팅방: {}, 발신자: {}", chatRoomId, senderId);
+    public WebSocketMessageDTO.Response sendMessage(WebSocketMessageDTO.Request request, Long senderId) {
 
-        ChatRoom chatRoom = findChatRoomOrThrow(chatRoomId);
+        log.info("메시지 전송 시작 - 채팅방: {}, 발신자: {}", request.chatRoomId(), senderId);
+
+        ChatRoom chatRoom = findChatRoomOrThrow(request.chatRoomId());
         Member sender = findMemberOrThrow(senderId);
 
         validateChatRoomMember(chatRoom, sender);
 
         // TODO: 다양한 타입의 텍스트 전송가능하도록 변경해야 함
-        ChatMessage chatMessage = ChatMessage.create(chatRoom, sender, content, MessageType.TEXT);
+        ChatMessage chatMessage = ChatMessage.create(chatRoom, sender, request.content(), MessageType.TEXT);
         ChatMessage savedMessage = chatMessageRepository.save(chatMessage);
         log.info("메시지 저장 완료 - 메시지 ID: {}", savedMessage.getId());
 

--- a/src/main/java/umc/cockple/demo/domain/chat/service/ChatWebSocketService.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/ChatWebSocketService.java
@@ -29,8 +29,9 @@ public class ChatWebSocketService {
     private final ChatConverter chatConverter;
 
     public WebSocketMessageDTO.Response sendMessage(WebSocketMessageDTO.Request request, Long senderId) {
-
         log.info("메시지 전송 시작 - 채팅방: {}, 발신자: {}", request.chatRoomId(), senderId);
+
+        validateRequest(request);
 
         ChatRoom chatRoom = findChatRoomOrThrow(request.chatRoomId());
         Member sender = findMemberOrThrow(senderId);
@@ -44,6 +45,16 @@ public class ChatWebSocketService {
         log.info("메시지 저장 완료 - 메시지 ID: {}", savedMessage.getId());
 
         return chatConverter.toSendMessageResponse(request, savedMessage, sender);
+    }
+
+    private void validateRequest(WebSocketMessageDTO.Request request) {
+        if(request.chatRoomId() == null) {
+            throw new ChatException(ChatErrorCode.CHATROOM_ID_NECESSARY);
+        }
+
+        if(request.content() == null || request.content().trim().isEmpty()) {
+            throw new ChatException(ChatErrorCode.CONTENT_NECESSARY);
+        }
     }
 
     private void validateChatRoomMember(ChatRoom chatRoom, Member member) {

--- a/src/main/java/umc/cockple/demo/domain/member/repository/MemberRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/member/repository/MemberRepository.java
@@ -45,4 +45,12 @@ public interface MemberRepository extends JpaRepository<Member, Long>, MemberRep
             """)
     Optional<Member> findMemberWithAddresses(Long memberId);
 
+    @Query("""
+            SELECT m FROM Member m
+            LEFT JOIN FETCH m.profileImg 
+            WHERE m.id = :memberId
+            AND m.isActive = 'ACTIVE'
+            """)
+    Optional<Member> findMemberWithProfileById(@Param("memberId") Long memberId);
+
 }

--- a/src/test/java/umc/cockple/demo/domain/chat/ChatWebSocketHandlerTest.java
+++ b/src/test/java/umc/cockple/demo/domain/chat/ChatWebSocketHandlerTest.java
@@ -1,20 +1,23 @@
 package umc.cockple.demo.domain.chat;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.MethodOrderer;
-import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.socket.TextMessage;
 import org.springframework.web.socket.WebSocketSession;
 import umc.cockple.demo.domain.chat.handler.ChatWebSocketHandler;
 import umc.cockple.demo.domain.chat.service.ChatWebSocketService;
 
+import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -40,6 +43,22 @@ class ChatWebSocketHandlerTest {
         sessionAttributes = new HashMap<>();
         when(session.getAttributes()).thenReturn(sessionAttributes);
         when(session.getId()).thenReturn("test-session-id");
-        when(session.isOpen()).thenReturn(true);
+    }
+
+    @Test
+    @Order(1)
+    @DisplayName("WebSocket 연결 성공 - 정상적인 memberId")
+    void afterConnectionEstablished_Success() throws Exception {
+        // Given
+        URI uri = URI.create("ws://localhost:8080/ws/chats?memberId=123");
+        when(session.getUri()).thenReturn(uri);
+        when(objectMapper.writeValueAsString(any())).thenReturn("{}");
+
+        // When
+        handler.afterConnectionEstablished(session);
+
+        // Then
+        assertThat(sessionAttributes.get("memberId")).isEqualTo(123L); // 세션에 memberId 저장됨
+        verify(session).sendMessage(any(TextMessage.class)); // 연결 성공 메시지 전송됨
     }
 }

--- a/src/test/java/umc/cockple/demo/domain/chat/ChatWebSocketHandlerTest.java
+++ b/src/test/java/umc/cockple/demo/domain/chat/ChatWebSocketHandlerTest.java
@@ -41,8 +41,6 @@ class ChatWebSocketHandlerTest {
     @BeforeEach
     void setUp() {
         sessionAttributes = new HashMap<>();
-        when(session.getAttributes()).thenReturn(sessionAttributes);
-        when(session.getId()).thenReturn("test-session-id");
     }
 
     @Test
@@ -52,6 +50,8 @@ class ChatWebSocketHandlerTest {
         // Given
         URI uri = URI.create("ws://localhost:8080/ws/chats?memberId=123");
         when(session.getUri()).thenReturn(uri);
+        when(session.getAttributes()).thenReturn(sessionAttributes);
+        when(session.getId()).thenReturn("test-session-id");
         when(objectMapper.writeValueAsString(any())).thenReturn("{}");
 
         // When
@@ -60,5 +60,20 @@ class ChatWebSocketHandlerTest {
         // Then
         assertThat(sessionAttributes.get("memberId")).isEqualTo(123L); // 세션에 memberId 저장됨
         verify(session).sendMessage(any(TextMessage.class)); // 연결 성공 메시지 전송됨
+    }
+
+    @Test
+    @Order(2)
+    @DisplayName("WebSocket 연결 실패 - memberId 없음")
+    void afterConnectionEstablished_NoMemberId() throws Exception {
+        // Given
+        URI uri = URI.create("ws://localhost:8080/ws/chats");
+        when(session.getUri()).thenReturn(uri);
+
+        // When
+        handler.afterConnectionEstablished(session);
+
+        // Then
+        verify(session).close(); // 연결 실패 시 세션 닫는 로직
     }
 }

--- a/src/test/java/umc/cockple/demo/domain/chat/ChatWebSocketHandlerTest.java
+++ b/src/test/java/umc/cockple/demo/domain/chat/ChatWebSocketHandlerTest.java
@@ -27,7 +27,6 @@ import static org.mockito.Mockito.when;
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 class ChatWebSocketHandlerTest {
 
-    @InjectMocks
     private ChatWebSocketHandler handler;
 
     @Mock
@@ -39,10 +38,20 @@ class ChatWebSocketHandlerTest {
     @Mock
     private WebSocketSession session;
 
+    @Mock
+    private WebSocketSession session1;
+
+    @Mock
+    private WebSocketSession session2;
+
+    @Mock
+    private WebSocketSession session3;
+
     private Map<String, Object> sessionAttributes;
 
     @BeforeEach
     void setUp() {
+        handler = new ChatWebSocketHandler(chatWebSocketService, objectMapper);
         sessionAttributes = new HashMap<>();
     }
 

--- a/src/test/java/umc/cockple/demo/domain/chat/ChatWebSocketHandlerTest.java
+++ b/src/test/java/umc/cockple/demo/domain/chat/ChatWebSocketHandlerTest.java
@@ -1,0 +1,45 @@
+package umc.cockple.demo.domain.chat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.socket.WebSocketSession;
+import umc.cockple.demo.domain.chat.handler.ChatWebSocketHandler;
+import umc.cockple.demo.domain.chat.service.ChatWebSocketService;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class ChatWebSocketHandlerTest {
+
+    @InjectMocks
+    private ChatWebSocketHandler handler;
+
+    @Mock
+    private ChatWebSocketService chatWebSocketService;
+
+    @Mock
+    private ObjectMapper objectMapper;
+
+    @Mock
+    private WebSocketSession session;
+
+    private Map<String, Object> sessionAttributes;
+
+    @BeforeEach
+    void setUp() {
+        sessionAttributes = new HashMap<>();
+        when(session.getAttributes()).thenReturn(sessionAttributes);
+        when(session.getId()).thenReturn("test-session-id");
+        when(session.isOpen()).thenReturn(true);
+    }
+}

--- a/src/test/java/umc/cockple/demo/domain/chat/ChatWebSocketHandlerTest.java
+++ b/src/test/java/umc/cockple/demo/domain/chat/ChatWebSocketHandlerTest.java
@@ -39,11 +39,11 @@ class ChatWebSocketHandlerTest {
     @Mock
     private WebSocketSession session;
 
-    private Map<String, Object> memberSessions;
+    private Map<String, Object> sessionAttributes;
 
     @BeforeEach
     void setUp() {
-        memberSessions = new HashMap<>();
+        sessionAttributes = new HashMap<>();
     }
 
     @Test
@@ -53,7 +53,7 @@ class ChatWebSocketHandlerTest {
         // Given
         URI uri = URI.create("ws://localhost:8080/ws/chats?memberId=123");
         when(session.getUri()).thenReturn(uri);
-        when(session.getAttributes()).thenReturn(memberSessions);
+        when(session.getAttributes()).thenReturn(sessionAttributes);
         when(session.getId()).thenReturn("test-session-id");
         when(objectMapper.writeValueAsString(any())).thenReturn("{}");
 
@@ -61,7 +61,7 @@ class ChatWebSocketHandlerTest {
         handler.afterConnectionEstablished(session);
 
         // Then
-        assertThat(memberSessions.get("memberId")).isEqualTo(123L); // 세션에 memberId 저장됨
+        assertThat(sessionAttributes.get("memberId")).isEqualTo(123L); // 세션에 memberId 저장됨
         verify(session).sendMessage(any(TextMessage.class)); // 연결 성공 메시지 전송됨
     }
 
@@ -101,8 +101,8 @@ class ChatWebSocketHandlerTest {
         when(objectMapper.readValue(messagePayload, WebSocketMessageDTO.Request.class))
                 .thenReturn(request);
 
-        memberSessions.put("memberId", 123L);
-        when(session.getAttributes()).thenReturn(memberSessions);
+        sessionAttributes.put("memberId", 123L);
+        when(session.getAttributes()).thenReturn(sessionAttributes);
         when(session.getId()).thenReturn("test-session-id");
 
         WebSocketMessageDTO.Response response = WebSocketMessageDTO.Response.builder()

--- a/src/test/java/umc/cockple/demo/domain/chat/ChatWebSocketHandlerTest.java
+++ b/src/test/java/umc/cockple/demo/domain/chat/ChatWebSocketHandlerTest.java
@@ -8,10 +8,13 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.web.socket.TextMessage;
 import org.springframework.web.socket.WebSocketSession;
+import umc.cockple.demo.domain.chat.dto.WebSocketMessageDTO;
+import umc.cockple.demo.domain.chat.enums.WebSocketMessageType;
 import umc.cockple.demo.domain.chat.handler.ChatWebSocketHandler;
 import umc.cockple.demo.domain.chat.service.ChatWebSocketService;
 
 import java.net.URI;
+import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -36,11 +39,11 @@ class ChatWebSocketHandlerTest {
     @Mock
     private WebSocketSession session;
 
-    private Map<String, Object> sessionAttributes;
+    private Map<String, Object> memberSessions;
 
     @BeforeEach
     void setUp() {
-        sessionAttributes = new HashMap<>();
+        memberSessions = new HashMap<>();
     }
 
     @Test
@@ -50,7 +53,7 @@ class ChatWebSocketHandlerTest {
         // Given
         URI uri = URI.create("ws://localhost:8080/ws/chats?memberId=123");
         when(session.getUri()).thenReturn(uri);
-        when(session.getAttributes()).thenReturn(sessionAttributes);
+        when(session.getAttributes()).thenReturn(memberSessions);
         when(session.getId()).thenReturn("test-session-id");
         when(objectMapper.writeValueAsString(any())).thenReturn("{}");
 
@@ -58,7 +61,7 @@ class ChatWebSocketHandlerTest {
         handler.afterConnectionEstablished(session);
 
         // Then
-        assertThat(sessionAttributes.get("memberId")).isEqualTo(123L); // 세션에 memberId 저장됨
+        assertThat(memberSessions.get("memberId")).isEqualTo(123L); // 세션에 memberId 저장됨
         verify(session).sendMessage(any(TextMessage.class)); // 연결 성공 메시지 전송됨
     }
 
@@ -75,5 +78,49 @@ class ChatWebSocketHandlerTest {
 
         // Then
         verify(session).close(); // 연결 실패 시 세션 닫는 로직
+    }
+
+    @Test
+    @Order(3)
+    @DisplayName("메시지 전송 성공")
+    void handleTextMessage_SendSuccess() throws Exception {
+        // Given
+        String messagePayload = """
+                {
+                    "type": "SEND",
+                    "chatRoomId": 1,
+                    "content": "안녕하세요!"
+                }
+                """;
+        TextMessage textMessage = new TextMessage(messagePayload);
+
+        WebSocketMessageDTO.Request request = new WebSocketMessageDTO.Request(
+                WebSocketMessageType.SEND, 1L, "안녕하세요!"
+        );
+
+        when(objectMapper.readValue(messagePayload, WebSocketMessageDTO.Request.class))
+                .thenReturn(request);
+
+        memberSessions.put("memberId", 123L);
+        when(session.getAttributes()).thenReturn(memberSessions);
+        when(session.getId()).thenReturn("test-session-id");
+
+        WebSocketMessageDTO.Response response = WebSocketMessageDTO.Response.builder()
+                .type(WebSocketMessageType.SEND)
+                .chatRoomId(1L)
+                .senderId(123L)
+                .senderName("테스트유저")
+                .content("안녕하세요!")
+                .createdAt(LocalDateTime.now())
+                .build();
+
+        when(chatWebSocketService.sendMessage(1L, "안녕하세요!", 123L))
+                .thenReturn(response);
+
+        // When
+        handler.handleTextMessage(session, textMessage);
+
+        // Then
+        verify(chatWebSocketService).sendMessage(1L, "안녕하세요!", 123L);
     }
 }

--- a/src/test/java/umc/cockple/demo/domain/chat/handler/ChatWebSocketHandlerTest.java
+++ b/src/test/java/umc/cockple/demo/domain/chat/handler/ChatWebSocketHandlerTest.java
@@ -97,6 +97,8 @@ class ChatWebSocketHandlerTest {
     @DisplayName("메시지 전송 성공")
     void handleTextMessage_SendSuccess() throws Exception {
         // Given
+        sessionAttributes.put("memberId", 123L);
+
         String messagePayload = """
                 {
                     "type": "SEND",
@@ -110,13 +112,6 @@ class ChatWebSocketHandlerTest {
                 WebSocketMessageType.SEND, 1L, "안녕하세요!"
         );
 
-        when(objectMapper.readValue(messagePayload, WebSocketMessageDTO.Request.class))
-                .thenReturn(request);
-
-        sessionAttributes.put("memberId", 123L);
-        when(session.getAttributes()).thenReturn(sessionAttributes);
-        when(session.getId()).thenReturn("test-session-id");
-
         WebSocketMessageDTO.Response response = WebSocketMessageDTO.Response.builder()
                 .type(WebSocketMessageType.SEND)
                 .chatRoomId(1L)
@@ -126,6 +121,10 @@ class ChatWebSocketHandlerTest {
                 .createdAt(LocalDateTime.now())
                 .build();
 
+        when(objectMapper.readValue(messagePayload, WebSocketMessageDTO.Request.class))
+                .thenReturn(request);
+        when(session.getAttributes()).thenReturn(sessionAttributes);
+        when(session.getId()).thenReturn("test-session-id");
         when(chatWebSocketService.sendMessage(1L, "안녕하세요!", 123L))
                 .thenReturn(response);
 

--- a/src/test/java/umc/cockple/demo/domain/chat/handler/ChatWebSocketHandlerTest.java
+++ b/src/test/java/umc/cockple/demo/domain/chat/handler/ChatWebSocketHandlerTest.java
@@ -116,6 +116,7 @@ class ChatWebSocketHandlerTest {
                 .chatRoomId(1L)
                 .senderId(123L)
                 .senderName("테스트유저")
+                .senderProfileImageUrl("테스트 이미지 url")
                 .content("안녕하세요!")
                 .createdAt(LocalDateTime.now())
                 .build();
@@ -210,6 +211,7 @@ class ChatWebSocketHandlerTest {
                 .chatRoomId(chatRoomId)
                 .senderId(senderId)
                 .senderName("발신자")
+                .senderProfileImageUrl("테스트 이미지 url")
                 .content("안녕하세요 모두!")
                 .createdAt(LocalDateTime.now())
                 .build();

--- a/src/test/java/umc/cockple/demo/domain/chat/handler/ChatWebSocketHandlerTest.java
+++ b/src/test/java/umc/cockple/demo/domain/chat/handler/ChatWebSocketHandlerTest.java
@@ -1,16 +1,14 @@
-package umc.cockple.demo.domain.chat;
+package umc.cockple.demo.domain.chat.handler;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.web.socket.TextMessage;
 import org.springframework.web.socket.WebSocketSession;
 import umc.cockple.demo.domain.chat.dto.WebSocketMessageDTO;
 import umc.cockple.demo.domain.chat.enums.WebSocketMessageType;
-import umc.cockple.demo.domain.chat.handler.ChatWebSocketHandler;
 import umc.cockple.demo.domain.chat.service.ChatWebSocketService;
 
 import java.net.URI;
@@ -53,6 +51,11 @@ class ChatWebSocketHandlerTest {
     void setUp() {
         handler = new ChatWebSocketHandler(chatWebSocketService, objectMapper);
         sessionAttributes = new HashMap<>();
+    }
+
+    @AfterEach
+    void tearDown() {
+        handler.clearAllSessionsForTest();
     }
 
     @Test


### PR DESCRIPTION
## ❤️ 기능 설명
1. 사용자가 메시지를 전송하면
문자열로 전송된 json을 objectMapper로 json으로 변환해 Request 객체에 담습니다.
2. 세션에서 멤버 id를 추출합니다.
3. Request 객체에서 메시지의 타입을 검사해 전송임을 확인합니다.
4. 서비스 단에서 기초 검증을 한 뒤에 메시지를 DB에 저장합니다.
5. 그 후 다른 사용자에게 전달할 데이터들을 반환합니다.
6. 채팅 -> 멤버 -> 웹소켓 으로 접근이 가능하므로 채팅방 세션에서 각 멤버별 세션을 추출하고, 병렬연산으로 각 멤버에게 메시지를 전달합니다.

swagger 테스트 성공 결과 스크린샷 첨부
<img width="650" height="566" alt="image" src="https://github.com/user-attachments/assets/8e90027e-9594-4211-b64c-1d48b22a1c73" />

<img width="1814" height="553" alt="image" src="https://github.com/user-attachments/assets/aab9d759-0ebb-45a0-bcac-3f3fd52b1cbd" />

<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #250 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 현재 로직은 채팅방 구독 로직이 구현이 되어 있지 않아 보낸 데이터를 받는 걸 확인할 수는 없습니다.
- [ ] 보낸 메시지의 타입을 현재는 모두 TEXT로 넣고 있습니다. 이모지와 이미지, 그리고 이들을 같이 보낼경우는 차차 구현해보겠습니다..
- [ ] 예외 테스트를 구현할 게 많은데, 너무 힘이 들어 포기했습니다... 꼭 필요한 테스트가 있다고 생각되신다면 코멘트 달아주세요.
<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
