### PR TITLE
[fix/#361] 모임 관련 검증 수정사항 반영

### DIFF
--- a/src/main/java/umc/cockple/demo/domain/party/service/PartyCommandServiceImpl.java
+++ b/src/main/java/umc/cockple/demo/domain/party/service/PartyCommandServiceImpl.java
@@ -381,18 +381,6 @@ public class PartyCommandServiceImpl implements PartyCommandService {
 
         //생성하려는 모임의 나이 조건에 본인도 적합한지 확인
         validateAgeRequirement(owner, command.minBirthYear(), command.maxBirthYear());
-
-        //생성하려는 모임의 급수 조건에 본인도 적합한지 확인
-        List<Level> requiredLevels;
-        if (ownerGender == Gender.FEMALE) {
-            requiredLevels = command.femaleLevel();
-        } else { // MALE
-            requiredLevels = command.maleLevel();
-        }
-        if (!requiredLevels.contains(ownerLevel)) {
-            throw new PartyException(PartyErrorCode.LEVEL_NOT_MATCH);
-        }
-
     }
 
     //모임 멤버 삭제 검증


### PR DESCRIPTION
## ❤️ 기능 설명
- 모임 생성 시에도 급수 조건을 따지지 않도록 수정 (사용자의 급수가 급수없음인 경우 급수 조건을 따질 수 없고, 사용자가 원하는 멤버의 급수대가 본인과 일치하지 않을 수 있기에 요구사항 변경)
- 모임 가입신청 처리 시, 이미 멤버인지 검증하는 로직 추가

swagger 테스트 성공 결과 스크린샷 첨부
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #361
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- 없습니다

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
