### PR TITLE
[debug/#506] HikariCP 데이터베이스 풀 설정으로 커넥션 에러 해결

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,6 +13,12 @@ spring:
     driver-class-name: com.mysql.cj.jdbc.Driver
     username: root
     password: ${DB_PASSWORD}
+    hikari:
+      keepalive-time: 60000
+      max-lifetime: 1800000
+      idle-timeout: 600000
+      minimum-idle: 5
+      maximum-pool-size: 10
 
   sql:
     init:


### PR DESCRIPTION
## ❤️ 기능 설명
max-lifetime yml 설정값을 MySQL의 time-wait 값보다 낮게 설정하여 커넥션 문제를 해결합니다.

swagger 테스트 성공 결과 스크린샷 첨부
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #506 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 나머지 값들은 일단 임의로 설정해두겠습니다.

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
