### PR TITLE
[fix/#294] 초대 알림 추가시 invitationId 넘겨주기

### DIFF
--- a/src/main/java/umc/cockple/demo/domain/notification/dto/CreateNotificationRequestDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/notification/dto/CreateNotificationRequestDTO.java
@@ -25,6 +25,7 @@ public record CreateNotificationRequestDTO(
         Long partyId,
         Long exerciseId, // 운동 관련이 아니면 필요 X
         LocalDate exerciseDate, // 운동 관련이 아니면 필요 X
+        Long invitationId, // INVITE 외 타입에서는 필요 X
         NotificationTarget target
 ) {
 }

--- a/src/main/java/umc/cockple/demo/domain/notification/service/NotificationCommandService.java
+++ b/src/main/java/umc/cockple/demo/domain/notification/service/NotificationCommandService.java
@@ -73,8 +73,9 @@ public class NotificationCommandService {
                     .orElseThrow(() -> new PartyException(PartyErrorCode.PARTY_NOT_FOUND));
 
             Map<String, Object> context = new HashMap<>();
-            context.put("exerciseId", dto.exerciseId());
-            context.put("exerciseDate", dto.exerciseDate());
+            if (dto.exerciseId() != null) context.put("exerciseId", dto.exerciseId());
+            if (dto.exerciseDate() != null) context.put("exerciseDate", dto.exerciseDate());
+            if (dto.invitationId() != null) context.put("invitationId", dto.invitationId());
 
             String content;
             String title = party.getPartyName();

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -32,8 +32,8 @@ spring:
 
   servlet:
     multipart:
-      max-file-size: 20MB
-      max-request-size: 20MB
+      max-file-size: 30MB
+      max-request-size: 30MB
 
 cloud:
   aws:


### PR DESCRIPTION
## ❤️ 기능 설명
프론트에서 초대 알림 추가시 invitationId를 요청해주셔서 data 필드 수정

swagger 테스트 성공 결과 스크린샷 첨부
<img width="1572" height="53" alt="스크린샷 2025-08-07 210244" src="https://github.com/user-attachments/assets/9347883b-6acd-44c2-ba10-c6c34481129c" />


<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #294 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [ ] 이슈넘버를 적었는가?
