### PR TITLE
[feat/#459] 대회기록 생성 API 응답DTO 필드 수정

### DIFF
--- a/src/main/java/umc/cockple/demo/domain/contest/converter/ContestConverter.java
+++ b/src/main/java/umc/cockple/demo/domain/contest/converter/ContestConverter.java
@@ -33,9 +33,19 @@ public class ContestConverter {
     }
 
     public ContestRecordCreateDTO.Response toCreateResponseDTO(Contest contest) {
+        List<Long> imgIds = contest.getContestImgs().stream()
+                .map(ContestImg::getId)
+                .collect(Collectors.toList());
+
+        List<Long> videoIds = contest.getContestVideos().stream()
+                .map(ContestVideo::getId)
+                .collect(Collectors.toList());
+
         return ContestRecordCreateDTO.Response.builder()
                 .contestId(contest.getId())
                 .createdAt(contest.getCreatedAt())
+                .contestImgIds(imgIds)
+                .contestVideoIds(videoIds)
                 .build();
     }
 

--- a/src/main/java/umc/cockple/demo/domain/contest/dto/ContestImgUpdateRequest.java
+++ b/src/main/java/umc/cockple/demo/domain/contest/dto/ContestImgUpdateRequest.java
@@ -1,0 +1,8 @@
+package umc.cockple.demo.domain.contest.dto;
+
+public record ContestImgUpdateRequest(
+        Long id,           // 기존 항목이면 id, 신규면 null
+        String imgKey,
+        int imgOrder
+) {
+}

--- a/src/main/java/umc/cockple/demo/domain/contest/dto/ContestRecordCreateDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/contest/dto/ContestRecordCreateDTO.java
@@ -38,10 +38,10 @@ public class ContestRecordCreateDTO {
 
             Boolean videoIsOpen,
 
-            List<String> contestVideos,
+            List<AddContestVideoRequest> contestVideos,
 
             @Size(max = 3, message = "이미지는 3개까지 업로드 가능합니다.")
-            List<String> contestImgs
+            List<AddContestImgRequest> contestImgs
 
     ) {
     }
@@ -57,15 +57,17 @@ public class ContestRecordCreateDTO {
             String content,
             Boolean contentIsOpen,
             Boolean videoIsOpen,
-            List<String> contestVideos,
-            List<String> contestImgs
+            List<AddContestVideoRequest> contestVideos,
+            List<AddContestImgRequest> contestImgs
     ) {
     }
 
     @Builder
     public record Response(
             Long contestId,
-            LocalDateTime createdAt
+            LocalDateTime createdAt,
+            List<Long> contestImgIds,
+            List<Long> contestVideoIds
     ) {
     }
 }

--- a/src/main/java/umc/cockple/demo/domain/contest/dto/ContestRecordUpdateDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/contest/dto/ContestRecordUpdateDTO.java
@@ -37,17 +37,12 @@ public class ContestRecordUpdateDTO {
 
             boolean videoIsOpen,
 
-            // 새로 추가할 영상 링크들
-            List<AddContestVideoRequest> contestVideos,
+            // 최종 상태의 이미지 목록 (기존 항목은 id 포함, 신규는 id null)
+            @Size(max = 3, message = "이미지는 3개까지 업로드 가능합니다.")
+            List<ContestImgUpdateRequest> contestImgs,
 
-            // 새로 추가할 이미지
-            List<AddContestImgRequest> contestImgs,
-
-            // 삭제할 이미지 id
-            List<Long> contestImgsToDelete,
-
-            // 삭제할 영상의 비디오 id
-            List<Long> contestVideoIdsToDelete
+            // 최종 상태의 영상 목록 (기존 항목은 id 포함, 신규는 id null)
+            List<ContestVideoUpdateRequest> contestVideos
 
     ) {
     }

--- a/src/main/java/umc/cockple/demo/domain/contest/dto/ContestVideoUpdateRequest.java
+++ b/src/main/java/umc/cockple/demo/domain/contest/dto/ContestVideoUpdateRequest.java
@@ -1,0 +1,8 @@
+package umc.cockple.demo.domain.contest.dto;
+
+public record ContestVideoUpdateRequest(
+        Long id,           // 기존 항목이면 id, 신규면 null
+        String videoKey,
+        int videoOrder
+) {
+}


### PR DESCRIPTION
## ❤️ 기능 설명
대회기록 생성 시 이미지, 비디오의 id를 반환하도록 수정합니다.

swagger 테스트 성공 결과 스크린샷 첨부
<img width="994" height="327" alt="image" src="https://github.com/user-attachments/assets/64d8c50c-951b-4e2c-a8cb-11e2e27614c8" />

<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #459 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [ ] 이슈넘버를 적었는가?
