### PR TITLE
[feat/#287] 다운로드 토큰 발급 구현

### DIFF
--- a/src/main/java/umc/cockple/demo/domain/chat/controller/ChatController.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/controller/ChatController.java
@@ -112,4 +112,17 @@ public class ChatController {
         ChatMessageDTO.Response response = chatQueryService.getChatMessages(roomId, memberId, cursor, size);
         return BaseResponse.success(CommonSuccessCode.OK, response);
     }
+
+    @PostMapping("/chats/files/{fileId}/download-token")
+    @Operation(summary = "채팅 파일 다운로드 토큰 발급", description = "채팅방에 업로드된 특정 파일을 다운로드할 수 있는 일회용 토큰을 발급합니다.")
+    @ApiResponse(responseCode = "200", description = "토큰 발급 성공")
+    @ApiResponse(responseCode = "403", description = "파일 접근 권한 없음")
+    @ApiResponse(responseCode = "404", description = "존재하지 않는 파일")
+    public BaseResponse<ChatDownloadTokenDTO.Response> issueDownloadToken(
+            @PathVariable Long fileId
+    ) {
+        Long memberId = SecurityUtil.getCurrentMemberId();
+        ChatDownloadTokenDTO.Response response = chatCommandService.issueDownloadToken(memberId, fileId);
+        return BaseResponse.success(CommonSuccessCode.OK, response);
+    }
 }

--- a/src/main/java/umc/cockple/demo/domain/chat/controller/ChatController.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/controller/ChatController.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.*;
 import umc.cockple.demo.domain.chat.dto.*;
 import umc.cockple.demo.domain.chat.enums.Direction;
 import umc.cockple.demo.domain.chat.service.ChatCommandService;
+import umc.cockple.demo.domain.chat.service.ChatFileService;
 import umc.cockple.demo.domain.chat.service.ChatQueryService;
 import umc.cockple.demo.global.response.BaseResponse;
 import umc.cockple.demo.global.response.code.status.CommonSuccessCode;
@@ -23,6 +24,7 @@ public class ChatController {
 
     private final ChatQueryService chatQueryService;
     private final ChatCommandService chatCommandService;
+    private final ChatFileService chatFileService;
 
     @PostMapping(value = "/chats/direct")
     @Operation(summary = "개인 채팅방 생성 및 참여", description = "개인 채팅방을 생성하고 상대방과 함께 참여합니다.")
@@ -122,7 +124,7 @@ public class ChatController {
             @PathVariable Long fileId
     ) {
         Long memberId = SecurityUtil.getCurrentMemberId();
-        ChatDownloadTokenDTO.Response response = chatCommandService.issueDownloadToken(memberId, fileId);
+        ChatDownloadTokenDTO.Response response = chatFileService.issueDownloadToken(memberId, fileId);
         return BaseResponse.success(CommonSuccessCode.OK, response);
     }
 }

--- a/src/main/java/umc/cockple/demo/domain/chat/converter/ChatConverter.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/converter/ChatConverter.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Component;
 import umc.cockple.demo.domain.chat.domain.ChatMessage;
 import umc.cockple.demo.domain.chat.domain.ChatRoom;
 import umc.cockple.demo.domain.chat.domain.ChatRoomMember;
+import umc.cockple.demo.domain.chat.domain.DownloadToken;
 import umc.cockple.demo.domain.chat.enums.WebSocketMessageType;
 import umc.cockple.demo.domain.member.domain.Member;
 import umc.cockple.demo.domain.chat.dto.*;
@@ -211,6 +212,16 @@ public class ChatConverter {
                 .messages(messages)
                 .hasNext(hasNext)
                 .nextCursor(nextCursor)
+                .build();
+    }
+
+    public ChatDownloadTokenDTO.Response toDownloadTokenResponse(DownloadToken token, int validityInSeconds) {
+        String downloadUrl = String.format("/api/chats/files/{fileId}/download?token=%s", token.getFileId(), token.getToken());
+        return ChatDownloadTokenDTO.Response.builder()
+                .downloadToken(token.getToken())
+                .downloadUrl(downloadUrl)
+                .expiresIn(validityInSeconds)
+                .expiresAt(token.getExpiresAt())
                 .build();
     }
 }

