### PR TITLE
[debug/#365] 잘못된 사용자id를 넘겨주어 생기던 로직 오류 해결

### DIFF
--- a/src/main/java/umc/cockple/demo/domain/party/service/PartyCommandServiceImpl.java
+++ b/src/main/java/umc/cockple/demo/domain/party/service/PartyCommandServiceImpl.java
@@ -204,8 +204,8 @@ public class PartyCommandServiceImpl implements PartyCommandService {
 
         //모임, 가입신청 조회
         Party party = findPartyOrThrow(partyId);
-        Member member = findMemberOrThrow(memberId);
         PartyJoinRequest partyJoinRequest = findJoinRequestOrThrow(requestId);
+        Member member = partyJoinRequest.getMember();
 
         //모임 활성화 검증
         validatePartyIsActive(party);


### PR DESCRIPTION
## ❤️ 기능 설명
fix/#361의 변경사항에서 사용자 id를 가입신청 대상의 사용자 id가 아닌 현재 사용자를 넘겨주어 문제 발생.

swagger 테스트 성공 결과 스크린샷 첨부
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #365
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- 없습니다.

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [ ] 이슈넘버를 적었는가?
