### PR TITLE
[debug/#503] 프로필 이미지 키값이 아닌 url로 반환되도록 수정

### DIFF
--- a/src/main/java/umc/cockple/demo/domain/party/converter/PartyConverter.java
+++ b/src/main/java/umc/cockple/demo/domain/party/converter/PartyConverter.java
@@ -24,6 +24,8 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class PartyConverter {
 
+    private final ImageService imageService;
+
     public PartySimpleDTO.Response toPartySimpleDTO(MemberParty memberParty, String imgUrl) {
         Party party = memberParty.getParty();
         return PartySimpleDTO.Response.builder()
@@ -140,8 +142,8 @@ public class PartyConverter {
         Member member = request.getMember();
         // status가 PENDING이 아닐 경우에만 updatedAt 값을 설정
         LocalDateTime updatedAt = (request.getStatus() != RequestStatus.PENDING) ? request.getUpdatedAt() : null;
-        //이미지가 null인 경우 null을 전달
-        String imageUrl = (member.getProfileImg() != null) ? member.getProfileImg().getImgKey() : null;
+        // 이미지 키를 URL로 변환
+        String imageUrl = getProfileUrl(member.getProfileImg());
         return PartyJoinDTO.Response.builder()
                 .joinRequestId(request.getId())
                 .userId(member.getId())
@@ -171,7 +173,7 @@ public class PartyConverter {
                     return PartyMemberDTO.MemberDetail.builder()
                             .memberId(member.getId())
                             .nickname(member.getNickname())
-                            .profileImageUrl(member.getProfileImg() != null ? member.getProfileImg().getImgKey() : null)
+                            .profileImageUrl(getProfileUrl(member.getProfileImg()))
                             .role(mp.getRole().name())
                             .gender(member.getGender().name())
                             .level(member.getLevel().getKoreanName())
@@ -213,5 +215,12 @@ public class PartyConverter {
             case "party_MEMBER" -> 2; // 일반 멤버
             default -> 99;
         };
+    }
+
+    private String getProfileUrl(umc.cockple.demo.domain.member.domain.ProfileImg profileImg) {
+        if (profileImg != null && profileImg.getImgKey() != null && !profileImg.getImgKey().isBlank()) {
+            return imageService.getUrlFromKey(profileImg.getImgKey());
+        }
+        return null;
     }
 }

--- a/src/main/java/umc/cockple/demo/domain/party/converter/PartyConverter.java
+++ b/src/main/java/umc/cockple/demo/domain/party/converter/PartyConverter.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Component;
 import umc.cockple.demo.domain.image.service.ImageService;
 import umc.cockple.demo.domain.member.domain.Member;
 import umc.cockple.demo.domain.member.domain.MemberParty;
+import umc.cockple.demo.domain.member.domain.ProfileImg;
 import umc.cockple.demo.domain.party.domain.Party;
 import umc.cockple.demo.domain.party.domain.PartyInvitation;
 import umc.cockple.demo.domain.party.domain.PartyJoinRequest;
@@ -217,7 +218,7 @@ public class PartyConverter {
         };
     }
 
-    private String getProfileUrl(umc.cockple.demo.domain.member.domain.ProfileImg profileImg) {
+    private String getProfileUrl(ProfileImg profileImg) {
         if (profileImg != null && profileImg.getImgKey() != null && !profileImg.getImgKey().isBlank()) {
             return imageService.getUrlFromKey(profileImg.getImgKey());
         }


### PR DESCRIPTION
## ❤️ 기능 설명
모임 멤버 조회에서 imageService.getUrlFromKey을 사용하여 프로필 이미지가 키가 아닌 url을 반환하도록 수정했습니다.

swagger 테스트 성공 결과 스크린샷 첨부
<img width="709" height="248" alt="image" src="https://github.com/user-attachments/assets/19ab889e-f81a-4fd1-906a-079ceec20412" />

<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #503
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- 없습니다.

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
