### PR TITLE
[fix/#326] 특정 지역으로 조회 시, addr2가 전체인 모임도 조회되도록 수정

### DIFF
--- a/src/main/java/umc/cockple/demo/domain/party/repository/PartyRepositoryCustomImpl.java
+++ b/src/main/java/umc/cockple/demo/domain/party/repository/PartyRepositoryCustomImpl.java
@@ -78,7 +78,7 @@ public class PartyRepositoryCustomImpl implements PartyRepositoryCustom {
     }
 
     private BooleanExpression addr2Eq(String addr2) {
-        return StringUtils.hasText(addr2) ? party.partyAddr.addr2.eq(addr2) : null;
+        return StringUtils.hasText(addr2) ? party.partyAddr.addr2.eq(addr2).or(party.partyAddr.addr2.eq("전체")) : null;
     }
 
     private BooleanExpression partyTypeIn(List<String> partyTypes) {


### PR DESCRIPTION
## ❤️ 기능 설명
모임 지역(addr2)을 특정 지역으로 조회 시, 모임 지역(addr2)가 전체인 모임도 의미 상 포함되므로 조회되도록 수정합니다.

swagger 테스트 성공 결과 스크린샷 첨부
<img width="716" height="242" alt="image" src="https://github.com/user-attachments/assets/3936ce36-001a-4c44-82d1-912f80a04f90" />
<img width="703" height="239" alt="image" src="https://github.com/user-attachments/assets/c48bba0d-d033-4d1e-ace3-c0ec07cfdf94" />
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #326
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- 없습니다.

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
