### PR TITLE
[fix/#453] 대회 기록 수정 API 이미지, 비디오 관련 로직 수정

### DIFF
--- a/src/main/java/umc/cockple/demo/domain/contest/converter/ContestConverter.java
+++ b/src/main/java/umc/cockple/demo/domain/contest/converter/ContestConverter.java
@@ -3,8 +3,11 @@ package umc.cockple.demo.domain.contest.converter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import umc.cockple.demo.domain.contest.domain.Contest;
+import umc.cockple.demo.domain.contest.domain.ContestImg;
+import umc.cockple.demo.domain.contest.domain.ContestVideo;
 import umc.cockple.demo.domain.contest.dto.*;
 
+import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -38,8 +41,20 @@ public class ContestConverter {
 
     // 대회 기록 수정
     public ContestRecordUpdateDTO.Response toUpdateResponseDTO(Contest contest) {
+        List<ContestImgResponse> imgResponses = contest.getContestImgs().stream()
+                .sorted(Comparator.comparing(ContestImg::getImgOrder))
+                .map(img -> new ContestImgResponse(img.getId(), img.getImgKey(), img.getImgOrder()))
+                .collect(Collectors.toList());
+
+        List<ContestVideoResponse> videoResponses = contest.getContestVideos().stream()
+                .sorted(Comparator.comparingInt(ContestVideo::getVideoOrder))
+                .map(video -> new ContestVideoResponse(video.getId(), video.getVideoUrl(), video.getVideoOrder()))
+                .collect(Collectors.toList());
+
         return ContestRecordUpdateDTO.Response.builder()
                 .contestId(contest.getId())
+                .contestImgs(imgResponses)
+                .contestVideos(videoResponses)
                 .UpdatedAt(contest.getUpdatedAt())
                 .build();
     }

--- a/src/main/java/umc/cockple/demo/domain/contest/dto/AddContestImgRequest.java
+++ b/src/main/java/umc/cockple/demo/domain/contest/dto/AddContestImgRequest.java
@@ -1,0 +1,7 @@
+package umc.cockple.demo.domain.contest.dto;
+
+public record AddContestImgRequest(
+        String imgKey,
+        int imgOrder
+) {
+}

--- a/src/main/java/umc/cockple/demo/domain/contest/dto/AddContestVideoRequest.java
+++ b/src/main/java/umc/cockple/demo/domain/contest/dto/AddContestVideoRequest.java
@@ -1,0 +1,7 @@
+package umc.cockple.demo.domain.contest.dto;
+
+public record AddContestVideoRequest(
+        String videoKey,
+        int videoOrder
+) {
+}

--- a/src/main/java/umc/cockple/demo/domain/contest/dto/ContestImgResponse.java
+++ b/src/main/java/umc/cockple/demo/domain/contest/dto/ContestImgResponse.java
@@ -1,0 +1,9 @@
+package umc.cockple.demo.domain.contest.dto;
+
+public record ContestImgResponse(
+        Long id,
+        String imgKey,
+        int imgOrder
+) {
+
+}

--- a/src/main/java/umc/cockple/demo/domain/contest/dto/ContestRecordUpdateDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/contest/dto/ContestRecordUpdateDTO.java
@@ -33,20 +33,20 @@ public class ContestRecordUpdateDTO {
             @Size(max = 100, message = "대회 기록은 최대 100자까지 가능합니다.")
             String content,
 
-            Boolean contentIsOpen,
+            boolean contentIsOpen,
 
-            Boolean videoIsOpen,
+            boolean videoIsOpen,
 
             // 새로 추가할 영상 링크들
-            List<String> contestVideos,
+            List<AddContestVideoRequest> contestVideos,
 
             // 새로 추가할 이미지
-            List<String> contestImgs,
+            List<AddContestImgRequest> contestImgs,
 
-            // 삭제할 이미지 imgKey (프론트에서 관리)
-            List<String> contestImgsToDelete,
+            // 삭제할 이미지 id
+            List<Long> contestImgsToDelete,
 
-            // 삭제할 영상의 비디오 아이디
+            // 삭제할 영상의 비디오 id
             List<Long> contestVideoIdsToDelete
 
     ) {
@@ -55,6 +55,8 @@ public class ContestRecordUpdateDTO {
     @Builder
     public record Response(
             Long contestId,
+            List<ContestImgResponse> contestImgs,
+            List<ContestVideoResponse> contestVideos,
             LocalDateTime UpdatedAt
     ) {
     }

--- a/src/main/java/umc/cockple/demo/domain/contest/dto/ContestVideoResponse.java
+++ b/src/main/java/umc/cockple/demo/domain/contest/dto/ContestVideoResponse.java
@@ -1,0 +1,8 @@
+package umc.cockple.demo.domain.contest.dto;
+
+public record ContestVideoResponse(
+        Long id,
+        String videoUrl,
+        int videoOrder
+) {
+}

--- a/src/main/java/umc/cockple/demo/domain/contest/exception/ContestErrorCode.java
+++ b/src/main/java/umc/cockple/demo/domain/contest/exception/ContestErrorCode.java
@@ -14,6 +14,8 @@ public enum ContestErrorCode implements BaseErrorCode {
 
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "CONTEST201", "존재하지 않는 회원입니다."),
     CONTEST_NOT_FOUND(HttpStatus.NOT_FOUND, "CONTEST202", "존재하지 않는 대회기록입니다."),
+    CONTEST_IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "CONTEST203", "존재하지 않는 대회 이미지입니다."),
+    CONTEST_VIDEO_NOT_FOUND(HttpStatus.NOT_FOUND, "CONTEST204", "존재하지 않는 대회 영상입니다."),
 
     NO_DELETE_AUTHORITY(HttpStatus.FORBIDDEN, "CONTEST301", "권한이 없습니다."),
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -38,7 +38,7 @@ spring:
 
   data:
     redis:
-      host: cockple-redis
+      host: localhost
       port: 6379
       lettuce:
         pool:


### PR DESCRIPTION
## ❤️ 기능 설명

대회기록 수정시 이미지 처리 로직에 오류가 있어서 이를 해결합니다.

swagger 테스트 성공 결과 스크린샷 첨부
<img width="1032" height="613" alt="스크린샷 2026-01-23 174635" src="https://github.com/user-attachments/assets/89ab9893-59ac-4db2-96e4-9ddb84381777" />

<img width="803" height="248" alt="스크린샷 2026-01-23 174703" src="https://github.com/user-attachments/assets/a79b22c6-148b-4524-8848-b3f0ff4eabfb" />


<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #453 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [ ] 이슈넘버를 적었는가?
