### PR TITLE
[fix#348] 운동 신청 시 급수 조건이 맞지 않더라도 신청할 수 있도록 변경

### DIFF
--- a/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseValidator.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseValidator.java
@@ -40,7 +40,7 @@ public class ExerciseValidator {
         validateAlreadyStarted(exercise, ExerciseErrorCode.EXERCISE_ALREADY_STARTED_PARTICIPATION);
         validateAlreadyJoined(exercise, member);
         validateJoinPermission(exercise, member);
-        validateMemberLevel(exercise.getParty(), member);
+//        validateMemberLevel(exercise.getParty(), member);
         validateMemberAge(exercise.getParty(), member);
     }
 


### PR DESCRIPTION
## ❤️ 기능 설명
운동 신청 시 급수 조건이 맞지 않아도 신청할 수 있도록 검증 메서드를 주석처리 했습니다.

swagger 테스트 성공 결과 스크린샷 첨부
<img width="1430" height="64" alt="image" src="https://github.com/user-attachments/assets/a499b1f9-78f9-4ed3-9b9f-6ca5ae054925" />


<img width="828" height="823" alt="image" src="https://github.com/user-attachments/assets/48591e00-8614-47af-8bc8-3a2f051eac7a" />

<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #348 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 혹시 요구사항이 바뀔 수도 있으므로 코드 삭제 대신 호출 로직을 주석 처리 했습니다!

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