--- a/src/main/java/umc/cockple/demo/domain/chat/domain/ChatMessage.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/domain/ChatMessage.java
@@ -41,6 +41,9 @@ public class ChatMessage extends BaseEntity {
     @OneToMany(mappedBy = "chatMessage", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ChatMessageImg> chatMessageImgs = new ArrayList<>();
 
+    @OneToMany(mappedBy = "chatMessage", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ChatMessageFile> chatMessageFiles = new ArrayList<>();
+
     public static ChatMessage create(ChatRoom chatRoom, Member sender, String content, MessageType type) {
         return ChatMessage.builder()
                 .chatRoom(chatRoom)

--- a/src/main/java/umc/cockple/demo/domain/chat/domain/ChatMessageFile.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/domain/ChatMessageFile.java
@@ -1,0 +1,41 @@
+package umc.cockple.demo.domain.chat.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import umc.cockple.demo.global.common.BaseEntity;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class ChatMessageFile extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "chat_message_id")
+    private ChatMessage chatMessage;
+
+    @Column(nullable = false)
+    private String fileKey;
+
+    @Column(nullable = false)
+    private String originalFileName;
+
+    private Long fileSize;
+
+    private String fileType;
+
+    public static ChatMessageFile create(ChatMessage message, String originalFileName, String fileKey, Long fileSize, String fileType) {
+        return ChatMessageFile.builder()
+                .chatMessage(message)
+                .fileKey(fileKey)
+                .originalFileName(originalFileName)
+                .fileSize(fileSize)
+                .fileType(fileType)
+                .build();
+    }
+}

--- a/src/main/java/umc/cockple/demo/domain/chat/domain/DownloadToken.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/domain/DownloadToken.java
@@ -1,0 +1,32 @@
+package umc.cockple.demo.domain.chat.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import umc.cockple.demo.global.common.BaseEntity;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class DownloadToken extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String token;
+
+    @Column(nullable = false)
+    private Long fileId;
+
+    @Column(nullable = false)
+    private Long memberId;
+
+    @Column(nullable = false)
+    private LocalDateTime expiresAt;
+}

--- a/src/main/java/umc/cockple/demo/domain/chat/domain/DownloadToken.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/domain/DownloadToken.java
@@ -29,4 +29,13 @@ public class DownloadToken extends BaseEntity {
 
     @Column(nullable = false)
     private LocalDateTime expiresAt;
+
+    public static DownloadToken create(Long fileId, Long memberId, int validityInSeconds) {
+        return DownloadToken.builder()
+                .token("downloadToken_" + UUID.randomUUID().toString()) //랜덤 토큰 생성
+                .fileId(fileId)
+                .memberId(memberId)
+                .expiresAt(LocalDateTime.now().plusSeconds(validityInSeconds))
+                .build();
+    }
 }

--- a/src/main/java/umc/cockple/demo/domain/chat/dto/ChatDownloadTokenDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/dto/ChatDownloadTokenDTO.java
@@ -9,7 +9,7 @@ public class ChatDownloadTokenDTO {
     public record Response(
             String downloadToken,
             String downloadUrl,
-            Long expiresIn,
+            int expiresIn,
             LocalDateTime expiresAt
     ) {}
 }

--- a/src/main/java/umc/cockple/demo/domain/chat/dto/ChatDownloadTokenDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/dto/ChatDownloadTokenDTO.java
@@ -1,0 +1,15 @@
+package umc.cockple.demo.domain.chat.dto;
+
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+public class ChatDownloadTokenDTO {
+    @Builder
+    public record Response(
+            String downloadToken,
+            String downloadUrl,
+            Long expiresIn,
+            LocalDateTime expiresAt
+    ) {}
+}

--- a/src/main/java/umc/cockple/demo/domain/chat/exception/ChatErrorCode.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/exception/ChatErrorCode.java
@@ -20,9 +20,10 @@ public enum ChatErrorCode implements BaseErrorCode {
     CHAT_ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "CHAT201", "채팅방을 찾을 수 없습니다."),
     CHAT_ROOM_MEMBER_NOT_FOUND(HttpStatus.BAD_REQUEST, "CHAT202", "채팅방 멤버가 존재하지 않습니다."),
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "CHAT203", "사용자를 찾을 수 없습니다."),
+    FILE_NOT_FOUND(HttpStatus.NOT_FOUND, "CHAT204", "존재하지 않는 파일입니다."),
 
     // 3xx: 인증/인가 문제
