### PR TITLE
[feat/#288] 파일 다운로드 구현

### DIFF
--- a/src/main/java/umc/cockple/demo/domain/chat/controller/ChatController.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/controller/ChatController.java
@@ -4,6 +4,8 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.core.io.Resource;
+import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import umc.cockple.demo.domain.chat.dto.*;
@@ -123,5 +125,17 @@ public class ChatController {
         Long memberId = SecurityUtil.getCurrentMemberId();
         ChatDownloadTokenDTO.Response response = chatFileService.issueDownloadToken(memberId, fileId);
         return BaseResponse.success(CommonSuccessCode.OK, response);
+    }
+
+    @GetMapping("/chats/files/{fileId}/download")
+    @Operation(summary = "채팅 파일 다운로드", description = "발급받은 다운로드 토큰을 검증하고, 유효할 경우 실제 파일 데이터를 반환합니다.")
+    @ApiResponse(responseCode = "200", description = "파일 다운로드 성공")
+    @ApiResponse(responseCode = "403", description = "유효하지 않거나 만료된 토큰")
+    @ApiResponse(responseCode = "404", description = "존재하지 않는 파일")
+    public ResponseEntity<Resource> downloadFile(
+            @PathVariable Long fileId,
+            @RequestParam String token
+    ) {
+        return chatFileService.downloadFile(fileId, token);
     }
 }

