### PR TITLE
[feat/#262] 모임 초대 처리 API 구현

### DIFF
--- a/src/main/java/umc/cockple/demo/domain/party/controller/PartyController.java
+++ b/src/main/java/umc/cockple/demo/domain/party/controller/PartyController.java
@@ -285,4 +285,23 @@ public class PartyController {
         PartyInviteCreateDTO.Response response = partyCommandService.createInvitation(partyId, request.userId(), memberId);
         return BaseResponse.success(CommonSuccessCode.CREATED, response);
     }
+
+    @PatchMapping("/parties/invitations/{invitationId}")
+    @Operation(summary = "모임 초대 처리",
+            description = "사용자가 모임 초대를 승인하거나 거절합니다.")
+    @ApiResponse(responseCode = "200", description = "모임 초대 처리 성공")
+    @ApiResponse(responseCode = "403", description = "해당 사용자의 초대가 아님")
+    @ApiResponse(responseCode = "404", description = "존재하지 않는 모임 초대")
+    @ApiResponse(responseCode = "409", description = "이미 처리된 모임 초대")
+    public BaseResponse<Void> actionInvitation(
+            @PathVariable Long invitationId,
+            @RequestBody @Valid PartyInviteActionDTO.Request request,
+            Authentication authentication
+    ){
+        // TODO: JWT 인증 구현 후 교체 예정
+        Long memberId = 2L; // 임시값
+
+        partyCommandService.actionInvitation(memberId, request, invitationId);
+        return BaseResponse.success(CommonSuccessCode.OK);
+    }
 }

--- a/src/main/java/umc/cockple/demo/domain/party/domain/PartyInvitation.java
+++ b/src/main/java/umc/cockple/demo/domain/party/domain/PartyInvitation.java
@@ -40,4 +40,8 @@ public class PartyInvitation extends BaseEntity {
                 .status(RequestStatus.PENDING)
                 .build();
     }
+
+    public void updateStatus(RequestStatus requestStatus) {
+        this.status=requestStatus;
+    }
 }

--- a/src/main/java/umc/cockple/demo/domain/party/dto/PartyInviteActionDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/party/dto/PartyInviteActionDTO.java
@@ -1,0 +1,14 @@
+package umc.cockple.demo.domain.party.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import umc.cockple.demo.domain.party.enums.RequestAction;
+
+public class PartyInviteActionDTO {
+
+    @Builder
+    @Schema(name = "PartyInviteRequestDTO", description = "모임 초대 처리 요청")
+    public record Request(
+            RequestAction action
+    ){}
+}

