### PR TITLE
[feat/#312] 채팅방 목록 조회에서 마지막 메시지 업데이트 되도록 로직 구현

### DIFF
--- a/src/main/java/umc/cockple/demo/Application.java
+++ b/src/main/java/umc/cockple/demo/Application.java
@@ -2,10 +2,12 @@ package umc.cockple.demo;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableCaching
 public class Application {
 
 	public static void main(String[] args) {

--- a/src/main/java/umc/cockple/demo/domain/chat/converter/ChatConverter.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/converter/ChatConverter.java
@@ -46,14 +46,13 @@ public class ChatConverter {
                 .build();
     }
 
-    public PartyChatRoomDTO.LastMessageInfo toPartyLastMessageInfo(ChatMessage message) {
+    public PartyChatRoomDTO.LastMessageInfo toPartyLastMessageInfo(ChatRoomListCacheDTO.LastMessageCache message) {
         if (message == null) return null;
 
         return PartyChatRoomDTO.LastMessageInfo.builder()
-                .messageId(message.getId())
-                .content(message.getDisplayContent())
-                .timestamp(message.getCreatedAt())
-                .messageType(message.getType().name())
+                .content(message.content())
+                .timestamp(message.timestamp())
+                .messageType(message.messageType())
                 .build();
     }
 
@@ -86,14 +85,13 @@ public class ChatConverter {
                 .build();
     }
 
-    public DirectChatRoomDTO.LastMessageInfo toDirectLastMessageInfo(ChatMessage message) {
+    public DirectChatRoomDTO.LastMessageInfo toDirectLastMessageInfo(ChatRoomListCacheDTO.LastMessageCache message) {
         if (message == null) return null;
 
         return DirectChatRoomDTO.LastMessageInfo.builder()
-                .messageId(message.getId())
-                .content(message.getDisplayContent())
-                .timestamp(message.getCreatedAt())
-                .messageType(message.getType().name())
+                .content(message.content())
+                .timestamp(message.timestamp())
+                .messageType(message.messageType())
                 .build();
     }
 

--- a/src/main/java/umc/cockple/demo/domain/chat/dto/ChatRoomListCacheDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/dto/ChatRoomListCacheDTO.java
@@ -1,0 +1,17 @@
+package umc.cockple.demo.domain.chat.dto;
+
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+public class ChatRoomListCacheDTO {
+
+    @Builder
+    public record LastMessageCache(
+            Long messageId,
+            String content,
+            LocalDateTime timestamp,
+            String messageType
+    ) {
+    }
+}

--- a/src/main/java/umc/cockple/demo/domain/chat/dto/ChatRoomListCacheDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/dto/ChatRoomListCacheDTO.java
@@ -8,7 +8,6 @@ public class ChatRoomListCacheDTO {
 
     @Builder
     public record LastMessageCache(
-            Long messageId,
             String content,
             LocalDateTime timestamp,
             String messageType

--- a/src/main/java/umc/cockple/demo/domain/chat/dto/DirectChatRoomDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/dto/DirectChatRoomDTO.java
@@ -29,7 +29,6 @@ public class DirectChatRoomDTO {
     // 마지막 메시지 정보
     @Builder
     public record LastMessageInfo(
-            Long messageId,
             String content,
             LocalDateTime timestamp,
             String messageType

--- a/src/main/java/umc/cockple/demo/domain/chat/dto/PartyChatRoomDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/dto/PartyChatRoomDTO.java
@@ -31,7 +31,6 @@ public class PartyChatRoomDTO {
     // 마지막 메시지 정보
     @Builder
     public record LastMessageInfo(
-            Long messageId,
             String content,
             LocalDateTime timestamp,
             String messageType

--- a/src/main/java/umc/cockple/demo/domain/chat/dto/WebSocketMessageDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/dto/WebSocketMessageDTO.java
@@ -11,6 +11,7 @@ public class WebSocketMessageDTO {
     public record Request(
             WebSocketMessageType type,
             Long chatRoomId,
+            List<Long> memberRooms,
             String content,
             List<FileInfo> files,
             List<ImageInfo> images,

--- a/src/main/java/umc/cockple/demo/domain/chat/dto/WebSocketMessageDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/dto/WebSocketMessageDTO.java
@@ -97,4 +97,20 @@ public class WebSocketMessageDTO {
     ) {
     }
 
+    @Builder
+    public record ChatRoomListUpdate(
+            WebSocketMessageType type,
+            Long chatRoomId,
+            LastMessageUpdate lastMessage,
+            int newUnreadCount,
+            LocalDateTime timestamp
+    ) {
+        @Builder
+        public record LastMessageUpdate(
+                String content,
+                LocalDateTime timestamp,
+                String messageType
+        ) {
+        }
+    }
 }

--- a/src/main/java/umc/cockple/demo/domain/chat/dto/WebSocketMessageDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/dto/WebSocketMessageDTO.java
@@ -114,4 +114,13 @@ public class WebSocketMessageDTO {
         ) {
         }
     }
+
+    @Builder
+    public record ChatListSubscriptionResponse(
+            WebSocketMessageType type,
+            List<Long> chatRoomIds,
+            String message,
+            LocalDateTime timestamp
+    ) {
+    }
 }

--- a/src/main/java/umc/cockple/demo/domain/chat/enums/WebSocketMessageType.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/enums/WebSocketMessageType.java
@@ -3,9 +3,9 @@ package umc.cockple.demo.domain.chat.enums;
 public enum WebSocketMessageType {
     CONNECT,
     SEND,
-    READ,
     SUBSCRIBE,
     UNSUBSCRIBE,
     ERROR,
-    UNREAD_COUNT_UPDATE
+    UNREAD_COUNT_UPDATE,
+    CHAT_ROOM_LIST_UPDATE,
 }

--- a/src/main/java/umc/cockple/demo/domain/chat/enums/WebSocketMessageType.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/enums/WebSocketMessageType.java
@@ -5,6 +5,8 @@ public enum WebSocketMessageType {
     SEND,
     SUBSCRIBE,
     UNSUBSCRIBE,
+    SUBSCRIBE_CHAT_LIST,
+    UNSUBSCRIBE_CHAT_LIST,
     ERROR,
     UNREAD_COUNT_UPDATE,
     CHAT_ROOM_LIST_UPDATE,

--- a/src/main/java/umc/cockple/demo/domain/chat/events/ChatEventListener.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/events/ChatEventListener.java
@@ -9,6 +9,7 @@ import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 import umc.cockple.demo.domain.chat.dto.WebSocketMessageDTO;
 import umc.cockple.demo.domain.chat.dto.WebSocketMessageDTO.ChatRoomListUpdate.LastMessageUpdate;
+import umc.cockple.demo.domain.chat.service.websocket.ChatListSubscriptionService;
 import umc.cockple.demo.domain.chat.service.websocket.ChatRoomListCacheService;
 import umc.cockple.demo.domain.chat.service.websocket.ChatSendService;
 import umc.cockple.demo.domain.chat.service.websocket.SubscriptionService;
@@ -25,6 +26,8 @@ public class ChatEventListener {
     private final ChatSendService chatSendService;
     private final SubscriptionService subscriptionService;
     private final ChatRoomListCacheService chatRoomListCacheService;
+    private final ChatListSubscriptionService chatListSubscriptionService;
+
 
     @EventListener
     @Async
@@ -69,6 +72,31 @@ public class ChatEventListener {
             }
         } catch (Exception e) {
             log.error("채팅방 구독 이벤트 처리 중 오류 발생", e);
+        }
+    }
+
+    @EventListener
+    @Async
+    public void handleChatListSubscription(ChatListSubscriptionEvent event) {
+        log.info("채팅방 목록 구독 이벤트 처리 시작 - 멤버: {}, 액션: {}, 채팅방 수: {}",
+                event.memberId(), event.action(), event.chatRoomIds().size());
+
+        try {
+            switch (event.action()) {
+                case "SUBSCRIBE" -> {
+                    chatListSubscriptionService.subscribeToChatList(event.memberId(), event.chatRoomIds());
+                    log.info("채팅방 목록 구독 완료 - 멤버: {}, 채팅방 수: {}", event.memberId(), event.chatRoomIds().size());
+                }
+                case "UNSUBSCRIBE" -> {
+                    chatListSubscriptionService.unsubscribeFromChatList(event.memberId(), event.chatRoomIds());
+                    log.info("채팅방 목록 구독 해제 완료 - 멤버: {}, 채팅방 수: {}", event.memberId(), event.chatRoomIds().size());
+                }
+                default -> log.warn("알 수 없는 채팅방 목록 구독 액션: {}", event.action());
+            }
+
+        } catch (Exception e) {
+            log.error("채팅방 목록 구독 이벤트 처리 중 오류 발생 - 멤버: {}, 액션: {}",
+                    event.memberId(), event.action(), e);
         }
     }
 

--- a/src/main/java/umc/cockple/demo/domain/chat/events/ChatListSubscriptionEvent.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/events/ChatListSubscriptionEvent.java
@@ -1,0 +1,28 @@
+package umc.cockple.demo.domain.chat.events;
+
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record ChatListSubscriptionEvent(
+        Long memberId,
+        List<Long> chatRoomIds,
+        String action
+) {
+    public static ChatListSubscriptionEvent subscribe(Long memberId, List<Long> chatRoomIds) {
+        return ChatListSubscriptionEvent.builder()
+                .memberId(memberId)
+                .chatRoomIds(chatRoomIds)
+                .action("SUBSCRIBE")
+                .build();
+    }
+
+    public static ChatListSubscriptionEvent unsubscribe(Long memberId, List<Long> chatRoomIds) {
+        return ChatListSubscriptionEvent.builder()
+                .memberId(memberId)
+                .chatRoomIds(chatRoomIds)
+                .action("UNSUBSCRIBE")
+                .build();
+    }
+}

--- a/src/main/java/umc/cockple/demo/domain/chat/events/ChatRoomListUpdateEvent.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/events/ChatRoomListUpdateEvent.java
@@ -1,0 +1,30 @@
+package umc.cockple.demo.domain.chat.events;
+
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+
+@Builder
+public record ChatRoomListUpdateEvent(
+        Long chatRoomId,
+        String content,
+        LocalDateTime timestamp,
+        String messageType,
+        Map<Long, Integer> memberUnreadCounts
+) {
+    public static ChatRoomListUpdateEvent create(
+            Long chatRoomId,
+            String content,
+            LocalDateTime timestamp,
+            String messageType,
+            Map<Long, Integer> memberUnreadCounts) {
+        return ChatRoomListUpdateEvent.builder()
+                .chatRoomId(chatRoomId)
+                .content(content)
+                .timestamp(timestamp)
+                .messageType(messageType)
+                .memberUnreadCounts(memberUnreadCounts)
+                .build();
+    }
+}

--- a/src/main/java/umc/cockple/demo/domain/chat/exception/ChatErrorCode.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/exception/ChatErrorCode.java
@@ -15,6 +15,9 @@ public enum ChatErrorCode implements BaseErrorCode {
     CHATROOM_ID_NECESSARY(HttpStatus.BAD_REQUEST, "CHAT102", "채팅방 ID가 필요합니다."),
     EMPTY_MESSAGE_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "CHAT103", "빈 메세지는 보낼 수 없습니다."),
     MESSAGE_TO_LONG(HttpStatus.BAD_REQUEST, "CHAT104", "메시지는 1000자를 초과할 수 없습니다."),
+    CHATROOM_LIST_EMPTY(HttpStatus.BAD_REQUEST, "CHAT105", "구독할 채팅방 목록이 필요합니다."),
+    TOO_MANY_CHATROOMS(HttpStatus.BAD_REQUEST, "CHAT106", "한 번에 구독할 수 있는 채팅방은 최대 100개입니다."),
+    INVALID_CHATROOM_ID(HttpStatus.BAD_REQUEST, "CHAT107", "유효하지 않은 채팅방 ID입니다."),
 
     // 2xx: 리소스 없음
     CHAT_ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "CHAT201", "채팅방을 찾을 수 없습니다."),

--- a/src/main/java/umc/cockple/demo/domain/chat/handler/ChatWebSocketHandler.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/handler/ChatWebSocketHandler.java
@@ -192,7 +192,7 @@ public class ChatWebSocketHandler extends TextWebSocketHandler {
                     ChatListSubscriptionEvent.subscribe(memberId, request.memberRooms());
             eventPublisher.publishEvent(subscribeEvent);
 
-            webSocketMessageService.sendSubscriptionMessage(session, null, "SUBSCRIBE_CHAT_LIST");
+            webSocketMessageService.sendChatListSubscriptionMessage(session, request.memberRooms(), "SUBSCRIBE_CHAT_LIST");
 
         } catch (ChatException e) {
             log.warn("채팅방 목록 구독 검증 실패 - 멤버: {}, 이유: {}", memberId, e.getErrorReason().getMessage());
@@ -211,7 +211,7 @@ public class ChatWebSocketHandler extends TextWebSocketHandler {
                     ChatListSubscriptionEvent.unsubscribe(memberId, request.memberRooms());
             eventPublisher.publishEvent(unsubscribeEvent);
 
-            webSocketMessageService.sendSubscriptionMessage(session, null, "UNSUBSCRIBE_CHAT_LIST");
+            webSocketMessageService.sendChatListSubscriptionMessage(session, request.memberRooms(), "UNSUBSCRIBE_CHAT_LIST");
 
         } catch (ChatException e) {
             log.warn("채팅방 목록 구독 해제 검증 실패 - 멤버: {}, 이유: {}", memberId, e.getErrorReason().getMessage());

--- a/src/main/java/umc/cockple/demo/domain/chat/service/ChatQueryServiceImpl.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/ChatQueryServiceImpl.java
@@ -20,6 +20,7 @@ import umc.cockple.demo.domain.chat.repository.ChatMessageRepository;
 import umc.cockple.demo.domain.chat.repository.ChatRoomMemberRepository;
 import umc.cockple.demo.domain.chat.repository.ChatRoomRepository;
 import umc.cockple.demo.domain.chat.repository.MessageReadStatusRepository;
+import umc.cockple.demo.domain.chat.service.websocket.ChatRoomListCacheService;
 import umc.cockple.demo.domain.image.service.ImageService;
 import umc.cockple.demo.domain.member.domain.Member;
 import umc.cockple.demo.domain.member.domain.ProfileImg;
@@ -49,6 +50,7 @@ public class ChatQueryServiceImpl implements ChatQueryService {
     private final ChatConverter chatConverter;
     private final ImageService imageService;
     private final ChatProcessor chatProcessor;
+    private final ChatRoomListCacheService chatRoomListCacheService;
 
     @Override
     public PartyChatRoomDTO.Response getPartyChatRooms(Long memberId, int page, int size) {
@@ -195,7 +197,7 @@ public class ChatQueryServiceImpl implements ChatQueryService {
                         unreadCount = messageReadStatusRepository.countUnreadMessagesAfter(chatRoomId, memberId, lastReadMessageId);
                     }
 
-                    ChatMessage lastMessage = chatMessageRepository.findTop1ByChatRoom_IdOrderByCreatedAtDesc(chatRoomId);
+                    ChatRoomListCacheDTO.LastMessageCache lastMessage = chatRoomListCacheService.getLastMessage(chatRoomId);
                     String imgUrl = getImageUrl(chatRoom.getParty().getPartyImg());
 
                     return chatConverter.toPartyChatRoomInfo(
@@ -238,7 +240,7 @@ public class ChatQueryServiceImpl implements ChatQueryService {
                         unreadCount = messageReadStatusRepository.countUnreadMessagesAfter(chatRoomId, memberId, lastReadMessageId);
                     }
 
-                    ChatMessage lastMessage = chatMessageRepository.findTop1ByChatRoom_IdOrderByCreatedAtDesc(chatRoomId);
+                    ChatRoomListCacheDTO.LastMessageCache lastMessage = chatRoomListCacheService.getLastMessage(chatRoomId);
 
                     String displayProfileImgUrl = getImageUrl(displayMember.getMember().getProfileImg());
 

--- a/src/main/java/umc/cockple/demo/domain/chat/service/ChatValidator.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/ChatValidator.java
@@ -36,6 +36,16 @@ public class ChatValidator {
         validateChatRoomMember(chatRoomId, senderId);
     }
 
+    public void validateChatListSubscriptionRequest(Long memberId, List<Long> chatRoomIds) {
+        validateChatRoomIds(chatRoomIds);
+        validateChatRoomId(memberId, chatRoomIds);
+    }
+
+    public void validateChatListUnsubscriptionRequest(Long memberId, List<Long> chatRoomIds) {
+        validateChatRoomIds(chatRoomIds);
+        validateChatRoomId(memberId, chatRoomIds);
+    }
+
     // ========== 세부 검증 메서드 ==========
 
     private void validateChatRoom(Long chatRoomId) {
@@ -64,6 +74,30 @@ public class ChatValidator {
 
         if (content != null && content.length() > 1000) {
             throw new ChatException(ChatErrorCode.MESSAGE_TO_LONG);
+        }
+    }
+
+    private static void validateChatRoomIds(List<Long> chatRoomIds) {
+        if (chatRoomIds == null || chatRoomIds.isEmpty()) {
+            throw new ChatException(ChatErrorCode.CHATROOM_LIST_EMPTY);
+        }
+
+        if (chatRoomIds.size() > 100) {
+            throw new ChatException(ChatErrorCode.TOO_MANY_CHATROOMS);
+        }
+    }
+
+    private void validateChatRoomId(Long memberId, List<Long> chatRoomIds) {
+        List<Long> uniqueRoomIds = chatRoomIds.stream().distinct().toList();
+
+        for (Long chatRoomId : uniqueRoomIds) {
+            if (chatRoomId == null || chatRoomId <= 0) {
+                throw new ChatException(ChatErrorCode.INVALID_CHATROOM_ID);
+            }
+
+            if (!chatRoomMemberRepository.existsByChatRoomIdAndMemberId(chatRoomId, memberId)) {
+                throw new ChatException(ChatErrorCode.CHAT_ROOM_ACCESS_DENIED);
+            }
         }
     }
 }

--- a/src/main/java/umc/cockple/demo/domain/chat/service/websocket/ChatListSubscriptionService.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/websocket/ChatListSubscriptionService.java
@@ -1,0 +1,64 @@
+package umc.cockple.demo.domain.chat.service.websocket;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ChatListSubscriptionService {
+
+    private final StringRedisTemplate stringRedisTemplate;
+
+    private static final String CHAT_LIST_SUBSCRIBERS = "chatlist:subscribers:";
+
+    public void subscribeToChatList(Long memberId, List<Long> chatRoomIds) {
+        try {
+            for (Long chatRoomId : chatRoomIds) {
+                String key = CHAT_LIST_SUBSCRIBERS + chatRoomId;
+                stringRedisTemplate.opsForSet().add(key, memberId.toString());
+                stringRedisTemplate.expire(key, Duration.ofHours(2));
+            }
+            log.info("채팅방 목록 구독 완료 - 멤버: {}, 채팅방 수: {}", memberId, chatRoomIds.size());
+        } catch (Exception e) {
+            log.error("채팅방 목록 구독 실패 - 멤버: {}", memberId, e);
+        }
+    }
+
+    public void unsubscribeFromChatList(Long memberId, List<Long> chatRoomIds) {
+        try {
+            for (Long chatRoomId : chatRoomIds) {
+                String key = CHAT_LIST_SUBSCRIBERS + chatRoomId;
+                stringRedisTemplate.opsForSet().remove(key, memberId.toString());
+            }
+            log.info("채팅방 목록 구독 해제 완료 - 멤버: {}", memberId);
+        } catch (Exception e) {
+            log.error("채팅방 목록 구독 해제 실패 - 멤버: {}", memberId, e);
+        }
+    }
+
+    public Set<Long> getChatListSubscribers(Long chatRoomId) {
+        try {
+            String key = CHAT_LIST_SUBSCRIBERS + chatRoomId;
+            Set<String> members = stringRedisTemplate.opsForSet().members(key);
+
+            if (members == null || members.isEmpty()) {
+                return Set.of();
+            }
+
+            return members.stream()
+                    .map(Long::parseLong)
+                    .collect(Collectors.toSet());
+        } catch (Exception e) {
+            log.error("채팅방 목록 구독자 조회 실패 - 채팅방: {}", chatRoomId, e);
+            return Set.of();
+        }
+    }
+}

--- a/src/main/java/umc/cockple/demo/domain/chat/service/websocket/ChatRoomListCacheService.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/websocket/ChatRoomListCacheService.java
@@ -6,6 +6,7 @@ import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import umc.cockple.demo.domain.chat.domain.ChatMessage;
+import umc.cockple.demo.domain.chat.dto.ChatRoomListCacheDTO;
 import umc.cockple.demo.domain.chat.repository.ChatMessageRepository;
 
 @Service
@@ -26,6 +27,10 @@ public class ChatRoomListCacheService {
         }
 
         return ChatRoomListCacheDTO.LastMessageCache.builder()
+                .messageId(lastMessage.getId())
+                .content(lastMessage.getContent())
+                .timestamp(lastMessage.getCreatedAt())
+                .messageType(lastMessage.getType().name())
                 .build();
     }
 

--- a/src/main/java/umc/cockple/demo/domain/chat/service/websocket/ChatRoomListCacheService.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/websocket/ChatRoomListCacheService.java
@@ -27,7 +27,6 @@ public class ChatRoomListCacheService {
         }
 
         return ChatRoomListCacheDTO.LastMessageCache.builder()
-                .messageId(lastMessage.getId())
                 .content(lastMessage.getContent())
                 .timestamp(lastMessage.getCreatedAt())
                 .messageType(lastMessage.getType().name())

--- a/src/main/java/umc/cockple/demo/domain/chat/service/websocket/ChatRoomListCacheService.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/websocket/ChatRoomListCacheService.java
@@ -1,0 +1,41 @@
+package umc.cockple.demo.domain.chat.service.websocket;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+import umc.cockple.demo.domain.chat.domain.ChatMessage;
+import umc.cockple.demo.domain.chat.repository.ChatMessageRepository;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ChatRoomListCacheService {
+
+    private final ChatMessageRepository chatMessageRepository;
+
+    @Cacheable(value = "chatRoomLastMessage", key = "#chatRoomId")
+    public ChatRoomListCacheDTO.LastMessageCache getLastMessage(Long chatRoomId) {
+        log.info("캐시 미스 - 채팅방 {} 마지막 메시지 DB 조회", chatRoomId);
+
+        ChatMessage lastMessage = chatMessageRepository.findTop1ByChatRoom_IdOrderByCreatedAtDesc(chatRoomId);
+
+        if (lastMessage == null) {
+            return null;
+        }
+
+        return ChatRoomListCacheDTO.LastMessageCache.builder()
+                .build();
+    }
+
+    @CacheEvict(value = "chatRoomLastMessage", key = "#chatRoomId")
+    public void evictLastMessage(Long chatRoomId) {
+        log.info("채팅방 {} 마지막 메시지 캐시 무효화", chatRoomId);
+    }
+
+    @CacheEvict(value = "chatRoomLastMessage", allEntries = true)
+    public void evictAllLastMessages() {
+        log.info("모든 채팅방 마지막 메시지 캐시 무효화");
+    }
+}

--- a/src/main/java/umc/cockple/demo/domain/chat/service/websocket/SubscriptionService.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/websocket/SubscriptionService.java
@@ -1,6 +1,7 @@
 package umc.cockple.demo.domain.chat.service.websocket;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.Builder;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.StringRedisTemplate;
@@ -8,6 +9,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.socket.TextMessage;
 import org.springframework.web.socket.WebSocketSession;
 import umc.cockple.demo.domain.chat.dto.WebSocketMessageDTO;
+import umc.cockple.demo.domain.chat.dto.WebSocketMessageDTO.ChatRoomListUpdate.LastMessageUpdate;
 import umc.cockple.demo.domain.chat.enums.WebSocketMessageType;
 
 import java.time.LocalDateTime;
@@ -167,4 +169,10 @@ public class SubscriptionService {
             }
         }
     }
+
+    @Builder
+    public record ChatRoomListUpdateData(
+            LastMessageUpdate lastMessage,
+            int unreadCount  // 단순화된 int
+    ) {}
 }

--- a/src/main/java/umc/cockple/demo/domain/chat/service/websocket/WebSocketMessageService.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/websocket/WebSocketMessageService.java
@@ -11,6 +11,7 @@ import umc.cockple.demo.domain.chat.dto.WebSocketMessageDTO;
 import umc.cockple.demo.domain.chat.enums.WebSocketMessageType;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Service
 @Slf4j
@@ -61,6 +62,40 @@ public class WebSocketMessageService {
 
         sendMessage(session, subscriptionResponse);
     }
+
+    public void sendChatListSubscriptionMessage(WebSocketSession session, List<Long> chatRoomIds, String action) {
+        if (!session.isOpen()) {
+            log.warn("세션이 닫혀있어 채팅방 목록 구독 응답 메시지를 전송할 수 없습니다.");
+            return;
+        }
+
+        WebSocketMessageType messageType;
+        String message;
+
+        switch (action) {
+            case "SUBSCRIBE_CHAT_LIST":
+                messageType = WebSocketMessageType.SUBSCRIBE_CHAT_LIST;
+                message = String.format("채팅방 목록 구독이 완료되었습니다. (총 %d개)", chatRoomIds.size());
+                break;
+            case "UNSUBSCRIBE_CHAT_LIST":
+                messageType = WebSocketMessageType.UNSUBSCRIBE_CHAT_LIST;
+                message = "채팅방 목록 구독이 해제되었습니다.";
+                break;
+            default:
+                log.error("알 수 없는 채팅방 목록 구독 액션: {}", action);
+                return;
+        }
+
+        WebSocketMessageDTO.ChatListSubscriptionResponse response = WebSocketMessageDTO.ChatListSubscriptionResponse.builder()
+                .type(messageType)
+                .chatRoomIds(chatRoomIds)
+                .message(message)
+                .timestamp(LocalDateTime.now())
+                .build();
+
+        sendMessage(session, response);
+    }
+
 
     private void sendMessage(WebSocketSession session, Object message) {
         try {

--- a/src/main/java/umc/cockple/demo/global/config/RedisConfig.java
+++ b/src/main/java/umc/cockple/demo/global/config/RedisConfig.java
@@ -4,13 +4,18 @@ import jakarta.annotation.PostConstruct;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.time.Duration;
 
 // 기본 설정들만 해놔서 필요하시면 수정, 추가하시면 됩니다!
 @Configuration
@@ -45,5 +50,17 @@ public class RedisConfig {
         StringRedisTemplate redisTemplate = new StringRedisTemplate();
         redisTemplate.setConnectionFactory(redisConnectionFactory());
         return redisTemplate;
+    }
+
+    @Bean
+    public RedisCacheManager cacheManager(RedisConnectionFactory redisConnectionFactory) {
+        RedisCacheConfiguration config = RedisCacheConfiguration.defaultCacheConfig()
+                .entryTtl(Duration.ofMinutes(30))
+                .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer()));
+
+        return RedisCacheManager.builder(redisConnectionFactory)
+                .cacheDefaults(config)
+                .build();
     }
 }

--- a/src/main/java/umc/cockple/demo/global/config/RedisConfig.java
+++ b/src/main/java/umc/cockple/demo/global/config/RedisConfig.java
@@ -30,14 +30,13 @@ public class RedisConfig {
     @Bean
     public RedisConnectionFactory redisConnectionFactory() {
         RedisStandaloneConfiguration configuration = new RedisStandaloneConfiguration(redisHost, redisPort);
-
         return new LettuceConnectionFactory(configuration);
     }
 
     @Bean
-    public RedisTemplate<String, Object> redisTemplate() {
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
         RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
-        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setConnectionFactory(redisConnectionFactory);
         redisTemplate.setKeySerializer(new StringRedisSerializer());
         redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer());
         redisTemplate.setHashKeySerializer(new StringRedisSerializer());
@@ -46,9 +45,9 @@ public class RedisConfig {
     }
 
     @Bean
-    public StringRedisTemplate stringRedisTemplate() {
+    public StringRedisTemplate stringRedisTemplate(RedisConnectionFactory redisConnectionFactory) {
         StringRedisTemplate redisTemplate = new StringRedisTemplate();
-        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setConnectionFactory(redisConnectionFactory);
         return redisTemplate;
     }
 


### PR DESCRIPTION
## ❤️ 기능 설명
채팅방 목록 구독 및 구독 해제 Request를 구현했고,
구독한 상태에서 누군가가 채팅을 보내면 마지막 메세지 업데이트 응답을 받습니다.
이것도 Redis로 구독을 관리합니다.

swagger 테스트 성공 결과 스크린샷 첨부
### 채팅방 목록 구독 성공
<img width="2337" height="498" alt="image" src="https://github.com/user-attachments/assets/f7648048-2eda-4cc3-bd34-f9094a1679b2" />

### 채팅방 목록 구독 실패
채팅방 목록이 NULL일 때

채팅방 목록이 비어있을 때
<img width="2333" height="509" alt="image" src="https://github.com/user-attachments/assets/58cd7326-27c6-44fb-a154-879d96c9d150" />

채팅방에 권한이 없을 때
<img width="2303" height="509" alt="image" src="https://github.com/user-attachments/assets/d7f6a0bb-f4b8-464e-b972-59fe3946c219" />

### 채팅방 목록 구독했는데 누군가가 채팅 보낼 때
<img width="2317" height="433" alt="image" src="https://github.com/user-attachments/assets/4f22fc63-68a1-4446-82ff-f8d7f96bdef2" />

### 채팅방 목록 구독 해제 성공
<img width="2307" height="503" alt="image" src="https://github.com/user-attachments/assets/125cf044-b141-46ad-b453-c388e87b342e" />

### 채팅방 목록 구독 해제 실패
채팅방 목록을 NULL로 했을 때
<img width="2294" height="503" alt="image" src="https://github.com/user-attachments/assets/f0ba5a4d-5bc0-4974-a89e-2295fa879398" />

채팅방 목록을 비웠을 때
<img width="2383" height="522" alt="image" src="https://github.com/user-attachments/assets/2f54d54f-c21a-42a6-bbb1-9389a5a013b7" />

채팅방에 권한이 없을 때
<img width="2319" height="512" alt="image" src="https://github.com/user-attachments/assets/298d2a80-63d8-4def-bdb2-cb2d81f942d9" />


<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #312 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 로직이 좀 많이 복잡합니다.. 2개 PR로 나눌걸 그랬습니다

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
