### PR TITLE
[feat/#306] JWT를 활용해 웹소켓 연결 인증 단계 구현

### DIFF
--- a/src/main/java/umc/cockple/demo/domain/chat/handler/ChatWebSocketHandler.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/handler/ChatWebSocketHandler.java
@@ -34,13 +34,13 @@ public class ChatWebSocketHandler extends TextWebSocketHandler {
         log.info("웹소켓 연결 성공");
 
         try {
-            Long memberId = extractMemberIdFromURL(session);
+            Long memberId = (Long) session.getAttributes().get("memberId");
+            Boolean authenticated = (Boolean) session.getAttributes().get("authenticated");
 
-            if (memberId != null) {
+            if (memberId != null && Boolean.TRUE.equals(authenticated)) {
                 MemberConnectionInfo memberInfo = chatWebSocketService.getMemberConnectionInfo(memberId);
-
-                session.getAttributes().put("memberId", memberId);
                 session.getAttributes().put("memberName", memberInfo.memberName());
+
                 subscriptionService.addSession(memberId, session);
                 log.info("사용자 연결 완료 - memberId: {}, 세션 ID: {}", memberId, session.getId());
 
@@ -115,19 +115,6 @@ public class ChatWebSocketHandler extends TextWebSocketHandler {
     }
 
     // ========== 내부 메서드들 ==========
-
-    private Long extractMemberIdFromURL(WebSocketSession session) {
-        String query = session.getUri().getQuery();
-        if (query != null && query.contains("memberId=")) {
-            try {
-                String memberIdStr = query.split("memberId=")[1].split("&")[0]; // Id값 뽑아내기.
-                return Long.parseLong(memberIdStr);
-            } catch (Exception e) {
-                log.error("memberId 추출 실패", e);
-            }
-        }
-        return null;
-    }
 
     private void sendConnectionSuccessMessage(WebSocketSession session, MemberConnectionInfo memberInfo) {
         try {

--- a/src/main/java/umc/cockple/demo/domain/chat/interceptor/JWTWebSocketAuthInterceptor.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/interceptor/JWTWebSocketAuthInterceptor.java
@@ -1,0 +1,28 @@
+package umc.cockple.demo.domain.chat.interceptor;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.WebSocketHandler;
+import org.springframework.web.socket.server.HandshakeInterceptor;
+
+import java.util.Map;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class JWTWebSocketAuthInterceptor implements HandshakeInterceptor {
+
+    @Override
+    public boolean beforeHandshake(ServerHttpRequest request, ServerHttpResponse response,
+                                   WebSocketHandler wsHandler, Map<String, Object> attributes) throws Exception {
+        return false;
+    }
+
+    @Override
+    public void afterHandshake(ServerHttpRequest request, ServerHttpResponse response, WebSocketHandler wsHandler, Exception exception) {
+
+    }
+}

--- a/src/main/java/umc/cockple/demo/domain/chat/interceptor/JWTWebSocketAuthInterceptor.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/interceptor/JWTWebSocketAuthInterceptor.java
@@ -21,12 +21,28 @@ public class JWTWebSocketAuthInterceptor implements HandshakeInterceptor {
         log.info("JWT 기반 WebSocket 인증 시작");
 
         try {
+            String token = extractTokenFromRequest(request);
 
             return true;
         } catch (Exception e) {
             log.error("JWT 인증 처리 중 오류 발생", e);
             return false;
         }
+    }
+
+    private String extractTokenFromRequest(ServerHttpRequest request) {
+        String query = request.getURI().getQuery();
+
+        if (query != null) {
+            String[] params = query.split("&");
+            for (String param : params) {
+                if (param.startsWith("token=")) {
+                    return param.substring(6);
+                }
+            }
+        }
+
+        return null;
     }
 
     @Override

--- a/src/main/java/umc/cockple/demo/domain/chat/interceptor/JWTWebSocketAuthInterceptor.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/interceptor/JWTWebSocketAuthInterceptor.java
@@ -18,11 +18,22 @@ public class JWTWebSocketAuthInterceptor implements HandshakeInterceptor {
     @Override
     public boolean beforeHandshake(ServerHttpRequest request, ServerHttpResponse response,
                                    WebSocketHandler wsHandler, Map<String, Object> attributes) throws Exception {
-        return false;
+        log.info("JWT 기반 WebSocket 인증 시작");
+
+        try {
+
+            return true;
+        } catch (Exception e) {
+            log.error("JWT 인증 처리 중 오류 발생", e);
+            return false;
+        }
     }
 
     @Override
-    public void afterHandshake(ServerHttpRequest request, ServerHttpResponse response, WebSocketHandler wsHandler, Exception exception) {
-
+    public void afterHandshake(ServerHttpRequest request, ServerHttpResponse response,
+                               WebSocketHandler wsHandler, Exception exception) {
+        if (exception != null) {
+            log.error("JWT HandshakeInterceptor 실행 중 오류", exception);
+        }
     }
 }

--- a/src/main/java/umc/cockple/demo/domain/chat/interceptor/JWTWebSocketAuthInterceptor.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/interceptor/JWTWebSocketAuthInterceptor.java
@@ -4,9 +4,11 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.server.ServerHttpRequest;
 import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
 import org.springframework.web.socket.WebSocketHandler;
 import org.springframework.web.socket.server.HandshakeInterceptor;
+import umc.cockple.demo.global.jwt.domain.JwtTokenProvider;
 
 import java.util.Map;
 
@@ -14,6 +16,8 @@ import java.util.Map;
 @Slf4j
 @RequiredArgsConstructor
 public class JWTWebSocketAuthInterceptor implements HandshakeInterceptor {
+
+    private final JwtTokenProvider jwtTokenProvider;
 
     @Override
     public boolean beforeHandshake(ServerHttpRequest request, ServerHttpResponse response,
@@ -23,10 +27,26 @@ public class JWTWebSocketAuthInterceptor implements HandshakeInterceptor {
         try {
             String token = extractTokenFromRequest(request);
 
+            if (isValidToken(token)) return false;
+
+            Long memberId = jwtTokenProvider.getUserId(token);
+
+            attributes.put("memberId", memberId);
+            attributes.put("authenticated", true);
+
+            log.info("JWT 인증 성공 - memberId: {}", memberId);
             return true;
         } catch (Exception e) {
             log.error("JWT 인증 처리 중 오류 발생", e);
             return false;
+        }
+    }
+
+    @Override
+    public void afterHandshake(ServerHttpRequest request, ServerHttpResponse response,
+                               WebSocketHandler wsHandler, Exception exception) {
+        if (exception != null) {
+            log.error("JWT HandshakeInterceptor 실행 중 오류", exception);
         }
     }
 
@@ -45,11 +65,16 @@ public class JWTWebSocketAuthInterceptor implements HandshakeInterceptor {
         return null;
     }
 
-    @Override
-    public void afterHandshake(ServerHttpRequest request, ServerHttpResponse response,
-                               WebSocketHandler wsHandler, Exception exception) {
-        if (exception != null) {
-            log.error("JWT HandshakeInterceptor 실행 중 오류", exception);
+    private boolean isValidToken(String token) {
+        if (token == null) {
+            log.error("JWT 토큰이 없습니다");
+            return true;
         }
+
+        if (!jwtTokenProvider.validateToken(token)) {
+            log.error("유효하지 않은 JWT 토큰");
+            return true;
+        }
+        return false;
     }
 }

--- a/src/main/java/umc/cockple/demo/global/config/WebSocketConfig.java
+++ b/src/main/java/umc/cockple/demo/global/config/WebSocketConfig.java
@@ -6,6 +6,7 @@ import org.springframework.web.socket.config.annotation.EnableWebSocket;
 import org.springframework.web.socket.config.annotation.WebSocketConfigurer;
 import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry;
 import umc.cockple.demo.domain.chat.handler.ChatWebSocketHandler;
+import umc.cockple.demo.domain.chat.interceptor.JWTWebSocketAuthInterceptor;
 
 @Configuration
 @EnableWebSocket
@@ -13,12 +14,14 @@ import umc.cockple.demo.domain.chat.handler.ChatWebSocketHandler;
 public class WebSocketConfig implements WebSocketConfigurer {
 
     private final ChatWebSocketHandler chatWebSocketHandler;
+    private final JWTWebSocketAuthInterceptor jwtWebSocketAuthInterceptor;
 
     @Override
     public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
         registry
                 .addHandler(chatWebSocketHandler, "/ws/chats")
-                .setAllowedOrigins("*") // TODO: 운영 환경에서는 변경 필요. CORS 방지
+                .addInterceptors(jwtWebSocketAuthInterceptor)
+                .setAllowedOrigins("http://localhost:5173", "https://cockple.store")
                 .withSockJS(); // 브라우저 호환성
     }
 }


### PR DESCRIPTION
## ❤️ 기능 설명
웹소켓 연결 시 스프링 시큐리티 필터를 지나는 대신
인터셉터에서 JWT로 검증합니다.

또한, 이 JWT에서 memberId를 받아옵니다.

테스트할때는 쿼리 파라미터로 ?token=토큰값 을 추가하면 됩니다.


swagger 테스트 성공 결과 스크린샷 첨부
<img width="2148" height="966" alt="image" src="https://github.com/user-attachments/assets/14e150b7-4cd9-4bc4-b608-9d26d1f13f6b" />

<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #306 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 기존 pr 올린 코드랑 충돌이 있을 예정입니다. 머지되면 해결하겠습니다!!

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
