### PR TITLE
[chore/#500] CI/CD 파이프라인 개선

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -33,11 +33,18 @@ jobs:
           chmod +x ./gradlew
           ./gradlew clean build -x test
 
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
       - name: Docker BUILD_PUSH
-        run: |
-          docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }}
-          docker build -f Dockerfile -t ${{ secrets.DOCKER_REPO }}:${{ steps.vars.outputs.DOCKER_TAG }} .
-          docker push ${{ secrets.DOCKER_REPO }}:${{ steps.vars.outputs.DOCKER_TAG }}
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ secrets.DOCKER_REPO }}:${{ steps.vars.outputs.DOCKER_TAG }}
 
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -10,10 +10,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v5
         with:
           java-version: '17'
           distribution: "adopt"
@@ -40,7 +40,7 @@ jobs:
           docker push ${{ secrets.DOCKER_REPO }}:${{ steps.vars.outputs.DOCKER_TAG }}
 
       - name: Copy files to server
-        uses: appleboy/scp-action@master
+        uses: appleboy/scp-action@v1
         with:
           host: ${{ secrets.HOST }}
           username: ubuntu
@@ -49,7 +49,7 @@ jobs:
           target: /home/ubuntu/cockple
 
       - name: Deploy
-        uses: appleboy/ssh-action@master
+        uses: appleboy/ssh-action@v1
         with:
           host: ${{ secrets.HOST }}
           username: ubuntu

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -39,6 +39,13 @@ jobs:
           docker build -f Dockerfile -t ${{ secrets.DOCKER_REPO }}:${{ steps.vars.outputs.DOCKER_TAG }} .
           docker push ${{ secrets.DOCKER_REPO }}:${{ steps.vars.outputs.DOCKER_TAG }}
 
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
       - name: Copy files to server
         uses: appleboy/scp-action@v1
         with:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           java-version: '17'
-          distribution: "adopt"
+          distribution: 'temurin'
           cache: gradle
 
       - name: Set environment variables by branch

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,8 +34,8 @@ jobs:
       - name: Grant execute permission for Gradle
         run: chmod +x gradlew
 
-      - name: Build (Debug Mode)
-        run: ./gradlew clean build --stacktrace --info --scan
+      - name: Build
+        run: ./gradlew build --stacktrace
 
       - name: Upload Test Report
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '17'
           distribution: 'temurin'
@@ -39,7 +39,7 @@ jobs:
 
       - name: Upload Test Report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: test-report
           path: build/reports/tests/test


### PR DESCRIPTION
## ❤️ 기능 설명
CI/CD 파이프라인을 개선합니다.

**CD job 분리**
- 기존 단일 job → build / deploy job으로 분리
- build job 성공 시에만 deploy job 실행 (needs: build)
- Actions UI에서 실패 지점(빌드 vs 배포) 명확히 구분 가능
- 배포만 실패했을 때 deploy job만 re-run 가능

**Docker BUILD_PUSH 개선**
- 기존 docker CLI 직접 호출 → docker/build-push-action@v6으로 교체

**CI 빌드 옵션 정리**
- --info 제거: 과도한 로그로 오히려 실패 원인 파악이 어려움
- --scan 제거: 매 PR마다 외부 서비스(gradle.com)에 빌드 정보 업로드되는 문제

**구버전 action 업데이트**

<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #500 
<br>
<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
