### PR TITLE
[fix/#324] 모임 주소 중복 유니크 제약조건 추가

### DIFF
--- a/src/main/java/umc/cockple/demo/domain/party/domain/PartyAddr.java
+++ b/src/main/java/umc/cockple/demo/domain/party/domain/PartyAddr.java
@@ -12,6 +12,12 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Getter
+@Table(name = "party_addr", uniqueConstraints = {
+        @UniqueConstraint(
+                name = "uk_addr1_addr2",
+                columnNames = {"addr1", "addr2"}
+        )
+})
 public class PartyAddr extends BaseEntity {
 
     @Id


### PR DESCRIPTION
## ❤️ 기능 설명
addr1과 addr2가 둘다 같은 경우를 막기 위해 복합 유니크 제약조건 추가

swagger 테스트 성공 결과 스크린샷 첨부
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #324 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- 없습니다.

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
