### PR TITLE
[feat/#400] 채팅 메시지에서 이모티콘과 일반 이미지 구분 기능 구현

### DIFF
--- a/src/main/java/umc/cockple/demo/domain/chat/converter/ChatConverter.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/converter/ChatConverter.java
@@ -6,9 +6,9 @@ import umc.cockple.demo.domain.chat.domain.ChatMessage;
 import umc.cockple.demo.domain.chat.domain.ChatRoom;
 import umc.cockple.demo.domain.chat.domain.ChatRoomMember;
 import umc.cockple.demo.domain.chat.domain.DownloadToken;
+import umc.cockple.demo.domain.chat.dto.*;
 import umc.cockple.demo.domain.chat.enums.WebSocketMessageType;
 import umc.cockple.demo.domain.member.domain.Member;
-import umc.cockple.demo.domain.chat.dto.*;
 
 import java.util.Collections;
 import java.util.List;
@@ -140,7 +140,7 @@ public class ChatConverter {
     }
 
     public WebSocketMessageDTO.MessageResponse toSystemMessageResponse(
-            Long chatRoomId, String content, ChatMessage savedMessage){
+            Long chatRoomId, String content, ChatMessage savedMessage) {
         return WebSocketMessageDTO.MessageResponse.builder()
                 .type(WebSocketMessageType.SEND)
                 .chatRoomId(chatRoomId)

--- a/src/main/java/umc/cockple/demo/domain/chat/converter/ChatConverter.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/converter/ChatConverter.java
@@ -2,10 +2,7 @@ package umc.cockple.demo.domain.chat.converter;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
-import umc.cockple.demo.domain.chat.domain.ChatMessage;
-import umc.cockple.demo.domain.chat.domain.ChatRoom;
-import umc.cockple.demo.domain.chat.domain.ChatRoomMember;
-import umc.cockple.demo.domain.chat.domain.DownloadToken;
+import umc.cockple.demo.domain.chat.domain.*;
 import umc.cockple.demo.domain.chat.dto.*;
 import umc.cockple.demo.domain.chat.enums.WebSocketMessageType;
 import umc.cockple.demo.domain.member.domain.Member;
@@ -169,23 +166,42 @@ public class ChatConverter {
                 .build();
     }
 
-    public ChatRoomDetailDTO.MessageInfo toChatRoomDetailMessageInfo(
+    public ChatCommonDTO.MessageInfo toCommonMessageInfo(
             ChatMessage message,
-            Member sender,
             String senderProfileImageUrl,
-            List<String> imageUrls,
+            List<ChatCommonDTO.ImageInfo> processedImages,
             boolean isMyMessage) {
-        return ChatRoomDetailDTO.MessageInfo.builder()
+
+        return ChatCommonDTO.MessageInfo.builder()
                 .messageId(message.getId())
-                .senderId(sender.getId())
-                .senderName(sender.getMemberName())
+                .senderId(message.getSender().getId())
+                .senderName(message.getSender().getMemberName())
                 .senderProfileImageUrl(senderProfileImageUrl)
                 .content(message.getContent())
                 .messageType(message.getType())
-                .imageUrls(imageUrls)
+                .images(processedImages)
                 .timestamp(message.getCreatedAt())
                 .isMyMessage(isMyMessage)
                 .build();
+    }
+
+    public ChatCommonDTO.ImageInfo toImageInfo(ChatMessageImg img, String imageUrl) {
+        return ChatCommonDTO.ImageInfo.builder()
+                .imageId(img.getId())
+                .imageUrl(imageUrl)
+                .imgOrder(img.getImgOrder())
+                .isEmoji(img.getIsEmoji())
+                .originalFileName(img.getOriginalFileName())
+                .fileSize(img.getFileSize())
+                .fileType(img.getFileType())
+                .build();
+    }
+
+    public List<ChatRoomDetailDTO.MessageInfo> toChatRoomDetailMessageInfos(
+            List<ChatCommonDTO.MessageInfo> commonMessages) {
+        return commonMessages.stream()
+                .map(ChatRoomDetailDTO.MessageInfo::from)
+                .toList();
     }
 
     public ChatRoomDetailDTO.MemberInfo toChatRoomDetailMemberInfo(Member member, String memberProfileImgUrl) {
@@ -207,23 +223,11 @@ public class ChatConverter {
                 .build();
     }
 
-    public ChatMessageDTO.MessageInfo toPreviousMessageInfo(
-            ChatMessage message,
-            Member sender,
-            String senderProfileImageUrl,
-            List<String> imageUrls,
-            boolean isMyMessage) {
-        return ChatMessageDTO.MessageInfo.builder()
-                .messageId(message.getId())
-                .senderId(sender.getId())
-                .senderName(sender.getMemberName())
-                .senderProfileImageUrl(senderProfileImageUrl)
-                .content(message.getContent())
-                .messageType(message.getType())
-                .imageUrls(imageUrls)
-                .timestamp(message.getCreatedAt())
-                .isMyMessage(isMyMessage)
-                .build();
+    public List<ChatMessageDTO.MessageInfo> toChatMessageInfos(
+            List<ChatCommonDTO.MessageInfo> commonMessages) {
+        return commonMessages.stream()
+                .map(ChatMessageDTO.MessageInfo::from)
+                .toList();
     }
 
     public ChatMessageDTO.Response toChatMessageResponse(

--- a/src/main/java/umc/cockple/demo/domain/chat/converter/ChatConverter.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/converter/ChatConverter.java
@@ -118,7 +118,7 @@ public class ChatConverter {
 
     public WebSocketMessageDTO.MessageResponse toSendMessageResponse(
             Long chatRoomId, String content,
-            List<WebSocketMessageDTO.MessageResponse.ImageInfo> images,
+            List<ChatCommonDTO.ImageInfo> images,
             List<WebSocketMessageDTO.MessageResponse.FileInfo> files,
             ChatMessage savedMessage, Member sender, String senderProfileImageUrl, int unreadCount) {
         return WebSocketMessageDTO.MessageResponse.builder()

--- a/src/main/java/umc/cockple/demo/domain/chat/domain/ChatMessageImg.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/domain/ChatMessageImg.java
@@ -32,7 +32,13 @@ public class ChatMessageImg extends BaseEntity {
 
     private String fileType;
 
+    @Column(nullable = false)
+    @Builder.Default
+    private Boolean isEmoji = false;
+
     public static ChatMessageImg create(ChatMessage message, String imgKey, Integer imgOrder, String originalFileName, Long fileSize, String fileType) {
+        boolean isEmoji = isEmojiFileName(originalFileName);
+
         return ChatMessageImg.builder()
                 .chatMessage(message)
                 .imgKey(imgKey)
@@ -40,7 +46,15 @@ public class ChatMessageImg extends BaseEntity {
                 .originalFileName(originalFileName)
                 .fileSize(fileSize)
                 .fileType(fileType)
+                .isEmoji(isEmoji)
                 .build();
+    }
+
+    private static boolean isEmojiFileName(String originalFileName) {
+        if (originalFileName == null) {
+            return false;
+        }
+        return "emoji.png".equalsIgnoreCase(originalFileName.trim());
     }
 }
 

--- a/src/main/java/umc/cockple/demo/domain/chat/dto/ChatCommonDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/dto/ChatCommonDTO.java
@@ -1,0 +1,44 @@
+package umc.cockple.demo.domain.chat.dto;
+
+import lombok.Builder;
+import umc.cockple.demo.domain.chat.enums.MessageType;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class ChatCommonDTO {
+
+    @Builder
+    public record MessageInfo(
+            Long messageId,
+            Long senderId,
+            String senderName,
+            String senderProfileImageUrl,
+            String content,
+            MessageType messageType,
+            List<ImageInfo> images,
+            LocalDateTime timestamp,
+            boolean isMyMessage
+    ) {
+    }
+
+    @Builder
+    public record ImageInfo(
+            Long imageId,
+            String imageUrl,
+            Integer imgOrder,
+            Boolean isEmoji,
+            String originalFileName,
+            Long fileSize,
+            String fileType
+    ) {
+    }
+
+    @Builder
+    public record MemberInfo(
+            Long memberId,
+            String memberName,
+            String profileImgUrl
+    ) {
+    }
+}

--- a/src/main/java/umc/cockple/demo/domain/chat/dto/ChatMessageDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/dto/ChatMessageDTO.java
@@ -25,9 +25,22 @@ public class ChatMessageDTO {
             String senderProfileImageUrl,
             String content,
             MessageType messageType,
-            List<String> imageUrls,
+            List<ChatCommonDTO.ImageInfo> images,
             LocalDateTime timestamp,
             boolean isMyMessage
     ) {
+        public static MessageInfo from(ChatCommonDTO.MessageInfo common) {
+            return MessageInfo.builder()
+                    .messageId(common.messageId())
+                    .senderId(common.senderId())
+                    .senderName(common.senderName())
+                    .senderProfileImageUrl(common.senderProfileImageUrl())
+                    .content(common.content())
+                    .messageType(common.messageType())
+                    .images(common.images())
+                    .timestamp(common.timestamp())
+                    .isMyMessage(common.isMyMessage())
+                    .build();
+        }
     }
 }

--- a/src/main/java/umc/cockple/demo/domain/chat/dto/ChatRoomDetailDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/dto/ChatRoomDetailDTO.java
@@ -36,10 +36,21 @@ public class ChatRoomDetailDTO {
             String senderProfileImageUrl,
             String content,
             MessageType messageType,
-            List<String> imageUrls,  // 이미지 메시지인 경우
+            List<ImageInfo> images,
             LocalDateTime timestamp,
-            boolean isMyMessage    // 내가 보낸 메시지인지
+            boolean isMyMessage
     ) {
+        @Builder
+        public record ImageInfo(
+                Long imageId,
+                String imageUrl,
+                Integer imgOrder,
+                Boolean isEmoji,
+                String originalFileName,
+                Long fileSize,
+                String fileType
+        ) {
+        }
     }
 
     @Builder

--- a/src/main/java/umc/cockple/demo/domain/chat/dto/ChatRoomDetailDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/dto/ChatRoomDetailDTO.java
@@ -36,20 +36,22 @@ public class ChatRoomDetailDTO {
             String senderProfileImageUrl,
             String content,
             MessageType messageType,
-            List<ImageInfo> images,
+            List<ChatCommonDTO.ImageInfo> images,
             LocalDateTime timestamp,
             boolean isMyMessage
     ) {
-        @Builder
-        public record ImageInfo(
-                Long imageId,
-                String imageUrl,
-                Integer imgOrder,
-                Boolean isEmoji,
-                String originalFileName,
-                Long fileSize,
-                String fileType
-        ) {
+        public static MessageInfo from(ChatCommonDTO.MessageInfo common) {
+            return MessageInfo.builder()
+                    .messageId(common.messageId())
+                    .senderId(common.senderId())
+                    .senderName(common.senderName())
+                    .senderProfileImageUrl(common.senderProfileImageUrl())
+                    .content(common.content())
+                    .messageType(common.messageType())
+                    .images(common.images())
+                    .timestamp(common.timestamp())
+                    .isMyMessage(common.isMyMessage())
+                    .build();
         }
     }
 
@@ -59,5 +61,12 @@ public class ChatRoomDetailDTO {
             String memberName,
             String profileImgUrl
     ) {
+        public static MemberInfo from(ChatCommonDTO.MemberInfo common) {
+            return MemberInfo.builder()
+                    .memberId(common.memberId())
+                    .memberName(common.memberName())
+                    .profileImgUrl(common.profileImgUrl())
+                    .build();
+        }
     }
 }

--- a/src/main/java/umc/cockple/demo/domain/chat/dto/WebSocketMessageDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/dto/WebSocketMessageDTO.java
@@ -53,7 +53,7 @@ public class WebSocketMessageDTO {
             Long messageId,
             String content,
             List<FileInfo> files,
-            List<ImageInfo> images,
+            List<ChatCommonDTO.ImageInfo> images,
             Long senderId,
             String senderName,
             String senderProfileImageUrl,
@@ -66,14 +66,6 @@ public class WebSocketMessageDTO {
                 String originalFileName,
                 Long fileSize,
                 String fileType
-        ) {
-        }
-
-        @Builder
-        public record ImageInfo(
-                Long imageId,
-                String imageUrl,
-                Integer imgOrder
         ) {
         }
     }

--- a/src/main/java/umc/cockple/demo/domain/chat/service/ChatProcessor.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/ChatProcessor.java
@@ -1,0 +1,69 @@
+package umc.cockple.demo.domain.chat.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import umc.cockple.demo.domain.chat.converter.ChatConverter;
+import umc.cockple.demo.domain.chat.domain.ChatMessage;
+import umc.cockple.demo.domain.chat.domain.ChatMessageImg;
+import umc.cockple.demo.domain.chat.dto.ChatCommonDTO;
+import umc.cockple.demo.domain.image.service.ImageService;
+import umc.cockple.demo.domain.member.domain.Member;
+import umc.cockple.demo.domain.member.domain.ProfileImg;
+
+import java.util.Comparator;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class ChatProcessor {
+
+    private final ImageService imageService;
+    private final ChatConverter chatConverter;
+
+    public List<ChatCommonDTO.MessageInfo> processMessages(Long memberId, List<ChatMessage> recentMessages) {
+        return recentMessages.stream()
+                .map(message -> processAndConvertMessage(message, memberId))
+                .toList();
+    }
+
+    private ChatCommonDTO.MessageInfo processAndConvertMessage(ChatMessage message, Long memberId) {
+        Member sender = message.getSender();
+        String senderProfileImageUrl = generateProfileImageUrl(sender.getProfileImg());
+        List<ChatCommonDTO.ImageInfo> processedImages = processMessageImages(message);
+        boolean isMyMessage = isMyMessage(sender.getId(), memberId);
+        return chatConverter.toCommonMessageInfo(message, senderProfileImageUrl, processedImages, isMyMessage);
+    }
+
+    private String generateProfileImageUrl(ProfileImg profileImg) {
+        if (profileImg != null && profileImg.getImgKey() != null && !profileImg.getImgKey().isBlank()) {
+            return imageService.getUrlFromKey(profileImg.getImgKey());
+        }
+        return null;
+    }
+
+    private List<ChatCommonDTO.ImageInfo> processMessageImages(ChatMessage message) {
+        return message.getChatMessageImgs().stream()
+                .sorted(Comparator.comparing(ChatMessageImg::getImgOrder))
+                .map(this::processSingleImage)
+                .toList();
+    }
+
+    private ChatCommonDTO.ImageInfo processSingleImage(ChatMessageImg img) {
+        String imageUrl = generateImageUrl(img);
+        return chatConverter.toImageInfo(img, imageUrl);
+    }
+
+    private String generateImageUrl(ChatMessageImg img) {
+        if (img != null && img.getImgKey() != null && !img.getImgKey().isBlank()) {
+            return imageService.getUrlFromKey(img.getImgKey());
+        }
+        return null;
+    }
+
+    private boolean isMyMessage(Long senderId, Long currentUserId) {
+        return senderId.equals(currentUserId);
+    }
+
+}

--- a/src/main/java/umc/cockple/demo/domain/chat/service/ChatProcessor.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/ChatProcessor.java
@@ -36,7 +36,7 @@ public class ChatProcessor {
         return chatConverter.toCommonMessageInfo(message, senderProfileImageUrl, processedImages, isMyMessage);
     }
 
-    private String generateProfileImageUrl(ProfileImg profileImg) {
+    public String generateProfileImageUrl(ProfileImg profileImg) {
         if (profileImg != null && profileImg.getImgKey() != null && !profileImg.getImgKey().isBlank()) {
             return imageService.getUrlFromKey(profileImg.getImgKey());
         }
@@ -55,7 +55,7 @@ public class ChatProcessor {
         return chatConverter.toImageInfo(img, imageUrl);
     }
 
-    private String generateImageUrl(ChatMessageImg img) {
+    public String generateImageUrl(ChatMessageImg img) {
         if (img != null && img.getImgKey() != null && !img.getImgKey().isBlank()) {
             return imageService.getUrlFromKey(img.getImgKey());
         }


### PR DESCRIPTION
## ❤️ 기능 설명
- [x]  채팅 이미지 전송 시 이모티콘 여부 판별 로직 구현
- [x]  ChatMessageImg 엔티티에 isEmoji 필드 추가
- [x] REST API 응답에 이모티콘 구분 정보 포함
- [x]  WebSocket 응답에 이모티콘 구분 정보 포함
- [x] 클라이언트 originalFileName="emoji.png" 신호 기반 이모티콘 판별

swagger 테스트 성공 결과 스크린샷 첨부
### 메시지 전송
전송
<img width="2371" height="467" alt="image" src="https://github.com/user-attachments/assets/eaf0664e-40a0-47ec-9789-318806bd6661" />
저장
<img width="1074" height="47" alt="image" src="https://github.com/user-attachments/assets/60ecb4d6-a2df-4d79-8f23-d911b7a8c6a5" />
상대방
<img width="2356" height="478" alt="image" src="https://github.com/user-attachments/assets/735422f7-451e-47dd-a9af-0927f8bcb27e" />

### 초기 채팅방 조회
<img width="2138" height="1175" alt="image" src="https://github.com/user-attachments/assets/37428a53-1265-4bf0-bb86-a2ac69c10e28" />

### 과거 메시지 조회
<img width="2142" height="1145" alt="image" src="https://github.com/user-attachments/assets/3649e6f3-cd7f-4f14-8366-21d7740bed2f" />

<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #400 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 컨버터로 넘길 dto를 만드는 메서드를 프로세서로 한 번 빼봤는데 더 코드가 스파게티가 되는 거 같네요.... 어렵습니다
<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
