### PR TITLE
[feat/#280] 과거 메시지 조회 API 구현

### DIFF
--- a/src/main/java/umc/cockple/demo/domain/chat/controller/ChatController.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/controller/ChatController.java
@@ -120,14 +120,14 @@ public class ChatController {
     @GetMapping("/chats/rooms/{roomId}/messages/previous")
     @Operation(summary = "채팅방 과거 메시지 조회", description = "채팅방의 과거 메시지를 페이징하여 조회합니다.")
     @ApiResponse(responseCode = "200", description = "조회 성공")
-    public BaseResponse<Slice<ChatMessageDTO.Response>> getChatMessages(
+    public BaseResponse<Slice<ChatMessageDTO.MessageInfo>> getChatMessages(
             @PathVariable Long roomId,
             @RequestParam Long cursor,
             @PageableDefault(size = 50, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
     ) {
         Long memberId = SecurityUtil.getCurrentMemberId();
 
-        Slice<ChatMessageDTO.Response> response
+        Slice<ChatMessageDTO.MessageInfo> response
                 = chatQueryService.getChatMessages(roomId, memberId, cursor, pageable);
 
         return BaseResponse.success(CommonSuccessCode.OK, response);

--- a/src/main/java/umc/cockple/demo/domain/chat/controller/ChatController.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/controller/ChatController.java
@@ -5,15 +5,13 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import umc.cockple.demo.domain.chat.domain.ChatMessage;
-import umc.cockple.demo.domain.chat.dto.ChatRoomDetailDTO;
-import umc.cockple.demo.domain.chat.dto.DirectChatRoomCreateDTO;
-import umc.cockple.demo.domain.chat.dto.DirectChatRoomDTO;
-import umc.cockple.demo.domain.chat.dto.PartyChatRoomDTO;
+import umc.cockple.demo.domain.chat.dto.*;
 import umc.cockple.demo.domain.chat.enums.Direction;
 import umc.cockple.demo.domain.chat.service.ChatCommandService;
 import umc.cockple.demo.domain.chat.service.ChatQueryService;
@@ -122,14 +120,14 @@ public class ChatController {
     @GetMapping("/chats/rooms/{roomId}/messages/previous")
     @Operation(summary = "채팅방 과거 메시지 조회", description = "채팅방의 과거 메시지를 페이징하여 조회합니다.")
     @ApiResponse(responseCode = "200", description = "조회 성공")
-    public BaseResponse<Slice<ChatMessageDTO.Resposne>> getChatMessages(
+    public BaseResponse<Slice<ChatMessageDTO.Response>> getChatMessages(
             @PathVariable Long roomId,
             @RequestParam Long cursor,
             @PageableDefault(size = 50, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
     ) {
         Long memberId = SecurityUtil.getCurrentMemberId();
 
-        Slice<ChatMessageDTO.Resposne> response
+        Slice<ChatMessageDTO.Response> response
                 = chatQueryService.getChatMessages(roomId, memberId, cursor, pageable);
 
         return BaseResponse.success(CommonSuccessCode.OK, response);

--- a/src/main/java/umc/cockple/demo/domain/chat/controller/ChatController.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/controller/ChatController.java
@@ -4,8 +4,12 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+import umc.cockple.demo.domain.chat.domain.ChatMessage;
 import umc.cockple.demo.domain.chat.dto.ChatRoomDetailDTO;
 import umc.cockple.demo.domain.chat.dto.DirectChatRoomCreateDTO;
 import umc.cockple.demo.domain.chat.dto.DirectChatRoomDTO;
@@ -107,10 +111,26 @@ public class ChatController {
     @ApiResponse(responseCode = "200", description = "조회 성공")
     public BaseResponse<ChatRoomDetailDTO.Response> getChatRoomDetail(
             @PathVariable Long roomId
-    ){
+    ) {
         Long memberId = SecurityUtil.getCurrentMemberId();
 
         ChatRoomDetailDTO.Response response = chatQueryService.getChatRoomDetail(roomId, memberId);
+
+        return BaseResponse.success(CommonSuccessCode.OK, response);
+    }
+
+    @GetMapping("/chats/rooms/{roomId}/messages/previous")
+    @Operation(summary = "채팅방 과거 메시지 조회", description = "채팅방의 과거 메시지를 페이징하여 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "조회 성공")
+    public BaseResponse<Slice<ChatMessageDTO.Resposne>> getChatMessages(
+            @PathVariable Long roomId,
+            @RequestParam Long cursor,
+            @PageableDefault(size = 50, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+    ) {
+        Long memberId = SecurityUtil.getCurrentMemberId();
+
+        Slice<ChatMessageDTO.Resposne> response
+                = chatQueryService.getChatMessages(roomId, memberId, cursor, pageable);
 
         return BaseResponse.success(CommonSuccessCode.OK, response);
     }

--- a/src/main/java/umc/cockple/demo/domain/chat/controller/ChatController.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/controller/ChatController.java
@@ -4,13 +4,8 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
-import org.springframework.data.domain.Sort;
-import org.springframework.data.web.PageableDefault;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
-import umc.cockple.demo.domain.chat.domain.ChatMessage;
 import umc.cockple.demo.domain.chat.dto.*;
 import umc.cockple.demo.domain.chat.enums.Direction;
 import umc.cockple.demo.domain.chat.service.ChatCommandService;
@@ -120,16 +115,13 @@ public class ChatController {
     @GetMapping("/chats/rooms/{roomId}/messages/previous")
     @Operation(summary = "채팅방 과거 메시지 조회", description = "채팅방의 과거 메시지를 페이징하여 조회합니다.")
     @ApiResponse(responseCode = "200", description = "조회 성공")
-    public BaseResponse<Slice<ChatMessageDTO.MessageInfo>> getChatMessages(
+    public BaseResponse<ChatMessageDTO.Response> getChatMessages(
             @PathVariable Long roomId,
             @RequestParam Long cursor,
-            @PageableDefault(size = 50, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+            @RequestParam(defaultValue = "50") int size
     ) {
         Long memberId = SecurityUtil.getCurrentMemberId();
-
-        Slice<ChatMessageDTO.MessageInfo> response
-                = chatQueryService.getChatMessages(roomId, memberId, cursor, pageable);
-
+        ChatMessageDTO.Response response = chatQueryService.getChatMessages(roomId, memberId, cursor, size);
         return BaseResponse.success(CommonSuccessCode.OK, response);
     }
 }

--- a/src/main/java/umc/cockple/demo/domain/chat/converter/ChatConverter.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/converter/ChatConverter.java
@@ -5,10 +5,7 @@ import org.springframework.stereotype.Component;
 import umc.cockple.demo.domain.chat.domain.ChatMessage;
 import umc.cockple.demo.domain.chat.domain.ChatRoom;
 import umc.cockple.demo.domain.chat.domain.ChatRoomMember;
-import umc.cockple.demo.domain.chat.dto.ChatRoomDetailDTO;
-import umc.cockple.demo.domain.chat.dto.DirectChatRoomCreateDTO;
-import umc.cockple.demo.domain.chat.dto.DirectChatRoomDTO;
-import umc.cockple.demo.domain.chat.dto.PartyChatRoomDTO;
+import umc.cockple.demo.domain.chat.dto.*;
 import umc.cockple.demo.domain.member.domain.Member;
 
 import java.util.List;
@@ -156,6 +153,25 @@ public class ChatConverter {
                 .chatRoomInfo(roomInfo)
                 .messages(messageInfos)
                 .participants(memberInfos)
+                .build();
+    }
+
+    public ChatMessageDTO.MessageInfo toPreviousMessageInfo(
+            ChatMessage message,
+            Member sender,
+            String senderProfileImageUrl,
+            List<String> imageUrls,
+            boolean isMyMessage) {
+        return ChatMessageDTO.MessageInfo.builder()
+                .messageId(message.getId())
+                .senderId(sender.getId())
+                .senderName(sender.getMemberName())
+                .senderProfileImageUrl(senderProfileImageUrl)
+                .content(message.getContent())
+                .messageType(message.getType())
+                .imageUrls(imageUrls)
+                .timestamp(message.getCreatedAt())
+                .isMyMessage(isMyMessage)
                 .build();
     }
 }

--- a/src/main/java/umc/cockple/demo/domain/chat/converter/ChatConverter.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/converter/ChatConverter.java
@@ -174,4 +174,13 @@ public class ChatConverter {
                 .isMyMessage(isMyMessage)
                 .build();
     }
+
+    public ChatMessageDTO.Response toChatMessageResponse(
+            List<ChatMessageDTO.MessageInfo> messages, boolean hasNext, Long nextCursor) {
+        return ChatMessageDTO.Response.builder()
+                .messages(messages)
+                .hasNext(hasNext)
+                .nextCursor(nextCursor)
+                .build();
+    }
 }

--- a/src/main/java/umc/cockple/demo/domain/chat/dto/ChatMessageDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/dto/ChatMessageDTO.java
@@ -9,12 +9,6 @@ import java.util.List;
 public class ChatMessageDTO {
 
     @Builder
-    public record Response(
-            List<MessageInfo> messages
-    ) {
-    }
-
-    @Builder
     public record MessageInfo(
             Long messageId,
             Long senderId,

--- a/src/main/java/umc/cockple/demo/domain/chat/dto/ChatMessageDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/dto/ChatMessageDTO.java
@@ -9,6 +9,15 @@ import java.util.List;
 public class ChatMessageDTO {
 
     @Builder
+    public record Response(
+            List<MessageInfo> messages,
+            Boolean hasNext,
+            Long nextCursor,
+            int totalElements
+    ) {
+    }
+
+    @Builder
     public record MessageInfo(
             Long messageId,
             Long senderId,

--- a/src/main/java/umc/cockple/demo/domain/chat/dto/ChatMessageDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/dto/ChatMessageDTO.java
@@ -1,0 +1,30 @@
+package umc.cockple.demo.domain.chat.dto;
+
+import lombok.Builder;
+import umc.cockple.demo.domain.chat.enums.MessageType;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class ChatMessageDTO {
+
+    @Builder
+    public record Response(
+            List<MessageInfo> messages
+    ) {
+    }
+
+    @Builder
+    public record MessageInfo(
+            Long messageId,
+            Long senderId,
+            String senderName,
+            String senderProfileImageUrl,
+            String content,
+            MessageType messageType,
+            List<String> imageUrls,
+            LocalDateTime timestamp,
+            boolean isMyMessage
+    ) {
+    }
+}

--- a/src/main/java/umc/cockple/demo/domain/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/repository/ChatMessageRepository.java
@@ -1,6 +1,7 @@
 package umc.cockple.demo.domain.chat.repository;
 
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -33,5 +34,18 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> 
             """)
     List<ChatMessage> findRecentMessagesWithImages(
             @Param("chatRoomId") Long chatRoomId,
+            Pageable pageable);
+
+    @Query("""
+            SELECT m FROM ChatMessage m
+            JOIN FETCH m.sender
+            LEFT JOIN FETCH m.chatMessageImgs
+            WHERE m.chatRoom.id = :chatRoomId
+            AND m.id < :cursor
+            ORDER BY m.createdAt DESC
+            """)
+    Slice<ChatMessage> findByRoomIdAndIdLessThanOrderByCreatedAtDesc(
+            @Param("chatRoomId") Long chatRoomId,
+            @Param("cursor") Long cursor,
             Pageable pageable);
 }

--- a/src/main/java/umc/cockple/demo/domain/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/repository/ChatMessageRepository.java
@@ -1,7 +1,6 @@
 package umc.cockple.demo.domain.chat.repository;
 
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -43,10 +42,9 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> 
             WHERE m.chatRoom.id = :chatRoomId
             AND m.id < :cursor
             ORDER BY m.createdAt DESC
-            LIMIT :size
             """)
     List<ChatMessage> findByRoomIdAndIdLessThanOrderByCreatedAtDesc(
             @Param("chatRoomId") Long chatRoomId,
             @Param("cursor") Long cursor,
-            @Param("size") int size);
+            Pageable pageable);
 }

--- a/src/main/java/umc/cockple/demo/domain/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/repository/ChatMessageRepository.java
@@ -43,9 +43,10 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> 
             WHERE m.chatRoom.id = :chatRoomId
             AND m.id < :cursor
             ORDER BY m.createdAt DESC
+            LIMIT :size
             """)
-    Slice<ChatMessage> findByRoomIdAndIdLessThanOrderByCreatedAtDesc(
+    List<ChatMessage> findByRoomIdAndIdLessThanOrderByCreatedAtDesc(
             @Param("chatRoomId") Long chatRoomId,
             @Param("cursor") Long cursor,
-            Pageable pageable);
+            @Param("size") int size);
 }

--- a/src/main/java/umc/cockple/demo/domain/chat/repository/ChatRoomMemberRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/repository/ChatRoomMemberRepository.java
@@ -47,5 +47,7 @@ public interface ChatRoomMemberRepository extends JpaRepository<ChatRoomMember, 
             ORDER BY m.memberName ASC
             """)
     List<ChatRoomMember> findChatRoomMembersWithMemberById(@Param("chatRoomId") Long chatRoomId);
+
+    Boolean existsByChatRoomIdAndMemberId(Long roomId, Long memberId);
 }
 

--- a/src/main/java/umc/cockple/demo/domain/chat/service/ChatCommandServiceImpl.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/ChatCommandServiceImpl.java
@@ -1,9 +1,9 @@
 package umc.cockple.demo.domain.chat.service;
 
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import umc.cockple.demo.domain.chat.converter.ChatConverter;
 import umc.cockple.demo.domain.chat.domain.ChatRoom;
 import umc.cockple.demo.domain.chat.domain.ChatRoomMember;

--- a/src/main/java/umc/cockple/demo/domain/chat/service/ChatQueryService.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/ChatQueryService.java
@@ -1,5 +1,8 @@
 package umc.cockple.demo.domain.chat.service;
 
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import umc.cockple.demo.domain.chat.dto.ChatMessageDTO;
 import umc.cockple.demo.domain.chat.dto.ChatRoomDetailDTO;
 import umc.cockple.demo.domain.chat.dto.DirectChatRoomDTO;
 import umc.cockple.demo.domain.chat.dto.PartyChatRoomDTO;
@@ -15,4 +18,6 @@ public interface ChatQueryService {
     DirectChatRoomDTO.Response searchDirectChatRoomsByName(Long memberId, String name, Long cursor, int size, Direction direction);
 
     ChatRoomDetailDTO.Response getChatRoomDetail(Long roomId, Long memberId);
+
+    Slice<ChatMessageDTO.MessageInfo> getChatMessages(Long roomId, Long memberId, Long cursor, Pageable pageable);
 }

--- a/src/main/java/umc/cockple/demo/domain/chat/service/ChatQueryService.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/ChatQueryService.java
@@ -1,7 +1,5 @@
 package umc.cockple.demo.domain.chat.service;
 
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
 import umc.cockple.demo.domain.chat.dto.ChatMessageDTO;
 import umc.cockple.demo.domain.chat.dto.ChatRoomDetailDTO;
 import umc.cockple.demo.domain.chat.dto.DirectChatRoomDTO;
@@ -19,5 +17,5 @@ public interface ChatQueryService {
 
     ChatRoomDetailDTO.Response getChatRoomDetail(Long roomId, Long memberId);
 
-    Slice<ChatMessageDTO.MessageInfo> getChatMessages(Long roomId, Long memberId, Long cursor, Pageable pageable);
+    ChatMessageDTO.Response getChatMessages(Long roomId, Long memberId, Long cursor, int size);
 }

--- a/src/main/java/umc/cockple/demo/domain/chat/service/ChatQueryServiceImpl.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/ChatQueryServiceImpl.java
@@ -115,7 +115,8 @@ public class ChatQueryServiceImpl implements ChatQueryService {
 
         validateChatRoomAccess(roomId, memberId);
 
-        List<ChatMessage> messages = findMessagesWithCursor(roomId, cursor, size + 1);
+        Pageable pageable = PageRequest.of(0, size+1);
+        List<ChatMessage> messages = findMessagesWithCursor(roomId, cursor, pageable);
 
         boolean hasNext = messages.size() > size;
         if (hasNext) {
@@ -371,7 +372,7 @@ public class ChatQueryServiceImpl implements ChatQueryService {
         return chatMessageRepository.findRecentMessagesWithImages(roomId, pageable);
     }
 
-    private List<ChatMessage> findMessagesWithCursor(Long roomId, Long cursor, int size) {
-        return chatMessageRepository.findByRoomIdAndIdLessThanOrderByCreatedAtDesc(roomId, cursor, size);
+    private List<ChatMessage> findMessagesWithCursor(Long roomId, Long cursor, Pageable pageable) {
+        return chatMessageRepository.findByRoomIdAndIdLessThanOrderByCreatedAtDesc(roomId, cursor, pageable);
     }
 }

--- a/src/main/java/umc/cockple/demo/domain/chat/service/ChatQueryServiceImpl.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/ChatQueryServiceImpl.java
@@ -123,6 +123,8 @@ public class ChatQueryServiceImpl implements ChatQueryService {
         }
 
         Collections.reverse(messages);
+
+        List<ChatMessageDTO.MessageInfo> messageInfos = buildPreviousMessageInfos(memberId, messages);
     }
 
     // ========== 검증 로직 ==========
@@ -247,7 +249,13 @@ public class ChatQueryServiceImpl implements ChatQueryService {
     private List<ChatRoomDetailDTO.MessageInfo> buildMessageInfos(Long memberId, List<ChatMessage> recentMessages) {
         return recentMessages.stream()
                 .map(message -> buildMessageInfo(message, memberId))
-                .collect(Collectors.toList());
+                .toList();
+    }
+
+    private List<ChatMessageDTO.MessageInfo> buildPreviousMessageInfos(Long memberId, List<ChatMessage> recentMessages) {
+        return recentMessages.stream()
+                .map(message -> buildPreviousMessageInfo(message, memberId))
+                .toList();
     }
 
     private ChatRoomDetailDTO.MessageInfo buildMessageInfo(ChatMessage message, Long currentUserId) {
@@ -263,6 +271,26 @@ public class ChatQueryServiceImpl implements ChatQueryService {
         boolean isMyMessage = sender.getId().equals(currentUserId);
 
         return chatConverter.toChatRoomDetailMessageInfo(
+                message,
+                sender,
+                senderProfileImageUrl,
+                imageUrls,
+                isMyMessage);
+    }
+
+    private ChatMessageDTO.MessageInfo buildPreviousMessageInfo(ChatMessage message, Long currentUserId) {
+        Member sender = message.getSender();
+
+        String senderProfileImageUrl = getImageUrl(sender.getProfileImg());
+
+        List<String> imageUrls = message.getChatMessageImgs().stream()
+                .sorted(Comparator.comparing(ChatMessageImg::getImgOrder))
+                .map(this::getImageUrl)
+                .toList();
+
+        boolean isMyMessage = sender.getId().equals(currentUserId);
+
+        return chatConverter.toPreviousMessageInfo(
                 message,
                 sender,
                 senderProfileImageUrl,

--- a/src/main/java/umc/cockple/demo/domain/chat/service/ChatQueryServiceImpl.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/ChatQueryServiceImpl.java
@@ -125,6 +125,11 @@ public class ChatQueryServiceImpl implements ChatQueryService {
         Collections.reverse(messages);
 
         List<ChatMessageDTO.MessageInfo> messageInfos = buildPreviousMessageInfos(memberId, messages);
+
+        Long nextCursor = hasNext && !messages.isEmpty()
+                ? messages.get(0).getId() : null;
+
+        log.info("[채팅방 과거 메시지 조회 완료] - 메시지 수: {}, hasNext: {}", messages.size(), hasNext);
     }
 
     // ========== 검증 로직 ==========

--- a/src/main/java/umc/cockple/demo/domain/chat/service/ChatQueryServiceImpl.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/ChatQueryServiceImpl.java
@@ -1,12 +1,12 @@
 package umc.cockple.demo.domain.chat.service;
 
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import umc.cockple.demo.domain.chat.converter.ChatConverter;
 import umc.cockple.demo.domain.chat.domain.ChatMessage;
 import umc.cockple.demo.domain.chat.domain.ChatMessageImg;
@@ -36,7 +36,7 @@ import java.util.stream.Collectors;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-@Transactional
+@Transactional(readOnly = true)
 public class ChatQueryServiceImpl implements ChatQueryService {
 
     private final ChatRoomRepository chatRoomRepository;

--- a/src/main/java/umc/cockple/demo/domain/chat/service/ChatQueryServiceImpl.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/ChatQueryServiceImpl.java
@@ -116,6 +116,11 @@ public class ChatQueryServiceImpl implements ChatQueryService {
         validateChatRoomAccess(roomId, memberId);
 
         List<ChatMessage> messages = findMessagesWithCursor(roomId, cursor, size + 1);
+
+        boolean hasNext = messages.size() > size;
+        if (hasNext) {
+            messages = messages.subList(0, size);
+        }
     }
 
     // ========== 검증 로직 ==========

--- a/src/main/java/umc/cockple/demo/domain/chat/service/ChatQueryServiceImpl.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/ChatQueryServiceImpl.java
@@ -121,6 +121,8 @@ public class ChatQueryServiceImpl implements ChatQueryService {
         if (hasNext) {
             messages = messages.subList(0, size);
         }
+
+        Collections.reverse(messages);
     }
 
     // ========== 검증 로직 ==========

--- a/src/main/java/umc/cockple/demo/domain/chat/service/ChatQueryServiceImpl.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/ChatQueryServiceImpl.java
@@ -115,6 +115,8 @@ public class ChatQueryServiceImpl implements ChatQueryService {
                 roomId, memberId, cursor, pageable.getPageSize());
 
         validateChatRoomAccess(roomId, memberId);
+
+        Slice<ChatMessage> messageSlice = findMessagesWithCursor(roomId, cursor, pageable);
     }
 
     // ========== 검증 로직 ==========
@@ -326,5 +328,9 @@ public class ChatQueryServiceImpl implements ChatQueryService {
 
     private List<ChatMessage> findRecentMessagesWithImages(Long roomId, Pageable pageable) {
         return chatMessageRepository.findRecentMessagesWithImages(roomId, pageable);
+    }
+
+    private Slice<ChatMessage> findMessagesWithCursor(Long roomId, Long cursor, Pageable pageable) {
+        return chatMessageRepository.findByRoomIdAndIdLessThanOrderByCreatedAtDesc(roomId, cursor, pageable);
     }
 }

--- a/src/main/java/umc/cockple/demo/domain/chat/service/ChatQueryServiceImpl.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/ChatQueryServiceImpl.java
@@ -130,6 +130,8 @@ public class ChatQueryServiceImpl implements ChatQueryService {
                 ? messages.get(0).getId() : null;
 
         log.info("[채팅방 과거 메시지 조회 완료] - 메시지 수: {}, hasNext: {}", messages.size(), hasNext);
+
+        return chatConverter.toChatMessageResponse(messageInfos, hasNext, nextCursor);
     }
 
     // ========== 검증 로직 ==========


### PR DESCRIPTION
## ❤️ 기능 설명
과거 메시지 조회 API를 구현합니다.

초기 데이터를 조회하는 API는 따로 있으므로 커서 값이 null인 경우는 고려하지 않습니다.
가장 마지막으로 읽은 메시지의 id값을 커서로 지정하여 그 값보다 작은(즉, 옛날) 메시지들을 size만큼 가져옵니다.

swagger 테스트 성공 결과 스크린샷 첨부
<img width="2162" height="1183" alt="image" src="https://github.com/user-attachments/assets/10687d59-e257-4602-b8e1-98564b1fc32a" />

<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #280 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!
- [ ] 초기 채팅방 조회 시 채팅방 정보 + 참여자 정보도 보여줘야 하기에 이건 메시지만 조회하도록 2개의 api를 분리했습니다.
- [ ] 불러오는 데이터가 변하지 않는다면 1개의 API로 구현했을 거 같습니다!

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
