### PR TITLE
[debug/#380] 운동 상세 조회 API에서 멤버 ID값이 아닌 멤버 운동 참여 ID값을 반환하던 로직 에러 해결

### DIFF
--- a/src/main/java/umc/cockple/demo/domain/exercise/converter/ExerciseConverter.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/converter/ExerciseConverter.java
@@ -396,7 +396,7 @@ public class ExerciseConverter {
         Role role = memberRoles.get(member.getId());
 
         return ExerciseDetailDTO.ParticipantInfo.builder()
-                .participantId(memberParticipant.getId())
+                .participantId(member.getId())
                 .participantNumber(0)
                 .profileImageUrl(getImageUrl(member.getProfileImg()))
                 .name(member.getMemberName())
@@ -413,7 +413,7 @@ public class ExerciseConverter {
         Member member = memberParticipant.getMember();
 
         return ExerciseDetailDTO.ParticipantInfo.builder()
-                .participantId(memberParticipant.getId())
+                .participantId(member.getId())
                 .participantNumber(0)
                 .profileImageUrl(getImageUrl(member.getProfileImg()))
                 .name(member.getMemberName())


### PR DESCRIPTION
## ❤️ 기능 설명
운동 상세 조회 API에서 멤버 운동 참여 ID값 대신 멤버 ID값을 반환하도록 변경했습니다.

swagger 테스트 성공 결과 스크린샷 첨부
<img width="480" height="785" alt="image" src="https://github.com/user-attachments/assets/de2acff8-7201-4d4f-935c-87c4f4a88845" />

<img width="1055" height="299" alt="image" src="https://github.com/user-attachments/assets/d0074444-0739-40ca-be84-f33dd6ef5da4" />
운동 참여 id는 6이지만 멤버 id인 2를 제대로 반환합니다!

<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #380 
<br>
<br>

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
