### PR TITLE
[fix/#362] 현재 (목록/개인) 채팅방 목록 조회 및 검색 API에서 채팅방이 없을 때 에러 던지는 걸 빈 배열 던지는 걸로 반환

### DIFF
--- a/src/main/java/umc/cockple/demo/domain/chat/converter/ChatConverter.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/converter/ChatConverter.java
@@ -10,7 +10,7 @@ import umc.cockple.demo.domain.chat.enums.WebSocketMessageType;
 import umc.cockple.demo.domain.member.domain.Member;
 import umc.cockple.demo.domain.chat.dto.*;
 
-import java.time.LocalDateTime;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -23,6 +23,13 @@ public class ChatConverter {
         return PartyChatRoomDTO.Response.builder()
                 .content(chatRoomInfos)
                 .hasNext(hasNext)
+                .build();
+    }
+
+    public PartyChatRoomDTO.Response toEmptyPartyChatRoomInfos() {
+        return PartyChatRoomDTO.Response.builder()
+                .content(Collections.emptyList())
+                .hasNext(false)
                 .build();
     }
 

--- a/src/main/java/umc/cockple/demo/domain/chat/converter/ChatConverter.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/converter/ChatConverter.java
@@ -68,6 +68,13 @@ public class ChatConverter {
                 .build();
     }
 
+    public DirectChatRoomDTO.Response toEmptyDirectChatRoomInfos() {
+        return DirectChatRoomDTO.Response.builder()
+                .content(Collections.emptyList())
+                .hasNext(false)
+                .build();
+    }
+
     public DirectChatRoomDTO.ChatRoomInfo toDirectChatRoomInfo(ChatRoom chatRoom,
                                                                ChatRoomMember chatRoomMember,
                                                                int unreadCount,

--- a/src/main/java/umc/cockple/demo/domain/chat/service/ChatQueryServiceImpl.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/ChatQueryServiceImpl.java
@@ -210,7 +210,7 @@ public class ChatQueryServiceImpl implements ChatQueryService {
 
     private DirectChatRoomDTO.Response toDirectChatRoomInfos(Slice<ChatRoom> chatRooms, Long memberId) {
         if (chatRooms.isEmpty()) {
-            throw new ChatException(ChatErrorCode.CHAT_ROOM_NOT_FOUND);
+            return chatConverter.toEmptyDirectChatRoomInfos();
         }
         // 각 채팅방에 대해 ChatRoomInfo 생성
         List<DirectChatRoomDTO.ChatRoomInfo> roomInfos = chatRooms.stream()

--- a/src/main/java/umc/cockple/demo/domain/chat/service/ChatQueryServiceImpl.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/ChatQueryServiceImpl.java
@@ -177,7 +177,7 @@ public class ChatQueryServiceImpl implements ChatQueryService {
     // ========== 비즈니스 로직 ==========
     private PartyChatRoomDTO.Response toPartyChatRoomInfos(Slice<ChatRoom> chatRooms, Long memberId) {
         if (chatRooms.isEmpty()) {
-            throw new ChatException(ChatErrorCode.CHAT_ROOM_NOT_FOUND);
+            return chatConverter.toEmptyPartyChatRoomInfos();
         }
         List<PartyChatRoomDTO.ChatRoomInfo> roomInfos = chatRooms.stream()
                 .map(chatRoom -> {


### PR DESCRIPTION
## ❤️ 기능 설명

swagger 테스트 성공 결과 스크린샷 첨부
개인 채팅방 목록 조회
<img width="569" height="782" alt="image" src="https://github.com/user-attachments/assets/83fa0cfd-58c5-4d9c-b068-9ffe7cd78eb2" />

개인 채팅방 이름 검색
<img width="541" height="778" alt="image" src="https://github.com/user-attachments/assets/c1b8428a-b35a-4918-9a5a-8d8c7000a38b" />

모임 채팅방 목록 조회
<img width="550" height="814" alt="image" src="https://github.com/user-attachments/assets/7de829d7-199f-44ac-a04b-76f1d9b51646" />

모임 채팅방 이름 검색
<img width="569" height="776" alt="image" src="https://github.com/user-attachments/assets/04517824-c4fa-42d4-85c0-3cbc40300f6f" />


<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #362 
<br>
<br>

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
