### PR TITLE
[feat/#311] 파일 다운로드 리팩토링 / 파일 업로드 API 구현

### DIFF
--- a/src/main/java/umc/cockple/demo/domain/chat/controller/ChatController.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/controller/ChatController.java
@@ -123,7 +123,7 @@ public class ChatController {
             @PathVariable Long fileId
     ) {
         Long memberId = SecurityUtil.getCurrentMemberId();
-        ChatDownloadTokenDTO.Response response = chatFileService.issueDownloadToken(memberId, fileId);
+        ChatDownloadTokenDTO.Response response = chatFileService.issueDownloadToken(fileId, memberId);
         return BaseResponse.success(CommonSuccessCode.OK, response);
     }
 

--- a/src/main/java/umc/cockple/demo/domain/chat/converter/ChatConverter.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/converter/ChatConverter.java
@@ -215,7 +215,7 @@ public class ChatConverter {
     }
 
     public ChatDownloadTokenDTO.Response toDownloadTokenResponse(DownloadToken token, int validityInSeconds) {
-        String downloadUrl = String.format("/api/chats/files/{fileId}/download?token=%s", token.getFileId(), token.getToken());
+        String downloadUrl = String.format("/api/chats/files/%d/download?token=%s", token.getFileId(), token.getToken());
         return ChatDownloadTokenDTO.Response.builder()
                 .downloadToken(token.getToken())
                 .downloadUrl(downloadUrl)

--- a/src/main/java/umc/cockple/demo/domain/image/controller/ImgController.java
+++ b/src/main/java/umc/cockple/demo/domain/image/controller/ImgController.java
@@ -7,6 +7,7 @@ import org.springframework.http.MediaType;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+import umc.cockple.demo.domain.image.dto.FileUploadDTO;
 import umc.cockple.demo.domain.image.dto.ImageUploadResponseDTO;
 import umc.cockple.demo.domain.image.service.ImageService;
 import umc.cockple.demo.global.enums.DomainType;
@@ -39,5 +40,13 @@ public class ImgController {
                                                                 @RequestParam("domainType") DomainType domainType) {
 
         return BaseResponse.success(CommonSuccessCode.ACCEPTED, imageService.uploadImages(images, domainType));
+    }
+
+    @PostMapping(value = "/s3/upload/file", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @Operation(summary = "파일 업로드", description = "S3에 파일을 업로드하고 파일정보를 반환합니다.")
+    public BaseResponse<FileUploadDTO.Response> fileUpload(@RequestPart("file") MultipartFile file,
+                                                  @RequestParam("domainType") DomainType domainType) {
+
+        return BaseResponse.success(CommonSuccessCode.ACCEPTED, imageService.uploadFile(file, domainType));
     }
 }

--- a/src/main/java/umc/cockple/demo/domain/image/controller/ImgController.java
+++ b/src/main/java/umc/cockple/demo/domain/image/controller/ImgController.java
@@ -8,7 +8,7 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 import umc.cockple.demo.domain.image.dto.FileUploadDTO;
-import umc.cockple.demo.domain.image.dto.ImageUploadResponseDTO;
+import umc.cockple.demo.domain.image.dto.ImageUploadDTO;
 import umc.cockple.demo.domain.image.service.ImageService;
 import umc.cockple.demo.global.enums.DomainType;
 import umc.cockple.demo.global.response.BaseResponse;
@@ -27,8 +27,8 @@ public class ImgController {
 
     @PostMapping(value = "/s3/upload/img", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @Operation(summary = "이미지 업로드", description = "S3에 이미지를 업로드하고 이미지 URL과 imgKey를 반환합니다.")
-    public BaseResponse<ImageUploadResponseDTO> imgUpload(@RequestPart("image") MultipartFile image,
-                                                          @RequestParam("domainType") DomainType domainType) {
+    public BaseResponse<ImageUploadDTO.Response> imgUpload(@RequestPart("image") MultipartFile image,
+                                                           @RequestParam("domainType") DomainType domainType) {
 
         return BaseResponse.success(CommonSuccessCode.ACCEPTED, imageService.uploadImage(image, domainType));
     }
@@ -36,7 +36,7 @@ public class ImgController {
 
     @PostMapping(value = "/s3/upload/imgs", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @Operation(summary = "이미지 여러장 업로드", description = "S3에 이미지 여러장을 업로드하고 이미지 URL과 imgKey를 반환합니다.")
-    public BaseResponse<List<ImageUploadResponseDTO>> imgUpload(@RequestPart("image") List<MultipartFile> images,
+    public BaseResponse<List<ImageUploadDTO.Response>> imgUpload(@RequestPart("image") List<MultipartFile> images,
                                                                 @RequestParam("domainType") DomainType domainType) {
 
         return BaseResponse.success(CommonSuccessCode.ACCEPTED, imageService.uploadImages(images, domainType));

--- a/src/main/java/umc/cockple/demo/domain/image/controller/ImgController.java
+++ b/src/main/java/umc/cockple/demo/domain/image/controller/ImgController.java
@@ -9,7 +9,7 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 import umc.cockple.demo.domain.image.dto.ImageUploadResponseDTO;
 import umc.cockple.demo.domain.image.service.ImageService;
-import umc.cockple.demo.global.enums.ImgType;
+import umc.cockple.demo.global.enums.DomainType;
 import umc.cockple.demo.global.response.BaseResponse;
 import umc.cockple.demo.global.response.code.status.CommonSuccessCode;
 
@@ -27,17 +27,17 @@ public class ImgController {
     @PostMapping(value = "/s3/upload/img", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @Operation(summary = "이미지 업로드", description = "S3에 이미지를 업로드하고 이미지 URL과 imgKey를 반환합니다.")
     public BaseResponse<ImageUploadResponseDTO> imgUpload(@RequestPart("image") MultipartFile image,
-                                                          @RequestParam("imageType") ImgType imgType) {
+                                                          @RequestParam("domainType") DomainType domainType) {
 
-        return BaseResponse.success(CommonSuccessCode.ACCEPTED, imageService.uploadImage(image, imgType));
+        return BaseResponse.success(CommonSuccessCode.ACCEPTED, imageService.uploadImage(image, domainType));
     }
 
 
     @PostMapping(value = "/s3/upload/imgs", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @Operation(summary = "이미지 여러장 업로드", description = "S3에 이미지 여러장을 업로드하고 이미지 URL과 imgKey를 반환합니다.")
     public BaseResponse<List<ImageUploadResponseDTO>> imgUpload(@RequestPart("image") List<MultipartFile> images,
-                                                                @RequestParam("imageType") ImgType imgType) {
+                                                                @RequestParam("domainType") DomainType domainType) {
 
-        return BaseResponse.success(CommonSuccessCode.ACCEPTED, imageService.uploadImages(images, imgType));
+        return BaseResponse.success(CommonSuccessCode.ACCEPTED, imageService.uploadImages(images, domainType));
     }
 }

--- a/src/main/java/umc/cockple/demo/domain/image/dto/FileUploadDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/image/dto/FileUploadDTO.java
@@ -1,4 +1,15 @@
 package umc.cockple.demo.domain.image.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
 public class FileUploadDTO {
+    @Builder
+    public record Response(
+            String fileKey,
+            String fileUrl,
+            String originalFileName,
+            Long fileSize,
+            String fileType
+    ) {}
 }

--- a/src/main/java/umc/cockple/demo/domain/image/dto/FileUploadDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/image/dto/FileUploadDTO.java
@@ -1,0 +1,4 @@
+package umc.cockple.demo.domain.image.dto;
+
+public class FileUploadDTO {
+}

--- a/src/main/java/umc/cockple/demo/domain/image/dto/FileUploadDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/image/dto/FileUploadDTO.java
@@ -1,6 +1,5 @@
 package umc.cockple.demo.domain.image.dto;
 
-import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 public class FileUploadDTO {

--- a/src/main/java/umc/cockple/demo/domain/image/dto/ImageUploadDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/image/dto/ImageUploadDTO.java
@@ -1,0 +1,11 @@
+package umc.cockple.demo.domain.image.dto;
+
+import lombok.Builder;
+
+public class ImageUploadDTO{
+    @Builder
+    public record Response(
+            String imgUrl,
+            String imgKey
+    ) {}
+}

--- a/src/main/java/umc/cockple/demo/domain/image/dto/ImageUploadResponseDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/image/dto/ImageUploadResponseDTO.java
@@ -1,6 +1,0 @@
-package umc.cockple.demo.domain.image.dto;
-
-public record ImageUploadResponseDTO(
-        String imgUrl,
-        String imgKey
-) {}

--- a/src/main/java/umc/cockple/demo/domain/image/exception/S3ErrorCode.java
+++ b/src/main/java/umc/cockple/demo/domain/image/exception/S3ErrorCode.java
@@ -20,7 +20,9 @@ public enum S3ErrorCode implements BaseErrorCode {
     IMAGE_UPLOAD_IO_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR, "IMG502", "이미지 업로드 중, IO 예외가 발생하였습니다. 서버 관리자에게 문의해주세요"),
     IMAGE_STILL_EXIST(HttpStatus.INTERNAL_SERVER_ERROR,"IMG503" ,"이미지가 삭제되지 않고 S3에 남아있습니다. 서버 관리자에게 문의해주세요" ),
     IMAGE_DELETE_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR,"IMG504" ,"이미지 삭제에 실패하였습니다. 서버관리자에게 문의해주세요" ),
-    IMAGE_BUCKET_DIRECTORY_NULL(HttpStatus.BAD_REQUEST, "IMG401", "버킷 디렉토리 값이 유효하지 않습니다."),
+    IMAGE_BUCKET_DIRECTORY_NULL(HttpStatus.BAD_REQUEST, "IMG505", "버킷 디렉토리 값이 유효하지 않습니다."),
+    FILE_UPLOAD_AMAZON_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR, "IMG506", "파일 업로드 중, AWS 예외가 발생하였습니다. 서버 관리자에게 문의해주세요"),
+    FILE_UPLOAD_IO_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR, "IMG507", "파일 업로드 중, IO 예외가 발생하였습니다. 서버 관리자에게 문의해주세요"),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/umc/cockple/demo/domain/image/service/ImageService.java
+++ b/src/main/java/umc/cockple/demo/domain/image/service/ImageService.java
@@ -43,9 +43,7 @@ public class ImageService {
         String imgUrl = uploadToS3(image, key, false);
 
         log.info("[이미지 업로드 완료]");
-
-        // 업로드된 이미지의 전체 URL 반환
-        return new ImageUploadResponseDTO(imgUrl, extractKeyFromUrl(imgUrl, domainType));
+        return new ImageUploadResponseDTO(imgUrl, key);
     }
 
     public FileUploadDTO.Response uploadFile(MultipartFile file, DomainType domainType) {
@@ -126,21 +124,6 @@ public class ImageService {
         String uuid = UUID.randomUUID().toString();
 
         return domainType.getDirectory() + "/" + uuid + "." + extension;
-    }
-
-    public String extractKeyFromUrl(String url, DomainType domainType) {
-        int startIndex;
-        if (domainType == DomainType.CONTEST) {
-            startIndex = url.indexOf("contest-images/");
-        } else if (domainType == DomainType.PROFILE) {
-            startIndex = url.indexOf("profile-image/");
-        } else if (domainType == DomainType.CHAT) {
-            startIndex = url.indexOf("chat-images/");
-        } else {
-            startIndex = url.indexOf("party-images/");
-        }
-
-        return url.substring(startIndex);
     }
 
     public String getUrlFromKey(String key) {

--- a/src/main/java/umc/cockple/demo/domain/image/service/ImageService.java
+++ b/src/main/java/umc/cockple/demo/domain/image/service/ImageService.java
@@ -12,13 +12,14 @@ import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 import org.springframework.web.multipart.MultipartFile;
 import umc.cockple.demo.domain.image.dto.FileUploadDTO;
-import umc.cockple.demo.domain.image.dto.ImageUploadResponseDTO;
+import umc.cockple.demo.domain.image.dto.ImageUploadDTO;
 import umc.cockple.demo.domain.image.exception.S3ErrorCode;
 import umc.cockple.demo.domain.image.exception.S3Exception;
 import umc.cockple.demo.global.enums.DomainType;
 
 import java.io.IOException;
-import java.util.*;
+import java.util.List;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 @Service
@@ -32,7 +33,7 @@ public class ImageService {
     private final AmazonS3 amazonS3;
 
 
-    public ImageUploadResponseDTO uploadImage(MultipartFile image, DomainType domainType) {
+    public ImageUploadDTO.Response uploadImage(MultipartFile image, DomainType domainType) {
         if (image == null || image.isEmpty()) {
             return null;
         }
@@ -43,7 +44,10 @@ public class ImageService {
         String imgUrl = uploadToS3(image, key, false);
 
         log.info("[이미지 업로드 완료]");
-        return new ImageUploadResponseDTO(imgUrl, key);
+        return ImageUploadDTO.Response.builder()
+                .imgUrl(imgUrl)
+                .imgKey(key)
+                .build();
     }
 
     public FileUploadDTO.Response uploadFile(MultipartFile file, DomainType domainType) {
@@ -72,7 +76,7 @@ public class ImageService {
      * @param images MultipartFile 이미지 리스트
      * @return 업로드된 이미지 URL 리스트
      */
-    public List<ImageUploadResponseDTO> uploadImages(List<MultipartFile> images, DomainType domainType) {
+    public List<ImageUploadDTO.Response> uploadImages(List<MultipartFile> images, DomainType domainType) {
         if (images == null || images.isEmpty()) {
             return List.of(); // 빈 리스트 반환
         }

--- a/src/main/java/umc/cockple/demo/domain/image/service/ImageService.java
+++ b/src/main/java/umc/cockple/demo/domain/image/service/ImageService.java
@@ -4,6 +4,7 @@ import com.amazonaws.AmazonServiceException;
 import com.amazonaws.HttpMethod;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
+import com.amazonaws.services.s3.model.S3Object;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -134,19 +135,7 @@ public class ImageService {
         return amazonS3.getUrl(bucket, key).toString();
     }
 
-    public Resource downloadFile(String fileKey) throws MalformedURLException {
-        Date expiration = new Date();
-        long expTimeMillis = expiration.getTime();
-        expTimeMillis += 1000 * 60;
-        expiration.setTime(expTimeMillis);
-
-        //Pre-signed URL 생성
-        GeneratePresignedUrlRequest generatePresignedUrlRequest =
-                new GeneratePresignedUrlRequest(bucket, fileKey)
-                        .withMethod(HttpMethod.GET)
-                        .withExpiration(expiration);
-        URL url = amazonS3.generatePresignedUrl(generatePresignedUrlRequest);
-        System.out.println("url테스트: " + url);
-        return new UrlResource(url);
+    public S3Object downloadFile(String fileKey) {
+        return amazonS3.getObject(bucket, fileKey);
     }
 }

--- a/src/main/java/umc/cockple/demo/domain/image/service/ImageService.java
+++ b/src/main/java/umc/cockple/demo/domain/image/service/ImageService.java
@@ -1,7 +1,9 @@
 package umc.cockple.demo.domain.image.service;
 
 import com.amazonaws.AmazonServiceException;
+import com.amazonaws.HttpMethod;
 import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -133,7 +135,18 @@ public class ImageService {
     }
 
     public Resource downloadFile(String fileKey) throws MalformedURLException {
-        URL fileUrl = amazonS3.getUrl(bucket, fileKey);
-        return new UrlResource(fileUrl);
+        Date expiration = new Date();
+        long expTimeMillis = expiration.getTime();
+        expTimeMillis += 1000 * 60;
+        expiration.setTime(expTimeMillis);
+
+        //Pre-signed URL 생성
+        GeneratePresignedUrlRequest generatePresignedUrlRequest =
+                new GeneratePresignedUrlRequest(bucket, fileKey)
+                        .withMethod(HttpMethod.GET)
+                        .withExpiration(expiration);
+        URL url = amazonS3.generatePresignedUrl(generatePresignedUrlRequest);
+        System.out.println("url테스트: " + url);
+        return new UrlResource(url);
     }
 }

--- a/src/main/java/umc/cockple/demo/global/enums/DomainType.java
+++ b/src/main/java/umc/cockple/demo/global/enums/DomainType.java
@@ -1,9 +1,15 @@
 package umc.cockple.demo.global.enums;
 
-public enum DomainType {
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
-    CONTEST,
-    PROFILE,
-    PARTY,
-    CHAT
+@Getter
+@RequiredArgsConstructor
+public enum DomainType {
+    CONTEST("contest"),
+    PROFILE("profile"),
+    CHAT("chat"),
+    PARTY("party");
+
+    private final String directory;
 }

--- a/src/main/java/umc/cockple/demo/global/enums/DomainType.java
+++ b/src/main/java/umc/cockple/demo/global/enums/DomainType.java
@@ -1,4 +1,9 @@
 package umc.cockple.demo.global.enums;
 
 public enum DomainType {
+
+    CONTEST,
+    PROFILE,
+    PARTY,
+    CHAT
 }

--- a/src/main/java/umc/cockple/demo/global/enums/DomainType.java
+++ b/src/main/java/umc/cockple/demo/global/enums/DomainType.java
@@ -1,0 +1,4 @@
+package umc.cockple.demo.global.enums;
+
+public enum DomainType {
+}

--- a/src/main/java/umc/cockple/demo/global/enums/ImgType.java
+++ b/src/main/java/umc/cockple/demo/global/enums/ImgType.java
@@ -1,9 +1,0 @@
-package umc.cockple.demo.global.enums;
-
-public enum ImgType {
-
-    CONTEST,
-    PROFILE,
-    PARTY,
-    CHAT
-}


### PR DESCRIPTION
## ❤️ 기능 설명
- 파일 다운로드를 S3Object를 직접 가져오는 방식으로 리팩토링했습니다.
  - Pre-signed URL (임시 비밀번호가 포함된 URL) 방식으로 구현하다가 헤더 불일치로 인하여 생기는 오류로 인하여 S3Object를 직접 가져오는 getObject 방식으로 변경했습니다.
  - getObject 방식이 메타데이터나 파일을 직접 다룰 수 있기에 보안상 더 안전하고 코드도 간소화되나, 비용적으로 Pre-signed URL이 더 좋기에 추후에 리팩토링 고려 중입니다.
 
- 파일 업로드 API를 구현했습니다.

swagger 테스트 성공 결과 스크린샷 첨부

파일 다운로드
<img width="704" height="152" alt="image" src="https://github.com/user-attachments/assets/eacfc695-2477-4a8c-874f-95ed0ecd16e0" />
<img width="702" height="152" alt="image" src="https://github.com/user-attachments/assets/9f922936-84dc-4b4a-9c19-c76dfa2d648a" />

파일 업로드
<img width="713" height="263" alt="image" src="https://github.com/user-attachments/assets/c3d66476-7ad8-437f-b540-5b93d212ee1e" />
<img width="704" height="114" alt="image" src="https://github.com/user-attachments/assets/059f2bce-a7f5-4885-9b69-3d02230aa0da" />

<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #311
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 현재 파일 업로드 구현을 이미지 서비스 내부에 구현 해놨습니다. 이것을 파일 서비스를 만들어 분리해놓는 것이 좋을지, 중복되는 코드가 많기에 이미지 업로드 코드와 합쳐 리팩토링할지 의견 여쭤봅니다.  
- [ ] Pre-signed URL 방식은 CORS 문제가 있다는데 이거에 대해 잘 아시는분 계신가요?

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
