### PR TITLE
[fix/#494] 채팅방 목록/검색/초기 조회 API - 상대방 탈퇴 여부 반환

### DIFF
--- a/src/main/java/umc/cockple/demo/domain/chat/converter/ChatConverter.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/converter/ChatConverter.java
@@ -154,6 +154,7 @@ public class ChatConverter {
             ChatRoom chatRoom,
             String displayName,
             String profileImageUrl,
+            boolean isCounterPartWithdrawn,
             int memberCount,
             Long lastReadMessageId) {
         return ChatRoomDetailDTO.ChatRoomInfo.builder()
@@ -161,6 +162,7 @@ public class ChatConverter {
                 .chatRoomType(chatRoom.getType())
                 .displayName(displayName)
                 .profileImageUrl(profileImageUrl)
+                .isCounterPartWithdrawn(isCounterPartWithdrawn)
                 .memberCount(memberCount)
                 .lastReadMessageId(lastReadMessageId)
                 .build();

--- a/src/main/java/umc/cockple/demo/domain/chat/converter/ChatConverter.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/converter/ChatConverter.java
@@ -73,6 +73,7 @@ public class ChatConverter {
 
     public DirectChatRoomDTO.ChatRoomInfo toDirectChatRoomInfo(ChatRoom chatRoom,
                                                                ChatRoomMember chatRoomMember,
+                                                               boolean isWithdrawn,
                                                                int unreadCount,
                                                                DirectChatRoomDTO.LastMessageInfo lastMessageInfo,
                                                                String imgUrl) {
@@ -80,6 +81,7 @@ public class ChatConverter {
                 .chatRoomId(chatRoom.getId())
                 .displayName(chatRoomMember.getDisplayName())
                 .profileImgUrl(imgUrl)
+                .isWithdrawn(isWithdrawn)
                 .unreadCount(unreadCount)
                 .lastMessage(lastMessageInfo)
                 .build();

--- a/src/main/java/umc/cockple/demo/domain/chat/dto/ChatRoomDetailDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/dto/ChatRoomDetailDTO.java
@@ -23,6 +23,7 @@ public class ChatRoomDetailDTO {
             ChatRoomType chatRoomType,
             String displayName,
             String profileImageUrl,
+            boolean isCounterPartWithdrawn,
             int memberCount,
             Long lastReadMessageId
     ) {

--- a/src/main/java/umc/cockple/demo/domain/chat/dto/DirectChatRoomDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/dto/DirectChatRoomDTO.java
@@ -21,6 +21,7 @@ public class DirectChatRoomDTO {
             Long chatRoomId,
             String displayName,
             String profileImgUrl,
+            boolean isWithdrawn,
             int unreadCount,
             LastMessageInfo lastMessage
     ) {

--- a/src/main/java/umc/cockple/demo/domain/chat/service/ChatQueryServiceImpl.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/ChatQueryServiceImpl.java
@@ -23,6 +23,7 @@ import umc.cockple.demo.domain.chat.service.websocket.ChatRoomListCacheService;
 import umc.cockple.demo.domain.image.service.ImageService;
 import umc.cockple.demo.domain.member.domain.Member;
 import umc.cockple.demo.domain.member.domain.ProfileImg;
+import umc.cockple.demo.domain.member.enums.MemberStatus;
 import umc.cockple.demo.domain.member.repository.MemberPartyRepository;
 import umc.cockple.demo.domain.party.domain.Party;
 import umc.cockple.demo.domain.party.domain.PartyImg;
@@ -240,11 +241,14 @@ public class ChatQueryServiceImpl implements ChatQueryService {
 
                     LastMessageCacheDTO lastMessage = chatRoomListCacheService.getLastMessage(chatRoomId);
 
-                    String displayProfileImgUrl = getImageUrl(displayMember.getMember().getProfileImg());
+                    Member counterPartMember = displayMember.getMember();
+                    String displayProfileImgUrl = getImageUrl(counterPartMember.getProfileImg());
+                    boolean isWithdrawn = counterPartMember.getIsActive() == MemberStatus.INACTIVE;
 
                     return chatConverter.toDirectChatRoomInfo(
                             chatRoom,
                             myMember,
+                            isWithdrawn,
                             unreadCount,
                             chatConverter.toDirectLastMessageInfo(lastMessage),
                             displayProfileImgUrl

--- a/src/main/java/umc/cockple/demo/domain/chat/service/ChatQueryServiceImpl.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/ChatQueryServiceImpl.java
@@ -262,6 +262,7 @@ public class ChatQueryServiceImpl implements ChatQueryService {
     private ChatRoomDetailDTO.ChatRoomInfo buildChatRoomInfo(ChatRoom chatRoom, ChatRoomMember myMembership) {
         String displayName;
         String profileImageUrl = null;
+        boolean isCounterPartWithdrawn = false;
 
         if (chatRoom.getType() == ChatRoomType.DIRECT) {
             ChatRoomMember counterPart = findCounterPartWithMemberOrThrow(chatRoom, myMembership);
@@ -269,6 +270,7 @@ public class ChatQueryServiceImpl implements ChatQueryService {
 
             displayName = member.getMemberName();
             profileImageUrl = getImageUrl(member.getProfileImg());
+            isCounterPartWithdrawn = member.getIsActive() == MemberStatus.INACTIVE;
         } else {
             displayName = chatRoom.getParty().getPartyName();
             profileImageUrl = getImageUrl(chatRoom.getParty().getPartyImg());
@@ -281,6 +283,7 @@ public class ChatQueryServiceImpl implements ChatQueryService {
                 chatRoom,
                 displayName,
                 profileImageUrl,
+                isCounterPartWithdrawn,
                 memberCount,
                 lastReadMessageId);
     }


### PR DESCRIPTION
## ❤️ 기능 설명
채팅방 관련 API 3종에서 상대방 유저의 탈퇴 여부를 추가로 반환합니다.

- **개인 채팅방 목록/검색 API** (`DirectChatRoomDTO.ChatRoomInfo`)
- `isWithdrawn` 필드 추가 — 상대방의 `MemberStatus`가 `INACTIVE`이면 `true`
- **초기 채팅방 조회 API** (`ChatRoomDetailDTO.ChatRoomInfo`)
- `isCounterPartWithdrawn` 필드 추가 — DM방일 때만 적용, 모임 채팅방은 항상 `false`

swagger 테스트 성공 결과 스크린샷 첨부
채팅방 목록 조회
<img width="2332" height="961" alt="image" src="https://github.com/user-attachments/assets/a0c606a2-6c1a-42a2-9a0c-26ed0895a87a" />

채팅방 검색
<img width="2367" height="967" alt="image" src="https://github.com/user-attachments/assets/08e2b4c6-5b2c-40f1-8663-60ddb69b1f88" />

초기 채팅방 조회
<img width="2355" height="795" alt="image" src="https://github.com/user-attachments/assets/fbf24aea-e9fb-4441-8668-968315dab0ff" />

<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #494 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 테스트 코드는 일단 추후에 작성해보겠습니다.
<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
