### PR TITLE
[feat/#419] 채팅방 목록에서 이모티콘과 일반 사진 구분 표시

### DIFF
--- a/src/main/java/umc/cockple/demo/domain/chat/domain/ChatMessage.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/domain/ChatMessage.java
@@ -61,21 +61,21 @@ public class ChatMessage extends BaseEntity {
             return this.content;
         }
 
-        boolean hasImages = this.chatMessageImgs != null && !this.chatMessageImgs.isEmpty();
-        boolean hasFiles = this.chatMessageFiles != null && !this.chatMessageFiles.isEmpty();
+        if (this.chatMessageImgs != null && !this.chatMessageImgs.isEmpty()) {
+            ChatMessageImg firstImg = this.chatMessageImgs.get(0);
+            int count = this.chatMessageImgs.size();
 
-        if (hasImages && hasFiles) {
-            return "사진과 파일을 보냈습니다.";
+            if (firstImg.getIsEmoji()) {
+                return "이모티콘을 보냈습니다.";
+            } else {
+                return count > 1 ?
+                        String.format("사진 %d장을 보냈습니다.", count) :
+                        "사진을 보냈습니다.";
+            }
         }
 
-        if (hasImages) {
-            int imageCount = this.chatMessageImgs.size();
-            return imageCount > 1 ?
-                    String.format("사진 %d장을 보냈습니다.", imageCount) :
-                    "사진을 보냈습니다.";
-        }
-
-        if (hasFiles) {
+        // 파일이 있는 경우
+        if (this.chatMessageFiles != null && !this.chatMessageFiles.isEmpty()) {
             int fileCount = this.chatMessageFiles.size();
             return fileCount > 1 ?
                     String.format("파일 %d개를 보냈습니다.", fileCount) :

--- a/src/main/java/umc/cockple/demo/domain/chat/service/websocket/ChatRoomListCacheService.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/websocket/ChatRoomListCacheService.java
@@ -27,7 +27,7 @@ public class ChatRoomListCacheService {
         }
 
         return LastMessageCacheDTO.builder()
-                .content(lastMessage.getContent())
+                .content(lastMessage.getDisplayContent())
                 .timestamp(lastMessage.getCreatedAt())
                 .messageType(lastMessage.getType().name())
                 .build();


### PR DESCRIPTION
## ❤️ 기능 설명
채팅방 목록 조회 및 검색 API에서 마지막 메시지가 사진 혹은 이모티콘일경우
빈 content 대신 '사진을 보냈습니다.' 혹은 '이모티콘을 보냈습니다'와 같은 String을 반환합니다.

swagger 테스트 성공 결과 스크린샷 첨부
이모티콘일때
<img width="1040" height="1073" alt="image" src="https://github.com/user-attachments/assets/5b77b015-45de-4b2c-9b24-4119ccf94eb9" />

사진일 때
<img width="1069" height="1063" alt="image" src="https://github.com/user-attachments/assets/88ba283f-85f7-4daf-9caf-42f45c63ddf4" />

<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #419 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
