### PR TITLE
[feat/#256] 모임 채팅방 목록 조회 slice 기반 무한스크롤 구현

### DIFF
--- a/src/main/java/umc/cockple/demo/domain/chat/controller/ChatController.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/controller/ChatController.java
@@ -6,10 +6,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
-import umc.cockple.demo.domain.chat.dto.ChatRoomDetailDTO;
-import umc.cockple.demo.domain.chat.dto.DirectChatRoomCreateDTO;
-import umc.cockple.demo.domain.chat.dto.DirectChatRoomDTO;
-import umc.cockple.demo.domain.chat.dto.PartyChatRoomDTO;
+import umc.cockple.demo.domain.chat.dto.*;
 import umc.cockple.demo.domain.chat.enums.Direction;
 import umc.cockple.demo.domain.chat.service.ChatCommandService;
 import umc.cockple.demo.domain.chat.service.ChatQueryService;
@@ -107,11 +104,24 @@ public class ChatController {
     @ApiResponse(responseCode = "200", description = "조회 성공")
     public BaseResponse<ChatRoomDetailDTO.Response> getChatRoomDetail(
             @PathVariable Long roomId
-    ){
+    ) {
         Long memberId = SecurityUtil.getCurrentMemberId();
 
         ChatRoomDetailDTO.Response response = chatQueryService.getChatRoomDetail(roomId, memberId);
 
+        return BaseResponse.success(CommonSuccessCode.OK, response);
+    }
+
+    @GetMapping("/chats/rooms/{roomId}/messages/previous")
+    @Operation(summary = "채팅방 과거 메시지 조회", description = "채팅방의 과거 메시지를 페이징하여 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "조회 성공")
+    public BaseResponse<ChatMessageDTO.Response> getChatMessages(
+            @PathVariable Long roomId,
+            @RequestParam Long cursor,
+            @RequestParam(defaultValue = "50") int size
+    ) {
+        Long memberId = SecurityUtil.getCurrentMemberId();
+        ChatMessageDTO.Response response = chatQueryService.getChatMessages(roomId, memberId, cursor, size);
         return BaseResponse.success(CommonSuccessCode.OK, response);
     }
 }

--- a/src/main/java/umc/cockple/demo/domain/chat/controller/ChatController.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/controller/ChatController.java
@@ -42,13 +42,12 @@ public class ChatController {
     @ApiResponse(responseCode = "200", description = "조회 성공")
     public BaseResponse<PartyChatRoomDTO.Response> getPartyChatRooms(
             //@AuthenticationPrincipal Long memberId,
-            @RequestParam(required = false) Long cursor,
-            @RequestParam(defaultValue = "10") int size,
-            @RequestParam(defaultValue = "DESC") Direction direction
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size
     ) {
         // TODO: JWT 인증 구현 후 교체 예정
         Long memberId = 1L; // 임시값
-        PartyChatRoomDTO.Response response = chatQueryService.getPartyChatRooms(memberId, cursor, size, direction);
+        PartyChatRoomDTO.Response response = chatQueryService.getPartyChatRooms(memberId, page, size);
         return BaseResponse.success(CommonSuccessCode.OK, response);
     }
 
@@ -58,13 +57,12 @@ public class ChatController {
     public BaseResponse<PartyChatRoomDTO.Response> searchPartyChatRooms(
             //@AuthenticationPrincipal Long memberId,
             @RequestParam String name,
-            @RequestParam(required = false) Long cursor,
-            @RequestParam(defaultValue = "10") int size,
-            @RequestParam(defaultValue = "DESC") Direction direction
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size
     ) {
         // TODO: JWT 인증 구현 후 교체 예정
         Long memberId = 1L; // 임시값
-        PartyChatRoomDTO.Response response = chatQueryService.searchPartyChatRoomsByName(memberId, name, cursor, size, direction);
+        PartyChatRoomDTO.Response response = chatQueryService.searchPartyChatRoomsByName(memberId, name, page, size);
         return BaseResponse.success(CommonSuccessCode.OK, response);
     }
 

--- a/src/main/java/umc/cockple/demo/domain/chat/converter/ChatConverter.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/converter/ChatConverter.java
@@ -5,10 +5,7 @@ import org.springframework.stereotype.Component;
 import umc.cockple.demo.domain.chat.domain.ChatMessage;
 import umc.cockple.demo.domain.chat.domain.ChatRoom;
 import umc.cockple.demo.domain.chat.domain.ChatRoomMember;
-import umc.cockple.demo.domain.chat.dto.ChatRoomDetailDTO;
-import umc.cockple.demo.domain.chat.dto.DirectChatRoomCreateDTO;
-import umc.cockple.demo.domain.chat.dto.DirectChatRoomDTO;
-import umc.cockple.demo.domain.chat.dto.PartyChatRoomDTO;
+import umc.cockple.demo.domain.chat.dto.*;
 import umc.cockple.demo.domain.member.domain.Member;
 
 import java.util.List;
@@ -156,6 +153,34 @@ public class ChatConverter {
                 .chatRoomInfo(roomInfo)
                 .messages(messageInfos)
                 .participants(memberInfos)
+                .build();
+    }
+
+    public ChatMessageDTO.MessageInfo toPreviousMessageInfo(
+            ChatMessage message,
+            Member sender,
+            String senderProfileImageUrl,
+            List<String> imageUrls,
+            boolean isMyMessage) {
+        return ChatMessageDTO.MessageInfo.builder()
+                .messageId(message.getId())
+                .senderId(sender.getId())
+                .senderName(sender.getMemberName())
+                .senderProfileImageUrl(senderProfileImageUrl)
+                .content(message.getContent())
+                .messageType(message.getType())
+                .imageUrls(imageUrls)
+                .timestamp(message.getCreatedAt())
+                .isMyMessage(isMyMessage)
+                .build();
+    }
+
+    public ChatMessageDTO.Response toChatMessageResponse(
+            List<ChatMessageDTO.MessageInfo> messages, boolean hasNext, Long nextCursor) {
+        return ChatMessageDTO.Response.builder()
+                .messages(messages)
+                .hasNext(hasNext)
+                .nextCursor(nextCursor)
                 .build();
     }
 }

--- a/src/main/java/umc/cockple/demo/domain/chat/converter/ChatConverter.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/converter/ChatConverter.java
@@ -16,10 +16,10 @@ import java.util.stream.Collectors;
 public class ChatConverter {
 
     // ===모임 채팅방 목록===
-    public PartyChatRoomDTO.Response toPartyChatRoomListResponse(List<PartyChatRoomDTO.ChatRoomInfo> chatRoomInfos) {
+    public PartyChatRoomDTO.Response toPartyChatRoomListResponse(List<PartyChatRoomDTO.ChatRoomInfo> chatRoomInfos, boolean hasNext) {
         return PartyChatRoomDTO.Response.builder()
                 .content(chatRoomInfos)
-                .totalElements(chatRoomInfos.size())
+                .hasNext(hasNext)
                 .build();
     }
 
@@ -30,8 +30,8 @@ public class ChatConverter {
                                                              String imgUrl) {
         return PartyChatRoomDTO.ChatRoomInfo.builder()
                 .chatRoomId(chatRoom.getId())
-                .partyId(chatRoom.getId())
-                .partyName(chatRoom.getName())
+                .partyId(chatRoom.getParty().getId())
+                .partyName(chatRoom.getParty().getPartyName())
                 .partyImgUrl(imgUrl)
                 .memberCount(memberCount)
                 .unreadCount(unreadCount)

--- a/src/main/java/umc/cockple/demo/domain/chat/dto/ChatMessageDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/dto/ChatMessageDTO.java
@@ -1,0 +1,33 @@
+package umc.cockple.demo.domain.chat.dto;
+
+import lombok.Builder;
+import umc.cockple.demo.domain.chat.enums.MessageType;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class ChatMessageDTO {
+
+    @Builder
+    public record Response(
+            List<MessageInfo> messages,
+            Boolean hasNext,
+            Long nextCursor,
+            int totalElements
+    ) {
+    }
+
+    @Builder
+    public record MessageInfo(
+            Long messageId,
+            Long senderId,
+            String senderName,
+            String senderProfileImageUrl,
+            String content,
+            MessageType messageType,
+            List<String> imageUrls,
+            LocalDateTime timestamp,
+            boolean isMyMessage
+    ) {
+    }
+}

--- a/src/main/java/umc/cockple/demo/domain/chat/dto/PartyChatRoomDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/dto/PartyChatRoomDTO.java
@@ -11,7 +11,7 @@ public class PartyChatRoomDTO {
     @Builder
     public record Response(
             List<ChatRoomInfo> content,
-            int totalElements
+            boolean hasNext
     ) {
     }
 

--- a/src/main/java/umc/cockple/demo/domain/chat/exception/ChatErrorCode.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/exception/ChatErrorCode.java
@@ -15,10 +15,9 @@ public enum ChatErrorCode implements BaseErrorCode {
 
     // 2xx: 리소스 없음
     CHAT_ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "CHAT201", "채팅방을 찾을 수 없습니다."),
-    CHAT_ROOM_MEMBER_NOT_FOUND(HttpStatus.BAD_REQUEST, "CHAT202", "채팅방 멤버가 존재하지 않습니다."),
+    CHAT_ROOM_MEMBER_NOT_FOUND(HttpStatus.BAD_REQUEST, "CHAT202", "채팅방에 참여한 멤버가 아닙니다."),
 
     // 3xx: 인증/인가 문제
-    NOT_CHAT_ROOM_MEMBER(HttpStatus.BAD_REQUEST, "CHAT301", "채팅방에 참여한 멤버가 아닙니다."),
     PARTY_MEMBER_NOT_FOUND(HttpStatus.BAD_REQUEST, "CHAT302", "모임에 참여한 회원이 아닙니다.");
 
     private final HttpStatus httpStatus;

--- a/src/main/java/umc/cockple/demo/domain/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/repository/ChatMessageRepository.java
@@ -34,4 +34,17 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> 
     List<ChatMessage> findRecentMessagesWithImages(
             @Param("chatRoomId") Long chatRoomId,
             Pageable pageable);
+
+    @Query("""
+            SELECT m FROM ChatMessage m
+            JOIN FETCH m.sender
+            LEFT JOIN FETCH m.chatMessageImgs
+            WHERE m.chatRoom.id = :chatRoomId
+            AND m.id < :cursor
+            ORDER BY m.createdAt DESC
+            """)
+    List<ChatMessage> findByRoomIdAndIdLessThanOrderByCreatedAtDesc(
+            @Param("chatRoomId") Long chatRoomId,
+            @Param("cursor") Long cursor,
+            Pageable pageable);
 }

--- a/src/main/java/umc/cockple/demo/domain/chat/repository/ChatRoomMemberRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/repository/ChatRoomMemberRepository.java
@@ -47,5 +47,7 @@ public interface ChatRoomMemberRepository extends JpaRepository<ChatRoomMember, 
             ORDER BY m.memberName ASC
             """)
     List<ChatRoomMember> findChatRoomMembersWithMemberById(@Param("chatRoomId") Long chatRoomId);
+
+    Boolean existsByChatRoomIdAndMemberId(Long roomId, Long memberId);
 }
 

--- a/src/main/java/umc/cockple/demo/domain/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/repository/ChatRoomRepository.java
@@ -1,6 +1,7 @@
 package umc.cockple.demo.domain.chat.repository;
 
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -10,45 +11,40 @@ import java.util.List;
 import java.util.Optional;
 
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
+
     @Query("""
             SELECT cr FROM ChatRoom cr
             JOIN cr.chatRoomMembers crm
             WHERE crm.member.id = :memberId
-            AND cr.type = 'PARTY'
-            AND (:cursor IS NULL OR
-                 (:direction = 'desc' AND cr.id < :cursor) OR
-                 (:direction = 'asc' AND cr.id > :cursor))
-            ORDER BY
-                CASE WHEN :direction = 'asc' THEN cr.id END ASC,
-                CASE WHEN :direction = 'desc' THEN cr.id END DESC
+            ORDER BY (
+                SELECT MAX(cm.id)
+                FROM ChatMessage cm
+                WHERE cm.chatRoom.id = cr.id
+            ) DESC
             """)
-    List<ChatRoom> findPartyChatRoomsByMemberId(
+    Slice<ChatRoom> findChatRoomsByOrderByLastMsgIdDesc(
             @Param("memberId") Long memberId,
-            @Param("cursor") Long cursor,
-            @Param("direction") String direction,
             Pageable pageable
     );
 
+
     @Query("""
-            
             SELECT cr FROM ChatRoom cr
             JOIN cr.chatRoomMembers crm
             WHERE crm.member.id = :memberId
-            AND cr.party.partyName LIKE %:name%
-            AND (:cursor IS NULL OR
-                 (:direction = 'desc' AND cr.id < :cursor) OR
-                 (:direction = 'asc' AND cr.id > :cursor))
-            ORDER BY
-                CASE WHEN :direction = 'asc' THEN cr.id END ASC,
-                CASE WHEN :direction = 'desc' THEN cr.id END DESC
+              AND cr.party.partyName LIKE %:name%
+            ORDER BY (
+                SELECT MAX(cm.id)
+                FROM ChatMessage cm
+                WHERE cm.chatRoom.id = cr.id
+            ) DESC
             """)
-    List<ChatRoom> searchPartyChatRoomsByName(
+    Slice<ChatRoom> searchPartyChatRoomsByName(
             @Param("memberId") Long memberId,
             @Param("name") String name,
-            @Param("cursor") Long cursor,
-            @Param("direction") String direction,
             Pageable pageable
     );
+
 
     ChatRoom findByPartyId(Long partyId);
 

--- a/src/main/java/umc/cockple/demo/domain/chat/service/ChatCommandServiceImpl.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/ChatCommandServiceImpl.java
@@ -1,9 +1,9 @@
 package umc.cockple.demo.domain.chat.service;
 
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import umc.cockple.demo.domain.chat.converter.ChatConverter;
 import umc.cockple.demo.domain.chat.domain.ChatRoom;
 import umc.cockple.demo.domain.chat.domain.ChatRoomMember;

--- a/src/main/java/umc/cockple/demo/domain/chat/service/ChatQueryService.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/ChatQueryService.java
@@ -7,9 +7,9 @@ import umc.cockple.demo.domain.chat.dto.PartyChatRoomDTO;
 import umc.cockple.demo.domain.chat.enums.Direction;
 
 public interface ChatQueryService {
-    PartyChatRoomDTO.Response getPartyChatRooms(Long memberId, Long cursor, int size, Direction direction);
+    PartyChatRoomDTO.Response getPartyChatRooms(Long memberId, int page, int size);
 
-    PartyChatRoomDTO.Response searchPartyChatRoomsByName(Long memberId, String name, Long cursor, int size, Direction direction);
+    PartyChatRoomDTO.Response searchPartyChatRoomsByName(Long memberId, String name, int page, int size);
 
     DirectChatRoomDTO.Response getDirectChatRooms(Long memberId, Long cursor, int size, Direction direction);
 

--- a/src/main/java/umc/cockple/demo/domain/chat/service/ChatQueryService.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/ChatQueryService.java
@@ -1,5 +1,6 @@
 package umc.cockple.demo.domain.chat.service;
 
+import umc.cockple.demo.domain.chat.dto.ChatMessageDTO;
 import umc.cockple.demo.domain.chat.dto.ChatRoomDetailDTO;
 import umc.cockple.demo.domain.chat.dto.DirectChatRoomDTO;
 import umc.cockple.demo.domain.chat.dto.PartyChatRoomDTO;
@@ -15,4 +16,6 @@ public interface ChatQueryService {
     DirectChatRoomDTO.Response searchDirectChatRoomsByName(Long memberId, String name, Long cursor, int size, Direction direction);
 
     ChatRoomDetailDTO.Response getChatRoomDetail(Long roomId, Long memberId);
+
+    ChatMessageDTO.Response getChatMessages(Long roomId, Long memberId, Long cursor, int size);
 }

--- a/src/main/java/umc/cockple/demo/domain/chat/service/ChatQueryServiceImpl.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/ChatQueryServiceImpl.java
@@ -144,7 +144,7 @@ public class ChatQueryServiceImpl implements ChatQueryService {
 
     private void validateChatRoomAccess(Long roomId, Long memberId) {
         if (!chatRoomMemberRepository.existsByChatRoomIdAndMemberId(roomId, memberId))
-            throw new ChatException(ChatErrorCode.NOT_CHAT_ROOM_MEMBER);
+            throw new ChatException(ChatErrorCode.CHAT_ROOM_MEMBER_NOT_FOUND);
     }
 
     // ========== 비즈니스 로직 ==========

--- a/src/main/java/umc/cockple/demo/domain/chat/service/ChatQueryServiceImpl.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/ChatQueryServiceImpl.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import umc.cockple.demo.domain.chat.converter.ChatConverter;
@@ -45,21 +46,23 @@ public class ChatQueryServiceImpl implements ChatQueryService {
     private final ImageService imageService;
 
     @Override
-    public PartyChatRoomDTO.Response getPartyChatRooms(Long memberId, Long cursor, int size, Direction direction) {
+    public PartyChatRoomDTO.Response getPartyChatRooms(Long memberId, int page, int size) {
         log.info("[모임 채팅방 목록 조회 시작]- 요청자: {}", memberId);
-        Pageable pageable = PageRequest.of(0, size);
-        List<ChatRoom> chatRooms = chatRoomRepository.findPartyChatRoomsByMemberId(memberId, cursor, direction.name().toLowerCase(), pageable);
+        Pageable pageable = PageRequest.of(page, size);
+        Slice<ChatRoom> chatRooms = chatRoomRepository.findChatRoomsByOrderByLastMsgIdDesc(memberId, pageable);
+        PartyChatRoomDTO.Response response = toPartyChatRoomInfos(chatRooms, memberId);
         log.info("[모임 채팅방 목록 조회 완료]");
-        return toPartyChatRoomInfos(chatRooms, memberId);
+        return response;
     }
 
     @Override
-    public PartyChatRoomDTO.Response searchPartyChatRoomsByName(Long memberId, String name, Long cursor, int size, Direction direction) {
+    public PartyChatRoomDTO.Response searchPartyChatRoomsByName(Long memberId, String name, int page, int size) {
         log.info("[모임 채팅방 이름 검색 시작]- 요청자: {}", memberId);
-        Pageable pageable = PageRequest.of(0, size);
-        List<ChatRoom> chatRooms = chatRoomRepository.searchPartyChatRoomsByName(memberId, name, cursor, direction.name().toLowerCase(), pageable);
+        Pageable pageable = PageRequest.of(page, size);
+        Slice<ChatRoom> chatRooms = chatRoomRepository.searchPartyChatRoomsByName(memberId, name, pageable);
+        PartyChatRoomDTO.Response response = toPartyChatRoomInfos(chatRooms, memberId);
         log.info("[모임 채팅방 이름 검색 완료]");
-        return toPartyChatRoomInfos(chatRooms, memberId);
+        return response;
     }
 
     @Override
@@ -67,8 +70,9 @@ public class ChatQueryServiceImpl implements ChatQueryService {
         log.info("[개인 채팅방 목록 조회 시작]- 요청자: {}", memberId);
         Pageable pageable = PageRequest.of(0, size);
         List<ChatRoom> chatRooms = chatRoomRepository.findDirectChatRoomByMemberId(memberId, cursor, direction.name().toLowerCase(), pageable);
+        DirectChatRoomDTO.Response response = toDirectChatRoomInfos(chatRooms, memberId);
         log.info("[개인 채팅방 목록 조회 완료]");
-        return toDirectChatRoomInfos(chatRooms, memberId);
+        return response;
     }
 
     @Override
@@ -76,8 +80,9 @@ public class ChatQueryServiceImpl implements ChatQueryService {
         log.info("[개인 채팅방 이름 검색 시작]- 요청자: {}", memberId);
         Pageable pageable = PageRequest.of(0, size);
         List<ChatRoom> chatRooms = chatRoomRepository.searchDirectChatRoomsByName(memberId, name, cursor, direction.name().toLowerCase(), pageable);
+        DirectChatRoomDTO.Response response = toDirectChatRoomInfos(chatRooms, memberId);
         log.info("[개인 채팅방 이름 검색 완료]");
-        return toDirectChatRoomInfos(chatRooms, memberId);
+        return response;
     }
 
     @Override
@@ -143,34 +148,25 @@ public class ChatQueryServiceImpl implements ChatQueryService {
     }
 
     // ========== 비즈니스 로직 ==========
-    private PartyChatRoomDTO.Response toPartyChatRoomInfos(List<ChatRoom> chatRooms, Long memberId) {
+    private PartyChatRoomDTO.Response toPartyChatRoomInfos(Slice<ChatRoom> chatRooms, Long memberId) {
         if (chatRooms.isEmpty()) {
             throw new ChatException(ChatErrorCode.CHAT_ROOM_NOT_FOUND);
         }
-        // 각 채팅방에 대해 ChatRoomInfo 생성
         List<PartyChatRoomDTO.ChatRoomInfo> roomInfos = chatRooms.stream()
+                .filter(chatRoom -> chatRoom.getType() == ChatRoomType.PARTY)
                 .map(chatRoom -> {
                     Long chatRoomId = chatRoom.getId();
-                    int memberCount = chatRoomMemberRepository.countByChatRoomId(chatRoomId);
+
                     ChatRoomMember chatRoomMember = chatRoomMemberRepository.findByChatRoomIdAndMemberId(chatRoomId, memberId)
                             .orElseThrow(() -> new ChatException(ChatErrorCode.CHAT_ROOM_MEMBER_NOT_FOUND));
 
-                    boolean isPartyMember = chatRoom.getParty().getMemberParties().stream()
-                            .anyMatch(mp -> mp.getMember().equals(chatRoomMember.getMember()));
-                    if (!isPartyMember) {
-                        throw new ChatException(ChatErrorCode.PARTY_MEMBER_NOT_FOUND);
-                    }
-
-
-                    ChatRoomMember roomMember = chatRoomMemberRepository.findByChatRoomIdAndMemberId(chatRoomId, memberId)
-                            .orElseThrow(() -> new ChatException(ChatErrorCode.NOT_CHAT_ROOM_MEMBER));
-                    Long lastReadMessageId = roomMember.getLastReadMessageId();
+                    int memberCount = chatRoomMemberRepository.countByChatRoomId(chatRoomId);
+                    Long lastReadMessageId = chatRoomMember.getLastReadMessageId();
                     int unreadCount = (lastReadMessageId == null)
                             ? 0
                             : chatMessageRepository.countUnreadMessages(chatRoomId, lastReadMessageId);
 
                     ChatMessage lastMessage = chatMessageRepository.findTop1ByChatRoom_IdOrderByCreatedAtDesc(chatRoomId);
-
                     String imgUrl = getImageUrl(chatRoom.getParty().getPartyImg());
 
                     return chatConverter.toPartyChatRoomInfo(
@@ -183,7 +179,7 @@ public class ChatQueryServiceImpl implements ChatQueryService {
                 })
                 .collect(Collectors.toList());
 
-        return chatConverter.toPartyChatRoomListResponse(roomInfos);
+        return chatConverter.toPartyChatRoomListResponse(roomInfos, chatRooms.hasNext());
     }
 
     private DirectChatRoomDTO.Response toDirectChatRoomInfos(List<ChatRoom> chatRooms, Long memberId) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -30,6 +30,11 @@ spring:
         use_sql_comments: true
         default_batch_fetch_size: 1000
 
+  servlet:
+    multipart:
+      max-file-size: 20MB
+      max-request-size: 20MB
+
 cloud:
   aws:
     s3:


### PR DESCRIPTION
## ❤️ 기능 설명

swagger 테스트 성공 결과 스크린샷 첨부
<br>
<img width="730" height="509" alt="스크린샷 2025-08-04 22 50 04" src="https://github.com/user-attachments/assets/3ab186e0-87b4-4308-a7ba-e6b708e59067" />

채팅방 목록을 lastMessage 아이디 기준으로 정렬하도록 했습니다.

<img width="957" height="607" alt="스크린샷 2025-08-04 22 48 59" src="https://github.com/user-attachments/assets/bf3e242a-bdb6-4cfb-91e6-5a4c8176b253" />

민턴이즈에 새로운 채팅이 왔을 경우, 민턴이즈의 lastMessage 시간이 더 최신이기 때문에 민턴이즈가 클리어 채팅방보다 위에 있습니다.

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #256 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