--- a/src/main/java/umc/cockple/demo/domain/chat/exception/ChatErrorCode.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/exception/ChatErrorCode.java
@@ -23,7 +23,11 @@ public enum ChatErrorCode implements BaseErrorCode {
     FILE_NOT_FOUND(HttpStatus.NOT_FOUND, "CHAT204", "존재하지 않는 파일입니다."),
 
     // 3xx: 인증/인가 문제
-    PARTY_MEMBER_NOT_FOUND(HttpStatus.BAD_REQUEST, "CHAT301", "모임에 참여한 회원이 아닙니다.");
+    PARTY_MEMBER_NOT_FOUND(HttpStatus.BAD_REQUEST, "CHAT301", "모임에 참여한 회원이 아닙니다."),
+    INVALID_DOWNLOAD_TOKEN(HttpStatus.FORBIDDEN, "CHAT302", "유효하지 않거나 만료된 다운로드 토큰입니다."),
+
+    // 5xx: 서버 내부 문제
+    RESPONSE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "CHAT501", "파일 다운로드 응답 생성에 실패했습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/umc/cockple/demo/domain/chat/repository/DownloadTokenRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/repository/DownloadTokenRepository.java
@@ -3,5 +3,8 @@ package umc.cockple.demo.domain.chat.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import umc.cockple.demo.domain.chat.domain.DownloadToken;
 
+import java.util.Optional;
+
 public interface DownloadTokenRepository extends JpaRepository<DownloadToken, Long> {
+    Optional<DownloadToken> findByToken(String token);
 }

--- a/src/main/java/umc/cockple/demo/domain/chat/service/ChatCommandService.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/ChatCommandService.java
@@ -1,8 +1,10 @@
 package umc.cockple.demo.domain.chat.service;
 
+import umc.cockple.demo.domain.chat.dto.ChatDownloadTokenDTO;
 import umc.cockple.demo.domain.chat.dto.DirectChatRoomCreateDTO;
 
 public interface ChatCommandService {
 
     DirectChatRoomCreateDTO.Response createDirectChatRoom(Long memberId, Long targetMemberId);
+    ChatDownloadTokenDTO.Response issueDownloadToken(Long memberId, Long fileId);
 }

--- a/src/main/java/umc/cockple/demo/domain/chat/service/ChatCommandService.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/ChatCommandService.java
@@ -1,10 +1,8 @@
 package umc.cockple.demo.domain.chat.service;
 
-import umc.cockple.demo.domain.chat.dto.ChatDownloadTokenDTO;
 import umc.cockple.demo.domain.chat.dto.DirectChatRoomCreateDTO;
 
 public interface ChatCommandService {
 
     DirectChatRoomCreateDTO.Response createDirectChatRoom(Long memberId, Long targetMemberId);
-    ChatDownloadTokenDTO.Response issueDownloadToken(Long memberId, Long fileId);
 }

--- a/src/main/java/umc/cockple/demo/domain/chat/service/ChatFileService.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/ChatFileService.java
@@ -1,7 +1,10 @@
 package umc.cockple.demo.domain.chat.service;
 
+import org.springframework.core.io.Resource;
+import org.springframework.http.ResponseEntity;
 import umc.cockple.demo.domain.chat.dto.ChatDownloadTokenDTO;
 
 public interface ChatFileService {
     ChatDownloadTokenDTO.Response issueDownloadToken(Long fileId, Long memberId);
+    ResponseEntity<Resource> downloadFile(Long fileId, String token);
 }

--- a/src/main/java/umc/cockple/demo/domain/chat/service/ChatFileServiceImpl.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/ChatFileServiceImpl.java
@@ -34,7 +34,7 @@ public class ChatFileServiceImpl implements ChatFileService{
     private final ChatConverter chatConverter;
     private final ChatRoomMemberRepository chatRoomMemberRepository;
     private final ImageService imageService;
-    private static final int TOKEN_VALIDITY_SECONDS = 60;
+    private static final int TOKEN_VALIDITY_SECONDS = 180;
 
     @Override
     public ChatDownloadTokenDTO.Response issueDownloadToken(Long fileId, Long memberId) {

--- a/src/main/java/umc/cockple/demo/domain/chat/service/ChatFileServiceImpl.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/ChatFileServiceImpl.java
@@ -2,6 +2,9 @@ package umc.cockple.demo.domain.chat.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.io.Resource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import umc.cockple.demo.domain.chat.converter.ChatConverter;
@@ -13,6 +16,12 @@ import umc.cockple.demo.domain.chat.exception.ChatException;
 import umc.cockple.demo.domain.chat.repository.ChatFileRepository;
 import umc.cockple.demo.domain.chat.repository.ChatRoomMemberRepository;
 import umc.cockple.demo.domain.chat.repository.DownloadTokenRepository;
+import umc.cockple.demo.domain.image.service.ImageService;
+
+import java.net.MalformedURLException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
 
 @Service
 @Transactional
@@ -24,6 +33,7 @@ public class ChatFileServiceImpl implements ChatFileService{
     private final DownloadTokenRepository downloadTokenRepository;
     private final ChatConverter chatConverter;
     private final ChatRoomMemberRepository chatRoomMemberRepository;
+    private final ImageService imageService;
     private static final int TOKEN_VALIDITY_SECONDS = 60;
 
     @Override
@@ -41,8 +51,24 @@ public class ChatFileServiceImpl implements ChatFileService{
         downloadTokenRepository.save(downloadToken);
 
         log.info("다운로드 토큰 발급 완료 - fileId: {}", fileId);
-
         return chatConverter.toDownloadTokenResponse(downloadToken, TOKEN_VALIDITY_SECONDS);
+    }
+
+    @Override
+    public ResponseEntity<Resource> downloadFile(Long fileId, String token) {
+        log.info("파일 다운로드 시작 - fileId: {}", fileId);
+
+        //토큰 검증
+        validateToken(fileId, token);
+        //채팅 파일 조회
+        ChatMessageFile chatFile = findChatFileOrThrow(fileId);
+
+        //S3에서 파일 리소스 가져오기
+        Resource resource = getResourceFromS3(chatFile.getFileKey());
+        ResponseEntity<Resource> responseEntity = createDownloadResponseEntity(chatFile, resource);
+
+        log.info("파일 다운로드 완료 - fileName: {}", chatFile.getOriginalFileName());
+        return responseEntity;
     }
 
     private ChatMessageFile findChatFileOrThrow(Long fileId) {
@@ -54,5 +80,37 @@ public class ChatFileServiceImpl implements ChatFileService{
         Long roomId = chatFile.getChatMessage().getChatRoom().getId();
         if (!chatRoomMemberRepository.existsByChatRoomIdAndMemberId(roomId, memberId))
             throw new ChatException(ChatErrorCode.CHAT_ROOM_MEMBER_NOT_FOUND);
+    }
+
+    private void validateToken(Long fileId, String tokenValue) {
+        DownloadToken token = downloadTokenRepository.findByToken(tokenValue)
+                .orElseThrow(() -> new ChatException(ChatErrorCode.INVALID_DOWNLOAD_TOKEN));
+        //토큰 유효성 검증 (만료 시간, 파일 ID)
+        if (token.getExpiresAt().isBefore(LocalDateTime.now()) || !token.getFileId().equals(fileId)) {
+            throw new ChatException(ChatErrorCode.INVALID_DOWNLOAD_TOKEN);
+        }
+        //사용된 토큰 삭제
+        downloadTokenRepository.delete(token);
+    }
+
+    private Resource getResourceFromS3(String fileKey) {
+        try {
+            return imageService.downloadFile(fileKey);
+        } catch (MalformedURLException e) {
+            throw new ChatException(ChatErrorCode.FILE_NOT_FOUND);
+        }
+    }
+
+    private ResponseEntity<Resource> createDownloadResponseEntity(ChatMessageFile chatFile, Resource resource) {
+        try {
+            String encodedFileName = URLEncoder.encode(chatFile.getOriginalFileName(), StandardCharsets.UTF_8);
+            HttpHeaders headers = new HttpHeaders();
+            headers.add(HttpHeaders.CONTENT_TYPE, chatFile.getFileType());
+            headers.add(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + encodedFileName + "\"");
+            headers.add(HttpHeaders.CONTENT_LENGTH, String.valueOf(chatFile.getFileSize()));
+            return ResponseEntity.ok().headers(headers).body(resource);
+        } catch (Exception e) {
+            throw new ChatException(ChatErrorCode.RESPONSE_FAILED);
+        }
     }
 }

--- a/src/main/java/umc/cockple/demo/domain/image/service/ImageService.java
+++ b/src/main/java/umc/cockple/demo/domain/image/service/ImageService.java
@@ -5,6 +5,8 @@ import com.amazonaws.services.s3.AmazonS3;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.UrlResource;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 import org.springframework.web.multipart.MultipartFile;
@@ -14,6 +16,8 @@ import umc.cockple.demo.domain.image.exception.S3Exception;
 import umc.cockple.demo.global.enums.ImgType;
 
 import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -126,5 +130,10 @@ public class ImageService {
 
     public String getUrlFromKey(String key) {
         return amazonS3.getUrl(bucket, key).toString();
+    }
+
+    public Resource downloadFile(String fileKey) throws MalformedURLException {
+        URL fileUrl = amazonS3.getUrl(bucket, fileKey);
+        return new UrlResource(fileUrl);
     }
 }


### PR DESCRIPTION
## ❤️ 기능 설명
파일을 다운로드하는 API를 구현합니다.

swagger 테스트 성공 결과 스크린샷 첨부
<img width="575" height="32" alt="image" src="https://github.com/user-attachments/assets/7824ec60-9fe1-4835-841f-62c34ed138ad" />
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #288
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!
- [ ] 개발 순서를 잘못 잡았습니다 ㅠ 파일 업로드를 먼저 구현하지 않아 s3에서 파일을 다운로드하는 것은 확인하지 못했습니다. 현재 임시 테스트 코드로 로그가 정상적으로 나오는 것은 확인했습니다. 추후에 파일 업로드를 구현하고 구현을 완료하겠습니다.
- [ ] 이전의 pull request가 merge되지 않아 이전 커밋도 포함되어 있습니다.  "feat: 채팅 파일 다운로드 API 서비스 메서드 추가" 여기부터 봐주시면 감사하겠습니다.

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
