### PR TITLE
[debug/#289] 전송 이미지 크기 설정

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -30,6 +30,11 @@ spring:
         use_sql_comments: true
         default_batch_fetch_size: 1000
 
+  servlet:
+    multipart:
+      max-file-size: 20MB
+      max-request-size: 20MB
+
 cloud:
   aws:
     s3:


### PR DESCRIPTION
## ❤️ 기능 설명
카카오톡으로 받은 모임 기본이미지로 이미지 업로드 api 실행 중 413 에러 발생 
<img width="1621" height="953" alt="스크린샷 2025-08-07 155129" src="https://github.com/user-attachments/assets/d023b5f4-aeae-4945-ab3c-9e2cf1c62fc8" />

스프링 서버, 배포 서버의 nginx에 body 크기를 크게 지정해서 디버깅

결과
<img width="1464" height="1159" alt="image" src="https://github.com/user-attachments/assets/5f3e4136-4817-4540-97f4-bd800598f319" />

근데 nginx에서도 괜찮은지는 배포서버로 실행해야해서 merge 후 알 수 있을 거 같습니다 ㅜㅜ

<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #289 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 설정파일만 변경했으니 부담 없이 확인 부탁드립니다 !
<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [ ] 이슈넘버를 적었는가?
