### PR TITLE
[feat/#322] 탈퇴 회원 시큐리티 필터에서 검증

### DIFF
--- a/src/main/java/umc/cockple/demo/domain/member/domain/Member.java
+++ b/src/main/java/umc/cockple/demo/domain/member/domain/Member.java
@@ -170,4 +170,8 @@ public class Member extends BaseEntity {
     public void setRefreshToken(String refreshToken) {
         this.refreshToken = refreshToken;
     }
+
+    public void rejoin() {
+        this.isActive = MemberStatus.ACTIVE;
+    }
 }

--- a/src/main/java/umc/cockple/demo/domain/member/service/MemberCommandService.java
+++ b/src/main/java/umc/cockple/demo/domain/member/service/MemberCommandService.java
@@ -10,6 +10,7 @@ import umc.cockple.demo.domain.member.domain.*;
 import umc.cockple.demo.domain.member.dto.MemberDetailInfoRequestDTO;
 import umc.cockple.demo.domain.member.dto.UpdateProfileRequestDTO;
 import umc.cockple.demo.domain.member.dto.kakao.KakaoLoginDTO;
+import umc.cockple.demo.domain.member.enums.MemberPartyStatus;
 import umc.cockple.demo.domain.member.exception.MemberErrorCode;
 import umc.cockple.demo.domain.member.exception.MemberException;
 import umc.cockple.demo.domain.member.repository.*;
@@ -252,9 +253,12 @@ public class MemberCommandService {
             throw new MemberException(MemberErrorCode.ALREADY_WITHDRAW);
         }
 
-        // 모임장인 경우 -> 탈퇴 불가
+        // 활성화 된 모임의 모임장인 경우 -> 탈퇴 불가
         boolean isLeader = member.getMemberParties().stream()
-                .anyMatch(MemberParty::isLeader);
+                .anyMatch(memberParty ->
+                        memberParty.isLeader()
+                                && memberParty.getStatus() == MemberPartyStatus.ACTIVE
+                );
 
         if (isLeader) {
             throw new MemberException(MemberErrorCode.MANAGER_CANNOT_LEAVE);

--- a/src/main/java/umc/cockple/demo/global/config/SecurityConfig.java
+++ b/src/main/java/umc/cockple/demo/global/config/SecurityConfig.java
@@ -13,6 +13,8 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import umc.cockple.demo.domain.member.repository.MemberRepository;
+import umc.cockple.demo.global.exception.RestAuthenticationEntryPoint;
 import umc.cockple.demo.global.jwt.domain.JwtTokenProvider;
 import umc.cockple.demo.global.security.filter.JwtAuthenticationFilter;
 
@@ -23,8 +25,9 @@ import java.util.List;
 @RequiredArgsConstructor
 public class SecurityConfig {
 
-    private final JwtTokenProvider jwtTokenProvider;
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
     private final CorsConfigurationSource corsConfigurationSource;
+    private final RestAuthenticationEntryPoint restEntryPoint;
 
 
     @Bean
@@ -46,6 +49,7 @@ public class SecurityConfig {
         http
                 .cors(cors -> cors.configurationSource(corsConfigurationSource))
                 .csrf(AbstractHttpConfigurer::disable)
+                .exceptionHandling(e -> e.authenticationEntryPoint(restEntryPoint))
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .formLogin(AbstractHttpConfigurer::disable)
                 .sessionManagement(session ->
@@ -55,7 +59,7 @@ public class SecurityConfig {
                         .requestMatchers("/api/oauth/login", "/api/auth/dev-token").permitAll()
                         .anyRequest().authenticated()
                 )
-                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider),
+                .addFilterBefore(jwtAuthenticationFilter,
                         UsernamePasswordAuthenticationFilter.class)
         ;
 

--- a/src/main/java/umc/cockple/demo/global/exception/RestAuthenticationEntryPoint.java
+++ b/src/main/java/umc/cockple/demo/global/exception/RestAuthenticationEntryPoint.java
@@ -1,0 +1,23 @@
+package umc.cockple.demo.global.exception;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class RestAuthenticationEntryPoint implements AuthenticationEntryPoint {
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException {
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED); // 401
+        response.setContentType("application/json;charset=UTF-8");
+        String body = """
+        {"success":false,"code":"AUTH-401","message":"%s"}
+        """.formatted(authException.getMessage() == null ? "Unauthorized" : authException.getMessage());
+        response.getWriter().write(body);
+    }
+}

--- a/src/main/java/umc/cockple/demo/global/exception/RestAuthenticationEntryPoint.java
+++ b/src/main/java/umc/cockple/demo/global/exception/RestAuthenticationEntryPoint.java
@@ -16,8 +16,8 @@ public class RestAuthenticationEntryPoint implements AuthenticationEntryPoint {
         response.setStatus(HttpServletResponse.SC_UNAUTHORIZED); // 401
         response.setContentType("application/json;charset=UTF-8");
         String body = """
-        {"success":false,"code":"AUTH-401","message":"%s"}
-        """.formatted(authException.getMessage() == null ? "Unauthorized" : authException.getMessage());
+        {"success":false,"code":"AUTH401","message":"%s"}
+        """.formatted(authException.getMessage() == null ? "권한이 존재하지 않습니다" : authException.getMessage());
         response.getWriter().write(body);
     }
 }

--- a/src/main/java/umc/cockple/demo/global/oauth2/service/KakaoOauthService.java
+++ b/src/main/java/umc/cockple/demo/global/oauth2/service/KakaoOauthService.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import umc.cockple.demo.domain.member.domain.Member;
 import umc.cockple.demo.domain.member.dto.kakao.KakaoLoginDTO;
+import umc.cockple.demo.domain.member.enums.MemberStatus;
 import umc.cockple.demo.domain.member.exception.MemberErrorCode;
 import umc.cockple.demo.domain.member.exception.MemberException;
 import umc.cockple.demo.domain.member.repository.MemberRepository;
@@ -45,8 +46,13 @@ public class KakaoOauthService {
                 memberRepository.save(Member.builder()
                         .socialId(info.kakaoId())
                         .nickname(info.nickname())
+                        .isActive(MemberStatus.ACTIVE)
                         .build())
         );
+
+        if (member.getIsActive() == MemberStatus.INACTIVE) {
+            member.rejoin();
+        }
 
         // 4. jwt 발급
         String accessToken = jwtTokenProvider.createAccessToken(member.getId(), member.getNickname());

--- a/src/main/java/umc/cockple/demo/global/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/umc/cockple/demo/global/security/filter/JwtAuthenticationFilter.java
@@ -6,37 +6,75 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
+import umc.cockple.demo.domain.member.domain.Member;
+import umc.cockple.demo.domain.member.enums.MemberStatus;
+import umc.cockple.demo.domain.member.exception.MemberErrorCode;
+import umc.cockple.demo.domain.member.exception.MemberException;
 import umc.cockple.demo.domain.member.repository.MemberRepository;
+import umc.cockple.demo.global.exception.RestAuthenticationEntryPoint;
 import umc.cockple.demo.global.jwt.domain.JwtTokenProvider;
+import umc.cockple.demo.global.response.dto.ErrorReasonDTO;
 import umc.cockple.demo.global.security.domain.CustomUserDetails;
 
 import java.io.IOException;
 
 @RequiredArgsConstructor
+@Component
 @Slf4j
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtTokenProvider jwtTokenProvider;
+    private final MemberRepository memberRepository;
+    private final RestAuthenticationEntryPoint restEntryPoint;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
 
         String token = resolveToken(request);
 
-        if (token != null && jwtTokenProvider.validateToken(token)) {
+        // token이 null -> 로그 찍고 그대로 진행
+        if (token == null) {
+            log.trace("Authorization 헤더에 토큰 없음");
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        try {
+
+            if (!jwtTokenProvider.validateToken(token)) {
+                throw new MemberException(MemberErrorCode.INVALID_TOKEN);
+            }
+
+
+            Long memberId = jwtTokenProvider.getUserId(token);
+            Member member = memberRepository.findById(memberId)
+                    .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
+
+            // 탈퇴 회원 검증
+            if (member.getIsActive() == MemberStatus.INACTIVE) {
+                throw new MemberException(MemberErrorCode.ALREADY_WITHDRAW);
+            }
+
             Authentication auth = jwtTokenProvider.getAuthentication(token);
             SecurityContextHolder.getContext().setAuthentication(auth);
             log.debug("인증 정보 SecurityContext에 저장 완료: {}", auth.getName());
-        }else {
-            log.trace("Authorization 헤더에 토큰 없음 혹은 유효하지 않음");
-        }
 
-        filterChain.doFilter(request, response);
+            filterChain.doFilter(request, response);
+
+        } catch (MemberException e) {
+            SecurityContextHolder.clearContext();
+            restEntryPoint.commence(request, response, new BadCredentialsException(e.getMessage() == null ? "UNAUTHORIZED" : e.getMessage()));
+
+        } catch (RuntimeException e) { // 혹시 남아있는 경우에도 401로 변환
+            SecurityContextHolder.clearContext();
+            restEntryPoint.commence(request, response, new BadCredentialsException(e.getMessage() == null ? "UNAUTHORIZED" : e.getMessage()));
+        }
 
     }
 
@@ -50,4 +88,5 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         return null;
     }
+
 }


### PR DESCRIPTION
## ❤️ 기능 설명
- 기존에 status만 변경했었는데, status에 따라 시큐리티 필터에서 검증하도록 변경

swagger 테스트 성공 결과 스크린샷 첨부

회원 탈퇴
<img width="794" height="801" alt="스크린샷 2025-08-12 003619" src="https://github.com/user-attachments/assets/d24691f1-1af1-43dd-a8b7-aea5f992117b" />

탈퇴 후 다른 요청에 접근시 401 에러
<img width="807" height="1038" alt="스크린샷 2025-08-12 003642" src="https://github.com/user-attachments/assets/6406f2a2-29e9-44c1-95b9-0a1d4c9b1419" />

<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #322 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!



<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
