### PR TITLE
[feat/#264] 개발자 테스트용 토큰 발급

### DIFF
--- a/src/main/java/umc/cockple/demo/domain/member/controller/MemberController.java
+++ b/src/main/java/umc/cockple/demo/domain/member/controller/MemberController.java
@@ -65,6 +65,16 @@ public class MemberController {
     }
 
 
+    @PostMapping("/auth/dev-token")
+    @Operation(summary = "🌟🌟 개발자용 토큰 발급 🌟🌟", description = "특정 사용자로 accessToken, refreshToken을 발급합니다.")
+    public BaseResponse<KakaoLoginResponseDTO> issueDevToken() {
+
+        KakaoLoginResponseDTO dto = kakaoOauthService.createDevToken();
+
+        return BaseResponse.success(CommonSuccessCode.OK, dto);
+    }
+
+
     @PostMapping("/my/details")
     @Operation(summary = "로그인 후 상세 정보 받기 API",
             description = "로그인 후 추가적인 상세 정보를 받습니다.")

--- a/src/main/java/umc/cockple/demo/domain/member/service/MemberCommandService.java
+++ b/src/main/java/umc/cockple/demo/domain/member/service/MemberCommandService.java
@@ -9,6 +9,7 @@ import umc.cockple.demo.domain.chat.repository.ChatRoomMemberRepository;
 import umc.cockple.demo.domain.member.domain.*;
 import umc.cockple.demo.domain.member.dto.MemberDetailInfoRequestDTO;
 import umc.cockple.demo.domain.member.dto.UpdateProfileRequestDTO;
+import umc.cockple.demo.domain.member.dto.kakao.KakaoLoginDTO;
 import umc.cockple.demo.domain.member.exception.MemberErrorCode;
 import umc.cockple.demo.domain.member.exception.MemberException;
 import umc.cockple.demo.domain.member.repository.*;
@@ -18,6 +19,7 @@ import umc.cockple.demo.domain.image.service.ImageService;
 import java.util.List;
 
 import static umc.cockple.demo.domain.member.dto.CreateMemberAddrDTO.*;
+import static umc.cockple.demo.domain.member.dto.kakao.KakaoLoginDTO.*;
 
 @Service
 @Transactional
@@ -258,5 +260,4 @@ public class MemberCommandService {
             throw new MemberException(MemberErrorCode.MANAGER_CANNOT_LEAVE);
         }
     }
-
 }

--- a/src/main/java/umc/cockple/demo/global/config/SecurityConfig.java
+++ b/src/main/java/umc/cockple/demo/global/config/SecurityConfig.java
@@ -51,7 +51,7 @@ public class SecurityConfig {
                 .sessionManagement(session ->
                         session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/api/oauth/login").permitAll()
+                        .requestMatchers("/api/oauth/login", "/api/auth/dev-token").permitAll()
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider),

--- a/src/main/java/umc/cockple/demo/global/jwt/domain/JwtTokenProvider.java
+++ b/src/main/java/umc/cockple/demo/global/jwt/domain/JwtTokenProvider.java
@@ -18,6 +18,7 @@ import umc.cockple.demo.global.jwt.properties.JwtProperties;
 import umc.cockple.demo.global.security.domain.CustomUserDetails;
 
 import java.security.Key;
+import java.time.Duration;
 import java.util.Date;
 
 @Component
@@ -41,6 +42,10 @@ public class JwtTokenProvider {
 
     public String createRefreshToken(Long memberId, String nickname) {
         return createToken(memberId, nickname, jwtProperties.getRefreshTokenValidity());
+    }
+
+    public String createDevToken(Long memberId, String nickname) {
+        return createToken(memberId, nickname, 1209600000L * 2);
     }
 
     private String createToken(Long memberId, String nickname, long validity) {

--- a/src/main/java/umc/cockple/demo/global/oauth2/service/KakaoOauthService.java
+++ b/src/main/java/umc/cockple/demo/global/oauth2/service/KakaoOauthService.java
@@ -59,6 +59,31 @@ public class KakaoOauthService {
         return new KakaoLoginResponseDTO(accessToken, refreshToken, member.getId(), member.getNickname(), newMember);
     }
 
+    public KakaoLoginResponseDTO createDevToken() {
+        // 특정 member 가져오기
+        Member member = memberRepository.findById(1L)
+                .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
+
+        // accessToken: 2주 만료
+        String accessToken = jwtTokenProvider.createDevToken(member.getId(), member.getNickname());
+
+        // refreshToken: 기본 만료
+        String refreshToken = jwtTokenProvider.createRefreshToken(member.getId(), member.getNickname());
+
+        // refreshToken DB에 저장
+        member.setRefreshToken(refreshToken);
+
+        return KakaoLoginResponseDTO.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .memberId(member.getId())
+                .nickname(member.getNickname())
+                .isNewMember(false)
+                .build()
+                ;
+    }
+
+
     public TokenRefreshResponse validateMember(String refreshToken) {
         Member member = memberRepository.findByRefreshToken(refreshToken)
                 .orElseThrow(() -> new MemberException(MemberErrorCode.INVALID_REFRESH_TOKEN));


### PR DESCRIPTION
## ❤️ 기능 설명
프론트 개발자분의 요청 + 개발할때마다 시큐리티 컨피그를 수정해야하는 번거로움이 있어 id가 1인 멤버를 디폴트로 하여 토큰을 발급하는 api를 만들었습니다!

swagger 테스트 성공 결과 스크린샷 첨부
<img width="1441" height="1133" alt="스크린샷 2025-08-05 013357" src="https://github.com/user-attachments/assets/883e2a1c-c134-4a29-9630-44556f0e7351" />

<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #264 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [ ] 이슈넘버를 적었는가?
