### PR TITLE
[debug/#413] Redis에서 Jackson 직렬화 문제 해결

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -46,6 +46,14 @@ spring:
           min-idle: 2
           max-wait: 3000ms
 
+  jackson:
+    serialization:
+      write-dates-as-timestamps: false
+    deserialization:
+      fail-on-unknown-properties: false
+  cache:
+    type: redis
+
 cloud:
   aws:
     s3:


### PR DESCRIPTION
## ❤️ 기능 설명
채팅방 목록 조회 및 검색에서 Redis 캐싱을 사용하면서 Jackson에서 직렬화 문제가 발생했습니다.
설정을 추가하여 이를 해결합니다.

swagger 테스트 성공 결과 스크린샷 첨부
<img width="577" height="984" alt="image" src="https://github.com/user-attachments/assets/ac813c58-73fc-4ad4-bae9-ed27d263f319" />
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #413
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!
- [ ] 로컬에서는 원래 잘 나왔어서... 머지해보고 원격 환경에서 해봐야될 거 같습니다!

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
