### PR TITLE
[feat/#279] 초기 채팅방 조회 API 구현

### DIFF
--- a/src/main/java/umc/cockple/demo/domain/chat/controller/ChatController.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/controller/ChatController.java
@@ -105,12 +105,12 @@ public class ChatController {
     @GetMapping("/chats/rooms/{roomId}")
     @Operation(summary = "초기 채팅방 조회", description = "채팅방의 정보와 회원이 참여한 채팅방의 메시지를 최근 50개만 조회합니다.")
     @ApiResponse(responseCode = "200", description = "조회 성공")
-    public BaseResponse<ChatRoomDetailDTO.Response> getChatRoom(
+    public BaseResponse<ChatRoomDetailDTO.Response> getChatRoomDetail(
             @PathVariable Long roomId
     ){
         Long memberId = SecurityUtil.getCurrentMemberId();
 
-        ChatRoomDetailDTO.Response response = chatQueryService.getChatRoom(roomId, memberId);
+        ChatRoomDetailDTO.Response response = chatQueryService.getChatRoomDetail(roomId, memberId);
 
         return BaseResponse.success(CommonSuccessCode.OK, response);
     }

--- a/src/main/java/umc/cockple/demo/domain/chat/controller/ChatController.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/controller/ChatController.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+import umc.cockple.demo.domain.chat.dto.ChatRoomDetailDTO;
 import umc.cockple.demo.domain.chat.dto.DirectChatRoomCreateDTO;
 import umc.cockple.demo.domain.chat.dto.DirectChatRoomDTO;
 import umc.cockple.demo.domain.chat.dto.PartyChatRoomDTO;

--- a/src/main/java/umc/cockple/demo/domain/chat/controller/ChatController.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/controller/ChatController.java
@@ -14,6 +14,7 @@ import umc.cockple.demo.domain.chat.service.ChatCommandService;
 import umc.cockple.demo.domain.chat.service.ChatQueryService;
 import umc.cockple.demo.global.response.BaseResponse;
 import umc.cockple.demo.global.response.code.status.CommonSuccessCode;
+import umc.cockple.demo.global.security.utils.SecurityUtil;
 
 @RestController
 @RequiredArgsConstructor
@@ -97,6 +98,19 @@ public class ChatController {
         // TODO: JWT 인증 구현 후 교체 예정
         Long memberId = 1L; // 임시값
         DirectChatRoomDTO.Response response = chatQueryService.searchDirectChatRoomsByName(memberId, name, cursor, size, direction);
+        return BaseResponse.success(CommonSuccessCode.OK, response);
+    }
+
+    @GetMapping("/chats/rooms/{roomId}")
+    @Operation(summary = "초기 채팅방 조회", description = "채팅방의 정보와 회원이 참여한 채팅방의 메시지를 최근 50개만 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "조회 성공")
+    public BaseResponse<ChatRoomDetailDTO.Response> getChatRoom(
+            @PathVariable Long roomId
+    ){
+        Long memberId = SecurityUtil.getCurrentMemberId();
+
+        ChatRoomDetailDTO.Response response = chatQueryService.getChatRoom(roomId, memberId);
+
         return BaseResponse.success(CommonSuccessCode.OK, response);
     }
 }

--- a/src/main/java/umc/cockple/demo/domain/chat/converter/ChatConverter.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/converter/ChatConverter.java
@@ -147,4 +147,15 @@ public class ChatConverter {
                 .profileImgUrl(memberProfileImgUrl)
                 .build();
     }
+
+    public ChatRoomDetailDTO.Response toChatRoomDetailResponse(
+            ChatRoomDetailDTO.ChatRoomInfo roomInfo,
+            List<ChatRoomDetailDTO.MessageInfo> messageInfos,
+            List<ChatRoomDetailDTO.MemberInfo> memberInfos) {
+        return ChatRoomDetailDTO.Response.builder()
+                .chatRoomInfo(roomInfo)
+                .messages(messageInfos)
+                .participants(memberInfos)
+                .build();
+    }
 }

--- a/src/main/java/umc/cockple/demo/domain/chat/converter/ChatConverter.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/converter/ChatConverter.java
@@ -105,7 +105,7 @@ public class ChatConverter {
                 ).collect(Collectors.toList());
     }
 
-    public ChatRoomDetailDTO.ChatRoomInfo toChatRoomInfo(
+    public ChatRoomDetailDTO.ChatRoomInfo toChatRoomDetailChatRoomInfo(
             ChatRoom chatRoom,
             String displayName,
             String profileImageUrl,
@@ -121,7 +121,7 @@ public class ChatConverter {
                 .build();
     }
 
-    public ChatRoomDetailDTO.MessageInfo toMessageInfo(
+    public ChatRoomDetailDTO.MessageInfo toChatRoomDetailMessageInfo(
             ChatMessage message,
             Member sender,
             String senderProfileImageUrl,
@@ -140,7 +140,7 @@ public class ChatConverter {
                 .build();
     }
 
-    public ChatRoomDetailDTO.MemberInfo toChatRoomMemberInfo(Member member, String memberProfileImgUrl) {
+    public ChatRoomDetailDTO.MemberInfo toChatRoomDetailMemberInfo(Member member, String memberProfileImgUrl) {
         return ChatRoomDetailDTO.MemberInfo.builder()
                 .memberId(member.getId())
                 .memberName(member.getMemberName())

--- a/src/main/java/umc/cockple/demo/domain/chat/converter/ChatConverter.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/converter/ChatConverter.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Component;
 import umc.cockple.demo.domain.chat.domain.ChatMessage;
 import umc.cockple.demo.domain.chat.domain.ChatRoom;
 import umc.cockple.demo.domain.chat.domain.ChatRoomMember;
+import umc.cockple.demo.domain.chat.dto.ChatRoomDetailDTO;
 import umc.cockple.demo.domain.chat.dto.DirectChatRoomCreateDTO;
 import umc.cockple.demo.domain.chat.dto.DirectChatRoomDTO;
 import umc.cockple.demo.domain.chat.dto.PartyChatRoomDTO;
@@ -101,5 +102,21 @@ public class ChatConverter {
                         .memberName(m.getMember().getMemberName())
                         .build()
                 ).collect(Collectors.toList());
+    }
+
+    public ChatRoomDetailDTO.ChatRoomInfo toChatRoomInfo(
+            ChatRoom chatRoom,
+            String displayName,
+            String profileImageUrl,
+            int memberCount,
+            Long lastReadMessageId) {
+        return ChatRoomDetailDTO.ChatRoomInfo.builder()
+                .chatRoomId(chatRoom.getId())
+                .chatRoomType(chatRoom.getType())
+                .displayName(displayName)
+                .profileImageUrl(profileImageUrl)
+                .memberCount(memberCount)
+                .lastReadMessageId(lastReadMessageId)
+                .build();
     }
 }

--- a/src/main/java/umc/cockple/demo/domain/chat/converter/ChatConverter.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/converter/ChatConverter.java
@@ -9,6 +9,7 @@ import umc.cockple.demo.domain.chat.dto.ChatRoomDetailDTO;
 import umc.cockple.demo.domain.chat.dto.DirectChatRoomCreateDTO;
 import umc.cockple.demo.domain.chat.dto.DirectChatRoomDTO;
 import umc.cockple.demo.domain.chat.dto.PartyChatRoomDTO;
+import umc.cockple.demo.domain.member.domain.Member;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -117,6 +118,25 @@ public class ChatConverter {
                 .profileImageUrl(profileImageUrl)
                 .memberCount(memberCount)
                 .lastReadMessageId(lastReadMessageId)
+                .build();
+    }
+
+    public ChatRoomDetailDTO.MessageInfo toMessageInfo(
+            ChatMessage message,
+            Member sender,
+            String senderProfileImageUrl,
+            List<String> imageUrls,
+            boolean isMyMessage) {
+        return ChatRoomDetailDTO.MessageInfo.builder()
+                .messageId(message.getId())
+                .senderId(sender.getId())
+                .senderName(sender.getMemberName())
+                .senderProfileImageUrl(senderProfileImageUrl)
+                .content(message.getContent())
+                .messageType(message.getType())
+                .imageUrls(imageUrls)
+                .timestamp(message.getCreatedAt())
+                .isMyMessage(isMyMessage)
                 .build();
     }
 }

--- a/src/main/java/umc/cockple/demo/domain/chat/converter/ChatConverter.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/converter/ChatConverter.java
@@ -139,4 +139,12 @@ public class ChatConverter {
                 .isMyMessage(isMyMessage)
                 .build();
     }
+
+    public ChatRoomDetailDTO.MemberInfo toChatRoomMemberInfo(Member member, String memberProfileImgUrl) {
+        return ChatRoomDetailDTO.MemberInfo.builder()
+                .memberId(member.getId())
+                .memberName(member.getMemberName())
+                .profileImgUrl(memberProfileImgUrl)
+                .build();
+    }
 }

--- a/src/main/java/umc/cockple/demo/domain/chat/domain/ChatRoomMember.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/domain/ChatRoomMember.java
@@ -31,4 +31,6 @@ public class ChatRoomMember extends BaseEntity {
     public void updateDisplayName(String newDisplayName) {
         this.displayName = newDisplayName;
     }
+
+    public void updateLastReadMessageId(Long messageId) {this.lastReadMessageId = messageId;}
 }

--- a/src/main/java/umc/cockple/demo/domain/chat/dto/ChatRoomDetailDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/dto/ChatRoomDetailDTO.java
@@ -1,0 +1,4 @@
+package umc.cockple.demo.domain.chat.dto;
+
+public class ChatRoomDetailDTO {
+}

--- a/src/main/java/umc/cockple/demo/domain/chat/dto/ChatRoomDetailDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/dto/ChatRoomDetailDTO.java
@@ -1,4 +1,52 @@
 package umc.cockple.demo.domain.chat.dto;
 
+import lombok.Builder;
+import umc.cockple.demo.domain.chat.enums.ChatRoomType;
+import umc.cockple.demo.domain.chat.enums.MessageType;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
 public class ChatRoomDetailDTO {
+
+    @Builder
+    public record Response(
+            ChatRoomInfo chatRoomInfo,
+            List<MessageInfo> messages,
+            List<MemberInfo> participants
+    ){
+    }
+
+    @Builder
+    public record ChatRoomInfo(
+            Long chatRoomId,
+            ChatRoomType chatRoomType,
+            String displayName,
+            String profileImageUrl,
+            int memberCount,
+            Long lastReadMessageId
+    ) {
+    }
+
+    @Builder
+    public record MessageInfo(
+            Long messageId,
+            Long senderId,
+            String senderName,
+            String senderProfileImageUrl,
+            String content,
+            MessageType messageType,
+            List<String> imageUrls,  // 이미지 메시지인 경우
+            LocalDateTime timestamp,
+            boolean isMyMessage    // 내가 보낸 메시지인지
+    ) {
+    }
+
+    @Builder
+    public record MemberInfo(
+            Long memberId,
+            String memberName,
+            String profileImgUrl
+    ) {
+    }
 }

--- a/src/main/java/umc/cockple/demo/domain/chat/enums/MessageType.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/enums/MessageType.java
@@ -3,5 +3,5 @@ package umc.cockple.demo.domain.chat.enums;
 public enum MessageType {
     TEXT,
     IMAGE,
-    EMOJI
+    SYSTEM
 }

--- a/src/main/java/umc/cockple/demo/domain/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/repository/ChatMessageRepository.java
@@ -1,17 +1,20 @@
 package umc.cockple.demo.domain.chat.repository;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import umc.cockple.demo.domain.chat.domain.ChatMessage;
 
+import java.util.List;
+
 public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
 
     // 안 읽은 메시지 수 세기
     @Query("""
-                SELECT COUNT(m) FROM ChatMessage m
-                WHERE m.chatRoom.id = :chatRoomId
-                AND m.id > :lastReadMessageId
+            SELECT COUNT(m) FROM ChatMessage m
+            WHERE m.chatRoom.id = :chatRoomId
+            AND m.id > :lastReadMessageId
             """)
     int countUnreadMessages(
             @Param("chatRoomId") Long chatRoomId,
@@ -20,4 +23,14 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> 
 
     ChatMessage findTop1ByChatRoom_IdOrderByCreatedAtDesc(Long chatRoomId);
 
+    @Query("""
+            SELECT m FROM ChatMessage m 
+            LEFT JOIN FETCH m.chatMessageImgs
+            WHERE m.chatRoom.id = :chatRoomId 
+            AND m.isDeleted = false
+            ORDER BY m.createdAt DESC
+            """)
+    List<ChatMessage> findRecentMessagesWithImages(
+            @Param("chatRoomId") Long chatRoomId,
+            Pageable pageable);
 }

--- a/src/main/java/umc/cockple/demo/domain/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/repository/ChatMessageRepository.java
@@ -25,6 +25,7 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> 
 
     @Query("""
             SELECT m FROM ChatMessage m 
+            JOIN FETCH m.sender
             LEFT JOIN FETCH m.chatMessageImgs
             WHERE m.chatRoom.id = :chatRoomId 
             AND m.isDeleted = false

--- a/src/main/java/umc/cockple/demo/domain/chat/repository/ChatRoomMemberRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/repository/ChatRoomMemberRepository.java
@@ -38,5 +38,14 @@ public interface ChatRoomMemberRepository extends JpaRepository<ChatRoomMember, 
     Optional<ChatRoomMember> findCounterPartWithMember(
             @Param("chatRoomId") Long chatRoomId,
             @Param("myId") Long myId);
+
+    @Query("""
+            SELECT crm FROM ChatRoomMember crm
+            JOIN FETCH crm.member m
+            LEFT JOIN FETCH m.profileImg
+            WHERE crm.chatRoom.id = :chatRoomId
+            ORDER BY m.memberName ASC
+            """)
+    List<ChatRoomMember> findChatRoomMembersWithMemberById(@Param("chatRoomId") Long chatRoomId);
 }
 

--- a/src/main/java/umc/cockple/demo/domain/chat/repository/ChatRoomMemberRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/repository/ChatRoomMemberRepository.java
@@ -27,5 +27,16 @@ public interface ChatRoomMemberRepository extends JpaRepository<ChatRoomMember, 
     List<ChatRoomMember> findByChatRoomId(Long id);
 
     List<ChatRoomMember> findAllByMemberId(Long id);
+
+    @Query("""
+            SELECT crm FROM ChatRoomMember crm
+            JOIN FETCH crm.member m
+            LEFT JOIN FETCH m.profileImg
+            WHERE crm.chatRoom.id = :chatRoomId
+            AND crm.member.id != :myId
+            """)
+    Optional<ChatRoomMember> findCounterPartWithMember(
+            @Param("chatRoomId") Long chatRoomId,
+            @Param("myId") Long myId);
 }
 

--- a/src/main/java/umc/cockple/demo/domain/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/repository/ChatRoomRepository.java
@@ -104,4 +104,12 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
             @Param("direction") String direction,
             Pageable pageable
     );
+
+    @Query("""
+            SELECT cr FROM ChatRoom cr
+            JOIN FETCH cr.party p
+            LEFT JOIN FETCH p.partyImg img
+            WHERE cr.id = :roomId
+            """)
+    Optional<ChatRoom> findChatRoomWithPartyById(@Param("roomId") Long roomId);
 }

--- a/src/main/java/umc/cockple/demo/domain/chat/service/ChatQueryService.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/ChatQueryService.java
@@ -1,5 +1,6 @@
 package umc.cockple.demo.domain.chat.service;
 
+import umc.cockple.demo.domain.chat.dto.ChatRoomDetailDTO;
 import umc.cockple.demo.domain.chat.dto.DirectChatRoomDTO;
 import umc.cockple.demo.domain.chat.dto.PartyChatRoomDTO;
 import umc.cockple.demo.domain.chat.enums.Direction;
@@ -12,4 +13,6 @@ public interface ChatQueryService {
     DirectChatRoomDTO.Response getDirectChatRooms(Long memberId, Long cursor, int size, Direction direction);
 
     DirectChatRoomDTO.Response searchDirectChatRoomsByName(Long memberId, String name, Long cursor, int size, Direction direction);
+
+    ChatRoomDetailDTO.Response getChatRoomDetail(Long roomId, Long memberId);
 }

--- a/src/main/java/umc/cockple/demo/domain/chat/service/ChatQueryServiceImpl.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/ChatQueryServiceImpl.java
@@ -213,7 +213,7 @@ public class ChatQueryServiceImpl implements ChatQueryService {
         int memberCount = chatRoomMemberRepository.countByChatRoomId(chatRoom.getId());
         Long lastReadMessageId = myMembership.getLastReadMessageId();
 
-        return chatConverter.toChatRoomInfo(
+        return chatConverter.toChatRoomDetailChatRoomInfo(
                 chatRoom,
                 displayName,
                 profileImageUrl,
@@ -239,7 +239,7 @@ public class ChatQueryServiceImpl implements ChatQueryService {
 
         boolean isMyMessage = sender.getId().equals(currentUserId);
 
-        return chatConverter.toMessageInfo(
+        return chatConverter.toChatRoomDetailMessageInfo(
                 message,
                 sender,
                 senderProfileImageUrl,
@@ -257,7 +257,7 @@ public class ChatQueryServiceImpl implements ChatQueryService {
         Member member = chatRoomMember.getMember();
         String memberProfileImgUrl = getImageUrl(member.getProfileImg());
 
-        return chatConverter.toChatRoomMemberInfo(member, memberProfileImgUrl);
+        return chatConverter.toChatRoomDetailMemberInfo(member, memberProfileImgUrl);
     }
 
     private void updateLastReadMessage(ChatRoomMember myMembership, Long messageId) {

--- a/src/main/java/umc/cockple/demo/domain/chat/service/ChatQueryServiceImpl.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/ChatQueryServiceImpl.java
@@ -224,7 +224,12 @@ public class ChatQueryServiceImpl implements ChatQueryService {
 
         boolean isMyMessage = sender.getId().equals(currentUserId);
 
-        return chatConverter.toMessageInfo(message, senderProfileImageUrl, imageUrls, isMyMessage);
+        return chatConverter.toMessageInfo(
+                message,
+                sender,
+                senderProfileImageUrl,
+                imageUrls,
+                isMyMessage);
     }
 
     private String getImageUrl(PartyImg partyImg) {

--- a/src/main/java/umc/cockple/demo/domain/chat/service/ChatQueryServiceImpl.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/ChatQueryServiceImpl.java
@@ -90,9 +90,7 @@ public class ChatQueryServiceImpl implements ChatQueryService {
 
         Pageable pageable = PageRequest.of(0, 50);
         List<ChatMessage> recentMessages = findRecentMessagesWithImages(roomId, pageable);
-
         Collections.reverse(recentMessages);
-
         List<ChatRoomDetailDTO.MessageInfo> messageInfos = buildMessageInfos(memberId, recentMessages);
 
         List<ChatRoomMember> participants = findChatRoomMembersWithMemberOrThrow(roomId);

--- a/src/main/java/umc/cockple/demo/domain/chat/service/ChatQueryServiceImpl.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/ChatQueryServiceImpl.java
@@ -25,6 +25,7 @@ import umc.cockple.demo.domain.member.domain.Member;
 import umc.cockple.demo.domain.member.domain.ProfileImg;
 import umc.cockple.demo.domain.party.domain.PartyImg;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -84,6 +85,11 @@ public class ChatQueryServiceImpl implements ChatQueryService {
         ChatRoomMember myMembership = findChatRoomMembershipOrThrow(roomId, memberId);
 
         ChatRoomDetailDTO.ChatRoomInfo roomInfo = buildChatRoomInfo(chatRoom, myMembership);
+
+        Pageable pageable = PageRequest.of(0, 50);
+        List<ChatMessage> recentMessages = findRecentMessagesWithImages(roomId, pageable);
+
+        Collections.reverse(recentMessages);
 
         return null;
     }
@@ -231,5 +237,9 @@ public class ChatQueryServiceImpl implements ChatQueryService {
         return chatRoomMemberRepository
                 .findCounterPartWithMember(chatRoom.getId(), myMembership.getMember().getId())
                 .orElseThrow(() -> new ChatException(ChatErrorCode.CHAT_ROOM_MEMBER_NOT_FOUND));
+    }
+
+    private List<ChatMessage> findRecentMessagesWithImages(Long roomId, Pageable pageable) {
+        return chatMessageRepository.findRecentMessagesWithImages(roomId, pageable);
     }
 }

--- a/src/main/java/umc/cockple/demo/domain/chat/service/ChatQueryServiceImpl.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/ChatQueryServiceImpl.java
@@ -10,6 +10,7 @@ import umc.cockple.demo.domain.chat.converter.ChatConverter;
 import umc.cockple.demo.domain.chat.domain.ChatMessage;
 import umc.cockple.demo.domain.chat.domain.ChatRoom;
 import umc.cockple.demo.domain.chat.domain.ChatRoomMember;
+import umc.cockple.demo.domain.chat.dto.ChatRoomDetailDTO;
 import umc.cockple.demo.domain.chat.dto.DirectChatRoomDTO;
 import umc.cockple.demo.domain.chat.dto.PartyChatRoomDTO;
 import umc.cockple.demo.domain.chat.enums.Direction;
@@ -73,7 +74,13 @@ public class ChatQueryServiceImpl implements ChatQueryService {
         return toDirectChatRoomInfos(chatRooms, memberId);
     }
 
-    // ========== 비지니스 로직 ==========
+    @Override
+    public ChatRoomDetailDTO.Response getChatRoomDetail(Long roomId, Long memberId) {
+
+        return null;
+    }
+
+    // ========== 비즈니스 로직 ==========
     private PartyChatRoomDTO.Response toPartyChatRoomInfos(List<ChatRoom> chatRooms, Long memberId) {
         if (chatRooms.isEmpty()) {
             throw new ChatException(ChatErrorCode.CHAT_ROOM_NOT_FOUND);

--- a/src/main/java/umc/cockple/demo/domain/chat/service/ChatQueryServiceImpl.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/ChatQueryServiceImpl.java
@@ -21,6 +21,7 @@ import umc.cockple.demo.domain.chat.repository.ChatMessageRepository;
 import umc.cockple.demo.domain.chat.repository.ChatRoomMemberRepository;
 import umc.cockple.demo.domain.chat.repository.ChatRoomRepository;
 import umc.cockple.demo.domain.image.service.ImageService;
+import umc.cockple.demo.domain.member.domain.Member;
 import umc.cockple.demo.domain.member.domain.ProfileImg;
 import umc.cockple.demo.domain.party.domain.PartyImg;
 
@@ -185,13 +186,11 @@ public class ChatQueryServiceImpl implements ChatQueryService {
         String profileImageUrl = null;
 
         if (chatRoom.getType() == ChatRoomType.DIRECT) {
-            displayName = myMembership.getDisplayName();
+            ChatRoomMember counterPart = findCounterPartWithMember(chatRoom, myMembership);
+            Member member = counterPart.getMember();
 
-            ChatRoomMember counterPart = chatRoomMemberRepository
-                    .findCounterPartWithMember(chatRoom.getId(), myMembership.getMember().getId())
-                    .orElseThrow(() -> new ChatException(ChatErrorCode.CHAT_ROOM_MEMBER_NOT_FOUND));
-
-            profileImageUrl = getImageUrl(counterPart.getMember().getProfileImg());
+            displayName = member.getMemberName();
+            profileImageUrl = getImageUrl(member.getProfileImg());
         } else {
             displayName = chatRoom.getName();
             profileImageUrl = getImageUrl(chatRoom.getParty().getPartyImg());
@@ -215,5 +214,11 @@ public class ChatQueryServiceImpl implements ChatQueryService {
         return chatRoomMemberRepository
                 .findByChatRoomIdAndMemberId(roomId, memberId)
                 .orElseThrow(() -> new ChatException(ChatErrorCode.CHAT_ROOM_NOT_FOUND));
+    }
+
+    private ChatRoomMember findCounterPartWithMember(ChatRoom chatRoom, ChatRoomMember myMembership) {
+        return chatRoomMemberRepository
+                .findCounterPartWithMember(chatRoom.getId(), myMembership.getMember().getId())
+                .orElseThrow(() -> new ChatException(ChatErrorCode.CHAT_ROOM_MEMBER_NOT_FOUND));
     }
 }

--- a/src/main/java/umc/cockple/demo/domain/chat/service/ChatQueryServiceImpl.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/ChatQueryServiceImpl.java
@@ -97,6 +97,11 @@ public class ChatQueryServiceImpl implements ChatQueryService {
                 .map(message -> buildMessageInfo(message, memberId))
                 .collect(Collectors.toList());
 
+        List<ChatRoomMember> participants = findChatRoomMembersWithMemberOrThrow(roomId);
+        List<ChatRoomDetailDTO.MemberInfo> memberInfos = participants.stream()
+                .map(member -> buildMemberInfo(member))
+                .toList();
+
         return null;
     }
 
@@ -232,6 +237,10 @@ public class ChatQueryServiceImpl implements ChatQueryService {
                 isMyMessage);
     }
 
+    private ChatRoomDetailDTO.MemberInfo buildMemberInfo(ChatRoomMember member) {
+
+    }
+
     private String getImageUrl(PartyImg partyImg) {
         if (partyImg != null && partyImg.getImgKey() != null && !partyImg.getImgKey().isBlank()) {
             return imageService.getUrlFromKey(partyImg.getImgKey());
@@ -270,6 +279,10 @@ public class ChatQueryServiceImpl implements ChatQueryService {
         return chatRoomMemberRepository
                 .findCounterPartWithMember(chatRoom.getId(), myMembership.getMember().getId())
                 .orElseThrow(() -> new ChatException(ChatErrorCode.CHAT_ROOM_MEMBER_NOT_FOUND));
+    }
+
+    private List<ChatRoomMember> findChatRoomMembersWithMemberOrThrow(Long roomId) {
+        return chatRoomMemberRepository.findChatRoomMembersWithMemberById(roomId);
     }
 
     private List<ChatMessage> findRecentMessagesWithImages(Long roomId, Pageable pageable) {

--- a/src/main/java/umc/cockple/demo/domain/chat/service/ChatQueryServiceImpl.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/ChatQueryServiceImpl.java
@@ -219,8 +219,8 @@ public class ChatQueryServiceImpl implements ChatQueryService {
 
         List<String> imageUrls = message.getChatMessageImgs().stream()
                 .sorted(Comparator.comparing(ChatMessageImg::getImgOrder))
-                .map(img -> getImageUrl(img))
-                .collect(Collectors.toList());
+                .map(this::getImageUrl)
+                .toList();
 
         boolean isMyMessage = sender.getId().equals(currentUserId);
 

--- a/src/main/java/umc/cockple/demo/domain/chat/service/ChatQueryServiceImpl.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/ChatQueryServiceImpl.java
@@ -80,7 +80,7 @@ public class ChatQueryServiceImpl implements ChatQueryService {
     public ChatRoomDetailDTO.Response getChatRoomDetail(Long roomId, Long memberId) {
         log.info("[초기 채팅방 조회 시작] - roomId: {}, memberId: {}", roomId, memberId);
 
-        ChatRoom chatRoom = findChatRoomOrThrow(roomId);
+        ChatRoom chatRoom = findChatRoomWithPartyOrThrow(roomId);
         ChatRoomMember myMembership = findChatRoomMembershipOrThrow(roomId, memberId);
 
         ChatRoomDetailDTO.ChatRoomInfo roomInfo = buildChatRoomInfo(chatRoom, myMembership);
@@ -206,8 +206,9 @@ public class ChatQueryServiceImpl implements ChatQueryService {
 
     // ========== 조회 메서드 ==========
 
-    private ChatRoom findChatRoomOrThrow(Long roomId) {
-        return chatRoomRepository.findById(roomId).orElseThrow(() -> new ChatException(ChatErrorCode.CHAT_ROOM_NOT_FOUND));
+    private ChatRoom findChatRoomWithPartyOrThrow(Long roomId) {
+        return chatRoomRepository.findChatRoomWithPartyById(roomId)
+                .orElseThrow(() -> new ChatException(ChatErrorCode.CHAT_ROOM_NOT_FOUND));
     }
 
     private ChatRoomMember findChatRoomMembershipOrThrow(Long roomId, Long memberId) {

--- a/src/main/java/umc/cockple/demo/domain/chat/service/ChatQueryServiceImpl.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/ChatQueryServiceImpl.java
@@ -76,6 +76,10 @@ public class ChatQueryServiceImpl implements ChatQueryService {
 
     @Override
     public ChatRoomDetailDTO.Response getChatRoomDetail(Long roomId, Long memberId) {
+        log.info("[초기 채팅방 조회 시작] - roomId: {}, memberId: {}", roomId, memberId);
+
+        ChatRoom chatRoom = findChatRoomOrThrow(roomId);
+        ChatRoomMember myMembership = findChatRoomMembershipOrThrow(roomId, memberId);
 
         return null;
     }
@@ -179,5 +183,17 @@ public class ChatQueryServiceImpl implements ChatQueryService {
             return null;
         }
         return imageService.getUrlFromKey(profileImg.getImgKey());
+    }
+
+    // ========== 조회 메서드 ==========
+
+    private ChatRoom findChatRoomOrThrow(Long roomId) {
+        return chatRoomRepository.findById(roomId).orElseThrow(() -> new ChatException(ChatErrorCode.CHAT_ROOM_NOT_FOUND));
+    }
+
+    private ChatRoomMember findChatRoomMembershipOrThrow(Long roomId, Long memberId) {
+        return chatRoomMemberRepository
+                .findByChatRoomIdAndMemberId(roomId, memberId)
+                .orElseThrow(() -> new ChatException(ChatErrorCode.CHAT_ROOM_NOT_FOUND));
     }
 }

--- a/src/main/java/umc/cockple/demo/domain/chat/service/ChatQueryServiceImpl.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/ChatQueryServiceImpl.java
@@ -186,7 +186,7 @@ public class ChatQueryServiceImpl implements ChatQueryService {
         String profileImageUrl = null;
 
         if (chatRoom.getType() == ChatRoomType.DIRECT) {
-            ChatRoomMember counterPart = findCounterPartWithMember(chatRoom, myMembership);
+            ChatRoomMember counterPart = findCounterPartWithMemberOrThrow(chatRoom, myMembership);
             Member member = counterPart.getMember();
 
             displayName = member.getMemberName();
@@ -214,10 +214,10 @@ public class ChatQueryServiceImpl implements ChatQueryService {
     private ChatRoomMember findChatRoomMembershipOrThrow(Long roomId, Long memberId) {
         return chatRoomMemberRepository
                 .findByChatRoomIdAndMemberId(roomId, memberId)
-                .orElseThrow(() -> new ChatException(ChatErrorCode.CHAT_ROOM_NOT_FOUND));
+                .orElseThrow(() -> new ChatException(ChatErrorCode.CHAT_ROOM_MEMBER_NOT_FOUND));
     }
 
-    private ChatRoomMember findCounterPartWithMember(ChatRoom chatRoom, ChatRoomMember myMembership) {
+    private ChatRoomMember findCounterPartWithMemberOrThrow(ChatRoom chatRoom, ChatRoomMember myMembership) {
         return chatRoomMemberRepository
                 .findCounterPartWithMember(chatRoom.getId(), myMembership.getMember().getId())
                 .orElseThrow(() -> new ChatException(ChatErrorCode.CHAT_ROOM_MEMBER_NOT_FOUND));

--- a/src/main/java/umc/cockple/demo/domain/chat/service/ChatQueryServiceImpl.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/ChatQueryServiceImpl.java
@@ -93,14 +93,12 @@ public class ChatQueryServiceImpl implements ChatQueryService {
 
         Collections.reverse(recentMessages);
 
-        List<ChatRoomDetailDTO.MessageInfo> messageInfos = recentMessages.stream()
-                .map(message -> buildMessageInfo(message, memberId))
-                .collect(Collectors.toList());
+        List<ChatRoomDetailDTO.MessageInfo> messageInfos = buildMessageInfos(memberId, recentMessages);
 
         List<ChatRoomMember> participants = findChatRoomMembersWithMemberOrThrow(roomId);
-        List<ChatRoomDetailDTO.MemberInfo> memberInfos = participants.stream()
-                .map(member -> buildMemberInfo(member))
-                .toList();
+        List<ChatRoomDetailDTO.MemberInfo> memberInfos = buildMemberInfos(participants);
+
+
 
         return null;
     }
@@ -217,6 +215,12 @@ public class ChatQueryServiceImpl implements ChatQueryService {
                 lastReadMessageId);
     }
 
+    private List<ChatRoomDetailDTO.MessageInfo> buildMessageInfos(Long memberId, List<ChatMessage> recentMessages) {
+        return recentMessages.stream()
+                .map(message -> buildMessageInfo(message, memberId))
+                .collect(Collectors.toList());
+    }
+
     private ChatRoomDetailDTO.MessageInfo buildMessageInfo(ChatMessage message, Long currentUserId) {
         Member sender = message.getSender();
 
@@ -235,6 +239,12 @@ public class ChatQueryServiceImpl implements ChatQueryService {
                 senderProfileImageUrl,
                 imageUrls,
                 isMyMessage);
+    }
+
+    private List<ChatRoomDetailDTO.MemberInfo> buildMemberInfos(List<ChatRoomMember> participants) {
+        return participants.stream()
+                .map(this::buildMemberInfo)
+                .toList();
     }
 
     private ChatRoomDetailDTO.MemberInfo buildMemberInfo(ChatRoomMember member) {

--- a/src/main/java/umc/cockple/demo/domain/chat/service/ChatQueryServiceImpl.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/ChatQueryServiceImpl.java
@@ -103,7 +103,10 @@ public class ChatQueryServiceImpl implements ChatQueryService {
             updateLastReadMessage(myMembership, lastMessage.getId());
         }
 
-        return null;
+        log.info("[초기 채팅방 조회 완료] - 메시지 수: {}, 참여자 수: {}",
+                messageInfos.size(), memberInfos.size());
+
+        return chatConverter.toChatRoomDetailResponse(roomInfo, messageInfos, memberInfos);
     }
 
     // ========== 비즈니스 로직 ==========

--- a/src/main/java/umc/cockple/demo/domain/chat/service/ChatQueryServiceImpl.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/ChatQueryServiceImpl.java
@@ -187,10 +187,8 @@ public class ChatQueryServiceImpl implements ChatQueryService {
         if (chatRoom.getType() == ChatRoomType.DIRECT) {
             displayName = myMembership.getDisplayName();
 
-            ChatRoomMember counterPart = chatRoom.getChatRoomMembers().stream()
-                    .filter(chatMember -> !chatMember.getMember().getId()
-                            .equals(myMembership.getMember().getId()))
-                    .findFirst()
+            ChatRoomMember counterPart = chatRoomMemberRepository
+                    .findCounterPartWithMember(chatRoom.getId(), myMembership.getMember().getId())
                     .orElseThrow(() -> new ChatException(ChatErrorCode.CHAT_ROOM_MEMBER_NOT_FOUND));
 
             profileImageUrl = getImageUrl(counterPart.getMember().getProfileImg());

--- a/src/main/java/umc/cockple/demo/domain/chat/service/ChatQueryServiceImpl.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/ChatQueryServiceImpl.java
@@ -195,6 +195,16 @@ public class ChatQueryServiceImpl implements ChatQueryService {
             displayName = chatRoom.getName();
             profileImageUrl = getImageUrl(chatRoom.getParty().getPartyImg());
         }
+
+        int memberCount = chatRoomMemberRepository.countByChatRoomId(chatRoom.getId());
+        Long lastReadMessageId = myMembership.getLastReadMessageId();
+
+        return chatConverter.toChatRoomInfo(
+                chatRoom,
+                displayName,
+                profileImageUrl,
+                memberCount,
+                lastReadMessageId);
     }
 
     private String getImageUrl(ProfileImg profileImg) {

--- a/src/main/java/umc/cockple/demo/domain/chat/service/ChatQueryServiceImpl.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/ChatQueryServiceImpl.java
@@ -247,8 +247,11 @@ public class ChatQueryServiceImpl implements ChatQueryService {
                 .toList();
     }
 
-    private ChatRoomDetailDTO.MemberInfo buildMemberInfo(ChatRoomMember member) {
+    private ChatRoomDetailDTO.MemberInfo buildMemberInfo(ChatRoomMember chatRoomMember) {
+        Member member = chatRoomMember.getMember();
+        String memberProfileImgUrl = getImageUrl(member.getProfileImg());
 
+        return chatConverter.toChatRoomMemberInfo(member, memberProfileImgUrl);
     }
 
     private String getImageUrl(PartyImg partyImg) {

--- a/src/main/java/umc/cockple/demo/domain/chat/service/ChatQueryServiceImpl.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/ChatQueryServiceImpl.java
@@ -98,7 +98,10 @@ public class ChatQueryServiceImpl implements ChatQueryService {
         List<ChatRoomMember> participants = findChatRoomMembersWithMemberOrThrow(roomId);
         List<ChatRoomDetailDTO.MemberInfo> memberInfos = buildMemberInfos(participants);
 
-
+        if(!recentMessages.isEmpty()){
+            ChatMessage lastMessage = recentMessages.get(recentMessages.size() - 1);
+            updateLastReadMessage(myMembership, lastMessage.getId());
+        }
 
         return null;
     }
@@ -252,6 +255,11 @@ public class ChatQueryServiceImpl implements ChatQueryService {
         String memberProfileImgUrl = getImageUrl(member.getProfileImg());
 
         return chatConverter.toChatRoomMemberInfo(member, memberProfileImgUrl);
+    }
+
+    private void updateLastReadMessage(ChatRoomMember myMembership, Long messageId) {
+        myMembership.updateLastReadMessageId(messageId);
+        chatRoomMemberRepository.save(myMembership);
     }
 
     private String getImageUrl(PartyImg partyImg) {


### PR DESCRIPTION
## ❤️ 기능 설명
초기 채팅방 조회 api를 구현했습니다.
채팅방에 들어가면 호출하는 api입니다.

채팅방이 존재하는 지, 내가 채팅방에 들어갈 권한이 있는 지 검증합니다.

그 후 채팅방 정보, 최신 메시지 50개 정보, 참여자 정보를 조회하여 반환합니다.

swagger 테스트 성공 결과 스크린샷 첨부
<img width="2123" height="1156" alt="image" src="https://github.com/user-attachments/assets/ae9a09e0-fc3d-4399-96d7-fb0dea9397cf" />
<img width="2160" height="1169" alt="image" src="https://github.com/user-attachments/assets/6ae490b0-3f76-4c05-8b8e-10435351c85c" />
<img width="2084" height="581" alt="image" src="https://github.com/user-attachments/assets/14f3ea0b-10c6-4440-a15a-0d1dfbf028d7" />

잘못된 파라미터 값
<img width="2175" height="1395" alt="image" src="https://github.com/user-attachments/assets/93275ea3-ecf8-4765-9852-5b64bab2c0ff" />

<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #279 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!
- [ ] ALTER TABLE chat_message_img DROP COLUMN img_url;
이거 한 번씩 부탁드립니다! 저희 key만 저장하기로 해서 그거 반영했습니다.

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
