### PR TITLE
[feat/#462] 대회 상세 조회시 API 수정

### DIFF
--- a/src/main/java/umc/cockple/demo/domain/contest/converter/ContestConverter.java
+++ b/src/main/java/umc/cockple/demo/domain/contest/converter/ContestConverter.java
@@ -77,7 +77,7 @@ public class ContestConverter {
     }
 
     // 대회 기록 상세 조회
-    public ContestRecordDetailDTO.Response toDetailResponseDTO(Contest contest, List<String> imgUrls, List<String> videoUrls, String content) {
+    public ContestRecordDetailDTO.Response toDetailResponseDTO(Contest contest, List<Long> imgIds, List<String> imgUrls, List<Long> videoIds, List<String> videoUrls, String content) {
         return ContestRecordDetailDTO.Response.builder()
                 .contestId(contest.getId())
                 .contestName(contest.getContestName())
@@ -87,8 +87,10 @@ public class ContestConverter {
                 .level(contest.getLevel())
                 .contentIsOpen(contest.getContentIsOpen())
                 .content(content)
+                .contestImgIds(imgIds)
                 .contestImgUrls(imgUrls)
                 .videoIsOpen(contest.getVideoIsOpen())
+                .contestVideoIds(videoIds)
                 .contestVideoUrls(videoUrls)
                 .build();
     }

--- a/src/main/java/umc/cockple/demo/domain/contest/dto/ContestRecordDetailDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/contest/dto/ContestRecordDetailDTO.java
@@ -21,7 +21,9 @@ public class ContestRecordDetailDTO {
             String content,
             Boolean contentIsOpen,
             Boolean videoIsOpen,
+            List<Long> contestImgIds,
             List<String> contestImgUrls,
+            List<Long> contestVideoIds,
             List<String> contestVideoUrls
     ) {
     }


### PR DESCRIPTION
## ❤️ 기능 설명
상세조회시 이미지, 비디오 id 같이 조회되도록 수정

swagger 테스트 성공 결과 스크린샷 첨부
<img width="950" height="404" alt="image" src="https://github.com/user-attachments/assets/7433456c-ade9-4eb7-b43b-b49ace91b82c" />

<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #462 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [ ] 이슈넘버를 적었는가?
