### PR TITLE
[debug/#423] 내가 초대한 게스트 조회 API에서 대기자 번호 에러 해결

### DIFF
--- a/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseQueryService.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseQueryService.java
@@ -458,23 +458,17 @@ public class ExerciseQueryService {
     private Map<Long, ExerciseMyGuestListDTO.GuestGroups> createGuestNumberMap(List<ParticipantInfo> allParticipants, Integer maxCapacity) {
         Map<Long, ExerciseMyGuestListDTO.GuestGroups> guestNumberMap = new HashMap<>();
 
-        int size = allParticipants.size();
-        for (int i = 0; i < Math.min(size, maxCapacity); i++) {
+        for (int i = 0; i < allParticipants.size(); i++) {
             ExerciseDetailDTO.ParticipantInfo participant = allParticipants.get(i);
-            if ("GUEST".equals(participant.participantType())) {
-                guestNumberMap.put(participant.participantId(),
-                        ExerciseMyGuestListDTO.GuestGroups.participant(i + 1));
-            }
-        }
 
-        if (size > maxCapacity) {
-            int waitingNumber = 1;
-            for (int i = maxCapacity; i < size; i++) {
-                ExerciseDetailDTO.ParticipantInfo participant = allParticipants.get(i);
-                if ("GUEST".equals(participant.participantType())) {
+            if ("GUEST".equals(participant.participantType())) {
+                if (i < maxCapacity) {
+                    guestNumberMap.put(participant.participantId(),
+                            ExerciseMyGuestListDTO.GuestGroups.participant(i + 1));
+                } else {
+                    int waitingNumber = i - maxCapacity + 1;
                     guestNumberMap.put(participant.participantId(),
                             ExerciseMyGuestListDTO.GuestGroups.waiting(waitingNumber));
-                    waitingNumber++;
                 }
             }
         }


### PR DESCRIPTION
## ❤️ 기능 설명
내가 초대한 운동 게스트 목록에서 대기자에 들어갈경우 1번부터 번호를 부여해 문제가 생겼습니다.
시작 번호도 전체 번호를 기준으로 변경했습니다.

swagger 테스트 성공 결과 스크린샷 첨부
운동 상세 조회 API
<img width="714" height="1188" alt="image" src="https://github.com/user-attachments/assets/1ed11475-bf43-4923-91b5-c2a873e99a90" />


내가 초대한 운동 게스트 목록
<img width="535" height="1145" alt="image" src="https://github.com/user-attachments/assets/7297d0be-2163-47a3-b9a2-6f2e752f9916" />

<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #423
<br>
<br>
<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
