### PR TITLE
[debug#337] LEFT JOIN으로 개인 채팅 조회 안 되는 에러 해결

### DIFF
--- a/src/main/java/umc/cockple/demo/domain/chat/controller/ChatController.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/controller/ChatController.java
@@ -95,9 +95,7 @@ public class ChatController {
             @PathVariable Long roomId
     ) {
         Long memberId = SecurityUtil.getCurrentMemberId();
-
         ChatRoomDetailDTO.Response response = chatQueryService.getChatRoomDetail(roomId, memberId);
-
         return BaseResponse.success(CommonSuccessCode.OK, response);
     }
 

--- a/src/main/java/umc/cockple/demo/domain/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/repository/ChatRoomRepository.java
@@ -95,7 +95,7 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
 
     @Query("""
             SELECT cr FROM ChatRoom cr
-            JOIN FETCH cr.party p
+            LEFT JOIN FETCH cr.party p
             LEFT JOIN FETCH p.partyImg img
             WHERE cr.id = :roomId
             """)


### PR DESCRIPTION
## ❤️ 기능 설명
기존 sql 쿼리는 조인할 때 파티와 이너 조인을 합니다.
이는 개인 채팅방 조회 시 파티가 null값이므로 제대로 조회되지 않는 문제를 발생시킵니다.

이를 LEFT JOIN으로 해결하였습니다.

swagger 테스트 성공 결과 스크린샷 첨부
<img width="1162" height="1150" alt="image" src="https://github.com/user-attachments/assets/b58b1e53-32e9-4737-be6d-c141fcb14590" />

<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #337  
<br>
<br>

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
