### PR TITLE
[refactor/#465] 테스트 서버와 운영서버 분리를 위한 CI/CD 파이프라인 수정

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,8 +1,7 @@
 name: COCKPLE_CD
-
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "develop" ]
 
 permissions:
   contents: read
@@ -20,16 +19,30 @@ jobs:
           distribution: "adopt"
           cache: gradle
 
-
-      - name: Remove existing application.yml (if exists)
+      - name: Set environment variables by branch
+        id: vars
         run: |
-          rm -f src/main/resources/application.yml
+          if [ "${{ github.ref_name }}" == "main" ]; then
+            echo "APP_SECRET=APPLICATION" >> $GITHUB_OUTPUT
+            echo "DOCKER_TAG=latest" >> $GITHUB_OUTPUT
+            echo "COMPOSE_FILE=docker-compose.prod.yml" >> $GITHUB_OUTPUT
+          else
+            echo "APP_SECRET=APPLICATION_STAGING" >> $GITHUB_OUTPUT
+            echo "DOCKER_TAG=staging" >> $GITHUB_OUTPUT
+            echo "COMPOSE_FILE=docker-compose.staging.yml" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Remove existing application.yml
+        run: rm -f src/main/resources/application.yml
 
       - name: Make application.yml
         run: |
           mkdir -p src/main/resources
-          echo "${{ secrets.APPLICATION }}" > src/main/resources/application-dev.yml
-          mv src/main/resources/application-dev.yml src/main/resources/application.yml
+          if [ "${{ github.ref_name }}" == "main" ]; then
+            echo "${{ secrets.APPLICATION }}" > src/main/resources/application.yml
+          else
+            echo "${{ secrets.APPLICATION_STAGING }}" > src/main/resources/application.yml
+          fi
 
       - name: Build with Gradle
         run: |
@@ -39,9 +52,8 @@ jobs:
       - name: Docker BUILD_PUSH
         run: |
           docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }}
-          docker build -f Dockerfile -t ${{ secrets.DOCKER_REPO }} .
-          docker push ${{ secrets.DOCKER_REPO }}
-
+          docker build -f Dockerfile -t ${{ secrets.DOCKER_REPO }}:${{ steps.vars.outputs.DOCKER_TAG }} .
+          docker push ${{ secrets.DOCKER_REPO }}:${{ steps.vars.outputs.DOCKER_TAG }}
 
       - name: Deploy_EC2
         uses: appleboy/ssh-action@master
@@ -52,22 +64,30 @@ jobs:
           key: ${{ secrets.KEY }}
           script: |
             cd /home/ubuntu/home/monitor
-
             echo "=== 배포 전 상태 ==="
             sudo docker ps
-
             sudo docker image prune -f
-            sudo docker pull ${{ secrets.DOCKER_REPO }}
-            sudo docker stop cockple-app || true
-            sudo docker rm -f cockple-app || true
+            sudo docker pull ${{ secrets.DOCKER_REPO }}:${{ steps.vars.outputs.DOCKER_TAG }}
             
-            if ! sudo docker ps | grep -q redis; then
-              echo "Redis가 죽었음, 재시작 중..."
-              sudo docker compose up -d redis
-              sleep 10
+            if [ "${{ github.ref_name }}" == "main" ]; then
+              sudo docker stop cockple-app || true
+              sudo docker rm -f cockple-app || true
+              if ! sudo docker ps | grep -q cockple-redis; then
+                echo "Redis(prod)가 죽었음, 재시작 중..."
+                sudo docker compose -f docker-compose.prod.yml up -d redis
+                sleep 10
+              fi
+              sudo docker compose -f docker-compose.prod.yml up -d cockple-app
+            else
+              sudo docker stop cockple-app-staging || true
+              sudo docker rm -f cockple-app-staging || true
+              if ! sudo docker ps | grep -q cockple-redis-staging; then
+                echo "Redis(staging)가 죽었음, 재시작 중..."
+                sudo docker compose -f docker-compose.staging.yml up -d redis-staging
+                sleep 10
+              fi
+              sudo docker compose -f docker-compose.staging.yml up -d cockple-app-staging
             fi
             
-            sudo docker compose up -d cockple-app
-
             echo "=== 배포 후 상태 ==="
             sudo docker ps

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,10 +22,14 @@ jobs:
           distribution: 'temurin'
           cache: gradle
 
-      - name: Make application.yml (test용)
+      - name: Make application.yml (브랜치별 분기 - 개발용, 운영용)
         run: |
           mkdir -p src/main/resources
-          echo "${{ secrets.APPLICATION }}" > src/main/resources/application.yml
+          if [ "${{ github.base_ref }}" == "main" ]; then
+            echo "${{ secrets.APPLICATION }}" > src/main/resources/application.yml
+          else
+            echo "${{ secrets.APPLICATION_STAGING }}" > src/main/resources/application.yml
+          fi
 
       - name: Grant execute permission for Gradle
         run: chmod +x gradlew


### PR DESCRIPTION
## ❤️ 기능 설명
테스트용 서버와 운영용 서버를 분리합니다. 완전히 다른 인스턴스를 띄우기에는 금전적으로 부담이 있는 상황이라서 application 서버는 도커 컨테이너만 분리하고, DB는 인스턴스만 분리했습니다.


swagger 테스트 성공 결과 스크린샷 첨부
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #465 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [ ] 이슈넘버를 적었는가?
