### PR TITLE
[feat/#425] 특정 사용자 모임 조회 API 구현

### DIFF
--- a/src/main/java/umc/cockple/demo/domain/party/controller/PartyController.java
+++ b/src/main/java/umc/cockple/demo/domain/party/controller/PartyController.java
@@ -61,6 +61,21 @@ public class PartyController {
         return BaseResponse.success(CommonSuccessCode.OK, response);
     }
 
+    @GetMapping("/my/parties/{memberId}")
+    @Operation(summary = "사용자 모임 조회",
+            description = "특정 사용자가 가입한 모임을 조회합니다. ")
+    @ApiResponse(responseCode = "200", description = "모임 조회 성공")
+    @ApiResponse(responseCode = "404", description = "존재하지 않는 사용자")
+    public BaseResponse<Slice<PartyDTO.Response>> getMyParties(
+            @RequestParam(required = false, defaultValue = "false") Boolean created,
+            @RequestParam(required = false, defaultValue = "최신순") String sort,
+            @PageableDefault(size = 10) Pageable pageable,
+            @PathVariable Long memberId
+    ){
+        Slice<PartyDTO.Response> response = partyQueryService.getMyParties(memberId, created, sort, pageable);
+        return BaseResponse.success(CommonSuccessCode.OK, response);
+    }
+
     @GetMapping("/my/parties/suggestions")
     @Operation(summary = "추천 모임 조회",
             description = "사용자에게 추천되는 모임 목록을 조회합니다.")


### PR DESCRIPTION
## ❤️ 기능 설명
특정 사용자가 가입한 모임을 조회하는 API를 구현했습니다. 기존의 내 모임 조회의 서비스 메서드를 사용했습니다. 

swagger 테스트 성공 결과 스크린샷 첨부
<img width="716" height="395" alt="image" src="https://github.com/user-attachments/assets/844bfd51-897e-4100-8926-0248e28c57d1" />
<img width="704" height="248" alt="image" src="https://github.com/user-attachments/assets/ea13751e-9a07-47ae-8b99-f282e598a830" />
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #425 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- 없습니다

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
