### PR TITLE
[fix/#407] 내 운동 리스트 조회 API에 급수 필드 추가

### DIFF
--- a/src/main/java/umc/cockple/demo/domain/exercise/converter/ExerciseConverter.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/converter/ExerciseConverter.java
@@ -912,6 +912,7 @@ public class ExerciseConverter {
             Map<Long, Boolean> isCompletedMap) {
 
         Party party = exercise.getParty();
+        PartyLevelCache levelCache = createPartyLevelCache(party);
 
         return MyExerciseListDTO.ExerciseItem.builder()
                 .exerciseId(exercise.getId())
@@ -923,6 +924,8 @@ public class ExerciseConverter {
                 .buildingName(exercise.getExerciseAddr().getBuildingName())
                 .startTime(exercise.getStartTime())
                 .endTime(exercise.getEndTime())
+                .femaleLevel(levelCache.femaleLevel())
+                .maleLevel(levelCache.maleLevel())
                 .currentParticipants(participantCountMap.getOrDefault(exercise.getId(), 0))
                 .maxCapacity(exercise.getMaxCapacity())
                 .isCompleted(isCompletedMap.getOrDefault(exercise.getId(), false))

--- a/src/main/java/umc/cockple/demo/domain/exercise/dto/MyExerciseListDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/dto/MyExerciseListDTO.java
@@ -27,6 +27,8 @@ public class MyExerciseListDTO {
             String buildingName,
             LocalTime startTime,
             LocalTime endTime,
+            List<String> femaleLevel,
+            List<String> maleLevel,
             Integer currentParticipants,
             Integer maxCapacity,
             Boolean isCompleted,


### PR DESCRIPTION
## ❤️ 기능 설명
내 참여 운동 리스트 조회 API에 참여자들의 성별 급수 필드를 추가했습니다.

swagger 테스트 성공 결과 스크린샷 첨부
<img width="568" height="1160" alt="image" src="https://github.com/user-attachments/assets/fb9e7a7d-2b87-4da1-9668-634a6b1478e1" />

<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #407 
<br>
<br>
<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