--- a/src/main/java/umc/cockple/demo/domain/party/exception/PartyErrorCode.java
+++ b/src/main/java/umc/cockple/demo/domain/party/exception/PartyErrorCode.java
@@ -28,9 +28,11 @@ public enum PartyErrorCode implements BaseErrorCode {
     JoinRequest_NOT_FOUND(HttpStatus.NOT_FOUND, "PARTY202", "존재하지 않는 가입신청입니다."),
     JOIN_REQUEST_PARTY_NOT_FOUND(HttpStatus.NOT_FOUND, "PARTY203", "해당 모임에서 존재하지 않는 가입신청입니다."),
     NOT_MEMBER(HttpStatus.BAD_REQUEST, "PARTY204", "해당 모임의 멤버가 아닙니다."),
+    INVITATION_NOT_FOUND(HttpStatus.NOT_FOUND, "PARTY205", "존재하지 않는 모임 초대입니다."),
 
     INSUFFICIENT_PERMISSION(HttpStatus.FORBIDDEN, "PARTY301", "해당 작업을 수행할 권한이 없습니다."),
     INVALID_ACTION_FOR_OWNER(HttpStatus.FORBIDDEN, "PARTY302", "모임장은 수행할 수 없는 작업입니다."),
+    NOT_YOUR_INVITATION(HttpStatus.FORBIDDEN, "PARTY303", "해당 사용자의 초대가 아닙니다."),
 
     ALREADY_MEMBER(HttpStatus.CONFLICT, "PARTY401", "이미 가입된 모임입니다."),
     JOIN_REQUEST_ALREADY_EXISTS(HttpStatus.CONFLICT, "PARTY402", "처리 대기중인 가입 신청이 존재합니다."),
@@ -40,8 +42,8 @@ public enum PartyErrorCode implements BaseErrorCode {
     AGE_NOT_MATCH(HttpStatus.BAD_REQUEST, "PARTY406", "모임의 나이 조건에 맞지 않습니다."),
     PARTY_IS_DELETED(HttpStatus.BAD_REQUEST, "PARTY407", "이미 삭제된 모임입니다."),
     CANNOT_REMOVE_SELF(HttpStatus.BAD_REQUEST, "PARTY408", "자기 자신을 모임에서 삭제할 수 없습니다."),
-    INVITATION_ALREADY_EXISTS(HttpStatus.CONFLICT, "PARTY409", "처리 대기중인 초대가 존재합니다.");
-
+    INVITATION_ALREADY_EXISTS(HttpStatus.CONFLICT, "PARTY409", "처리 대기중인 초대가 존재합니다."),
+    INVITATION_ALREADY_ACTIONS(HttpStatus.CONFLICT, "PARTY410", "이미 처리된 모임 초대입니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/umc/cockple/demo/domain/party/service/PartyCommandService.java
+++ b/src/main/java/umc/cockple/demo/domain/party/service/PartyCommandService.java
@@ -1,9 +1,6 @@
 package umc.cockple.demo.domain.party.service;
 
-import umc.cockple.demo.domain.party.dto.PartyCreateDTO;
-import umc.cockple.demo.domain.party.dto.PartyInviteCreateDTO;
-import umc.cockple.demo.domain.party.dto.PartyJoinActionDTO;
-import umc.cockple.demo.domain.party.dto.PartyJoinCreateDTO;
+import umc.cockple.demo.domain.party.dto.*;
 
 public interface PartyCommandService {
     PartyCreateDTO.Response createParty(Long memberId, PartyCreateDTO.Request request);
@@ -13,4 +10,5 @@ public interface PartyCommandService {
     void leaveParty(Long partyId, Long memberId);
     void removeMember(Long partyId, Long memberIdToRemove, Long currentMemberId);
     PartyInviteCreateDTO.Response createInvitation(Long partyId, Long memberIdToInvite, Long currentMemberId);
+    void actionInvitation(Long memberId, PartyInviteActionDTO.Request request, Long invitationId);
 }

--- a/src/main/java/umc/cockple/demo/domain/party/service/PartyCommandServiceImpl.java
+++ b/src/main/java/umc/cockple/demo/domain/party/service/PartyCommandServiceImpl.java
@@ -17,10 +17,7 @@ import umc.cockple.demo.domain.member.repository.MemberPartyRepository;
 import umc.cockple.demo.domain.member.repository.MemberRepository;
 import umc.cockple.demo.domain.party.converter.PartyConverter;
 import umc.cockple.demo.domain.party.domain.*;
-import umc.cockple.demo.domain.party.dto.PartyCreateDTO;
-import umc.cockple.demo.domain.party.dto.PartyInviteCreateDTO;
-import umc.cockple.demo.domain.party.dto.PartyJoinActionDTO;
-import umc.cockple.demo.domain.party.dto.PartyJoinCreateDTO;
+import umc.cockple.demo.domain.party.dto.*;
 import umc.cockple.demo.domain.party.enums.ParticipationType;
 import umc.cockple.demo.domain.party.enums.PartyStatus;
 import umc.cockple.demo.domain.party.enums.RequestAction;
@@ -211,7 +208,7 @@ public class PartyCommandServiceImpl implements PartyCommandService{
         Member inviter = findMemberOrThrow(currentMemberId);
         Member invitee = findMemberOrThrow(memberIdToInvite);
 
-        //모임장 권한 검증
+        //멤버 초대 보내기 검증
         validateInvitation(party, inviter, invitee);
 
         PartyInvitation newInvitation = PartyInvitation.create(party, inviter, invitee);
@@ -223,11 +220,37 @@ public class PartyCommandServiceImpl implements PartyCommandService{
         return partyConverter.toInviteResponseDTO(savedPartyInvitation);
     }
 
+    @Override
+    public void actionInvitation(Long memberId, PartyInviteActionDTO.Request request, Long invitationId) {
+        log.info("모임 초대 처리 시작 - memberId: {}, invitationId: {}", memberId, invitationId);
+
+        //모임 초대 조회
+        PartyInvitation invitation = findInvitationOrThrow(invitationId);
+
+        //모임 초대 처리 검증
+        validateInvitationAction(invitation, memberId);
+
+        //비즈니스 로직 수행 (승인/거절에 따른 처리)
+        if(RequestAction.APPROVE.equals(request.action())){
+            approveInvitation(invitation);
+            //채팅방 참여 추가 필요
+        }else{
+            rejectInvitation(invitation);
+        }
+
+        log.info("모임 초대 처리 완료 - invitationId: {}", invitationId);
+    }
+
     // ========== 조회 메서드 ==========
     //가입신청 조회
     private PartyJoinRequest findJoinRequestOrThrow(Long requestId) {
         return partyJoinRequestRepository.findById(requestId)
                 .orElseThrow(() -> new PartyException(PartyErrorCode.JoinRequest_NOT_FOUND));
+    }
+
+    private PartyInvitation findInvitationOrThrow(Long invitationId) {
+        return partyInvitationRepository.findById(invitationId)
+                .orElseThrow(() -> new PartyException(PartyErrorCode.INVITATION_NOT_FOUND));
     }
 
     //사용자 조회
@@ -410,6 +433,7 @@ public class PartyCommandServiceImpl implements PartyCommandService{
         }
     }
 
+    //모임 초대 보내기 검증
     private void validateInvitation(Party party, Member inviter, Member invitee) {
         //모임장 권한 검증
         validateOwnerPermission(party, inviter.getId());
@@ -419,11 +443,30 @@ public class PartyCommandServiceImpl implements PartyCommandService{
             throw new PartyException(PartyErrorCode.ALREADY_MEMBER);
         }
 
-        // 이미 처리 대기중인 초대가 있는지 확인
+        //이미 처리 대기중인 초대가 있는지 검증
         if (partyInvitationRepository.existsByPartyAndInviteeAndStatus(party, invitee, RequestStatus.PENDING)) {
             throw new PartyException(PartyErrorCode.INVITATION_ALREADY_EXISTS);
         }
     }
+
+    //모임 초대 처리 검증
+    private void validateInvitationAction(PartyInvitation invitation, Long memberId) {
+        //초대받은 사용자와 현재 사용자가 일치하는지 검증
+        if (!memberId.equals(invitation.getInvitee().getId())){
+            throw new PartyException(PartyErrorCode.NOT_YOUR_INVITATION);
+        }
+
+        //이미 멤버인지 검증
+        if (memberPartyRepository.existsByPartyAndMember(invitation.getParty(), invitation.getInvitee())) {
+            throw new PartyException(PartyErrorCode.ALREADY_MEMBER);
+        }
+
+        //이미 처리된 모임 초대인지 검증
+        if (invitation.getStatus() != RequestStatus.PENDING){
+            throw new PartyException(PartyErrorCode.INVITATION_ALREADY_ACTIONS);
+        }
+    }
+
 
     //모임 활성화 여부 검증
     private void validatePartyIsActive(Party party) {
@@ -433,16 +476,28 @@ public class PartyCommandServiceImpl implements PartyCommandService{
     }
 
     // ========== 비즈니스 로직 메서드 ==========
-    private void rejectJoinRequest(PartyJoinRequest partyJoinRequest) {
-        partyJoinRequest.updateStatus(RequestStatus.REJECTED);
-    }
-
+    //가입 신청 승인, 승인
     private void approveJoinRequest(PartyJoinRequest partyJoinRequest) {
         partyJoinRequest.updateStatus(RequestStatus.APPROVED);
         Party party = partyJoinRequest.getParty();
         Member member = partyJoinRequest.getMember();
         MemberParty newMemberParty= MemberParty.create(party, member);
         party.addMember(newMemberParty);
+    }
+    private void rejectJoinRequest(PartyJoinRequest partyJoinRequest) {
+        partyJoinRequest.updateStatus(RequestStatus.REJECTED);
+    }
+
+    //모임 초대 승인, 거절
+    private void approveInvitation(PartyInvitation invitation) {
+        invitation.updateStatus(RequestStatus.APPROVED);
+        Party party = invitation.getParty();
+        Member member = invitation.getInvitee();
+        MemberParty newMemberParty= MemberParty.create(party, member);
+        party.addMember(newMemberParty);
+    }
+    private void rejectInvitation(PartyInvitation invitation) {
+        invitation.updateStatus(RequestStatus.REJECTED);
     }
 
     private void JoinPartyChatRoom(Long partyId, Long requestId, PartyJoinRequest partyJoinRequest) {

--- a/src/main/java/umc/cockple/demo/domain/party/service/PartyCommandServiceImpl.java
+++ b/src/main/java/umc/cockple/demo/domain/party/service/PartyCommandServiceImpl.java
@@ -191,7 +191,7 @@ public class PartyCommandServiceImpl implements PartyCommandService{
         //비즈니스 로직 수행 (승인/거절에 따른 처리)
         if(RequestAction.APPROVE.equals(request.action())){
             approveJoinRequest(partyJoinRequest);
-            JoinPartyChatRoom(partyId, requestId, partyJoinRequest);
+            JoinPartyChatRoom(partyId, partyJoinRequest.getMember());
         }else{
             rejectJoinRequest(partyJoinRequest);
         }
@@ -233,7 +233,7 @@ public class PartyCommandServiceImpl implements PartyCommandService{
         //비즈니스 로직 수행 (승인/거절에 따른 처리)
         if(RequestAction.APPROVE.equals(request.action())){
             approveInvitation(invitation);
-            //채팅방 참여 추가 필요
+            JoinPartyChatRoom(invitation.getParty().getId(), invitation.getInvitee());
         }else{
             rejectInvitation(invitation);
         }
@@ -500,15 +500,15 @@ public class PartyCommandServiceImpl implements PartyCommandService{
         invitation.updateStatus(RequestStatus.REJECTED);
     }
 
-    private void JoinPartyChatRoom(Long partyId, Long requestId, PartyJoinRequest partyJoinRequest) {
+    private void JoinPartyChatRoom(Long partyId, Member member) {
         log.info("모임 채팅방 자동 참여 시작 - partyId: {}", partyId);
         ChatRoom chatRoom = chatRoomRepository.findByPartyId(partyId);
         ChatRoomMember chatRoomMember = ChatRoomMember.builder()
                 .chatRoom(chatRoom)
-                .member(partyJoinRequest.getMember())
+                .member(member)
                 .build();
         chatRoomMemberRepository.save(chatRoomMember);
-        log.info("모임 채팅방 자동 참여 완료  - requestId: {}, chatRoomId: {}", requestId, chatRoom.getId());
+        log.info("모임 채팅방 자동 참여 완료  - requestId: {}, chatRoomId: {}", chatRoom.getId());
     }
 
     private void leavePartyChatRoom(Long partyId, Long memberId) {


### PR DESCRIPTION
## ❤️ 기능 설명
사용자가 모임의 초대를 처리(수락/거절)하는 API를 구현합니다.

swagger 테스트 성공 결과 스크린샷 첨부
<img width="810" height="278" alt="image" src="https://github.com/user-attachments/assets/49002034-2b8e-4195-94fd-7b9bb29adf43" />
<img width="794" height="76" alt="image" src="https://github.com/user-attachments/assets/dd15461b-01ae-4a3f-87d8-c7444c9c437e" />
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #262
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 수락 시, 자동으로 해당 모임의 채팅방에 참여하도록 했습니다.

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
