### PR TITLE
[fix/#421] profile imgKey null, 비어있는 값 모두 체크

### DIFF
--- a/src/main/java/umc/cockple/demo/domain/member/service/MemberCommandService.java
+++ b/src/main/java/umc/cockple/demo/domain/member/service/MemberCommandService.java
@@ -61,7 +61,7 @@ public class MemberCommandService {
 
         memberKeywordRepository.saveAll(keywords);
 
-        if (requestDTO.imgKey() != null) {
+        if (!StringUtils.hasText(requestDTO.imgKey())) {
             ProfileImg profile = ProfileImg.builder()
                     .member(member)
                     .imgKey(requestDTO.imgKey())

--- a/src/main/java/umc/cockple/demo/domain/member/service/MemberCommandService.java
+++ b/src/main/java/umc/cockple/demo/domain/member/service/MemberCommandService.java
@@ -61,7 +61,7 @@ public class MemberCommandService {
 
         memberKeywordRepository.saveAll(keywords);
 
-        if (!StringUtils.hasText(requestDTO.imgKey())) {
+        if (StringUtils.hasText(requestDTO.imgKey())) {
             ProfileImg profile = ProfileImg.builder()
                     .member(member)
                     .imgKey(requestDTO.imgKey())

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -37,7 +37,7 @@ spring:
 
   data:
     redis:
-      host: cockple-redis
+      host: localhost
       port: 6379
       lettuce:
         pool:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -37,7 +37,7 @@ spring:
 
   data:
     redis:
-      host: localhost
+      host: cockple-redis
       port: 6379
       lettuce:
         pool:


### PR DESCRIPTION
## ❤️ 기능 설명
기존에 imgKey에 대해 null 여부만 체크해서 profileImg의 key에 유효하지 않은 값이 들어가는 경우 발생

swagger 테스트 성공 결과 스크린샷 첨부
로그인시 프로필사진 미지정 경우 (프로필 null)
<img width="1045" height="1133" alt="스크린샷 2025-08-22 010936" src="https://github.com/user-attachments/assets/c5cf85de-ca72-40fd-bc26-91cc48466ec2" />

이후 사진 넣어도 적용 (원래 여기서 에러 발생)
<img width="1057" height="963" alt="스크린샷 2025-08-22 010952" src="https://github.com/user-attachments/assets/6721c3ea-03e7-47ff-a6a9-cbb30786c9f8" />


<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #421 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [ ] 이슈넘버를 적었는가?
