### PR TITLE
[feat/#265] 채팅방 구독 로직 구현

### DIFF
--- a/src/main/java/umc/cockple/demo/domain/chat/dto/MemberConnectionInfo.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/dto/MemberConnectionInfo.java
@@ -1,0 +1,10 @@
+package umc.cockple.demo.domain.chat.dto;
+
+import lombok.Builder;
+
+@Builder
+public record MemberConnectionInfo(
+        Long memberId,
+        String memberName
+) {
+}

--- a/src/main/java/umc/cockple/demo/domain/chat/dto/WebSocketMessageDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/dto/WebSocketMessageDTO.java
@@ -38,6 +38,15 @@ public class WebSocketMessageDTO {
     }
 
     @Builder
+    public record SubscriptionResponse(
+            WebSocketMessageType type,
+            Long chatRoomId,
+            String message,
+            LocalDateTime timestamp
+    ) {
+    }
+
+    @Builder
     public record ErrorResponse(
             WebSocketMessageType type,
             String errorCode,

--- a/src/main/java/umc/cockple/demo/domain/chat/events/ChatMessageSendEvent.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/events/ChatMessageSendEvent.java
@@ -1,0 +1,21 @@
+package umc.cockple.demo.domain.chat.events;
+
+import lombok.Builder;
+import umc.cockple.demo.domain.chat.enums.MessageType;
+
+@Builder
+public record ChatMessageSendEvent(
+        Long chatRoomId,
+        String content,
+        Long senderId,
+        MessageType messageType
+) {
+    public static ChatMessageSendEvent create(Long chatRoomId, String content, Long senderId) {
+        return ChatMessageSendEvent.builder()
+                .chatRoomId(chatRoomId)
+                .content(content)
+                .senderId(senderId)
+                .messageType(MessageType.TEXT)
+                .build();
+    }
+}

--- a/src/main/java/umc/cockple/demo/domain/chat/events/ChatRoomSubscriptionEvent.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/events/ChatRoomSubscriptionEvent.java
@@ -1,0 +1,18 @@
+package umc.cockple.demo.domain.chat.events;
+
+import lombok.Builder;
+
+@Builder
+public record ChatRoomSubscriptionEvent(
+        Long chatRoomId,
+        Long memberId,
+        String action
+) {
+    public static ChatRoomSubscriptionEvent subscribe(Long chatRoomId, Long memberId) {
+        return ChatRoomSubscriptionEvent.builder()
+                .chatRoomId(chatRoomId)
+                .memberId(memberId)
+                .action("SUBSCRIBE")
+                .build();
+    }
+}

--- a/src/main/java/umc/cockple/demo/domain/chat/handler/ChatWebSocketHandler.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/handler/ChatWebSocketHandler.java
@@ -70,6 +70,9 @@ public class ChatWebSocketHandler extends TextWebSocketHandler {
                 case SEND:
                     handleSendMessage(session, request, memberId);
                     break;
+                case SUBSCRIBE:
+                    handleSubscribe(session, request, memberId);
+                    break;
                 default:
                     sendErrorMessage(session, "UNKNOWN_TYPE", "알 수 없는 메시지 타입입니다:" + request.type());
             }
@@ -164,6 +167,17 @@ public class ChatWebSocketHandler extends TextWebSocketHandler {
             chatWebSocketService.sendMessage(request.chatRoomId(), request.content(), memberId);
         } catch (ChatException e) {
             log.error("메시지 전송 중 오류 발생", e);
+            sendErrorMessage(session, e.getCode().toString(), e.getMessage());
+        }
+    }
+
+    private void handleSubscribe(WebSocketSession session, WebSocketMessageDTO.Request request, Long memberId) {
+        log.info("채팅방 구독 처리 시작 - 채팅방 ID: {}, 사용자 ID: {}", request.chatRoomId(), memberId);
+
+        try {
+            chatWebSocketService.subscribeChatRoom(request.chatRoomId(), memberId);
+        } catch (ChatException e) {
+            log.error("채팅방 구독 중 에러 발생", e);
             sendErrorMessage(session, e.getCode().toString(), e.getMessage());
         }
     }

--- a/src/main/java/umc/cockple/demo/domain/chat/handler/ChatWebSocketHandler.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/handler/ChatWebSocketHandler.java
@@ -12,7 +12,7 @@ import umc.cockple.demo.domain.chat.dto.WebSocketMessageDTO;
 import umc.cockple.demo.domain.chat.enums.WebSocketMessageType;
 import umc.cockple.demo.domain.chat.exception.ChatException;
 import umc.cockple.demo.domain.chat.service.ChatWebSocketService;
-import umc.cockple.demo.domain.chat.service.WebSocketBroadcastService;
+import umc.cockple.demo.domain.chat.service.SubscriptionService;
 
 import java.time.LocalDateTime;
 
@@ -22,7 +22,7 @@ import java.time.LocalDateTime;
 public class ChatWebSocketHandler extends TextWebSocketHandler {
 
     private final ChatWebSocketService chatWebSocketService;
-    private final WebSocketBroadcastService broadcastService;
+    private final SubscriptionService subscriptionService;
     private final ObjectMapper objectMapper;
 
     @Override
@@ -34,7 +34,7 @@ public class ChatWebSocketHandler extends TextWebSocketHandler {
 
             if (memberId != null) {
                 session.getAttributes().put("memberId", memberId);
-                broadcastService.addSession(memberId, session);
+                subscriptionService.addSession(memberId, session);
                 log.info("사용자 연결 완료 - memberId: {}, 세션 ID: {}", memberId, session.getId());
 
                 sendConnectionSuccessMessage(session, memberId);
@@ -91,7 +91,7 @@ public class ChatWebSocketHandler extends TextWebSocketHandler {
         log.info("세션 ID: {}, 사용자 ID: {}, 종료 상태: {}", session.getId(), memberId, status);
 
         if (memberId != null) {
-            broadcastService.removeSession(memberId);
+            subscriptionService.removeSession(memberId);
             log.info("사용자 세션 정리 완료 - memberId: {}", memberId);
         }
     }

--- a/src/main/java/umc/cockple/demo/domain/chat/repository/ChatRoomMemberRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/repository/ChatRoomMemberRepository.java
@@ -30,8 +30,6 @@ public interface ChatRoomMemberRepository extends JpaRepository<ChatRoomMember, 
 
     List<ChatRoomMember> findAllByMemberId(Long id);
 
-    boolean existsByChatRoomAndMember(ChatRoom chatRoom, Member member);
-
     @Query("""
             SELECT crm FROM ChatRoomMember crm
             JOIN FETCH crm.member m

--- a/src/main/java/umc/cockple/demo/domain/chat/service/ChatWebSocketService.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/ChatWebSocketService.java
@@ -52,7 +52,7 @@ public class ChatWebSocketService {
         log.info("메시지 브로드캐스트 시작 - 채팅방 ID: {}", chatRoomId);
         WebSocketMessageDTO.Response response =
                 chatConverter.toSendMessageResponse(chatRoomId, content, savedMessage, sender, profileImageUrl);
-        subscriptionService.broadcastToChatRoom(chatRoomId, response);
+        subscriptionService.broadcastToChatRoom(chatRoomId, response, senderId);
         log.info("메시지 브로드캐스트 완료 - 채팅방 ID: {}", chatRoomId);
     }
 

--- a/src/main/java/umc/cockple/demo/domain/chat/service/ChatWebSocketService.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/ChatWebSocketService.java
@@ -7,6 +7,7 @@ import org.springframework.transaction.annotation.Transactional;
 import umc.cockple.demo.domain.chat.converter.ChatConverter;
 import umc.cockple.demo.domain.chat.domain.ChatMessage;
 import umc.cockple.demo.domain.chat.domain.ChatRoom;
+import umc.cockple.demo.domain.chat.dto.MemberConnectionInfo;
 import umc.cockple.demo.domain.chat.dto.WebSocketMessageDTO;
 import umc.cockple.demo.domain.chat.enums.MessageType;
 import umc.cockple.demo.domain.chat.exception.ChatErrorCode;
@@ -34,6 +35,18 @@ public class ChatWebSocketService {
     private final SubscriptionService subscriptionService;
 
     private final ChatConverter chatConverter;
+
+    public MemberConnectionInfo getMemberConnectionInfo(Long memberId) {
+        log.debug("멤버 연결 정보 조회 - memberId: {}", memberId);
+
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new ChatException(ChatErrorCode.MEMBER_NOT_FOUND));
+
+        return MemberConnectionInfo.builder()
+                .memberId(memberId)
+                .memberName(member.getMemberName())
+                .build();
+    }
 
     public void sendMessage(Long chatRoomId, String content, Long senderId) {
         log.info("메시지 전송 시작 - 채팅방: {}, 발신자: {}", chatRoomId, senderId);

--- a/src/main/java/umc/cockple/demo/domain/chat/service/ChatWebSocketService.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/ChatWebSocketService.java
@@ -31,7 +31,7 @@ public class ChatWebSocketService {
     private final ChatRoomMemberRepository chatRoomMemberRepository;
 
     private final ImageService imageService;
-    private final WebSocketBroadcastService broadcastService;
+    private final SubscriptionService subscriptionService;
 
     private final ChatConverter chatConverter;
 
@@ -52,7 +52,7 @@ public class ChatWebSocketService {
         log.info("메시지 브로드캐스트 시작 - 채팅방 ID: {}", chatRoomId);
         WebSocketMessageDTO.Response response =
                 chatConverter.toSendMessageResponse(chatRoomId, content, savedMessage, sender, profileImageUrl);
-        broadcastService.broadcastToChatRoom(chatRoomId, response);
+        subscriptionService.broadcastToChatRoom(chatRoomId, response);
         log.info("메시지 브로드캐스트 완료 - 채팅방 ID: {}", chatRoomId);
     }
 
@@ -65,12 +65,14 @@ public class ChatWebSocketService {
         WebSocketMessageDTO.Response broadcastSystemMessage
                 = chatConverter.toSystemMessageResponse(chatRoom.getId(), content, systemMessage);
 
-        broadcastService.broadcastToChatRoom(chatRoom.getId(), broadcastSystemMessage);
+        subscriptionService.broadcastToChatRoom(chatRoom.getId(), broadcastSystemMessage);
         log.info("시스템 메시지 브로드캐스트 완료 - chatRoomId: {}", chatRoom.getId());
     }
 
     public void subscribeChatRoom(Long chatRoomId, Long memberId) {
         validateChatRoom(chatRoomId);
+
+        subscriptionService.addToChatRoom(chatRoomId, memberId);
     }
 
     // ========== 검증 메서드 ==========
@@ -80,7 +82,6 @@ public class ChatWebSocketService {
         validateContent(content);
         validateChatRoomMember(chatRoomId, senderId);
     }
-
 
     // ========== 세부 검증 메서드 ==========
 

--- a/src/main/java/umc/cockple/demo/domain/chat/service/ChatWebSocketService.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/ChatWebSocketService.java
@@ -69,12 +69,6 @@ public class ChatWebSocketService {
         log.info("시스템 메시지 브로드캐스트 완료 - chatRoomId: {}", chatRoom.getId());
     }
 
-    public void subscribeChatRoom(Long chatRoomId, Long memberId) {
-        validateChatRoom(chatRoomId);
-
-        subscriptionService.addToChatRoom(chatRoomId, memberId);
-    }
-
     // ========== 검증 메서드 ==========
 
     private void validateSendMessage(Long chatRoomId, String content, Long senderId) {

--- a/src/main/java/umc/cockple/demo/domain/chat/service/SubscriptionService.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/SubscriptionService.java
@@ -46,6 +46,10 @@ public class SubscriptionService {
     }
 
     public void broadcastToChatRoom(Long chatRoomId, WebSocketMessageDTO.Response message) {
+        broadcastToChatRoom(chatRoomId, message, null);
+    }
+
+    public void broadcastToChatRoom(Long chatRoomId, WebSocketMessageDTO.Response message, Long senderId) {
         Set<Long> subscribers = chatRoomSubscriptions.get(chatRoomId);
         if (subscribers == null || subscribers.isEmpty()) {
             log.info("채팅방 {}에 구독 중인 사용자가 없습니다.", chatRoomId);
@@ -64,6 +68,10 @@ public class SubscriptionService {
         int successCount = 0;
 
         for (Long memberId : subscribers) {
+            if(memberId.equals(senderId)) {
+                continue;
+            }
+
             WebSocketSession session = memberSessions.get(memberId);
 
             if (session != null && session.isOpen()) {

--- a/src/main/java/umc/cockple/demo/domain/chat/service/SubscriptionService.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/SubscriptionService.java
@@ -19,8 +19,10 @@ public class SubscriptionService {
 
     private final ObjectMapper objectMapper;
 
-    private final Map<Long, Map<Long, WebSocketSession>> chatRoomSessions = new ConcurrentHashMap<>();
+    // 세션 관리
     private final Map<Long, WebSocketSession> memberSessions = new ConcurrentHashMap<>();
+    // 구독 관리
+    private final Map<Long, Set<Long>> chatRoomSubscriptions = new ConcurrentHashMap<>();
 
     public void addSession(Long memberId, WebSocketSession session) {
         memberSessions.put(memberId, session);
@@ -29,10 +31,10 @@ public class SubscriptionService {
     public void removeSession(Long memberId) {
         memberSessions.remove(memberId);
 
-        chatRoomSessions.forEach((chatRoomId, sessions) -> {
-            sessions.remove(memberId);
-            if (sessions.isEmpty()) {
-                chatRoomSessions.remove(chatRoomId);
+        chatRoomSubscriptions.forEach((chatRoomId, subscribers) -> {
+            subscribers.remove(memberId);
+            if (subscribers.isEmpty()) {
+                chatRoomSubscriptions.remove(chatRoomId);
             }
         });
     }

--- a/src/main/java/umc/cockple/demo/domain/chat/service/SubscriptionService.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/SubscriptionService.java
@@ -15,7 +15,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 @Service
 @RequiredArgsConstructor
 @Slf4j
-public class WebSocketBroadcastService {
+public class SubscriptionService {
 
     private final ObjectMapper objectMapper;
 
@@ -94,25 +94,5 @@ public class WebSocketBroadcastService {
                 log.info("빈 채팅방 세션 맵 제거 - 채팅방: {}", chatRoomId);
             }
         }
-    }
-
-    // ========== 테스트용 ==========
-    void clearAllSessionsForTest() {
-        memberSessions.clear();
-        chatRoomSessions.clear();
-    }
-
-    void addChatRoomSessionForTest(Long chatRoomId, Long memberId, WebSocketSession session) {
-        chatRoomSessions.computeIfAbsent(chatRoomId, k -> new ConcurrentHashMap<>())
-                .put(memberId, session);
-    }
-
-    void broadcastToChatRoomForTest(Long chatRoomId, WebSocketMessageDTO.Response message) {
-        broadcastToChatRoom(chatRoomId, message);
-    }
-
-    boolean isMemberInChatRoomForTest(Long chatRoomId, Long memberId) {
-        Map<Long, WebSocketSession> sessions = chatRoomSessions.get(chatRoomId);
-        return sessions != null && sessions.containsKey(memberId);
     }
 }

--- a/src/main/java/umc/cockple/demo/domain/chat/service/SubscriptionService.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/SubscriptionService.java
@@ -38,6 +38,13 @@ public class SubscriptionService {
         });
     }
 
+    public void subscribeToChatRoom(Long chatRoomId, Long memberId) {
+        chatRoomSubscriptions.computeIfAbsent(chatRoomId, k -> ConcurrentHashMap.newKeySet())
+                .add(memberId);
+
+        log.info("채팅방 구독 - 채팅방: {}, 사용자: {}", chatRoomId, memberId);
+    }
+
     public void broadcastToChatRoom(Long chatRoomId, WebSocketMessageDTO.Response message) {
         Set<Long> subscribers = chatRoomSubscriptions.get(chatRoomId);
         if (subscribers == null || subscribers.isEmpty()) {


### PR DESCRIPTION
## ❤️ 기능 설명
채팅방에 들어갈경우 SUBSCRIBE를 보내 채팅방을 구독하는 로직입니다.

서비스끼리 순환 참조가 일어나 이벤트를 기반으로 주고받는 방식으로 진행했습니다.

채팅방을 구독하는 것과 메시지를 보내는 것 모두 handleTextMessage에서 스위치문으로 이벤트를 발행합니다.
ChatEventListener가 이벤트를 받아 각각의 서비스로 호출합니다.

채팅방 메시지 보내기 -> ChatWebSocketService에서 메시지 저장 -> SubscriptionService에서 브로드캐스트
채팅방 구독 -> SubscriptionService에서 구독 처리

swagger 테스트 성공 결과 스크린샷 첨부
멤버 1, 2 웹소켓 연결
<img width="1670" height="1310" alt="image" src="https://github.com/user-attachments/assets/2d0b0fef-651f-47f4-a0eb-acd23fa44f3d" />
<img width="1089" height="872" alt="image" src="https://github.com/user-attachments/assets/5238d801-1d6a-43b3-997e-bea311d4f81a" />

멤버 1, 2 채팅방 구독 -> 채팅방 목록에서 채팅방 하나를 누른 상황
<img width="908" height="963" alt="image" src="https://github.com/user-attachments/assets/22fc3131-00b9-48f0-8d98-dd9fb5cda825" />
<img width="904" height="929" alt="image" src="https://github.com/user-attachments/assets/df0b0174-efb6-484c-8ba4-b67569534e58" />

멤버 1이 채팅을 보냄
<img width="658" height="895" alt="image" src="https://github.com/user-attachments/assets/d799f75c-d627-43fb-93ee-96000395cd79" />

-> 멤버 2에게 채팅이 감
<img width="735" height="871" alt="image" src="https://github.com/user-attachments/assets/cf93b154-7131-4f72-b399-32ed412dec15" />

멤버 2가 채팅을 보냄
<img width="559" height="632" alt="image" src="https://github.com/user-attachments/assets/a701c4a0-2b41-4e27-87fd-9fa67f1479e5" />

-> 멤버 1에게 채팅이 감
<img width="433" height="878" alt="image" src="https://github.com/user-attachments/assets/aba2f2f4-3498-498d-897d-523812a79fc8" />


<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #265 
close #307 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!
- [ ] 웹소켓은 순환 참조를 조심하세요 여러분....

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
