### PR TITLE
[feat/#231] 모임 정보 수정 API 구현

### DIFF
--- a/src/main/java/umc/cockple/demo/domain/party/controller/PartyController.java
+++ b/src/main/java/umc/cockple/demo/domain/party/controller/PartyController.java
@@ -133,6 +133,24 @@ public class PartyController {
         return BaseResponse.success(CommonSuccessCode.CREATED, response);
     }
 
+    @PatchMapping(value = "/parties/{partyId}")
+    @Operation(summary = "모임 정보 수정",
+            description = "특정 모임의 정보를 부분적으로 수정합니다.")
+    @ApiResponse(responseCode = "200", description = "모임 정보 수정 성공")
+    @ApiResponse(responseCode = "403", description = "모임장 권한 없음")
+    @ApiResponse(responseCode = "404", description = "존재하지 않는 모임")
+    public BaseResponse<Void> updateParty(
+            @PathVariable Long partyId,
+            @RequestBody @Valid PartyUpdateDTO.Request request,
+            Authentication authentication
+    ){
+        // TODO: JWT 인증 구현 후 교체 예정
+        Long memberId = 1L; // 임시값
+
+        partyCommandService.updateParty(partyId, memberId, request);
+        return BaseResponse.success(CommonSuccessCode.OK);
+    }
+
     @PatchMapping("/parties/{partyId}/status")
     @Operation(summary ="모임 삭제(비활성화)",
             description = "모임장이 모임을 삭제(비활성화)합니다.")

--- a/src/main/java/umc/cockple/demo/domain/party/domain/PartyImg.java
+++ b/src/main/java/umc/cockple/demo/domain/party/domain/PartyImg.java
@@ -27,4 +27,12 @@ public class PartyImg {
                 .party(party)
                 .build();
     }
+
+    public void updateKey(String newImgKey) {
+        this.imgKey = newImgKey;
+    }
+
+    protected void setParty(Party party) {
+        this.party = party;
+    }
 }

--- a/src/main/java/umc/cockple/demo/domain/party/dto/PartyUpdateDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/party/dto/PartyUpdateDTO.java
@@ -1,6 +1,8 @@
 package umc.cockple.demo.domain.party.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
 import lombok.Builder;
 
 import java.util.List;
@@ -9,7 +11,9 @@ public class PartyUpdateDTO {
     @Builder
     @Schema(name = "PartyUpdateRequestDTO", description = "모임 정보 수정 요청")
     public record Request(
+            @NotEmpty(message = "활동 요일은 필수 선택 항목입니다.")
             List<String> activityDay,
+            @NotBlank(message = "활동 시간은 필수 선택 항목입니다.")
             String activityTime,
             String designatedCock,
             Integer joinPrice,

--- a/src/main/java/umc/cockple/demo/domain/party/dto/PartyUpdateDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/party/dto/PartyUpdateDTO.java
@@ -1,0 +1,21 @@
+package umc.cockple.demo.domain.party.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+import java.util.List;
+
+public class PartyUpdateDTO {
+    @Builder
+    @Schema(name = "PartyUpdateRequestDTO", description = "모임 정보 수정 요청")
+    public record Request(
+            List<String> activityDay,
+            String activityTime,
+            String designatedCock,
+            Integer joinPrice,
+            Integer price,
+            String content,
+            String imgKey,
+            List<String> keyword
+    ){}
+}

--- a/src/main/java/umc/cockple/demo/domain/party/service/PartyCommandService.java
+++ b/src/main/java/umc/cockple/demo/domain/party/service/PartyCommandService.java
@@ -11,4 +11,5 @@ public interface PartyCommandService {
     void removeMember(Long partyId, Long memberIdToRemove, Long currentMemberId);
     PartyInviteCreateDTO.Response createInvitation(Long partyId, Long memberIdToInvite, Long currentMemberId);
     void actionInvitation(Long memberId, PartyInviteActionDTO.Request request, Long invitationId);
+    void updateParty(Long partyId, Long memberId, PartyUpdateDTO.Request request);
 }

--- a/src/main/java/umc/cockple/demo/domain/party/service/PartyCommandServiceImpl.java
+++ b/src/main/java/umc/cockple/demo/domain/party/service/PartyCommandServiceImpl.java
@@ -87,6 +87,22 @@ public class PartyCommandServiceImpl implements PartyCommandService{
     }
 
     @Override
+    public void updateParty(Long partyId, Long memberId, PartyUpdateDTO.Request request) {
+        log.info("모임 정보 수정 시작 - partyId: {}", partyId);
+
+        //모임 조회
+        Party party = findPartyOrThrow(partyId);
+
+        //모임장 권한 검증
+        validateOwnerPermission(party, memberId);
+
+        //비즈니스 로직 수행
+        party.update(request);
+
+        log.info("모임 정보 수정 완료 - partyId: {}", partyId);
+    }
+
+    @Override
     public void deleteParty(Long partyId, Long memberId) {
         log.info("모임 삭제 시작 - partyId: {}", partyId);
 


### PR DESCRIPTION
## ❤️ 기능 설명
특정 모임의 정보를 부분적으로 수정합니다.

swagger 테스트 성공 결과 스크린샷 첨부
<img width="716" height="324" alt="image" src="https://github.com/user-attachments/assets/732a7a9f-3b34-46e4-9575-3aef46e35615" />
<img width="706" height="67" alt="image" src="https://github.com/user-attachments/assets/69103a6a-8309-415e-88ab-6b051e5d52ca" />
모임 상세조회 api로 잘 변경된거 확인했습니다!
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #231
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- 없습니다.

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [ ] 이슈넘버를 적었는가?
