### PR TITLE
[fix/#375] 모임 상세 조회 응답 필드 추가

### DIFF
--- a/src/main/java/umc/cockple/demo/domain/party/converter/PartyConverter.java
+++ b/src/main/java/umc/cockple/demo/domain/party/converter/PartyConverter.java
@@ -48,20 +48,23 @@ public class PartyConverter {
                 .build();
     }
 
-    public PartyDetailDTO.Response toPartyDetailResponseDTO(Party party, Optional<MemberParty> memberPartyOpt, String imgUrl) {
-        // 급수 정보 가공
+    public PartyDetailDTO.Response toPartyDetailResponseDTO(Party party, Optional<MemberParty> memberPartyOpt, String imgUrl, boolean hasPendingJoinRequest) {
+        //급수 정보 가공
         List<String> femaleLevel = getLevelList(party, Gender.FEMALE);
         List<String> maleLevel = (party.getPartyType() == ParticipationType.WOMEN_DOUBLES) ?
                 null : getLevelList(party, Gender.MALE);
-        // 멤버 정보 가공
+        //멤버 정보 가공
         String memberStatus = memberPartyOpt.isPresent() ? "MEMBER" : "NOT_MEMBER";
         String memberRole = memberPartyOpt.map(mp -> mp.getRole().name()).orElse(null);
+        Boolean pendingRequestStatus = "NOT_MEMBER".equals(memberStatus) ? hasPendingJoinRequest : null;
 
         return PartyDetailDTO.Response.builder()
                 .partyId(party.getId())
+                .ownerId(party.getOwnerId())
                 .partyName(party.getPartyName())
                 .memberStatus(memberStatus)
                 .memberRole(memberRole)
+                .hasPendingJoinRequest(pendingRequestStatus)
                 .addr1(party.getPartyAddr().getAddr1())
                 .addr2(party.getPartyAddr().getAddr2())
                 .activityDays(party.getActiveDays().stream().map(day -> day.getActiveDay().getKoreanName()).toList())

--- a/src/main/java/umc/cockple/demo/domain/party/dto/PartyDetailDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/party/dto/PartyDetailDTO.java
@@ -9,9 +9,11 @@ public class PartyDetailDTO {
     @Builder
     public record Response(
             Long partyId,
+            Long ownerId,
             String partyName,
             String memberStatus,
             String memberRole,
+            Boolean hasPendingJoinRequest,
             String addr1,
             String addr2,
             List<String> activityDays,

--- a/src/main/java/umc/cockple/demo/domain/party/service/PartyQueryServiceImpl.java
+++ b/src/main/java/umc/cockple/demo/domain/party/service/PartyQueryServiceImpl.java
@@ -143,8 +143,11 @@ public class PartyQueryServiceImpl implements PartyQueryService{
         //memberParty 조회 로직 수행
         Optional<MemberParty> memberParty = memberPartyRepository.findByPartyAndMember(party, member);
 
+        //가입신청 상태 확인하는 비즈니스 로직 수행
+        boolean hasPendingJoinRequest = hasPendingJoinRequest(party, member, memberParty);
+
         String imgUrl = getImageUrl(party.getPartyImg());
-        PartyDetailDTO.Response response = partyConverter.toPartyDetailResponseDTO(party, memberParty, imgUrl);
+        PartyDetailDTO.Response response = partyConverter.toPartyDetailResponseDTO(party, memberParty, imgUrl, hasPendingJoinRequest);
 
         log.info("모임 상세 정보 조회 완료 - partyId: {}", partyId);
         return response;
@@ -319,6 +322,13 @@ public class PartyQueryServiceImpl implements PartyQueryService{
         List<Party> content = (start >= sortedParties.size()) ? Collections.emptyList() : sortedParties.subList(start, end);
         boolean hasNext = end < sortedParties.size();
         return new SliceImpl<>(content, pageable, hasNext);
+    }
+
+    private boolean hasPendingJoinRequest(Party party, Member member, Optional<MemberParty> memberParty){
+        if (memberParty.isEmpty()) {
+            return partyJoinRequestRepository.existsByPartyAndMemberAndStatus(party, member, RequestStatus.PENDING);
+        }
+        return false;
     }
 
     // ========== 데이터 변환 메서드 ==========


### PR DESCRIPTION
## ❤️ 기능 설명
- 모임 미가입 사용자가 가입 신청을 했을 시, 가입신청 버튼 비활성화를 위해 가입 신청 여부를 담은 필드 추가
- 모임장 채팅방으로의 연결을 위한 모임장 ID 필드 추가

swagger 테스트 성공 결과 스크린샷 첨부
<img width="158" height="78" alt="image" src="https://github.com/user-attachments/assets/685da9e9-987c-4047-9ff8-569d4f827124" />
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #375
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- 없습니다.

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