-    PARTY_MEMBER_NOT_FOUND(HttpStatus.BAD_REQUEST, "CHAT302", "모임에 참여한 회원이 아닙니다.");
+    PARTY_MEMBER_NOT_FOUND(HttpStatus.BAD_REQUEST, "CHAT301", "모임에 참여한 회원이 아닙니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/umc/cockple/demo/domain/chat/repository/ChatFileRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/repository/ChatFileRepository.java
@@ -1,0 +1,4 @@
+package umc.cockple.demo.domain.chat.repository;
+
+public interface ChatFileRepository {
+}

--- a/src/main/java/umc/cockple/demo/domain/chat/repository/ChatFileRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/repository/ChatFileRepository.java
@@ -1,4 +1,7 @@
 package umc.cockple.demo.domain.chat.repository;
 
-public interface ChatFileRepository {
+import org.springframework.data.jpa.repository.JpaRepository;
+import umc.cockple.demo.domain.chat.domain.ChatMessageFile;
+
+public interface ChatFileRepository extends JpaRepository<ChatMessageFile, Long> {
 }

--- a/src/main/java/umc/cockple/demo/domain/chat/repository/DownloadTokenRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/repository/DownloadTokenRepository.java
@@ -1,4 +1,7 @@
 package umc.cockple.demo.domain.chat.repository;
 
-public interface DownloadTokenRepository {
+import org.springframework.data.jpa.repository.JpaRepository;
+import umc.cockple.demo.domain.chat.domain.DownloadToken;
+
+public interface DownloadTokenRepository extends JpaRepository<DownloadToken, Long> {
 }

--- a/src/main/java/umc/cockple/demo/domain/chat/repository/DownloadTokenRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/repository/DownloadTokenRepository.java
@@ -1,0 +1,4 @@
+package umc.cockple.demo.domain.chat.repository;
+
+public interface DownloadTokenRepository {
+}

--- a/src/main/java/umc/cockple/demo/domain/chat/service/ChatCommandService.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/ChatCommandService.java
@@ -1,8 +1,10 @@
 package umc.cockple.demo.domain.chat.service;
 
+import umc.cockple.demo.domain.chat.dto.ChatDownloadTokenDTO;
 import umc.cockple.demo.domain.chat.dto.DirectChatRoomCreateDTO;
 
 public interface ChatCommandService {
 
     DirectChatRoomCreateDTO.Response createDirectChatRoom(Long memberId, Long targetMemberId);
+    ChatDownloadTokenDTO.Response issueDownloadToken(Long memberId, Long fileId);
 }

--- a/src/main/java/umc/cockple/demo/domain/chat/service/ChatCommandService.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/ChatCommandService.java
@@ -1,10 +1,8 @@
 package umc.cockple.demo.domain.chat.service;
 
-import umc.cockple.demo.domain.chat.dto.ChatDownloadTokenDTO;
 import umc.cockple.demo.domain.chat.dto.DirectChatRoomCreateDTO;
 
 public interface ChatCommandService {
 
     DirectChatRoomCreateDTO.Response createDirectChatRoom(Long memberId, Long targetMemberId);
-    ChatDownloadTokenDTO.Response issueDownloadToken(Long memberId, Long fileId);
 }

--- a/src/main/java/umc/cockple/demo/domain/chat/service/ChatFileService.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/ChatFileService.java
@@ -1,0 +1,7 @@
+package umc.cockple.demo.domain.chat.service;
+
+import umc.cockple.demo.domain.chat.dto.ChatDownloadTokenDTO;
+
+public interface ChatFileService {
+    ChatDownloadTokenDTO.Response issueDownloadToken(Long fileId, Long memberId);
+}

--- a/src/main/java/umc/cockple/demo/domain/chat/service/ChatFileServiceImpl.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/ChatFileServiceImpl.java
@@ -1,4 +1,58 @@
 package umc.cockple.demo.domain.chat.service;
 
-public class ChatFileServiceImpl {
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import umc.cockple.demo.domain.chat.converter.ChatConverter;
+import umc.cockple.demo.domain.chat.domain.ChatMessageFile;
+import umc.cockple.demo.domain.chat.domain.DownloadToken;
+import umc.cockple.demo.domain.chat.dto.ChatDownloadTokenDTO;
+import umc.cockple.demo.domain.chat.exception.ChatErrorCode;
+import umc.cockple.demo.domain.chat.exception.ChatException;
+import umc.cockple.demo.domain.chat.repository.ChatFileRepository;
+import umc.cockple.demo.domain.chat.repository.ChatRoomMemberRepository;
+import umc.cockple.demo.domain.chat.repository.DownloadTokenRepository;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+@Slf4j
+public class ChatFileServiceImpl implements ChatFileService{
+
+    private final ChatFileRepository chatFileRepository;
+    private final DownloadTokenRepository downloadTokenRepository;
+    private final ChatConverter chatConverter;
+    private final ChatRoomMemberRepository chatRoomMemberRepository;
+    private static final int TOKEN_VALIDITY_SECONDS = 60;
+
+    @Override
+    public ChatDownloadTokenDTO.Response issueDownloadToken(Long fileId, Long memberId) {
+        log.info("다운로드 토큰 발급 시작 - fileId: {}, memberId: {}", fileId, memberId);
+
+        //채팅 파일 조회
+        ChatMessageFile chatFile = findChatFileOrThrow(fileId);
+
+        //사용자 검증
+        validateMemberPermission(chatFile, memberId);
+
+        //다운로드 토큰 생성 및 저장
+        DownloadToken downloadToken = DownloadToken.create(fileId, memberId, TOKEN_VALIDITY_SECONDS);
+        downloadTokenRepository.save(downloadToken);
+
+        log.info("다운로드 토큰 발급 완료 - fileId: {}", fileId);
+
+        return chatConverter.toDownloadTokenResponse(downloadToken, TOKEN_VALIDITY_SECONDS);
+    }
+
+    private ChatMessageFile findChatFileOrThrow(Long fileId) {
+        return chatFileRepository.findById(fileId)
+                .orElseThrow(() -> new ChatException(ChatErrorCode.FILE_NOT_FOUND));
+    }
+
+    private void validateMemberPermission(ChatMessageFile chatFile, Long memberId) {
+        Long roomId = chatFile.getChatMessage().getChatRoom().getId();
+        if (!chatRoomMemberRepository.existsByChatRoomIdAndMemberId(roomId, memberId))
+            throw new ChatException(ChatErrorCode.CHAT_ROOM_MEMBER_NOT_FOUND);
+    }
 }

--- a/src/main/java/umc/cockple/demo/domain/chat/service/ChatFileServiceImpl.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/ChatFileServiceImpl.java
@@ -1,0 +1,4 @@
+package umc.cockple.demo.domain.chat.service;
+
+public class ChatFileServiceImpl {
+}


### PR DESCRIPTION
## ❤️ 기능 설명
다운로드 토큰을 발급하는 API를 구현합니다.

swagger 테스트 성공 결과 스크린샷 첨부
<img width="716" height="173" alt="image" src="https://github.com/user-attachments/assets/3c187716-8106-4822-83ed-4d32637fc8e3" />
<img width="705" height="130" alt="image" src="https://github.com/user-attachments/assets/2eb59ca5-393e-4b77-ab6c-44db00e29519" />
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #287
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 아직 파일 업로드 api가 없기에 데이터베이스에서 직접 채팅 파일을 생성해주고 다운로드 토큰 발급 테스트를 진행했습니다. 
- [ ] 상수인 TOKEN_VALIDITY_SECONDS (토큰 유효시간)을 이처럼 서비스 구현체 내부에 두는게 좋을지, 다른 곳에 두는게 좋을지 의견 부탁드립니다!

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
