### PR TITLE
[feat/#343] Redis 기반 채팅방 구독 관리 시스템 구축

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -88,6 +88,7 @@ dependencies {
 
     // redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'io.lettuce:lettuce-core'
 }
 
 tasks.named('test') {

--- a/src/main/java/umc/cockple/demo/domain/chat/service/websocket/RedisSubscriptionService.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/websocket/RedisSubscriptionService.java
@@ -5,6 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
+import java.time.Duration;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -17,10 +18,13 @@ public class RedisSubscriptionService {
 
     private static final String CHAT_ROOM_SUBSCRIBERS = "chatroom:subscribers:";
 
+    private static final Duration SUBSCRIPTION_TTL = Duration.ofHours(2);
+
     public void addSubscriber(Long chatRoomId, Long memberId) {
         try {
             String subscribersKey = CHAT_ROOM_SUBSCRIBERS + chatRoomId;
             redisTemplate.opsForSet().add(subscribersKey, memberId);
+            redisTemplate.expire(subscribersKey, SUBSCRIPTION_TTL);
 
             log.info("Redis 구독 추가 - 채팅방: {}, 멤버: {}", chatRoomId, memberId);
 
@@ -34,6 +38,14 @@ public class RedisSubscriptionService {
             String subscribersKey = CHAT_ROOM_SUBSCRIBERS + chatRoomId;
             redisTemplate.opsForSet().remove(subscribersKey, memberId);
 
+            Long remainingCount = redisTemplate.opsForSet().size(subscribersKey);
+            if (remainingCount != null && remainingCount == 0) {
+                redisTemplate.delete(subscribersKey);
+                log.debug("빈 구독 키 삭제 - 채팅방: {}", chatRoomId);
+            } else {
+                redisTemplate.expire(subscribersKey, SUBSCRIPTION_TTL);
+            }
+
             log.info("Redis 구독 제거 - 채팅방: {}, 멤버: {}", chatRoomId, memberId);
 
         } catch (Exception e) {
@@ -44,6 +56,11 @@ public class RedisSubscriptionService {
     public Set<Long> getSubscribers(Long chatRoomId) {
         try {
             String subscribersKey = CHAT_ROOM_SUBSCRIBERS + chatRoomId;
+
+            if (redisTemplate.hasKey(subscribersKey)) {
+                redisTemplate.expire(subscribersKey, SUBSCRIPTION_TTL);
+            }
+
             Set<Object> members = redisTemplate.opsForSet().members(subscribersKey);
 
             if (members == null || members.isEmpty()) {

--- a/src/main/java/umc/cockple/demo/domain/chat/service/websocket/RedisSubscriptionService.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/websocket/RedisSubscriptionService.java
@@ -1,0 +1,40 @@
+package umc.cockple.demo.domain.chat.service.websocket;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class RedisSubscriptionService {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    private static final String CHAT_ROOM_SUBSCRIBERS = "chatroom:subscribers:";
+
+    public void addSubscriber(Long chatRoomId, Long memberId) {
+        try {
+            String subscribersKey = CHAT_ROOM_SUBSCRIBERS + chatRoomId;
+            redisTemplate.opsForSet().add(subscribersKey, memberId);
+
+            log.info("Redis 구독 추가 - 채팅방: {}, 멤버: {}", chatRoomId, memberId);
+
+        } catch (Exception e) {
+            log.error("Redis 구독 추가 실패 - 채팅방: {}, 멤버: {}", chatRoomId, memberId, e);
+        }
+    }
+
+    public void removeSubscriber(Long chatRoomId, Long memberId) {
+        try {
+            String subscribersKey = CHAT_ROOM_SUBSCRIBERS + chatRoomId;
+            redisTemplate.opsForSet().remove(subscribersKey, memberId);
+
+            log.info("Redis 구독 제거 - 채팅방: {}, 멤버: {}", chatRoomId, memberId);
+
+        } catch (Exception e) {
+            log.error("Redis 구독 제거 실패 - 채팅방: {}, 멤버: {}", chatRoomId, memberId, e);
+        }
+    }
+}

--- a/src/main/java/umc/cockple/demo/domain/chat/service/websocket/RedisSubscriptionService.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/websocket/RedisSubscriptionService.java
@@ -36,7 +36,7 @@ public class RedisSubscriptionService {
     public void removeSubscriber(Long chatRoomId, Long memberId) {
         try {
             String subscribersKey = CHAT_ROOM_SUBSCRIBERS + chatRoomId;
-            stringRedisTemplate.opsForSet().remove(subscribersKey, memberId);
+            stringRedisTemplate.opsForSet().remove(subscribersKey, memberId.toString());
 
             Long remainingCount = stringRedisTemplate.opsForSet().size(subscribersKey);
             if (remainingCount != null && remainingCount == 0) {

--- a/src/main/java/umc/cockple/demo/domain/chat/service/websocket/RedisSubscriptionService.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/websocket/RedisSubscriptionService.java
@@ -5,6 +5,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
+import java.util.Set;
+import java.util.stream.Collectors;
+
 @Service
 @RequiredArgsConstructor
 @Slf4j
@@ -35,6 +38,25 @@ public class RedisSubscriptionService {
 
         } catch (Exception e) {
             log.error("Redis 구독 제거 실패 - 채팅방: {}, 멤버: {}", chatRoomId, memberId, e);
+        }
+    }
+
+    public Set<Long> getSubscribers(Long chatRoomId) {
+        try {
+            String subscribersKey = CHAT_ROOM_SUBSCRIBERS + chatRoomId;
+            Set<Object> members = redisTemplate.opsForSet().members(subscribersKey);
+
+            if (members == null || members.isEmpty()) {
+                return Set.of();
+            }
+
+            return members.stream()
+                    .map(Long.class::cast)
+                    .collect(Collectors.toSet());
+
+        } catch (Exception e) {
+            log.error("Redis 구독자 조회 실패 - 채팅방: {}", chatRoomId, e);
+            return Set.of();
         }
     }
 }

--- a/src/main/java/umc/cockple/demo/domain/chat/service/websocket/SubscriptionService.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/websocket/SubscriptionService.java
@@ -187,7 +187,11 @@ public class SubscriptionService {
             }
 
         } catch (Exception e) {
-            log.error("멤버 {} 구독 정리 중 오류 발생", memberId, e);
+            if (isShutdownRelatedError(e)) {
+                log.debug("서버 종료로 인한 구독 정리 실패(정상) - 멤버: {}", memberId);
+            } else {
+                log.error("멤버 {} 구독 정리 중 오류 발생", memberId, e);
+            }
         }
     }
 
@@ -205,5 +209,12 @@ public class SubscriptionService {
             log.error("구독 정리 실패 - 키: {}, 멤버: {}", key, memberId, e);
         }
         return cleanedCount;
+    }
+
+    private boolean isShutdownRelatedError(Throwable exception) {
+        if (exception == null) return false;
+
+        String message = exception.getMessage();
+        return message != null && message.contains("LettuceConnectionFactory was destroyed");
     }
 }

--- a/src/main/java/umc/cockple/demo/domain/chat/service/websocket/SubscriptionService.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/websocket/SubscriptionService.java
@@ -3,7 +3,7 @@ package umc.cockple.demo.domain.chat.service.websocket;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.web.socket.TextMessage;
 import org.springframework.web.socket.WebSocketSession;
@@ -26,7 +26,7 @@ public class SubscriptionService {
 
     private final SubscriptionReadProcessingService subscriptionReadProcessingService;
     private final RedisSubscriptionService redisSubscriptionService;
-    private final RedisTemplate<String, Object> redisTemplate;
+    private final StringRedisTemplate stringRedisTemplate;
 
     private final Map<Long, WebSocketSession> memberSessions = new ConcurrentHashMap<>();
 
@@ -172,7 +172,7 @@ public class SubscriptionService {
 
     private void cleanupMemberSubscriptions(Long memberId) {
         try {
-            Set<String> chatRoomKeys = redisTemplate.keys("chatroom:subscribers:*");
+            Set<String> chatRoomKeys = stringRedisTemplate.keys("chatroom:subscribers:*");
             if (chatRoomKeys == null || chatRoomKeys.isEmpty()) {
                 return;
             }
@@ -193,9 +193,9 @@ public class SubscriptionService {
 
     private int cleanupMemberSubscription(Long memberId, String key, int cleanedCount) {
         try {
-            Set<Object> members = redisTemplate.opsForSet().members(key);
+            Set<String> members = stringRedisTemplate.opsForSet().members(key);
             if (members != null && members.contains(memberId)) {
-                redisTemplate.opsForSet().remove(key, memberId);
+                stringRedisTemplate.opsForSet().remove(key, memberId);
                 cleanedCount++;
 
                 String chatRoomIdStr = key.replace("chatroom:subscribers:", "");

--- a/src/main/java/umc/cockple/demo/domain/chat/service/websocket/SubscriptionService.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/websocket/SubscriptionService.java
@@ -127,14 +127,10 @@ public class SubscriptionService {
 
     private void broadcastUnreadCountUpdates(
             Long chatRoomId, List<SubscriptionReadProcessingService.MessageUnreadUpdate> updates, Long excludedMemberId) {
-        Set<Long> subscribers = chatRoomSubscriptions.get(chatRoomId);
+        List<Long> subscribers = getActiveSubscribers(chatRoomId);
         if (subscribers == null || subscribers.isEmpty()) {
-            log.debug("브로드캐스트할 구독자가 없음 - 채팅방: {}", chatRoomId);
             return;
         }
-
-        log.debug("안읽은 수 업데이트 브로드캐스트 시작 - 채팅방: {}, 구독자 수: {}, 업데이트 메시지 수: {}",
-                chatRoomId, subscribers.size(), updates.size());
 
         for (SubscriptionReadProcessingService.MessageUnreadUpdate update : updates) {
             try {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -39,6 +39,12 @@ spring:
     redis:
       host: ${REDIS_HOST}
       port: 6379
+      lettuce:
+        pool:
+          max-active: 8
+          max-idle: 8
+          min-idle: 2
+          max-wait: 3000ms
 
 cloud:
   aws:


### PR DESCRIPTION
## ❤️ 기능 설명
- 현재 구독 정보를 메모리 기반으로 관리하고 있었는데, 이는 서버가 껐다가 켜질경우 구독 정보가 초기화되는 문제가 있었습니다.
- 이제 Redis에 구독 정보를 관리함으로써 서버가 꺼졌다가 켜져도 구독 정보가 그대로 유지됩니다.

- 구독 정보가 쌓여 문제가 될 수 있으므로 TTL 설정을 2시간으로 진행하여, 활성화되지 않은 지 2시간이 되면 자동으로 구독 정보를 삭제합니다.
- 또한 브라우저 종료 시 구독 정보를 정리하지 않음으로써 사용자 UX를 더 향상시켰습니다.

- 서버가 꺼졌을 때 자연적으로 발생하는 웹소켓 에러는 따로 잡아 DEBUG 레벨로 로그를 찍음으로써 로그를 더 깔끔하게 개선했습니다.

swagger 테스트 성공 결과 스크린샷 첨부
### 구독
<img width="2331" height="510" alt="image" src="https://github.com/user-attachments/assets/5c4558fc-bf3b-4163-b502-839de1a555f5" />

### 구독 해제
<img width="2319" height="502" alt="image" src="https://github.com/user-attachments/assets/5bfd265b-da58-4a7f-8034-fc6efc4eb698" />

### 웹소켓 연결 해제 후 구독 없이 메시지 전송
<img width="2353" height="213" alt="image" src="https://github.com/user-attachments/assets/9f54f671-52cc-4d3e-be86-a540577db70e" />
<img width="2319" height="329" alt="image" src="https://github.com/user-attachments/assets/83395d69-0bbd-43f5-bb7a-772cb768899c" />

### 서버 종료
<img width="1764" height="232" alt="image" src="https://github.com/user-attachments/assets/434eab08-c3f6-42db-b879-36bfaf927e94" />


<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #343 
<br>
<br>

## 리뷰어들에게 알릴 사항

- [ ] 로컬에서 테스트를 하고 싶으실 경우 Redis를 설치해서 실행시킨 후 진행해야 합니다!
- [ ] 도커를 활용하시거나 윈도우에서는 WSL를 활용하시면 쉽게 설치 가능합니다.

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
