### PR TITLE
[debug#359] 웹소켓 설정에서 프론트 배포 주소 CORS 허용

### DIFF
--- a/src/main/java/umc/cockple/demo/global/config/WebSocketConfig.java
+++ b/src/main/java/umc/cockple/demo/global/config/WebSocketConfig.java
@@ -21,7 +21,7 @@ public class WebSocketConfig implements WebSocketConfigurer {
         registry
                 .addHandler(chatWebSocketHandler, "/ws/chats")
                 .addInterceptors(jwtWebSocketAuthInterceptor)
-                .setAllowedOrigins("http://localhost:5173", "https://cockple.store")
+                .setAllowedOrigins("http://localhost:5173", "https://cockple.store", "https://cockple-fe.vercel.app/")
                 .withSockJS(); // 브라우저 호환성
     }
 }


### PR DESCRIPTION
## ❤️ 기능 설명
프론트 배포 주소에서 웹소켓 cors 허용이 되어있지 않아 에러가 발생했습니다.
이를 배포 주소를 추가하여 해결합니다.

swagger 테스트 성공 결과 스크린샷 첨부
테스트는 프론트 측에 여쭤봐야 할 거 같습니다!
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #359 
<br>
<br>

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
