### PR TITLE
[feat/#296] 키워드 추가 API 구현

### DIFF
--- a/src/main/java/umc/cockple/demo/domain/party/controller/PartyController.java
+++ b/src/main/java/umc/cockple/demo/domain/party/controller/PartyController.java
@@ -293,4 +293,21 @@ public class PartyController {
         partyCommandService.actionInvitation(memberId, request, invitationId);
         return BaseResponse.success(CommonSuccessCode.OK);
     }
+
+    @PostMapping("/parties/{partyId}/keywords")
+    @Operation(summary = "모임 키워드 추가",
+            description = "사용자가 모임에 키워드를 추가합니다.")
+    @ApiResponse(responseCode = "200", description = "키워드 추가 성공")
+    @ApiResponse(responseCode = "403", description = "모임장 권한 없음")
+    @ApiResponse(responseCode = "404", description = "존재하지 않는 모임")
+    @ApiResponse(responseCode = "409", description = "이미 추가된 키워드")
+    public BaseResponse<Void> addKeyword(
+            @PathVariable Long partyId,
+            @RequestBody @Valid PartyKeywordDTO.Request request
+    ){
+        Long memberId = SecurityUtil.getCurrentMemberId();
+
+        partyCommandService.addKeyword(partyId, memberId, request);
+        return BaseResponse.success(CommonSuccessCode.OK);
+    }
 }

--- a/src/main/java/umc/cockple/demo/domain/party/dto/PartyKeywordDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/party/dto/PartyKeywordDTO.java
@@ -1,0 +1,14 @@
+package umc.cockple.demo.domain.party.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
+
+public class PartyKeywordDTO {
+    @Builder
+    @Schema(name = "PartyKeywordRequestDTO", description = "모임 키워드 추가/삭제 요청")
+    public record Request(
+            @NotBlank(message = "키워드는 필수입니다.")
+            String keyword
+    ){}
+}

--- a/src/main/java/umc/cockple/demo/domain/party/exception/PartyErrorCode.java
+++ b/src/main/java/umc/cockple/demo/domain/party/exception/PartyErrorCode.java
@@ -43,7 +43,9 @@ public enum PartyErrorCode implements BaseErrorCode {
     PARTY_IS_DELETED(HttpStatus.BAD_REQUEST, "PARTY407", "이미 삭제된 모임입니다."),
     CANNOT_REMOVE_SELF(HttpStatus.BAD_REQUEST, "PARTY408", "자기 자신을 모임에서 삭제할 수 없습니다."),
     INVITATION_ALREADY_EXISTS(HttpStatus.CONFLICT, "PARTY409", "처리 대기중인 초대가 존재합니다."),
-    INVITATION_ALREADY_ACTIONS(HttpStatus.CONFLICT, "PARTY410", "이미 처리된 모임 초대입니다.");
+    INVITATION_ALREADY_ACTIONS(HttpStatus.CONFLICT, "PARTY410", "이미 처리된 모임 초대입니다."),
+    KEYWORD_ALREADY_EXISTS(HttpStatus.CONFLICT, "PARTY411", "이미 존재하는 키워드입니다.")
+    ;
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/umc/cockple/demo/domain/party/repository/PartyKeywordRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/party/repository/PartyKeywordRepository.java
@@ -1,4 +1,10 @@
 package umc.cockple.demo.domain.party.repository;
 
-public interface PartyKeywordRepository {
+import org.springframework.data.jpa.repository.JpaRepository;
+import umc.cockple.demo.domain.party.domain.Party;
+import umc.cockple.demo.domain.party.domain.PartyKeyword;
+import umc.cockple.demo.global.enums.Keyword;
+
+public interface PartyKeywordRepository extends JpaRepository<PartyKeyword, Long> {
+    boolean existsByPartyAndKeyword(Party party, Keyword keyword);
 }

--- a/src/main/java/umc/cockple/demo/domain/party/repository/PartyKeywordRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/party/repository/PartyKeywordRepository.java
@@ -1,0 +1,4 @@
+package umc.cockple.demo.domain.party.repository;
+
+public interface PartyKeywordRepository {
+}

--- a/src/main/java/umc/cockple/demo/domain/party/service/PartyCommandService.java
+++ b/src/main/java/umc/cockple/demo/domain/party/service/PartyCommandService.java
@@ -12,4 +12,5 @@ public interface PartyCommandService {
     PartyInviteCreateDTO.Response createInvitation(Long partyId, Long memberIdToInvite, Long currentMemberId);
     void actionInvitation(Long memberId, PartyInviteActionDTO.Request request, Long invitationId);
     void updateParty(Long partyId, Long memberId, PartyUpdateDTO.Request request);
+    void addKeyword(Long partyId, Long memberID, PartyKeywordDTO.Request request);
 }


### PR DESCRIPTION
## ❤️ 기능 설명
모임의 키워드를 등록하는 API를 구현합니다.

swagger 테스트 성공 결과 스크린샷 첨부
<img width="715" height="248" alt="image" src="https://github.com/user-attachments/assets/e181886f-34e5-4930-9352-3c4fa255ac78" />
<img width="706" height="85" alt="image" src="https://github.com/user-attachments/assets/8221e0d7-aef0-4b15-9215-9502e72aed3a" />
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #296
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- 없습니다.
<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
