### PR TITLE
[feat/#300] 채팅방 구독 해제 로직

### DIFF
--- a/src/main/java/umc/cockple/demo/domain/chat/events/ChatEventListener.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/events/ChatEventListener.java
@@ -57,6 +57,10 @@ public class ChatEventListener {
                     subscriptionService.subscribeToChatRoom(event.chatRoomId(), event.memberId());
                     log.info("사용자 {}가 채팅방 {}를 구독했습니다.", event.memberId(), event.chatRoomId());
                 }
+                case "UNSUBSCRIBE" -> {
+                    subscriptionService.unsubscribeToChatRoom(event.chatRoomId(), event.memberId());
+                    log.info("사용자 {}가 채팅방 {}를 구독해제했습니다.", event.memberId(), event.chatRoomId());
+                }
                 default -> log.warn("알 수 없는 구독 액션: {}", event.action());
             }
         } catch (Exception e) {

--- a/src/main/java/umc/cockple/demo/domain/chat/events/ChatRoomSubscriptionEvent.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/events/ChatRoomSubscriptionEvent.java
@@ -15,4 +15,12 @@ public record ChatRoomSubscriptionEvent(
                 .action("SUBSCRIBE")
                 .build();
     }
+
+    public static ChatRoomSubscriptionEvent unsubscribe(Long chatRoomId, Long memberId) {
+        return ChatRoomSubscriptionEvent.builder()
+                .chatRoomId(chatRoomId)
+                .memberId(memberId)
+                .action("UNSUBSCRIBE")
+                .build();
+    }
 }

--- a/src/main/java/umc/cockple/demo/domain/chat/handler/ChatWebSocketHandler.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/handler/ChatWebSocketHandler.java
@@ -85,6 +85,12 @@ public class ChatWebSocketHandler extends TextWebSocketHandler {
                     eventPublisher.publishEvent(subscribeEvent);
                     sendSubscriptionMessage(session, request.chatRoomId(), "SUBSCRIBE");
                     break;
+                case UNSUBSCRIBE:
+                    ChatRoomSubscriptionEvent unsubscribeEvent =
+                            ChatRoomSubscriptionEvent.unsubscribe(request.chatRoomId(), memberId);
+                    eventPublisher.publishEvent(unsubscribeEvent);
+                    sendSubscriptionMessage(session, request.chatRoomId(), "UNSUBSCRIBE");
+                    break;
                 default:
                     sendErrorMessage(session, "UNKNOWN_TYPE", "알 수 없는 메시지 타입입니다:" + request.type());
             }

--- a/src/main/java/umc/cockple/demo/domain/chat/service/SubscriptionService.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/SubscriptionService.java
@@ -45,6 +45,21 @@ public class SubscriptionService {
         log.info("채팅방 구독 - 채팅방: {}, 사용자: {}", chatRoomId, memberId);
     }
 
+    public void unsubscribeToChatRoom(Long chatRoomId, Long memberId) {
+        Set<Long> subscribers = chatRoomSubscriptions.get(chatRoomId);
+        if (subscribers == null || subscribers.isEmpty()) {
+            log.info("채팅방 {}에 구독 중인 사용자가 없습니다.", chatRoomId);
+            return;
+        }
+
+        subscribers.remove(memberId);
+        if (subscribers.isEmpty()) {
+            chatRoomSubscriptions.remove(chatRoomId);
+        }
+
+        log.info("채팅방 구독 해제 완료 - 채팅방: {}, 사용자: {}", chatRoomId, memberId);
+    }
+
     public void broadcastToChatRoom(Long chatRoomId, WebSocketMessageDTO.Response message) {
         broadcastToChatRoom(chatRoomId, message, null);
     }


### PR DESCRIPTION
## ❤️ 기능 설명
채팅방을 구독 해제하는 이벤트입니다.

채팅방에 구독 해제하고 나면 그 채팅방에 실시간 메시지가 전송되어도 메시지가 오지 않습니다.
채팅방에서 목록 뷰로 넘어갈 때 사용하면 될 거 같습니다.

swagger 테스트 성공 결과 스크린샷 첨부
연결 - 구독 - 메시지 보내기 - 메시지 보내기
<img width="2134" height="392" alt="image" src="https://github.com/user-attachments/assets/f862b282-8480-4335-b180-f14a1d594d31" />

연결 - 구독 - 메시지 받음 - 구독 해제(메시지 안 옴)
<img width="2137" height="424" alt="image" src="https://github.com/user-attachments/assets/7009560e-c1e1-41c5-bb46-aee6c7fe8a2e" />

<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #300 
<br>
<br>

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
