### PR TITLE
[deploy] CORS 빈이 제대로 등록되지 않을 수 있어 메서드 참조로 변경하여 배포

### DIFF
--- a/src/main/java/umc/cockple/demo/global/config/SecurityConfig.java
+++ b/src/main/java/umc/cockple/demo/global/config/SecurityConfig.java
@@ -26,7 +26,6 @@ import java.util.List;
 public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
-    private final CorsConfigurationSource corsConfigurationSource;
     private final RestAuthenticationEntryPoint restEntryPoint;
 
 
@@ -47,7 +46,7 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
-                .cors(cors -> cors.configurationSource(corsConfigurationSource))
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .csrf(AbstractHttpConfigurer::disable)
                 .exceptionHandling(e -> e.authenticationEntryPoint(restEntryPoint))
                 .httpBasic(AbstractHttpConfigurer::disable)

--- a/src/main/java/umc/cockple/demo/global/config/SecurityConfig.java
+++ b/src/main/java/umc/cockple/demo/global/config/SecurityConfig.java
@@ -13,9 +13,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
-import umc.cockple.demo.domain.member.repository.MemberRepository;
 import umc.cockple.demo.global.exception.RestAuthenticationEntryPoint;
-import umc.cockple.demo.global.jwt.domain.JwtTokenProvider;
 import umc.cockple.demo.global.security.filter.JwtAuthenticationFilter;
 
 import java.util.List;

--- a/src/main/java/umc/cockple/demo/global/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/umc/cockple/demo/global/security/filter/JwtAuthenticationFilter.java
@@ -7,7 +7,6 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.BadCredentialsException;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
@@ -19,8 +18,6 @@ import umc.cockple.demo.domain.member.exception.MemberException;
 import umc.cockple.demo.domain.member.repository.MemberRepository;
 import umc.cockple.demo.global.exception.RestAuthenticationEntryPoint;
 import umc.cockple.demo.global.jwt.domain.JwtTokenProvider;
-import umc.cockple.demo.global.response.dto.ErrorReasonDTO;
-import umc.cockple.demo.global.security.domain.CustomUserDetails;
 
 import java.io.IOException;
 


### PR DESCRIPTION
## ❤️ 기능 설명
CORS 빈이 제대로 등록되지 않을 수 있어 메서드 참조로 변경하여 배포합니다.