### PR TITLE
[fix/#339] 급수 검색에서 포함된 글자만으로도 조회되도록 수정 

### DIFF
--- a/src/main/java/umc/cockple/demo/domain/member/repository/MemberRepositoryCustomImpl.java
+++ b/src/main/java/umc/cockple/demo/domain/member/repository/MemberRepositoryCustomImpl.java
@@ -15,6 +15,7 @@ import umc.cockple.demo.domain.party.enums.RequestStatus;
 import umc.cockple.demo.global.enums.Gender;
 import umc.cockple.demo.global.enums.Level;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Stream;
 
@@ -92,7 +93,12 @@ public class MemberRepositoryCustomImpl implements MemberRepositoryCustom{
 
         //검색 조건이 있는 경우 필터링에 추가
         if (StringUtils.hasText(levelSearch)) {
-            return baseRequirement.and(member.level.eq(Level.fromKorean(levelSearch)));
+            //검색 문자열을 포함하는 모든 Level Enum 리스트로 저장
+            List<Level> matchedLevels = Arrays.stream(Level.values())
+                    .filter(level -> level.getKoreanName().contains(levelSearch))
+                    .toList();
+
+            return baseRequirement.and(member.level.in(matchedLevels));
         }
         return baseRequirement;
     }


### PR DESCRIPTION
## ❤️ 기능 설명
현재 신규멤버 추천 API의 급수 검색에서 급수 문자 전체를 입력해야만 조회가 되는 것을 급수 문자에 포함된 글자 입력만으로도 조회되도록 수정합니다.
ex) A조 멤버 검색 시, 기존에는 "A조" 모두 입력해야만 조회 -> "A" 입력만으로도 조회되도록 수정

swagger 테스트 성공 결과 스크린샷 첨부
<img width="559" height="298" alt="image" src="https://github.com/user-attachments/assets/4cfee9f5-78df-42f4-ae94-ec461cafd321" />
<img width="842" height="173" alt="image" src="https://github.com/user-attachments/assets/55f510da-3750-44d2-8ea6-b638c4ae14f9" />
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #339
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- 없습니다!

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
