### PR TITLE
[fix/#379] 프로필 사진 수정 오류

### DIFF
--- a/src/main/java/umc/cockple/demo/domain/member/domain/Member.java
+++ b/src/main/java/umc/cockple/demo/domain/member/domain/Member.java
@@ -115,7 +115,7 @@ public class Member extends BaseEntity {
         this.birth = requestDto.birth();
         this.level = requestDto.level();
         this.keywords = keywords;
-        this.profileImg = img;
+        updateProfileImg(img);
     }
 
     public void updateMemberFirst(MemberDetailInfoRequestDTO requestDto, List<MemberKeyword> keywords) {
@@ -132,7 +132,7 @@ public class Member extends BaseEntity {
         this.birth = requestDto.birth();
         this.level = requestDto.level();
         this.keywords = keywords;
-        this.profileImg = img;
+        updateProfileImg(img);
     }
 
     public void updateMember(UpdateProfileRequestDTO requestDto, List<MemberKeyword> keywords) {

--- a/src/main/java/umc/cockple/demo/domain/member/service/MemberCommandService.java
+++ b/src/main/java/umc/cockple/demo/domain/member/service/MemberCommandService.java
@@ -96,7 +96,7 @@ public class MemberCommandService {
 
     public void updateProfile(UpdateProfileRequestDTO requestDto, Long memberId) {
         // 회원 찾기
-        Member member = findByMemberId(memberId);
+        Member member = findProfileByMemberId(memberId);
 
         // 기존 키워드 삭제
         memberKeywordRepository.deleteAllByMember(member);
@@ -126,13 +126,14 @@ public class MemberCommandService {
         if (!StringUtils.hasText(imgKey)) {
             member.updateMember(requestDto, keywords);
         } else {
+            ProfileImg profile = member.getProfileImg();
             // 기존 이미지 존재시 이미지 새로 업로드
-            if (member.getProfileImg() != null && StringUtils.hasText(member.getProfileImg().getImgKey())) {
+            if (profile != null) {
 
                 // 프로필 사진이 변경되었을 경우에만 이미지 url 변경 및 S3 사진 변경
-                if (!member.getProfileImg().getImgKey().equals(imgKey)) {
-                    imageService.delete(member.getProfileImg().getImgKey());
-                    member.getProfileImg().updateProfile(imgKey);
+                if (!profile.getImgKey().equals(imgKey)) {
+                    imageService.delete(profile.getImgKey());
+                    profile.updateProfile(imgKey);
                 }
 
                 // 회원 정보 수정하기 (프로필 사진 제외)
@@ -248,6 +249,11 @@ public class MemberCommandService {
 
     private Member findByMemberId(Long memberId) {
         return memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
+    }
+
+    private Member findProfileByMemberId(Long memberId) {
+        return memberRepository.findMemberWithProfileById(memberId)
                 .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
     }
 

--- a/src/main/java/umc/cockple/demo/domain/member/service/MemberCommandService.java
+++ b/src/main/java/umc/cockple/demo/domain/member/service/MemberCommandService.java
@@ -127,7 +127,7 @@ public class MemberCommandService {
             member.updateMember(requestDto, keywords);
         } else {
             // 기존 이미지 존재시 이미지 새로 업로드
-            if (member.getProfileImg() != null) {
+            if (member.getProfileImg() != null && StringUtils.hasText(member.getProfileImg().getImgKey())) {
 
                 // 프로필 사진이 변경되었을 경우에만 이미지 url 변경 및 S3 사진 변경
                 if (!member.getProfileImg().getImgKey().equals(imgKey)) {
@@ -147,6 +147,7 @@ public class MemberCommandService {
 
                 // 회원 정보 수정하기 (프로필 사진까지)
                 member.updateMember(requestDto, keywords, img);
+
             }
         }
 

--- a/src/main/java/umc/cockple/demo/domain/member/service/MemberQueryService.java
+++ b/src/main/java/umc/cockple/demo/domain/member/service/MemberQueryService.java
@@ -5,6 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import umc.cockple.demo.domain.contest.domain.Contest;
+import umc.cockple.demo.domain.image.service.ImageService;
 import umc.cockple.demo.domain.member.converter.MemberConverter;
 import umc.cockple.demo.domain.member.domain.Member;
 import umc.cockple.demo.domain.member.domain.MemberAddr;
@@ -30,6 +31,7 @@ import static umc.cockple.demo.domain.member.converter.MemberConverter.*;
 public class MemberQueryService {
 
     private final MemberRepository memberRepository;
+    private final ImageService imageService;
 
     /*
     * 프로필 관련 조회 메서드
@@ -58,7 +60,7 @@ public class MemberQueryService {
         // 프로필 사진 null-safety
         String imgUrl = null;
         if (member.getProfileImg() != null) {
-            imgUrl = member.getProfileImg().getImgKey();
+            imgUrl = imageService.getUrlFromKey(member.getProfileImg().getImgKey());
         }
 
         // 각 메달 개수 카운트


### PR DESCRIPTION
## ❤️ 기능 설명
로컬로는 되는데 배포서버에서 DB관련 문제가 생겨서 다시 올립니다 ㅠㅡㅠ 

swagger 테스트 성공 결과 스크린샷 첨부
수정
<img width="964" height="1263" alt="image" src="https://github.com/user-attachments/assets/7a69561c-7629-41f5-abe9-776b509c87a1" />

조회
<img width="978" height="1078" alt="image" src="https://github.com/user-attachments/assets/d62ff03f-d7e0-4b4c-864c-1a81f6a9aa87" />


<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #379 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [ ] 이슈넘버를 적었는가?
