### PR TITLE
[feat/#265] 채팅방 구독 로직 구현

### DIFF
--- a/src/main/java/umc/cockple/demo/domain/chat/handler/ChatWebSocketHandler.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/handler/ChatWebSocketHandler.java
@@ -76,6 +76,9 @@ public class ChatWebSocketHandler extends TextWebSocketHandler {
                 case SEND:
                     handleSendMessage(session, request, memberId);
                     break;
+                case SUBSCRIBE:
+                    handleSubscribe(session, request, memberId);
+                    break;
                 default:
                     sendErrorMessage(session, "UNKNOWN_TYPE", "알 수 없는 메시지 타입입니다:" + request.type());
             }
@@ -184,6 +187,18 @@ public class ChatWebSocketHandler extends TextWebSocketHandler {
             sendErrorMessage(session, e.getCode().toString(), e.getMessage());
         } catch (Exception e) {
             log.error("메시지 전송 중 예상치 못한 오류 발생", e);
+            sendErrorMessage(session, "INTERNAL_ERROR", "예상치 못한 에러가 발생했습니다.");
+        }
+    }
+
+    private void handleSubscribe(WebSocketSession session, WebSocketMessageDTO.Request request, Long memberId) {
+        log.info("채팅방 구독 처리 시작");
+        log.info("채팅방 ID: {}, 사용자 ID: {}", request.chatRoomId(), memberId);
+
+        try {
+
+        } catch (Exception e) {
+            log.error("채팅방 구독 중 예상치 못한 오류 발생", e);
             sendErrorMessage(session, "INTERNAL_ERROR", "예상치 못한 에러가 발생했습니다.");
         }
     }

--- a/src/main/java/umc/cockple/demo/domain/chat/handler/ChatWebSocketHandler.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/handler/ChatWebSocketHandler.java
@@ -206,6 +206,12 @@ public class ChatWebSocketHandler extends TextWebSocketHandler {
                 return;
             }
 
+            chatRoomSessions.computeIfAbsent(chatRoomId, k -> new ConcurrentHashMap<>())
+                    .put(memberId, session);
+
+            log.info("채팅방 구독 완료 - 채팅방: {}, 사용자: {}", chatRoomId, memberId);
+
+            sendSubscribeSuccessMessage(session, chatRoomId, memberId);
         } catch (Exception e) {
             log.error("채팅방 구독 중 예상치 못한 오류 발생", e);
             sendErrorMessage(session, "INTERNAL_ERROR", "예상치 못한 에러가 발생했습니다.");

--- a/src/main/java/umc/cockple/demo/domain/chat/handler/asd.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/handler/asd.java
@@ -1,0 +1,4 @@
+package umc.cockple.demo.domain.chat.handler;
+
+public class asd {
+}

--- a/src/main/java/umc/cockple/demo/domain/chat/handler/asd.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/handler/asd.java
@@ -1,4 +1,0 @@
-package umc.cockple.demo.domain.chat.handler;
-
-public class asd {
-}

--- a/src/main/java/umc/cockple/demo/domain/chat/repository/ChatRoomMemberRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/repository/ChatRoomMemberRepository.java
@@ -30,8 +30,6 @@ public interface ChatRoomMemberRepository extends JpaRepository<ChatRoomMember, 
 
     List<ChatRoomMember> findAllByMemberId(Long id);
 
-    boolean existsByChatRoomAndMember(ChatRoom chatRoom, Member member);
-
     @Query("""
             SELECT crm FROM ChatRoomMember crm
             JOIN FETCH crm.member m

--- a/src/main/java/umc/cockple/demo/domain/chat/service/ChatWebSocketService.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/ChatWebSocketService.java
@@ -54,10 +54,12 @@ public class ChatWebSocketService {
         return chatConverter.toSendMessageResponse(chatRoomId, content, savedMessage, sender, profileImageUrl);
     }
 
+    public void validateSubscribe(Long chatRoomId, Long memberId) {
+        validateChatRoom(chatRoomId);
+    }
+
     private void validateInput(Long chatRoomId, String content) {
-        if (chatRoomId == null) {
-            throw new ChatException(ChatErrorCode.CHATROOM_ID_NECESSARY);
-        }
+        validateChatRoom(chatRoomId);
 
         if (content == null || content.trim().isEmpty()) {
             throw new ChatException(ChatErrorCode.CONTENT_NECESSARY);
@@ -65,6 +67,12 @@ public class ChatWebSocketService {
 
         if (content.length() > 1000) {
             throw new ChatException(ChatErrorCode.MESSAGE_TO_LONG);
+        }
+    }
+
+    private void validateChatRoom(Long chatRoomId){
+        if (chatRoomId == null) {
+            throw new ChatException(ChatErrorCode.CHATROOM_ID_NECESSARY);
         }
     }
 


### PR DESCRIPTION
## ❤️ 기능 설명
채팅방 구독을 할 수 있는 지 기초 검증(채팅방이 존재하는지, 채팅방의 멤버 중 한명인지)을 하고,
채팅방 세션에 멤버 세션을 넣어 구독을 처리합니다.

<img width="680" height="61" alt="image" src="https://github.com/user-attachments/assets/7964a481-707e-4aa4-a563-daf593000060" />
<br>
사실 이게 구독의 다입니다!

swagger 테스트 성공 결과 스크린샷 첨부
<img width="613" height="339" alt="image" src="https://github.com/user-attachments/assets/d7ce2074-7c25-469e-8683-22eacfb07242" />

구독 성공 테스트
<img width="1239" height="385" alt="image" src="https://github.com/user-attachments/assets/6ba8a5b1-83ba-4f2b-be2e-e37825101a8f" />

구독 실패 테스트
<img width="1367" height="398" alt="image" src="https://github.com/user-attachments/assets/e192dc44-4f17-4e26-b228-2f94cb700764" />

구독 성공 후 메시지 수신까지 테스트
<img width="1343" height="351" alt="image" src="https://github.com/user-attachments/assets/284f75dd-8e43-4bb1-a613-bd79b6ba810b" />

<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #265 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 구독중인 채팅방에 다시 구독을 시도해도 정상 flow로 실행되도록 했습니다!

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
