### PR TITLE
[feat/#496] 멤버 역할(부모임장) 설정 API 구현

### DIFF
--- a/src/main/java/umc/cockple/demo/domain/member/domain/MemberParty.java
+++ b/src/main/java/umc/cockple/demo/domain/member/domain/MemberParty.java
@@ -67,4 +67,8 @@ public class MemberParty extends BaseEntity {
         if (this.role == Role.party_MANAGER) return true;
         return false;
     }
+
+    public void changeRole(Role newRole) {
+        this.role = newRole;
+    }
 }

--- a/src/main/java/umc/cockple/demo/domain/member/exception/MemberErrorCode.java
+++ b/src/main/java/umc/cockple/demo/domain/member/exception/MemberErrorCode.java
@@ -23,6 +23,7 @@ public enum MemberErrorCode implements BaseErrorCode {
     ALREADY_WITHDRAW(HttpStatus.UNAUTHORIZED, "MEMBER301", "이미 탈퇴한 회원입니다."),
 
     MANAGER_CANNOT_LEAVE(HttpStatus.BAD_REQUEST, "MEMBER401", "모임장은 탈퇴할 수 없습니다. 모임 삭제를 먼저 해주세요."),
+    SUBMANAGER_CANNOT_LEAVE(HttpStatus.BAD_REQUEST, "MEMBER402", "부모임장은 탈퇴할 수 없습니다. 모임 탈퇴를 먼저 해주세요."),
 
     // 회원 주소 관련
     ADDRESS_NOT_FOUND(HttpStatus.NOT_FOUND, "MEM_ADDR201", "해당 주소를 찾을 수 없습니다."),

--- a/src/main/java/umc/cockple/demo/domain/member/repository/MemberPartyRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/member/repository/MemberPartyRepository.java
@@ -54,4 +54,6 @@ public interface MemberPartyRepository extends JpaRepository<MemberParty, Long> 
        WHERE mp.party.id = :partyId
        """)
     List<MemberParty> findAllByPartyIdWithMember(@Param("partyId") Long partyId);
+
+    Optional<MemberParty> findByPartyIdAndRole(Long partyId, Role role);
 }

--- a/src/main/java/umc/cockple/demo/domain/member/service/MemberCommandService.java
+++ b/src/main/java/umc/cockple/demo/domain/member/service/MemberCommandService.java
@@ -16,6 +16,7 @@ import umc.cockple.demo.domain.member.exception.MemberException;
 import umc.cockple.demo.domain.member.repository.*;
 import umc.cockple.demo.domain.member.enums.MemberStatus;
 import umc.cockple.demo.domain.image.service.ImageService;
+import umc.cockple.demo.global.enums.Role;
 
 import java.util.List;
 import umc.cockple.demo.global.oauth2.service.KakaoOauthService;
@@ -282,6 +283,17 @@ public class MemberCommandService {
 
         if (isLeader) {
             throw new MemberException(MemberErrorCode.MANAGER_CANNOT_LEAVE);
+        }
+
+        // 활성화 된 모임의 부모임장인 경우 -> 탈퇴 불가
+        boolean isSubOwner = member.getMemberParties().stream()
+                .anyMatch(memberParty ->
+                        memberParty.getRole() == Role.party_SUBMANAGER
+                                && memberParty.getStatus() == MemberPartyStatus.ACTIVE
+                );
+
+        if (isSubOwner) {
+            throw new MemberException(MemberErrorCode.SUBMANAGER_CANNOT_LEAVE);
         }
     }
 }

--- a/src/main/java/umc/cockple/demo/domain/notification/enums/NotificationTarget.java
+++ b/src/main/java/umc/cockple/demo/domain/notification/enums/NotificationTarget.java
@@ -8,7 +8,9 @@ public enum NotificationTarget {
     PARTY_MODIFY(NotificationType.CHANGE),
     PARTY_INVITE(NotificationType.INVITE),
     PARTY_INVITE_APPROVED(NotificationType.SIMPLE),
-    PARTY_JOINREQUEST_APPROVED(NotificationType.CHANGE);
+    PARTY_JOINREQUEST_APPROVED(NotificationType.CHANGE),
+    PARTY_SUBOWNER_ASSIGNED(NotificationType.SIMPLE),
+    PARTY_SUBOWNER_RELEASED(NotificationType.SIMPLE);
 
     private final NotificationType defaultType;
 

--- a/src/main/java/umc/cockple/demo/domain/notification/service/NotificationCommandService.java
+++ b/src/main/java/umc/cockple/demo/domain/notification/service/NotificationCommandService.java
@@ -42,7 +42,6 @@ public class NotificationCommandService {
     private final NotificationMessageGenerator notificationMessageGenerator;
     private final ObjectMapper objectMapper;
 
-
     // 알림 타입 변경 (초대 수락, 거절에 사용)
     public Response markAsReadNotification(Long memberId, Long notificationId, NotificationType type) {
         Notification notification = findByNotificationId(notificationId);
@@ -96,7 +95,11 @@ public class NotificationCommandService {
                 title = "새로운 모임";
             } else if (dto.target() == NotificationTarget.PARTY_INVITE_APPROVED) {
                 content = notificationMessageGenerator.generateInviteApprovedMessage(dto.subjectName());
-            }else {
+            } else if (dto.target() == NotificationTarget.PARTY_SUBOWNER_ASSIGNED) {
+                content = notificationMessageGenerator.generateSubOwnerAssignedMessage(dto.subjectName());
+            } else if (dto.target() == NotificationTarget.PARTY_SUBOWNER_RELEASED) {
+                content = notificationMessageGenerator.generateSubOwnerReleasedMessage(dto.subjectName());
+            } else {
                 content = notificationMessageGenerator.generateJoinRequestApprovedMessage();
             }
 

--- a/src/main/java/umc/cockple/demo/domain/notification/service/NotificationMessageGenerator.java
+++ b/src/main/java/umc/cockple/demo/domain/notification/service/NotificationMessageGenerator.java
@@ -36,4 +36,12 @@ public class NotificationMessageGenerator {
     public String generateExerciseAttendChangedMessage() {
         return "운동 참석으로 변경되었어요!";
     }
+
+    public String generateSubOwnerAssignedMessage(String nickname) {
+        return String.format("'%s'님이 부모임장으로 지정되었습니다.", nickname);
+    }
+
+    public String generateSubOwnerReleasedMessage(String nickname) {
+        return String.format("'%s'님의 부모임장 권한이 해제되었습니다.", nickname);
+    }
 }

--- a/src/main/java/umc/cockple/demo/domain/party/controller/PartyController.java
+++ b/src/main/java/umc/cockple/demo/domain/party/controller/PartyController.java
@@ -213,6 +213,22 @@ public class PartyController {
         return BaseResponse.success(CommonSuccessCode.OK);
     }
 
+    @PatchMapping("/parties/{partyId}/members/{memberId}/role")
+    @Operation(summary = "멤버 역할(부모임장) 설정", description = "모임장이 특정 멤버를 부모임장으로 지정하거나 해제합니다.")
+    @ApiResponse(responseCode = "200", description = "역할 변경 성공")
+    @ApiResponse(responseCode = "400", description = "유효하지 않은 역할 값")
+    @ApiResponse(responseCode = "403", description = "모임장 권한 없음 또는 모임장 역할 변경 시도")
+    @ApiResponse(responseCode = "404", description = "존재하지 않는 모임 또는 멤버")
+    public BaseResponse<Void> updateMemberRole(
+            @PathVariable Long partyId,
+            @PathVariable Long memberId,
+            @RequestBody @Valid PartyMemberRoleDTO.Request request) {
+        Long currentMemberId = SecurityUtil.getCurrentMemberId();
+
+        partyCommandService.updateMemberRole(partyId, memberId, currentMemberId, request);
+        return BaseResponse.success(CommonSuccessCode.OK);
+    }
+
     @PostMapping("/parties/{partyId}/join-requests")
     @Operation(summary = "모임 가입 신청",
             description = "사용자가 특정 모임에 가입을 신청합니다")

--- a/src/main/java/umc/cockple/demo/domain/party/dto/PartyMemberRoleDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/party/dto/PartyMemberRoleDTO.java
@@ -1,0 +1,13 @@
+package umc.cockple.demo.domain.party.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import umc.cockple.demo.global.enums.Role;
+
+public class PartyMemberRoleDTO {
+
+    @Schema(name = "PartyMemberRoleRequest")
+    public record Request(
+            @NotNull(message = "역할 값은 필수입니다.") Role role) {
+    }
+}

--- a/src/main/java/umc/cockple/demo/domain/party/exception/PartyErrorCode.java
+++ b/src/main/java/umc/cockple/demo/domain/party/exception/PartyErrorCode.java
@@ -44,8 +44,10 @@ public enum PartyErrorCode implements BaseErrorCode {
     PARTY_IS_DELETED(HttpStatus.BAD_REQUEST, "PARTY407", "이미 삭제된 모임입니다."),
     CANNOT_REMOVE_SELF(HttpStatus.BAD_REQUEST, "PARTY408", "자기 자신을 모임에서 삭제할 수 없습니다."),
     INVITATION_ALREADY_EXISTS(HttpStatus.CONFLICT, "PARTY409", "처리 대기중인 초대가 존재합니다."),
-    INVITATION_ALREADY_ACTIONS(HttpStatus.CONFLICT, "PARTY410", "이미 처리된 모임 초대입니다.")
-    ;
+    INVITATION_ALREADY_ACTIONS(HttpStatus.CONFLICT, "PARTY410", "이미 처리된 모임 초대입니다."),
+    INVALID_ROLE_VALUE(HttpStatus.BAD_REQUEST, "PARTY411", "유효하지 않은 역할 값입니다. (party_SUBMANAGER 또는 party_MEMBER를 입력해주세요.)"),
+    CANNOT_ASSIGN_TO_OWNER(HttpStatus.FORBIDDEN, "PARTY412", "모임장의 역할은 변경할 수 없습니다."),
+    ALREADY_SAME_ROLE(HttpStatus.CONFLICT, "PARTY413", "해당 멤버는 이미 요청한 역할을 가지고 있습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/umc/cockple/demo/domain/party/exception/PartyErrorCode.java
+++ b/src/main/java/umc/cockple/demo/domain/party/exception/PartyErrorCode.java
@@ -24,6 +24,7 @@ public enum PartyErrorCode implements BaseErrorCode {
     INVALID_ORDER_TYPE(HttpStatus.BAD_REQUEST, "PARTY106", "유효하지 않은 정렬 기준입니다. (최신순, 오래된 순, 운동 많은 순 중 하나여야 합니다.)"),
     INVALID_KEYWORD(HttpStatus.BAD_REQUEST, "PARTY107", "유효하지 않은 키워드입니다."),
     MALE_LEVEL_NOT_NEEDED(HttpStatus.BAD_REQUEST, "PARTY108", "여복 모임은 남자 급수를 설정할 수 없습니다."),
+    INVALID_ROLE_VALUE(HttpStatus.BAD_REQUEST, "PARTY411", "유효하지 않은 역할 값입니다. (party_SUBMANAGER 또는 party_MEMBER를 입력해주세요.)"),
 
     PARTY_NOT_FOUND(HttpStatus.NOT_FOUND, "PARTY201", "존재하지 않는 모임입니다."),
     JoinRequest_NOT_FOUND(HttpStatus.NOT_FOUND, "PARTY202", "존재하지 않는 가입신청입니다."),
@@ -34,6 +35,7 @@ public enum PartyErrorCode implements BaseErrorCode {
     INSUFFICIENT_PERMISSION(HttpStatus.FORBIDDEN, "PARTY301", "해당 작업을 수행할 권한이 없습니다."),
     INVALID_ACTION_FOR_OWNER(HttpStatus.FORBIDDEN, "PARTY302", "모임장은 수행할 수 없는 작업입니다."),
     NOT_YOUR_INVITATION(HttpStatus.FORBIDDEN, "PARTY303", "해당 사용자의 초대가 아닙니다."),
+    INVALID_ACTION_FOR_SUBOWNER(HttpStatus.FORBIDDEN, "PARTY304", "부모임장은 수행할 수 없는 작업입니다."),
 
     ALREADY_MEMBER(HttpStatus.CONFLICT, "PARTY401", "이미 가입된 모임입니다."),
     JOIN_REQUEST_ALREADY_EXISTS(HttpStatus.CONFLICT, "PARTY402", "처리 대기중인 가입 신청이 존재합니다."),
@@ -45,9 +47,8 @@ public enum PartyErrorCode implements BaseErrorCode {
     CANNOT_REMOVE_SELF(HttpStatus.BAD_REQUEST, "PARTY408", "자기 자신을 모임에서 삭제할 수 없습니다."),
     INVITATION_ALREADY_EXISTS(HttpStatus.CONFLICT, "PARTY409", "처리 대기중인 초대가 존재합니다."),
     INVITATION_ALREADY_ACTIONS(HttpStatus.CONFLICT, "PARTY410", "이미 처리된 모임 초대입니다."),
-    INVALID_ROLE_VALUE(HttpStatus.BAD_REQUEST, "PARTY411", "유효하지 않은 역할 값입니다. (party_SUBMANAGER 또는 party_MEMBER를 입력해주세요.)"),
-    CANNOT_ASSIGN_TO_OWNER(HttpStatus.FORBIDDEN, "PARTY412", "모임장의 역할은 변경할 수 없습니다."),
-    ALREADY_SAME_ROLE(HttpStatus.CONFLICT, "PARTY413", "해당 멤버는 이미 요청한 역할을 가지고 있습니다.");
+    CANNOT_ASSIGN_TO_OWNER(HttpStatus.FORBIDDEN, "PARTY411", "모임장의 역할은 변경할 수 없습니다."),
+    ALREADY_SAME_ROLE(HttpStatus.CONFLICT, "PARTY412", "해당 멤버는 이미 요청한 역할을 가지고 있습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/umc/cockple/demo/domain/party/exception/PartyErrorCode.java
+++ b/src/main/java/umc/cockple/demo/domain/party/exception/PartyErrorCode.java
@@ -47,8 +47,7 @@ public enum PartyErrorCode implements BaseErrorCode {
     CANNOT_REMOVE_SELF(HttpStatus.BAD_REQUEST, "PARTY408", "자기 자신을 모임에서 삭제할 수 없습니다."),
     INVITATION_ALREADY_EXISTS(HttpStatus.CONFLICT, "PARTY409", "처리 대기중인 초대가 존재합니다."),
     INVITATION_ALREADY_ACTIONS(HttpStatus.CONFLICT, "PARTY410", "이미 처리된 모임 초대입니다."),
-    CANNOT_ASSIGN_TO_OWNER(HttpStatus.FORBIDDEN, "PARTY411", "모임장의 역할은 변경할 수 없습니다."),
-    ALREADY_SAME_ROLE(HttpStatus.CONFLICT, "PARTY412", "해당 멤버는 이미 요청한 역할을 가지고 있습니다.");
+    CANNOT_ASSIGN_TO_OWNER(HttpStatus.FORBIDDEN, "PARTY411", "모임장의 역할은 변경할 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/umc/cockple/demo/domain/party/service/PartyCommandService.java
+++ b/src/main/java/umc/cockple/demo/domain/party/service/PartyCommandService.java
@@ -13,4 +13,5 @@ public interface PartyCommandService {
     void actionInvitation(Long memberId, PartyInviteActionDTO.Request request, Long invitationId);
     void updateParty(Long partyId, Long memberId, PartyUpdateDTO.Request request);
     void addKeyword(Long partyId, Long memberID, PartyKeywordDTO.Request request);
+    void updateMemberRole(Long partyId, Long targetMemberId, Long currentMemberId, PartyMemberRoleDTO.Request request);
 }

--- a/src/main/java/umc/cockple/demo/domain/party/service/PartyCommandServiceImpl.java
+++ b/src/main/java/umc/cockple/demo/domain/party/service/PartyCommandServiceImpl.java
@@ -195,7 +195,7 @@ public class PartyCommandServiceImpl implements PartyCommandService {
         }
         // 이미 같은 역할인 경우
         if (targetMemberParty.getRole() == newRole) {
-            throw new PartyException(PartyErrorCode.ALREADY_SAME_ROLE);
+            return;
         }
 
         // SUBOWNER 지정 시, 기존 부모임장 자동 해제


### PR DESCRIPTION
## ❤️ 기능 설명
모임장이 특정 멤버의 역할을 부모임장(party_SUBMANAGER)으로 지정하거나, 기존 부모임장을 일반 멤버(party_MEMBER)로 변경합니다.
- 모임장만 해당 API를 호출할 수 있습니다.
- 부모임장은 모임당 최대 1명만 지정 가능합니다.
- 기존에 부모임장이 있는 상태에서 다른 멤버를 부모임장으로 새로 지정할 경우, 기존 부모임장은 해제되고 새로운 멤버가 부모임장으로 지정됩니다.
- 부모임장 권한을 가진 상태에서는 모임 탈퇴 및 콕플 서비스 회원 탈퇴가 제한됩니다.
- 부모임장 지정 또는 해제 처리가 성공하면, 모임 전체 멤버를 대상으로 알림이 발송됩니다.
    - 지정 시: "OOO님이 부모임장으로 지정되었습니다.”
    - 해제 시: "OOO님의 부모임장 권한이 해제되었습니다.”

swagger 테스트 성공 결과 스크린샷 첨부
<img width="727" height="290" alt="image" src="https://github.com/user-attachments/assets/ee83acbf-5dd5-404a-beb0-7c9f537bcb54" />
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #496
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
