### PR TITLE
[debug/#390] content가 비어있을 때 hasContent가 true가 되는 에러 해결

### DIFF
--- a/src/main/java/umc/cockple/demo/domain/chat/service/ChatWebSocketService.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/ChatWebSocketService.java
@@ -189,7 +189,7 @@ public class ChatWebSocketService {
     }
 
     private void validateMessage(String content, List<FileInfo> files, List<ImageInfo> images) {
-        boolean hasContent = content != null && content.trim().isEmpty();
+        boolean hasContent = content != null && !content.trim().isEmpty();
         boolean hasFiles = files != null && !files.isEmpty();
         boolean hasImages = images != null && !images.isEmpty();
 


### PR DESCRIPTION
## ❤️ 기능 설명
hasContent를 체크할 때 부등호가 빠져있어 내용이 비어있어야 true를 반환했습니다.
content만 채워서 보낼경우 익셉션이 던져져 메시지 전송이 되지 않던 문제를 부등호를 추가해 해결했습니다..

swagger 테스트 성공 결과 스크린샷 첨부
<img width="2161" height="523" alt="image" src="https://github.com/user-attachments/assets/96862c68-1558-4743-af6a-e979c59cfa77" />

<img width="1394" height="448" alt="image" src="https://github.com/user-attachments/assets/e7e1efff-b875-4c38-ae47-922af18a958b" />

<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #390 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!
- [ ] 코드 테스트를 확실하게 하겠습니다!

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
