### PR TITLE
[fix/#512] 초기 채팅방 조회 및 과거 메시지 조회 API에 송신자 탈퇴 여부 필드 추가

### DIFF
--- a/src/main/java/umc/cockple/demo/domain/chat/converter/ChatConverter.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/converter/ChatConverter.java
@@ -172,13 +172,15 @@ public class ChatConverter {
             ChatMessage message,
             String senderProfileImageUrl,
             List<ChatCommonDTO.ImageInfo> processedImages,
-            boolean isMyMessage) {
+            boolean isMyMessage,
+            boolean isSenderWithdrawn) {
 
         return ChatCommonDTO.MessageInfo.builder()
                 .messageId(message.getId())
                 .senderId(message.getSender().getId())
                 .senderName(message.getSender().getMemberName())
                 .senderProfileImageUrl(senderProfileImageUrl)
+                .isSenderWithdrawn(isSenderWithdrawn)
                 .content(message.getContent())
                 .messageType(message.getType())
                 .images(processedImages)

--- a/src/main/java/umc/cockple/demo/domain/chat/dto/ChatCommonDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/dto/ChatCommonDTO.java
@@ -14,6 +14,7 @@ public class ChatCommonDTO {
             Long senderId,
             String senderName,
             String senderProfileImageUrl,
+            boolean isSenderWithdrawn,
             String content,
             MessageType messageType,
             List<ImageInfo> images,

--- a/src/main/java/umc/cockple/demo/domain/chat/dto/ChatMessageDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/dto/ChatMessageDTO.java
@@ -23,6 +23,7 @@ public class ChatMessageDTO {
             Long senderId,
             String senderName,
             String senderProfileImageUrl,
+            boolean isSenderWithdrawn,
             String content,
             MessageType messageType,
             List<ChatCommonDTO.ImageInfo> images,
@@ -35,6 +36,7 @@ public class ChatMessageDTO {
                     .senderId(common.senderId())
                     .senderName(common.senderName())
                     .senderProfileImageUrl(common.senderProfileImageUrl())
+                    .isSenderWithdrawn(common.isSenderWithdrawn())
                     .content(common.content())
                     .messageType(common.messageType())
                     .images(common.images())

--- a/src/main/java/umc/cockple/demo/domain/chat/dto/ChatRoomDetailDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/dto/ChatRoomDetailDTO.java
@@ -35,6 +35,7 @@ public class ChatRoomDetailDTO {
             Long senderId,
             String senderName,
             String senderProfileImageUrl,
+            boolean isSenderWithdrawn,
             String content,
             MessageType messageType,
             List<ChatCommonDTO.ImageInfo> images,
@@ -47,6 +48,7 @@ public class ChatRoomDetailDTO {
                     .senderId(common.senderId())
                     .senderName(common.senderName())
                     .senderProfileImageUrl(common.senderProfileImageUrl())
+                    .isSenderWithdrawn(common.isSenderWithdrawn())
                     .content(common.content())
                     .messageType(common.messageType())
                     .images(common.images())

--- a/src/main/java/umc/cockple/demo/domain/chat/service/ChatProcessor.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/ChatProcessor.java
@@ -10,6 +10,7 @@ import umc.cockple.demo.domain.chat.dto.ChatCommonDTO;
 import umc.cockple.demo.domain.image.service.ImageService;
 import umc.cockple.demo.domain.member.domain.Member;
 import umc.cockple.demo.domain.member.domain.ProfileImg;
+import umc.cockple.demo.domain.member.enums.MemberStatus;
 
 import java.util.Comparator;
 import java.util.List;
@@ -33,7 +34,8 @@ public class ChatProcessor {
         String senderProfileImageUrl = generateProfileImageUrl(sender.getProfileImg());
         List<ChatCommonDTO.ImageInfo> processedImages = processMessageImages(message);
         boolean isMyMessage = isMyMessage(sender.getId(), memberId);
-        return chatConverter.toCommonMessageInfo(message, senderProfileImageUrl, processedImages, isMyMessage);
+        boolean isSenderWithdrawn = sender.getIsActive() == MemberStatus.INACTIVE;
+        return chatConverter.toCommonMessageInfo(message, senderProfileImageUrl, processedImages, isMyMessage, isSenderWithdrawn);
     }
 
     public String generateProfileImageUrl(ProfileImg profileImg) {

--- a/src/main/java/umc/cockple/demo/domain/chat/service/ChatQueryServiceImpl.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/ChatQueryServiceImpl.java
@@ -29,6 +29,7 @@ import umc.cockple.demo.domain.party.domain.Party;
 import umc.cockple.demo.domain.party.domain.PartyImg;
 import umc.cockple.demo.domain.party.repository.PartyRepository;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -102,8 +103,9 @@ public class ChatQueryServiceImpl implements ChatQueryService {
 
         Pageable pageable = PageRequest.of(0, 50);
         List<ChatMessage> recentMessages = findRecentMessagesWithImages(roomId, pageable);
-        Collections.reverse(recentMessages);
-        List<ChatCommonDTO.MessageInfo> commonMessages = chatProcessor.processMessages(memberId, recentMessages);
+        List<ChatMessage> resultMessages = new ArrayList<>(recentMessages);
+        Collections.reverse(resultMessages);
+        List<ChatCommonDTO.MessageInfo> commonMessages = chatProcessor.processMessages(memberId, resultMessages);
         List<ChatRoomDetailDTO.MessageInfo> messageInfos = chatConverter.toChatRoomDetailMessageInfos(commonMessages);
 
         List<ChatRoomMember> participants = findChatRoomMembersWithMemberOrThrow(roomId);
@@ -126,18 +128,18 @@ public class ChatQueryServiceImpl implements ChatQueryService {
         List<ChatMessage> messages = findMessagesWithCursor(roomId, cursor, pageable);
 
         boolean hasNext = messages.size() > size;
-        if (hasNext) {
-            messages = messages.subList(0, size);
-        }
+        List<ChatMessage> resultMessages = hasNext
+                ? new ArrayList<>(messages.subList(0, size))
+                : new ArrayList<>(messages);
 
-        Collections.reverse(messages);
-        List<ChatCommonDTO.MessageInfo> commonMessages = chatProcessor.processMessages(memberId, messages);
+        Collections.reverse(resultMessages);
+        List<ChatCommonDTO.MessageInfo> commonMessages = chatProcessor.processMessages(memberId, resultMessages);
         List<ChatMessageDTO.MessageInfo> messageInfos = chatConverter.toChatMessageInfos(commonMessages);
 
-        Long nextCursor = hasNext && !messages.isEmpty()
-                ? messages.get(0).getId() : null;
+        Long nextCursor = hasNext && !resultMessages.isEmpty()
+                ? resultMessages.get(0).getId() : null;
 
-        log.info("[채팅방 과거 메시지 조회 완료] - 메시지 수: {}, hasNext: {}", messages.size(), hasNext);
+        log.info("[채팅방 과거 메시지 조회 완료] - 메시지 수: {}, hasNext: {}", resultMessages.size(), hasNext);
 
         return chatConverter.toChatMessageResponse(messageInfos, hasNext, nextCursor);
     }

--- a/src/test/java/umc/cockple/demo/domain/chat/integration/ChatIntegrationTest.java
+++ b/src/test/java/umc/cockple/demo/domain/chat/integration/ChatIntegrationTest.java
@@ -1,0 +1,267 @@
+package umc.cockple.demo.domain.chat.integration;
+
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.web.servlet.MockMvc;
+import umc.cockple.demo.domain.chat.domain.ChatMessage;
+import umc.cockple.demo.domain.chat.domain.ChatRoom;
+import umc.cockple.demo.domain.chat.domain.ChatRoomMember;
+import umc.cockple.demo.domain.chat.exception.ChatErrorCode;
+import umc.cockple.demo.domain.chat.repository.ChatMessageRepository;
+import umc.cockple.demo.domain.chat.repository.ChatRoomMemberRepository;
+import umc.cockple.demo.domain.chat.repository.ChatRoomRepository;
+import umc.cockple.demo.domain.member.domain.Member;
+import umc.cockple.demo.domain.member.repository.MemberPartyRepository;
+import umc.cockple.demo.domain.member.repository.MemberRepository;
+import umc.cockple.demo.domain.party.domain.Party;
+import umc.cockple.demo.domain.party.domain.PartyAddr;
+import umc.cockple.demo.domain.party.repository.PartyAddrRepository;
+import umc.cockple.demo.domain.party.repository.PartyRepository;
+import umc.cockple.demo.global.enums.Gender;
+import umc.cockple.demo.global.enums.Level;
+import umc.cockple.demo.global.enums.Role;
+import umc.cockple.demo.support.IntegrationTestBase;
+import umc.cockple.demo.support.SecurityContextHelper;
+import umc.cockple.demo.support.fixture.ChatFixture;
+import umc.cockple.demo.support.fixture.MemberFixture;
+import umc.cockple.demo.support.fixture.PartyFixture;
+
+import static org.hamcrest.Matchers.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class ChatIntegrationTest extends IntegrationTestBase {
+
+    @Autowired MockMvc mockMvc;
+    @Autowired MemberRepository memberRepository;
+    @Autowired PartyRepository partyRepository;
+    @Autowired PartyAddrRepository partyAddrRepository;
+    @Autowired MemberPartyRepository memberPartyRepository;
+    @Autowired ChatRoomRepository chatRoomRepository;
+    @Autowired ChatRoomMemberRepository chatRoomMemberRepository;
+    @Autowired ChatMessageRepository chatMessageRepository;
+
+    private Member member;
+    private Member otherMember;
+    private Party party;
+    private ChatRoom partyChatRoom;
+    private ChatRoom directChatRoom;
+
+    @BeforeEach
+    void setUp() {
+        member = memberRepository.save(MemberFixture.createMember("홍길동", Gender.MALE, Level.A, 1001L));
+        otherMember = memberRepository.save(MemberFixture.createMember("김철수", Gender.MALE, Level.B, 2002L));
+
+        PartyAddr addr = partyAddrRepository.save(PartyFixture.createPartyAddr("서울특별시", "강남구"));
+        party = partyRepository.save(PartyFixture.createParty("배드민턴 모임", member.getId(), addr));
+
+        memberPartyRepository.save(MemberFixture.createMemberParty(party, member, Role.party_MANAGER));
+        memberPartyRepository.save(MemberFixture.createMemberParty(party, otherMember, Role.party_MEMBER));
+
+        partyChatRoom = chatRoomRepository.save(ChatFixture.createPartyChatRoom(party));
+        directChatRoom = chatRoomRepository.save(ChatFixture.createDirectChatRoom());
+    }
+
+    @AfterEach
+    void tearDown() {
+        chatMessageRepository.deleteAll();
+        chatRoomMemberRepository.deleteAll();
+        chatRoomRepository.deleteAll();
+        memberPartyRepository.deleteAll();
+        partyRepository.deleteAll();
+        partyAddrRepository.deleteAll();
+        memberRepository.deleteAll();
+        SecurityContextHelper.clearAuthentication();
+    }
+
+    @Nested
+    @DisplayName("GET /api/chats/rooms/{roomId} - 초기 채팅방 조회")
+    class GetChatRoomDetail {
+
+        @Nested
+        @DisplayName("성공 케이스")
+        class Success {
+
+            @Test
+            @DisplayName("200 - 모임(PARTY) 채팅방 조회 시 파티 이름이 displayName에 들어간다")
+            void partyChatRoom_displayName_success() throws Exception {
+                chatRoomMemberRepository.save(ChatRoomMember.create(partyChatRoom, member));
+                SecurityContextHelper.setAuthentication(member.getId(), member.getNickname());
+
+                mockMvc.perform(get("/api/chats/rooms/{roomId}", partyChatRoom.getId()))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.data.chatRoomInfo.displayName").value("배드민턴 모임"));
+            }
+
+            @Test
+            @DisplayName("200 - 모임(PARTY) 채팅방 조회 시 모든 필드가 정확하게 반환된다")
+            void partyChatRoom_fullFieldValidation() throws Exception {
+                ChatRoomMember myCrm = ChatRoomMember.create(partyChatRoom, member);
+                myCrm.updateLastReadMessageId(0L);
+                chatRoomMemberRepository.save(myCrm);
+
+                ChatMessage lastMsg = chatMessageRepository.save(
+                        ChatFixture.createTextMessage(partyChatRoom, member, "최근 메시지"));
+
+                SecurityContextHelper.setAuthentication(member.getId(), member.getNickname());
+
+                mockMvc.perform(get("/api/chats/rooms/{roomId}", partyChatRoom.getId()))
+                        .andExpect(status().isOk())
+                        // 1. chatRoomInfo 전수 검사
+                        .andExpect(jsonPath("$.data.chatRoomInfo.chatRoomId").value(partyChatRoom.getId()))
+                        .andExpect(jsonPath("$.data.chatRoomInfo.chatRoomType").value("PARTY"))
+                        .andExpect(jsonPath("$.data.chatRoomInfo.displayName").value("배드민턴 모임"))
+                        .andExpect(jsonPath("$.data.chatRoomInfo.memberCount").value(1))
+                        .andExpect(jsonPath("$.data.chatRoomInfo.lastReadMessageId").exists())
+                        .andExpect(jsonPath("$.data.chatRoomInfo.isCounterPartWithdrawn").value(false))
+                        // 2. messages 리스트 및 첫 번째 메시지 필드 전수 검사
+                        .andExpect(jsonPath("$.data.messages").isArray())
+                        .andExpect(jsonPath("$.data.messages[0].messageId").value(lastMsg.getId()))
+                        .andExpect(jsonPath("$.data.messages[0].senderId").value(member.getId()))
+                        .andExpect(jsonPath("$.data.messages[0].senderName").value("홍길동"))
+                        .andExpect(jsonPath("$.data.messages[0].content").value("최근 메시지"))
+                        .andExpect(jsonPath("$.data.messages[0].messageType").value("TEXT"))
+                        .andExpect(jsonPath("$.data.messages[0].timestamp").exists())
+                        .andExpect(jsonPath("$.data.messages[0].isMyMessage").value(true))
+                        .andExpect(jsonPath("$.data.messages[0].isSenderWithdrawn").value(false))
+                        // 3. participants 리스트 및 첫 번째 참여자 필드 전수 검사
+                        .andExpect(jsonPath("$.data.participants").isArray())
+                        .andExpect(jsonPath("$.data.participants[0].memberId").value(member.getId()))
+                        .andExpect(jsonPath("$.data.participants[0].memberName").value("홍길동"));
+            }
+
+            @Test
+            @DisplayName("200 - 개인(DIRECT) 채팅방 조회 시 상대방 이름이 displayName에 들어간다")
+            void directChatRoom_success() throws Exception {
+                chatRoomMemberRepository.save(ChatRoomMember.create(directChatRoom, member));
+                chatRoomMemberRepository.save(ChatRoomMember.create(directChatRoom, otherMember));
+
+                SecurityContextHelper.setAuthentication(member.getId(), member.getNickname());
+
+                mockMvc.perform(get("/api/chats/rooms/{roomId}", directChatRoom.getId()))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.data.chatRoomInfo.chatRoomType").value("DIRECT"))
+                        .andExpect(jsonPath("$.data.chatRoomInfo.displayName").value("김철수"))
+                        .andExpect(jsonPath("$.data.chatRoomInfo.isCounterPartWithdrawn").value(false));
+            }
+
+            @Test
+            @DisplayName("200 - 개인 채팅방에서 상대방이 탈퇴한 경우 isCounterPartWithdrawn이 true이다")
+            void directChatRoom_counterPartWithdrawn() throws Exception {
+                Member withdrawnMember = memberRepository.save(
+                        MemberFixture.createWithdrawnMember("탈퇴한사용자", "탈퇴", 3003L));
+
+                chatRoomMemberRepository.save(ChatRoomMember.create(directChatRoom, member));
+                chatRoomMemberRepository.save(ChatRoomMember.create(directChatRoom, withdrawnMember));
+
+                SecurityContextHelper.setAuthentication(member.getId(), member.getNickname());
+
+                mockMvc.perform(get("/api/chats/rooms/{roomId}", directChatRoom.getId()))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.data.chatRoomInfo.isCounterPartWithdrawn").value(true));
+            }
+
+            @Test
+            @DisplayName("200 - 최근 메시지가 오래된 순으로 정렬되어 반환된다")
+            void messages_areInChronologicalOrder() throws Exception {
+                chatRoomMemberRepository.save(ChatRoomMember.create(partyChatRoom, member));
+
+                ChatMessage msg1 = chatMessageRepository.save(
+                        ChatFixture.createTextMessage(partyChatRoom, member, "첫 번째 메시지"));
+                ChatMessage msg2 = chatMessageRepository.save(
+                        ChatFixture.createTextMessage(partyChatRoom, member, "두 번째 메시지"));
+                ChatMessage msg3 = chatMessageRepository.save(
+                        ChatFixture.createTextMessage(partyChatRoom, member, "세 번째 메시지"));
+
+                SecurityContextHelper.setAuthentication(member.getId(), member.getNickname());
+
+                mockMvc.perform(get("/api/chats/rooms/{roomId}", partyChatRoom.getId()))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.data.messages", hasSize(3)))
+                        .andExpect(jsonPath("$.data.messages[0].messageId").value(msg1.getId()))
+                        .andExpect(jsonPath("$.data.messages[1].messageId").value(msg2.getId()))
+                        .andExpect(jsonPath("$.data.messages[2].messageId").value(msg3.getId()));
+            }
+
+            @Test
+            @DisplayName("200 - 내가 보낸 메시지는 isMyMessage가 true이다")
+            void myMessage_isMyMessageTrue() throws Exception {
+                chatRoomMemberRepository.save(ChatRoomMember.create(partyChatRoom, member));
+                chatMessageRepository.save(
+                        ChatFixture.createTextMessage(partyChatRoom, member, "내 메시지"));
+
+                SecurityContextHelper.setAuthentication(member.getId(), member.getNickname());
+
+                mockMvc.perform(get("/api/chats/rooms/{roomId}", partyChatRoom.getId()))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.data.messages[0].isMyMessage").value(true))
+                        .andExpect(jsonPath("$.data.messages[0].content").value("내 메시지"));
+            }
+
+            @Test
+            @DisplayName("200 - 상대방이 보낸 메시지는 isMyMessage가 false이다")
+            void otherMessage_isMyMessageFalse() throws Exception {
+                chatRoomMemberRepository.save(ChatRoomMember.create(partyChatRoom, member));
+                chatRoomMemberRepository.save(ChatRoomMember.create(partyChatRoom, otherMember));
+                chatMessageRepository.save(
+                        ChatFixture.createTextMessage(partyChatRoom, otherMember, "상대방 메시지"));
+
+                SecurityContextHelper.setAuthentication(member.getId(), member.getNickname());
+
+                mockMvc.perform(get("/api/chats/rooms/{roomId}", partyChatRoom.getId()))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.data.messages[0].isMyMessage").value(false))
+                        .andExpect(jsonPath("$.data.messages[0].isSenderWithdrawn").value(false));
+            }
+
+            @Test
+            @DisplayName("200 - 탈퇴한 사용자의 메시지는 isSenderWithdrawn이 true이다")
+            void withdrawnSender_isSenderWithdrawnTrue() throws Exception {
+                Member withdrawnMember = memberRepository.save(
+                        MemberFixture.createWithdrawnMember("탈퇴한사용자", "탈퇴", 3003L));
+
+                chatRoomMemberRepository.save(ChatRoomMember.create(partyChatRoom, member));
+                chatRoomMemberRepository.save(ChatRoomMember.create(partyChatRoom, withdrawnMember));
+                chatMessageRepository.save(
+                        ChatFixture.createTextMessage(partyChatRoom, withdrawnMember, "탈퇴자 메시지"));
+
+                SecurityContextHelper.setAuthentication(member.getId(), member.getNickname());
+
+                mockMvc.perform(get("/api/chats/rooms/{roomId}", partyChatRoom.getId()))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.data.messages[0].isSenderWithdrawn").value(true));
+            }
+        }
+
+        @Nested
+        @DisplayName("실패 케이스")
+        class Failure {
+
+            @Test
+            @DisplayName("404 - 존재하지 않는 채팅방 조회 시 CHAT_ROOM_NOT_FOUND 에러를 반환한다")
+            void chatRoomNotFound() throws Exception {
+                SecurityContextHelper.setAuthentication(member.getId(), member.getNickname());
+
+                mockMvc.perform(get("/api/chats/rooms/{roomId}", 999L))
+                        .andExpect(status().isNotFound())
+                        .andExpect(jsonPath("$.code").value(ChatErrorCode.CHAT_ROOM_NOT_FOUND.getCode()))
+                        .andExpect(jsonPath("$.message").value(ChatErrorCode.CHAT_ROOM_NOT_FOUND.getMessage()));
+            }
+
+            @Test
+            @DisplayName("400 - 채팅방 멤버가 아닌 사용자가 조회하면 CHAT_ROOM_ACCESS_DENIED 에러를 반환한다")
+            void notChatRoomMember() throws Exception {
+                // partyChatRoom에 member만 가입, otherMember는 비가입
+                chatRoomMemberRepository.save(ChatRoomMember.create(partyChatRoom, member));
+
+                SecurityContextHelper.setAuthentication(otherMember.getId(), otherMember.getNickname());
+
+                mockMvc.perform(get("/api/chats/rooms/{roomId}", partyChatRoom.getId()))
+                        .andExpect(status().isBadRequest())
+                        .andExpect(jsonPath("$.code").value(ChatErrorCode.CHAT_ROOM_ACCESS_DENIED.getCode()))
+                        .andExpect(jsonPath("$.message").value(ChatErrorCode.CHAT_ROOM_ACCESS_DENIED.getMessage()));
+            }
+        }
+    }
+}

--- a/src/test/java/umc/cockple/demo/domain/chat/integration/ChatIntegrationTest.java
+++ b/src/test/java/umc/cockple/demo/domain/chat/integration/ChatIntegrationTest.java
@@ -264,4 +264,203 @@ class ChatIntegrationTest extends IntegrationTestBase {
             }
         }
     }
+
+    @Nested
+    @DisplayName("GET /api/chats/rooms/{roomId}/messages/previous - 과거 메시지 조회")
+    class GetChatMessages {
+
+        @Nested
+        @DisplayName("성공 케이스")
+        class Success {
+
+            @Test
+            @DisplayName("200 - 과거 메시지 조회 시 모든 응답 필드가 정확하게 반환된다")
+            void getChatMessages_fullFieldValidation() throws Exception {
+                chatRoomMemberRepository.save(ChatRoomMember.create(partyChatRoom, member));
+
+                ChatMessage msg1 = chatMessageRepository.save(
+                        ChatFixture.createTextMessage(partyChatRoom, member, "이전 메시지"));
+                ChatMessage msg2 = chatMessageRepository.save(
+                        ChatFixture.createTextMessage(partyChatRoom, member, "최근 메시지"));
+
+                // msg2 이후부터 1개만 조회 -> msg2가 반환되고 hasNext=true, nextCursor=msg2.getId 확인
+                Long cursor = msg2.getId() + 1;
+
+                SecurityContextHelper.setAuthentication(member.getId(), member.getNickname());
+
+                mockMvc.perform(get("/api/chats/rooms/{roomId}/messages/previous", partyChatRoom.getId())
+                                .param("cursor", cursor.toString())
+                                .param("size", "1"))
+                        .andExpect(status().isOk())
+                        // 1. 공통 필드 전수 검사
+                        .andExpect(jsonPath("$.data.hasNext").value(true))
+                        .andExpect(jsonPath("$.data.nextCursor").value(msg2.getId()))
+                        // 2. messages 리스트 및 첫 번째 메시지 필드 전수 검사
+                        .andExpect(jsonPath("$.data.messages").isArray())
+                        .andExpect(jsonPath("$.data.messages", hasSize(1)))
+                        .andExpect(jsonPath("$.data.messages[0].messageId").value(msg2.getId()))
+                        .andExpect(jsonPath("$.data.messages[0].senderId").value(member.getId()))
+                        .andExpect(jsonPath("$.data.messages[0].senderName").value("홍길동"))
+                        .andExpect(jsonPath("$.data.messages[0].content").value("최근 메시지"))
+                        .andExpect(jsonPath("$.data.messages[0].messageType").value("TEXT"))
+                        .andExpect(jsonPath("$.data.messages[0].timestamp").exists())
+                        .andExpect(jsonPath("$.data.messages[0].isMyMessage").value(true))
+                        .andExpect(jsonPath("$.data.messages[0].isSenderWithdrawn").value(false));
+            }
+
+            @Test
+            @DisplayName("200 - 메시지가 오래된 순으로 정렬되어 반환된다")
+            void messages_areInChronologicalOrder() throws Exception {
+                chatRoomMemberRepository.save(ChatRoomMember.create(partyChatRoom, member));
+
+                ChatMessage msg1 = chatMessageRepository.save(
+                        ChatFixture.createTextMessage(partyChatRoom, member, "첫 번째 메시지"));
+                ChatMessage msg2 = chatMessageRepository.save(
+                        ChatFixture.createTextMessage(partyChatRoom, member, "두 번째 메시지"));
+                ChatMessage msg3 = chatMessageRepository.save(
+                        ChatFixture.createTextMessage(partyChatRoom, member, "세 번째 메시지"));
+
+                // cursor보다 id가 작은 메시지만 반환 → msg1, msg2, msg3 모두 cursor 미만이어야 하므로
+                // cursor를 msg3 이후 값으로 설정
+                Long cursor = msg3.getId() + 1;
+
+                SecurityContextHelper.setAuthentication(member.getId(), member.getNickname());
+
+                mockMvc.perform(get("/api/chats/rooms/{roomId}/messages/previous", partyChatRoom.getId())
+                                .param("cursor", cursor.toString())
+                                .param("size", "10"))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.data.messages", hasSize(3)))
+                        .andExpect(jsonPath("$.data.messages[0].messageId").value(msg1.getId()))
+                        .andExpect(jsonPath("$.data.messages[1].messageId").value(msg2.getId()))
+                        .andExpect(jsonPath("$.data.messages[2].messageId").value(msg3.getId()));
+            }
+
+            @Test
+            @DisplayName("200 - size보다 메시지가 많으면 hasNext가 true이고 nextCursor가 설정된다")
+            void hasNextTrue_whenMoreMessagesExist() throws Exception {
+                chatRoomMemberRepository.save(ChatRoomMember.create(partyChatRoom, member));
+
+                ChatMessage msg1 = chatMessageRepository.save(
+                        ChatFixture.createTextMessage(partyChatRoom, member, "메시지1"));
+                ChatMessage msg2 = chatMessageRepository.save(
+                        ChatFixture.createTextMessage(partyChatRoom, member, "메시지2"));
+                ChatMessage msg3 = chatMessageRepository.save(
+                        ChatFixture.createTextMessage(partyChatRoom, member, "메시지3"));
+
+                Long cursor = msg3.getId() + 1;
+
+                SecurityContextHelper.setAuthentication(member.getId(), member.getNickname());
+
+                mockMvc.perform(get("/api/chats/rooms/{roomId}/messages/previous", partyChatRoom.getId())
+                                .param("cursor", cursor.toString())
+                                .param("size", "2"))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.data.hasNext").value(true))
+                        .andExpect(jsonPath("$.data.nextCursor").isNumber())
+                        .andExpect(jsonPath("$.data.messages", hasSize(2)));
+            }
+
+            @Test
+            @DisplayName("200 - 메시지가 size 이하이면 hasNext가 false이고 nextCursor가 null이다")
+            void hasNextFalse_whenNoMoreMessages() throws Exception {
+                chatRoomMemberRepository.save(ChatRoomMember.create(partyChatRoom, member));
+
+                ChatMessage msg1 = chatMessageRepository.save(
+                        ChatFixture.createTextMessage(partyChatRoom, member, "메시지1"));
+                ChatMessage msg2 = chatMessageRepository.save(
+                        ChatFixture.createTextMessage(partyChatRoom, member, "메시지2"));
+
+                Long cursor = msg2.getId() + 1;
+
+                SecurityContextHelper.setAuthentication(member.getId(), member.getNickname());
+
+                mockMvc.perform(get("/api/chats/rooms/{roomId}/messages/previous", partyChatRoom.getId())
+                                .param("cursor", cursor.toString())
+                                .param("size", "10"))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.data.hasNext").value(false))
+                        .andExpect(jsonPath("$.data.nextCursor").doesNotExist())
+                        .andExpect(jsonPath("$.data.messages", hasSize(2)));
+            }
+
+            @Test
+            @DisplayName("200 - cursor보다 id가 작은 메시지만 반환된다")
+            void onlyMessagesBeforeCursorReturned() throws Exception {
+                chatRoomMemberRepository.save(ChatRoomMember.create(partyChatRoom, member));
+
+                ChatMessage msg1 = chatMessageRepository.save(
+                        ChatFixture.createTextMessage(partyChatRoom, member, "오래된 메시지"));
+                ChatMessage msg2 = chatMessageRepository.save(
+                        ChatFixture.createTextMessage(partyChatRoom, member, "cursor 이후 메시지"));
+
+                // msg2의 id를 cursor로 설정 → msg1만 반환되어야 함
+                SecurityContextHelper.setAuthentication(member.getId(), member.getNickname());
+
+                mockMvc.perform(get("/api/chats/rooms/{roomId}/messages/previous", partyChatRoom.getId())
+                                .param("cursor", msg2.getId().toString())
+                                .param("size", "10"))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.data.messages", hasSize(1)))
+                        .andExpect(jsonPath("$.data.messages[0].messageId").value(msg1.getId()));
+            }
+
+            @Test
+            @DisplayName("200 - 내가 보낸 메시지는 isMyMessage가 true이다")
+            void myMessage_isMyMessageTrue() throws Exception {
+                chatRoomMemberRepository.save(ChatRoomMember.create(partyChatRoom, member));
+
+                ChatMessage myMsg = chatMessageRepository.save(
+                        ChatFixture.createTextMessage(partyChatRoom, member, "내 메시지"));
+                Long cursor = myMsg.getId() + 1;
+
+                SecurityContextHelper.setAuthentication(member.getId(), member.getNickname());
+
+                mockMvc.perform(get("/api/chats/rooms/{roomId}/messages/previous", partyChatRoom.getId())
+                                .param("cursor", cursor.toString()))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.data.messages[0].isMyMessage").value(true));
+            }
+
+            @Test
+            @DisplayName("200 - 탈퇴한 사용자의 메시지는 isSenderWithdrawn이 true이다")
+            void withdrawnSender_isSenderWithdrawnTrue() throws Exception {
+                Member withdrawnMember = memberRepository.save(
+                        MemberFixture.createWithdrawnMember("탈퇴한사용자", "탈퇴", 3003L));
+
+                chatRoomMemberRepository.save(ChatRoomMember.create(partyChatRoom, member));
+                chatRoomMemberRepository.save(ChatRoomMember.create(partyChatRoom, withdrawnMember));
+
+                ChatMessage withdrawnMsg = chatMessageRepository.save(
+                        ChatFixture.createTextMessage(partyChatRoom, withdrawnMember, "탈퇴자 메시지"));
+                Long cursor = withdrawnMsg.getId() + 1;
+
+                SecurityContextHelper.setAuthentication(member.getId(), member.getNickname());
+
+                mockMvc.perform(get("/api/chats/rooms/{roomId}/messages/previous", partyChatRoom.getId())
+                                .param("cursor", cursor.toString()))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.data.messages[0].isSenderWithdrawn").value(true));
+            }
+        }
+
+        @Nested
+        @DisplayName("실패 케이스")
+        class Failure {
+
+            @Test
+            @DisplayName("400 - 채팅방 멤버가 아닌 사용자가 조회하면 CHAT_ROOM_ACCESS_DENIED 에러를 반환한다")
+            void notChatRoomMember() throws Exception {
+                chatRoomMemberRepository.save(ChatRoomMember.create(partyChatRoom, member));
+
+                SecurityContextHelper.setAuthentication(otherMember.getId(), otherMember.getNickname());
+
+                mockMvc.perform(get("/api/chats/rooms/{roomId}/messages/previous", partyChatRoom.getId())
+                                .param("cursor", "100"))
+                        .andExpect(status().isBadRequest())
+                        .andExpect(jsonPath("$.code").value(ChatErrorCode.CHAT_ROOM_ACCESS_DENIED.getCode()))
+                        .andExpect(jsonPath("$.message").value(ChatErrorCode.CHAT_ROOM_ACCESS_DENIED.getMessage()));
+            }
+        }
+    }
 }

--- a/src/test/java/umc/cockple/demo/domain/chat/service/ChatProcessorTest.java
+++ b/src/test/java/umc/cockple/demo/domain/chat/service/ChatProcessorTest.java
@@ -1,0 +1,352 @@
+package umc.cockple.demo.domain.chat.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import umc.cockple.demo.domain.chat.converter.ChatConverter;
+import umc.cockple.demo.domain.chat.domain.ChatMessage;
+import umc.cockple.demo.domain.chat.domain.ChatMessageImg;
+import umc.cockple.demo.domain.chat.domain.ChatRoom;
+import umc.cockple.demo.domain.chat.dto.ChatCommonDTO;
+import umc.cockple.demo.domain.chat.enums.MessageType;
+import umc.cockple.demo.domain.image.service.ImageService;
+import umc.cockple.demo.domain.member.domain.Member;
+import umc.cockple.demo.domain.member.domain.ProfileImg;
+import umc.cockple.demo.global.enums.Gender;
+import umc.cockple.demo.global.enums.Level;
+import umc.cockple.demo.support.fixture.ChatFixture;
+import umc.cockple.demo.support.fixture.MemberFixture;
+import umc.cockple.demo.support.fixture.PartyFixture;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ChatProcessor")
+class ChatProcessorTest {
+
+    @Mock
+    private ImageService imageService;
+
+    private ChatConverter chatConverter;
+    private ChatProcessor chatProcessor;
+
+    private Member sender;
+    private ChatRoom chatRoom;
+
+    @BeforeEach
+    void setUp() {
+        chatConverter = new ChatConverter();
+        chatProcessor = new ChatProcessor(imageService, chatConverter);
+
+        sender = MemberFixture.createMemberWithName("홍길동", "길동", Gender.MALE, Level.A, 1001L);
+        ReflectionTestUtils.setField(sender, "id", 10L);
+
+        var party = PartyFixture.createParty("모임", sender.getId(), PartyFixture.createPartyAddr("서울", "강남구"));
+        ReflectionTestUtils.setField(party, "id", 100L);
+        chatRoom = ChatFixture.createPartyChatRoom(party);
+        ReflectionTestUtils.setField(chatRoom, "id", 1L);
+    }
+
+    // ========== generateProfileImageUrl ==========
+
+    @Nested
+    @DisplayName("generateProfileImageUrl - 프로필 이미지 URL 생성")
+    class GenerateProfileImageUrl {
+
+        @Test
+        @DisplayName("profileImg가 null이면 null을 반환한다")
+        void returnsNull_whenProfileImgIsNull() {
+            String result = chatProcessor.generateProfileImageUrl(null);
+
+            assertThat(result).isNull();
+            verify(imageService, never()).getUrlFromKey(null);
+        }
+
+        @Test
+        @DisplayName("imgKey가 null이면 null을 반환하고 imageService를 호출하지 않는다")
+        void returnsNull_whenImgKeyIsNull() {
+            ProfileImg profileImg = ProfileImg.builder()
+                    .imgKey(null)
+                    .build();
+
+            String result = chatProcessor.generateProfileImageUrl(profileImg);
+
+            assertThat(result).isNull();
+            verify(imageService, never()).getUrlFromKey(null);
+        }
+
+        @Test
+        @DisplayName("imgKey가 공백 문자열이면 null을 반환하고 imageService를 호출하지 않는다")
+        void returnsNull_whenImgKeyIsBlank() {
+            ProfileImg profileImg = ProfileImg.builder()
+                    .imgKey("   ")
+                    .build();
+
+            String result = chatProcessor.generateProfileImageUrl(profileImg);
+
+            assertThat(result).isNull();
+            verify(imageService, never()).getUrlFromKey("   ");
+        }
+
+        @Test
+        @DisplayName("유효한 imgKey가 있으면 imageService로 URL을 생성해서 반환한다")
+        void returnsUrl_whenImgKeyIsValid() {
+            ProfileImg profileImg = ProfileImg.builder()
+                    .imgKey("profile/key123.jpg")
+                    .build();
+
+            given(imageService.getUrlFromKey("profile/key123.jpg"))
+                    .willReturn("https://cdn.example.com/profile/key123.jpg");
+
+            String result = chatProcessor.generateProfileImageUrl(profileImg);
+
+            assertThat(result).isEqualTo("https://cdn.example.com/profile/key123.jpg");
+            verify(imageService).getUrlFromKey("profile/key123.jpg");
+        }
+    }
+
+    // ========== generateImageUrl ==========
+
+    @Nested
+    @DisplayName("generateImageUrl - 채팅 이미지 URL 생성")
+    class GenerateImageUrl {
+
+        @Test
+        @DisplayName("img가 null이면 null을 반환한다")
+        void returnsNull_whenImgIsNull() {
+            String result = chatProcessor.generateImageUrl(null);
+
+            assertThat(result).isNull();
+        }
+
+        @Test
+        @DisplayName("imgKey가 null이면 null을 반환하고 imageService를 호출하지 않는다")
+        void returnsNull_whenImgKeyIsNull() {
+            ChatMessageImg img = ChatMessageImg.builder()
+                    .imgKey(null)
+                    .imgOrder(1)
+                    .originalFileName("photo.jpg")
+                    .fileSize(1024L)
+                    .fileType("image/jpeg")
+                    .build();
+
+            String result = chatProcessor.generateImageUrl(img);
+
+            assertThat(result).isNull();
+            verify(imageService, never()).getUrlFromKey(null);
+        }
+
+        @Test
+        @DisplayName("imgKey가 공백 문자열이면 null을 반환하고 imageService를 호출하지 않는다")
+        void returnsNull_whenImgKeyIsBlank() {
+            ChatMessageImg img = ChatMessageImg.builder()
+                    .imgKey("  ")
+                    .imgOrder(1)
+                    .originalFileName("photo.jpg")
+                    .fileSize(1024L)
+                    .fileType("image/jpeg")
+                    .build();
+
+            String result = chatProcessor.generateImageUrl(img);
+
+            assertThat(result).isNull();
+            verify(imageService, never()).getUrlFromKey("  ");
+        }
+
+        @Test
+        @DisplayName("유효한 imgKey가 있으면 imageService로 URL을 생성해서 반환한다")
+        void returnsUrl_whenImgKeyIsValid() {
+            ChatMessageImg img = ChatMessageImg.builder()
+                    .imgKey("chat/img456.jpg")
+                    .imgOrder(1)
+                    .originalFileName("photo.jpg")
+                    .fileSize(2048L)
+                    .fileType("image/jpeg")
+                    .build();
+
+            given(imageService.getUrlFromKey("chat/img456.jpg"))
+                    .willReturn("https://cdn.example.com/chat/img456.jpg");
+
+            String result = chatProcessor.generateImageUrl(img);
+
+            assertThat(result).isEqualTo("https://cdn.example.com/chat/img456.jpg");
+            verify(imageService).getUrlFromKey("chat/img456.jpg");
+        }
+    }
+
+    // ========== processMessages ==========
+
+    @Nested
+    @DisplayName("processMessages - 메시지 목록 처리")
+    class ProcessMessages {
+
+        @Test
+        @DisplayName("빈 메시지 목록을 처리하면 빈 리스트를 반환한다")
+        void returnsEmptyList_whenNoMessages() {
+            List<ChatCommonDTO.MessageInfo> result = chatProcessor.processMessages(sender.getId(), List.of());
+
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        @DisplayName("내가 보낸 메시지는 isMyMessage가 true이다")
+        void isMyMessage_true_whenSenderIsCurrentUser() {
+            ChatMessage message = ChatFixture.createTextMessage(chatRoom, sender, "내 메시지");
+            ReflectionTestUtils.setField(message, "id", 1L);
+
+            List<ChatCommonDTO.MessageInfo> result = chatProcessor.processMessages(sender.getId(), List.of(message));
+
+            assertThat(result).hasSize(1);
+            assertThat(result.get(0).isMyMessage()).isTrue();
+        }
+
+        @Test
+        @DisplayName("다른 사람이 보낸 메시지는 isMyMessage가 false이다")
+        void isMyMessage_false_whenSenderIsOther() {
+            Member other = MemberFixture.createMemberWithName("김철수", "철수", Gender.MALE, Level.B, 2002L);
+            ReflectionTestUtils.setField(other, "id", 20L);
+
+            ChatMessage message = ChatFixture.createTextMessage(chatRoom, other, "상대방 메시지");
+            ReflectionTestUtils.setField(message, "id", 1L);
+
+            List<ChatCommonDTO.MessageInfo> result = chatProcessor.processMessages(sender.getId(), List.of(message));
+
+            assertThat(result).hasSize(1);
+            assertThat(result.get(0).isMyMessage()).isFalse();
+        }
+
+        @Test
+        @DisplayName("탈퇴한 회원이 보낸 메시지는 isSenderWithdrawn이 true이다")
+        void isSenderWithdrawn_true_whenSenderIsInactive() {
+            Member withdrawn = MemberFixture.createWithdrawnMember("탈퇴한사용자", "탈퇴", 3003L);
+            ReflectionTestUtils.setField(withdrawn, "id", 30L);
+
+            ChatMessage message = ChatFixture.createTextMessage(chatRoom, withdrawn, "탈퇴자 메시지");
+            ReflectionTestUtils.setField(message, "id", 1L);
+
+            List<ChatCommonDTO.MessageInfo> result = chatProcessor.processMessages(sender.getId(), List.of(message));
+
+            assertThat(result).hasSize(1);
+            assertThat(result.get(0).isSenderWithdrawn()).isTrue();
+        }
+
+        @Test
+        @DisplayName("활성 회원이 보낸 메시지는 isSenderWithdrawn이 false이다")
+        void isSenderWithdrawn_false_whenSenderIsActive() {
+            ChatMessage message = ChatFixture.createTextMessage(chatRoom, sender, "활성 사용자 메시지");
+            ReflectionTestUtils.setField(message, "id", 1L);
+
+            List<ChatCommonDTO.MessageInfo> result = chatProcessor.processMessages(sender.getId(), List.of(message));
+
+            assertThat(result.get(0).isSenderWithdrawn()).isFalse();
+        }
+
+        @Test
+        @DisplayName("메시지 처리 결과에 senderName, content, messageType이 올바르게 매핑된다")
+        void messageFields_areCorrectlyMapped() {
+            ChatMessage message = ChatFixture.createTextMessage(chatRoom, sender, "안녕하세요");
+            ReflectionTestUtils.setField(message, "id", 1L);
+
+            List<ChatCommonDTO.MessageInfo> result = chatProcessor.processMessages(sender.getId(), List.of(message));
+
+            ChatCommonDTO.MessageInfo info = result.get(0);
+            assertThat(info.messageId()).isEqualTo(1L);
+            assertThat(info.senderId()).isEqualTo(sender.getId());
+            assertThat(info.senderName()).isEqualTo("홍길동");
+            assertThat(info.content()).isEqualTo("안녕하세요");
+            assertThat(info.messageType()).isEqualTo(MessageType.TEXT);
+        }
+
+        @Test
+        @DisplayName("발신자에게 프로필 이미지 키가 없으면 senderProfileImageUrl이 null이다")
+        void senderProfileImageUrl_isNull_whenNoProfileImg() {
+            // sender는 profileImg가 null인 상태 (MemberFixture 기본)
+            ChatMessage message = ChatFixture.createTextMessage(chatRoom, sender, "메시지");
+            ReflectionTestUtils.setField(message, "id", 1L);
+
+            List<ChatCommonDTO.MessageInfo> result = chatProcessor.processMessages(sender.getId(), List.of(message));
+
+            assertThat(result.get(0).senderProfileImageUrl()).isNull();
+            verify(imageService, never()).getUrlFromKey(null);
+        }
+
+        @Test
+        @DisplayName("여러 메시지를 처리하면 입력 순서가 유지된다")
+        void multipleMessages_preserveInputOrder() {
+            Member other = MemberFixture.createMemberWithName("김철수", "철수", Gender.MALE, Level.B, 2002L);
+            ReflectionTestUtils.setField(other, "id", 20L);
+
+            ChatMessage msg1 = ChatFixture.createTextMessage(chatRoom, sender, "첫 번째");
+            ReflectionTestUtils.setField(msg1, "id", 1L);
+            ChatMessage msg2 = ChatFixture.createTextMessage(chatRoom, other, "두 번째");
+            ReflectionTestUtils.setField(msg2, "id", 2L);
+            ChatMessage msg3 = ChatFixture.createTextMessage(chatRoom, sender, "세 번째");
+            ReflectionTestUtils.setField(msg3, "id", 3L);
+
+            List<ChatCommonDTO.MessageInfo> result = chatProcessor.processMessages(sender.getId(), List.of(msg1, msg2, msg3));
+
+            assertThat(result).hasSize(3);
+            assertThat(result.get(0).messageId()).isEqualTo(1L);
+            assertThat(result.get(0).isMyMessage()).isTrue();
+            assertThat(result.get(1).messageId()).isEqualTo(2L);
+            assertThat(result.get(1).isMyMessage()).isFalse();
+            assertThat(result.get(2).messageId()).isEqualTo(3L);
+            assertThat(result.get(2).isMyMessage()).isTrue();
+        }
+
+        @Test
+        @DisplayName("이미지가 포함된 메시지는 imgOrder 오름차순으로 정렬된다")
+        void messageImages_areSortedByImgOrder() {
+            ChatMessage message = ChatFixture.createTextMessage(chatRoom, sender, "이미지 메시지");
+            ReflectionTestUtils.setField(message, "id", 1L);
+
+            // imgOrder 역순으로 삽입: 3 → 1 → 2
+            ChatMessageImg img3 = ChatMessageImg.builder()
+                    .imgKey("img/third.jpg")
+                    .imgOrder(3)
+                    .originalFileName("third.jpg")
+                    .fileSize(100L)
+                    .fileType("image/jpeg")
+                    .build();
+            ChatMessageImg img1 = ChatMessageImg.builder()
+                    .imgKey("img/first.jpg")
+                    .imgOrder(1)
+                    .originalFileName("first.jpg")
+                    .fileSize(100L)
+                    .fileType("image/jpeg")
+                    .build();
+            ChatMessageImg img2 = ChatMessageImg.builder()
+                    .imgKey("img/second.jpg")
+                    .imgOrder(2)
+                    .originalFileName("second.jpg")
+                    .fileSize(100L)
+                    .fileType("image/jpeg")
+                    .build();
+
+            // ChatMessage의 chatMessageImgs에 역순으로 세팅
+            ReflectionTestUtils.setField(message, "chatMessageImgs", List.of(img3, img1, img2));
+
+            given(imageService.getUrlFromKey("img/first.jpg")).willReturn("https://cdn.example.com/first.jpg");
+            given(imageService.getUrlFromKey("img/second.jpg")).willReturn("https://cdn.example.com/second.jpg");
+            given(imageService.getUrlFromKey("img/third.jpg")).willReturn("https://cdn.example.com/third.jpg");
+
+            List<ChatCommonDTO.MessageInfo> result = chatProcessor.processMessages(sender.getId(), List.of(message));
+
+            List<ChatCommonDTO.ImageInfo> images = result.get(0).images();
+            assertThat(images).hasSize(3);
+            assertThat(images.get(0).imgOrder()).isEqualTo(1);
+            assertThat(images.get(1).imgOrder()).isEqualTo(2);
+            assertThat(images.get(2).imgOrder()).isEqualTo(3);
+        }
+    }
+}

--- a/src/test/java/umc/cockple/demo/domain/chat/service/ChatQueryServiceTest.java
+++ b/src/test/java/umc/cockple/demo/domain/chat/service/ChatQueryServiceTest.java
@@ -409,4 +409,247 @@ class ChatQueryServiceTest {
             verify(chatRoomRepository).findChatRoomWithPartyById(roomId);
         }
     }
+
+    @Nested
+    @DisplayName("getChatMessages - 과거 메시지 조회")
+    class GetChatMessages {
+
+        @Test
+        @DisplayName("cursor 이전 메시지가 size 이하이면 hasNext가 false이고 nextCursor가 null이다")
+        void noMoreMessages_hasNextFalse() {
+            // given
+            Long roomId = 1L;
+            Long memberId = 10L;
+            Long cursor = 100L;
+            int size = 3;
+
+            Member me = MemberFixture.createMemberWithName("홍길동", "길동", Gender.MALE, Level.A, 1001L);
+            ReflectionTestUtils.setField(me, "id", memberId);
+
+            Party party = PartyFixture.createParty("모임", memberId, PartyFixture.createPartyAddr("서울", "강남구"));
+            ReflectionTestUtils.setField(party, "id", 100L);
+
+            ChatRoom chatRoom = ChatFixture.createPartyChatRoom(party);
+            ReflectionTestUtils.setField(chatRoom, "id", roomId);
+
+            // DB는 최신순(id: 3→2→1)으로 반환, size+1=4개 요청했지만 3개만 존재
+            ChatMessage msg1 = ChatFixture.createTextMessage(chatRoom, me, "첫 번째 메시지");
+            ReflectionTestUtils.setField(msg1, "id", 1L);
+            ChatMessage msg2 = ChatFixture.createTextMessage(chatRoom, me, "두 번째 메시지");
+            ReflectionTestUtils.setField(msg2, "id", 2L);
+            ChatMessage msg3 = ChatFixture.createTextMessage(chatRoom, me, "세 번째 메시지");
+            ReflectionTestUtils.setField(msg3, "id", 3L);
+
+            given(chatRoomMemberRepository.existsByChatRoomIdAndMemberId(roomId, memberId)).willReturn(true);
+            given(chatMessageRepository.findByRoomIdAndIdLessThanOrderByCreatedAtDesc(eq(roomId), eq(cursor), any()))
+                    .willReturn(List.of(msg3, msg2, msg1));
+
+            // when
+            ChatMessageDTO.Response result = chatQueryService.getChatMessages(roomId, memberId, cursor, size);
+
+            // then
+            assertThat(result.hasNext()).isFalse();
+            assertThat(result.nextCursor()).isNull();
+            assertThat(result.messages()).hasSize(3);
+        }
+
+        @Test
+        @DisplayName("cursor 이전 메시지가 size보다 많으면 hasNext가 true이고 nextCursor가 설정된다")
+        void moreMessagesExist_hasNextTrue() {
+            // given
+            Long roomId = 1L;
+            Long memberId = 10L;
+            Long cursor = 100L;
+            int size = 2;
+
+            Member me = MemberFixture.createMemberWithName("홍길동", "길동", Gender.MALE, Level.A, 1001L);
+            ReflectionTestUtils.setField(me, "id", memberId);
+
+            Party party = PartyFixture.createParty("모임", memberId, PartyFixture.createPartyAddr("서울", "강남구"));
+            ReflectionTestUtils.setField(party, "id", 100L);
+
+            ChatRoom chatRoom = ChatFixture.createPartyChatRoom(party);
+            ReflectionTestUtils.setField(chatRoom, "id", roomId);
+
+            // DB는 최신순(3→2→1)으로 size+1=3개 반환 → hasNext=true
+            ChatMessage msg1 = ChatFixture.createTextMessage(chatRoom, me, "첫 번째 메시지");
+            ReflectionTestUtils.setField(msg1, "id", 1L);
+            ChatMessage msg2 = ChatFixture.createTextMessage(chatRoom, me, "두 번째 메시지");
+            ReflectionTestUtils.setField(msg2, "id", 2L);
+            ChatMessage msg3 = ChatFixture.createTextMessage(chatRoom, me, "세 번째 메시지");
+            ReflectionTestUtils.setField(msg3, "id", 3L);
+
+            given(chatRoomMemberRepository.existsByChatRoomIdAndMemberId(roomId, memberId)).willReturn(true);
+            given(chatMessageRepository.findByRoomIdAndIdLessThanOrderByCreatedAtDesc(eq(roomId), eq(cursor), any()))
+                    .willReturn(List.of(msg3, msg2, msg1));
+
+            // when
+            ChatMessageDTO.Response result = chatQueryService.getChatMessages(roomId, memberId, cursor, size);
+
+            // then
+            assertThat(result.hasNext()).isTrue();
+            // size개 자른 후 가장 오래된 메시지(subList[0])의 id
+            assertThat(result.nextCursor()).isEqualTo(2L);
+            assertThat(result.messages()).hasSize(2);
+        }
+
+        @Test
+        @DisplayName("반환된 메시지는 오래된 순(오름차순)으로 정렬된다")
+        void messages_areInChronologicalOrder() {
+            // given
+            Long roomId = 1L;
+            Long memberId = 10L;
+            Long cursor = 100L;
+            int size = 3;
+
+            Member me = MemberFixture.createMemberWithName("홍길동", "길동", Gender.MALE, Level.A, 1001L);
+            ReflectionTestUtils.setField(me, "id", memberId);
+
+            Party party = PartyFixture.createParty("모임", memberId, PartyFixture.createPartyAddr("서울", "강남구"));
+            ReflectionTestUtils.setField(party, "id", 100L);
+
+            ChatRoom chatRoom = ChatFixture.createPartyChatRoom(party);
+            ReflectionTestUtils.setField(chatRoom, "id", roomId);
+
+            // DB에서 최신순(3→2→1) 반환
+            ChatMessage msg1 = ChatFixture.createTextMessage(chatRoom, me, "첫 번째");
+            ReflectionTestUtils.setField(msg1, "id", 1L);
+            ChatMessage msg2 = ChatFixture.createTextMessage(chatRoom, me, "두 번째");
+            ReflectionTestUtils.setField(msg2, "id", 2L);
+            ChatMessage msg3 = ChatFixture.createTextMessage(chatRoom, me, "세 번째");
+            ReflectionTestUtils.setField(msg3, "id", 3L);
+
+            given(chatRoomMemberRepository.existsByChatRoomIdAndMemberId(roomId, memberId)).willReturn(true);
+            given(chatMessageRepository.findByRoomIdAndIdLessThanOrderByCreatedAtDesc(eq(roomId), eq(cursor), any()))
+                    .willReturn(List.of(msg3, msg2, msg1));
+
+            // when
+            ChatMessageDTO.Response result = chatQueryService.getChatMessages(roomId, memberId, cursor, size);
+
+            // then: 응답은 오래된 순(1→2→3)
+            List<ChatMessageDTO.MessageInfo> messages = result.messages();
+            assertThat(messages).hasSize(3);
+            assertThat(messages.get(0).messageId()).isEqualTo(1L);
+            assertThat(messages.get(1).messageId()).isEqualTo(2L);
+            assertThat(messages.get(2).messageId()).isEqualTo(3L);
+        }
+
+        @Test
+        @DisplayName("내가 보낸 메시지는 isMyMessage가 true이다")
+        void myMessage_isMyMessageTrue() {
+            // given
+            Long roomId = 1L;
+            Long memberId = 10L;
+            Long cursor = 100L;
+
+            Member me = MemberFixture.createMemberWithName("홍길동", "길동", Gender.MALE, Level.A, 1001L);
+            ReflectionTestUtils.setField(me, "id", memberId);
+
+            Party party = PartyFixture.createParty("모임", memberId, PartyFixture.createPartyAddr("서울", "강남구"));
+            ReflectionTestUtils.setField(party, "id", 100L);
+
+            ChatRoom chatRoom = ChatFixture.createPartyChatRoom(party);
+            ReflectionTestUtils.setField(chatRoom, "id", roomId);
+
+            ChatMessage myMessage = ChatFixture.createTextMessage(chatRoom, me, "내 메시지");
+            ReflectionTestUtils.setField(myMessage, "id", 1L);
+
+            given(chatRoomMemberRepository.existsByChatRoomIdAndMemberId(roomId, memberId)).willReturn(true);
+            given(chatMessageRepository.findByRoomIdAndIdLessThanOrderByCreatedAtDesc(eq(roomId), eq(cursor), any()))
+                    .willReturn(List.of(myMessage));
+
+            // when
+            ChatMessageDTO.Response result = chatQueryService.getChatMessages(roomId, memberId, cursor, 10);
+
+            // then
+            assertThat(result.messages().get(0).isMyMessage()).isTrue();
+        }
+
+        @Test
+        @DisplayName("상대방이 보낸 메시지는 isMyMessage가 false이다")
+        void otherMessage_isMyMessageFalse() {
+            // given
+            Long roomId = 1L;
+            Long memberId = 10L;
+            Long otherId = 20L;
+            Long cursor = 100L;
+
+            Member me = MemberFixture.createMemberWithName("홍길동", "길동", Gender.MALE, Level.A, 1001L);
+            ReflectionTestUtils.setField(me, "id", memberId);
+
+            Member other = MemberFixture.createMemberWithName("김철수", "철수", Gender.MALE, Level.B, 2002L);
+            ReflectionTestUtils.setField(other, "id", otherId);
+
+            Party party = PartyFixture.createParty("모임", memberId, PartyFixture.createPartyAddr("서울", "강남구"));
+            ReflectionTestUtils.setField(party, "id", 100L);
+
+            ChatRoom chatRoom = ChatFixture.createPartyChatRoom(party);
+            ReflectionTestUtils.setField(chatRoom, "id", roomId);
+
+            ChatMessage otherMessage = ChatFixture.createTextMessage(chatRoom, other, "상대방 메시지");
+            ReflectionTestUtils.setField(otherMessage, "id", 1L);
+
+            given(chatRoomMemberRepository.existsByChatRoomIdAndMemberId(roomId, memberId)).willReturn(true);
+            given(chatMessageRepository.findByRoomIdAndIdLessThanOrderByCreatedAtDesc(eq(roomId), eq(cursor), any()))
+                    .willReturn(List.of(otherMessage));
+
+            // when
+            ChatMessageDTO.Response result = chatQueryService.getChatMessages(roomId, memberId, cursor, 10);
+
+            // then
+            assertThat(result.messages().get(0).isMyMessage()).isFalse();
+            assertThat(result.messages().get(0).senderName()).isEqualTo("김철수");
+        }
+
+        @Test
+        @DisplayName("탈퇴한 사용자가 보낸 메시지는 isSenderWithdrawn이 true이다")
+        void withdrawnSenderMessage_isSenderWithdrawnTrue() {
+            // given
+            Long roomId = 1L;
+            Long memberId = 10L;
+            Long withdrawnId = 30L;
+            Long cursor = 100L;
+
+            Member me = MemberFixture.createMemberWithName("홍길동", "길동", Gender.MALE, Level.A, 1001L);
+            ReflectionTestUtils.setField(me, "id", memberId);
+
+            Member withdrawn = MemberFixture.createWithdrawnMember("탈퇴한사용자", "탈퇴", 3003L);
+            ReflectionTestUtils.setField(withdrawn, "id", withdrawnId);
+
+            Party party = PartyFixture.createParty("모임", memberId, PartyFixture.createPartyAddr("서울", "강남구"));
+            ReflectionTestUtils.setField(party, "id", 100L);
+
+            ChatRoom chatRoom = ChatFixture.createPartyChatRoom(party);
+            ReflectionTestUtils.setField(chatRoom, "id", roomId);
+
+            ChatMessage withdrawnMessage = ChatFixture.createTextMessage(chatRoom, withdrawn, "탈퇴자 메시지");
+            ReflectionTestUtils.setField(withdrawnMessage, "id", 1L);
+
+            given(chatRoomMemberRepository.existsByChatRoomIdAndMemberId(roomId, memberId)).willReturn(true);
+            given(chatMessageRepository.findByRoomIdAndIdLessThanOrderByCreatedAtDesc(eq(roomId), eq(cursor), any()))
+                    .willReturn(List.of(withdrawnMessage));
+
+            // when
+            ChatMessageDTO.Response result = chatQueryService.getChatMessages(roomId, memberId, cursor, 10);
+
+            // then
+            assertThat(result.messages().get(0).isSenderWithdrawn()).isTrue();
+        }
+
+        @Test
+        @DisplayName("채팅방 멤버가 아닌 사용자가 메시지를 조회하면 ChatException(CHAT_ROOM_ACCESS_DENIED)을 던진다")
+        void fail_notChatRoomMember() {
+            // given
+            Long roomId = 1L;
+            Long outsiderId = 99L;
+            Long cursor = 100L;
+
+            given(chatRoomMemberRepository.existsByChatRoomIdAndMemberId(roomId, outsiderId)).willReturn(false);
+
+            // when & then
+            assertThatThrownBy(() -> chatQueryService.getChatMessages(roomId, outsiderId, cursor, 10))
+                    .isInstanceOf(ChatException.class)
+                    .satisfies(e -> assertThat(((ChatException) e).getCode()).isEqualTo(ChatErrorCode.CHAT_ROOM_ACCESS_DENIED));
+        }
+    }
 }

--- a/src/test/java/umc/cockple/demo/domain/chat/service/ChatQueryServiceTest.java
+++ b/src/test/java/umc/cockple/demo/domain/chat/service/ChatQueryServiceTest.java
@@ -1,0 +1,412 @@
+package umc.cockple.demo.domain.chat.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import umc.cockple.demo.domain.chat.converter.ChatConverter;
+import umc.cockple.demo.domain.chat.domain.ChatMessage;
+import umc.cockple.demo.domain.chat.domain.ChatRoom;
+import umc.cockple.demo.domain.chat.domain.ChatRoomMember;
+import umc.cockple.demo.domain.chat.dto.ChatMessageDTO;
+import umc.cockple.demo.domain.chat.dto.ChatRoomDetailDTO;
+import umc.cockple.demo.domain.chat.enums.ChatRoomType;
+import umc.cockple.demo.domain.chat.exception.ChatErrorCode;
+import umc.cockple.demo.domain.chat.exception.ChatException;
+import umc.cockple.demo.domain.chat.repository.ChatMessageRepository;
+import umc.cockple.demo.domain.chat.repository.ChatRoomMemberRepository;
+import umc.cockple.demo.domain.chat.repository.ChatRoomRepository;
+import umc.cockple.demo.domain.chat.repository.MessageReadStatusRepository;
+import umc.cockple.demo.domain.chat.service.websocket.ChatRoomListCacheService;
+import umc.cockple.demo.domain.image.service.ImageService;
+import umc.cockple.demo.domain.member.domain.Member;
+import umc.cockple.demo.domain.member.repository.MemberPartyRepository;
+import umc.cockple.demo.domain.party.domain.Party;
+import umc.cockple.demo.domain.party.repository.PartyRepository;
+import umc.cockple.demo.global.enums.Gender;
+import umc.cockple.demo.global.enums.Level;
+import umc.cockple.demo.support.fixture.ChatFixture;
+import umc.cockple.demo.support.fixture.MemberFixture;
+import umc.cockple.demo.support.fixture.PartyFixture;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class ChatQueryServiceTest {
+
+    // Mocks (외부 I/O)
+    @Mock private ChatRoomRepository chatRoomRepository;
+    @Mock private ChatRoomMemberRepository chatRoomMemberRepository;
+    @Mock private ChatMessageRepository chatMessageRepository;
+    @Mock private PartyRepository partyRepository;
+    @Mock private MemberPartyRepository memberPartyRepository;
+    @Mock private MessageReadStatusRepository messageReadStatusRepository;
+    @Mock private ChatRoomListCacheService chatRoomListCacheService;
+    @Mock private ImageService imageService;
+
+    private ChatConverter chatConverter;
+    private ChatProcessor chatProcessor;
+    private ChatQueryServiceImpl chatQueryService;
+
+    @BeforeEach
+    void setUp() {
+        chatConverter = new ChatConverter();
+        chatProcessor = new ChatProcessor(imageService, chatConverter);
+        chatQueryService = new ChatQueryServiceImpl(
+                chatRoomRepository,
+                chatRoomMemberRepository,
+                chatMessageRepository,
+                partyRepository,
+                memberPartyRepository,
+                messageReadStatusRepository,
+                chatConverter,
+                imageService,
+                chatProcessor,
+                chatRoomListCacheService
+        );
+    }
+
+    @Nested
+    @DisplayName("getChatRoomDetail - 초기 채팅방 조회")
+    class GetChatRoomDetail {
+
+        @Test
+        @DisplayName("모임(PARTY) 채팅방 조회 시 파티 이름이 displayName이 된다")
+        void partyChatRoom_success() {
+            // given
+            Long roomId = 1L;
+            Long memberId = 10L;
+
+            Member me = MemberFixture.createMemberWithName("홍길동", "길동", Gender.MALE, Level.A, 1001L);
+            ReflectionTestUtils.setField(me, "id", memberId);
+
+            Party party = PartyFixture.createParty("배드민턴 모임", memberId, PartyFixture.createPartyAddr("서울", "강남구"));
+            ReflectionTestUtils.setField(party, "id", 100L);
+
+            ChatRoom chatRoom = ChatFixture.createPartyChatRoom(party);
+            ReflectionTestUtils.setField(chatRoom, "id", roomId);
+
+            ChatRoomMember myMembership = ChatFixture.createJoinedMemberWithLastRead(chatRoom, me, 30L);
+            ReflectionTestUtils.setField(myMembership, "id", 1L);
+
+            List<ChatRoomMember> participants = List.of(myMembership);
+
+            given(chatRoomRepository.findChatRoomWithPartyById(roomId)).willReturn(Optional.of(chatRoom));
+            given(chatRoomMemberRepository.findByChatRoomIdAndMemberId(roomId, memberId)).willReturn(Optional.of(myMembership));
+            given(chatMessageRepository.findRecentMessagesWithImages(eq(roomId), any())).willReturn(List.of());
+            given(chatRoomMemberRepository.findChatRoomMembersWithMemberById(roomId)).willReturn(participants);
+            given(chatRoomMemberRepository.countByChatRoomId(roomId)).willReturn(1);
+
+            // when
+            ChatRoomDetailDTO.Response result = chatQueryService.getChatRoomDetail(roomId, memberId);
+
+            // then
+            ChatRoomDetailDTO.ChatRoomInfo roomInfo = result.chatRoomInfo();
+            assertThat(roomInfo.chatRoomId()).isEqualTo(roomId);
+            assertThat(roomInfo.chatRoomType()).isEqualTo(ChatRoomType.PARTY);
+            assertThat(roomInfo.displayName()).isEqualTo("배드민턴 모임");
+            assertThat(roomInfo.memberCount()).isEqualTo(1);
+            assertThat(roomInfo.lastReadMessageId()).isEqualTo(30L);
+            assertThat(roomInfo.isCounterPartWithdrawn()).isFalse();
+            assertThat(result.messages()).isEmpty();
+            assertThat(result.participants()).hasSize(1);
+            assertThat(result.participants().get(0).memberName()).isEqualTo("홍길동");
+        }
+
+        @Test
+        @DisplayName("개인(DIRECT) 채팅방 조회 시 상대방 이름이 displayName이 된다")
+        void directChatRoom_success() {
+            // given
+            Long roomId = 2L;
+            Long memberId = 10L;
+            Long counterPartId = 20L;
+
+            Member me = MemberFixture.createMemberWithName("홍길동", "길동", Gender.MALE, Level.A, 1001L);
+            ReflectionTestUtils.setField(me, "id", memberId);
+
+            Member counterPart = MemberFixture.createMemberWithName("김철수", "철수", Gender.MALE, Level.B, 2002L);
+            ReflectionTestUtils.setField(counterPart, "id", counterPartId);
+
+            ChatRoom chatRoom = ChatFixture.createDirectChatRoom();
+            ReflectionTestUtils.setField(chatRoom, "id", roomId);
+
+            ChatRoomMember myMembership = ChatFixture.createJoinedMember(chatRoom, me);
+            ReflectionTestUtils.setField(myMembership, "id", 1L);
+
+            ChatRoomMember counterPartMembership = ChatFixture.createJoinedMember(chatRoom, counterPart);
+            ReflectionTestUtils.setField(counterPartMembership, "id", 2L);
+
+            List<ChatRoomMember> participants = List.of(myMembership, counterPartMembership);
+
+            given(chatRoomRepository.findChatRoomWithPartyById(roomId)).willReturn(Optional.of(chatRoom));
+            given(chatRoomMemberRepository.findByChatRoomIdAndMemberId(roomId, memberId)).willReturn(Optional.of(myMembership));
+            given(chatRoomMemberRepository.findCounterPartWithMember(roomId, memberId)).willReturn(Optional.of(counterPartMembership));
+            given(chatRoomMemberRepository.countByChatRoomId(roomId)).willReturn(2);
+            given(chatMessageRepository.findRecentMessagesWithImages(eq(roomId), any())).willReturn(List.of());
+            given(chatRoomMemberRepository.findChatRoomMembersWithMemberById(roomId)).willReturn(participants);
+
+            // when
+            ChatRoomDetailDTO.Response result = chatQueryService.getChatRoomDetail(roomId, memberId);
+
+            // then
+            ChatRoomDetailDTO.ChatRoomInfo roomInfo = result.chatRoomInfo();
+            assertThat(roomInfo.chatRoomType()).isEqualTo(ChatRoomType.DIRECT);
+            assertThat(roomInfo.displayName()).isEqualTo("김철수");
+            assertThat(roomInfo.memberCount()).isEqualTo(2);
+            assertThat(roomInfo.isCounterPartWithdrawn()).isFalse();
+        }
+
+        @Test
+        @DisplayName("개인 채팅방에서 상대방이 탈퇴한 경우 isCounterPartWithdrawn이 true이다")
+        void directChatRoom_counterPartWithdrawn() {
+            // given
+            Long roomId = 3L;
+            Long memberId = 10L;
+            Long counterPartId = 20L;
+
+            Member me = MemberFixture.createMemberWithName("홍길동", "길동", Gender.MALE, Level.A, 1001L);
+            ReflectionTestUtils.setField(me, "id", memberId);
+
+            Member withdrawnCounterPart = MemberFixture.createWithdrawnMember("탈퇴한사용자", "탈퇴", 2002L);
+            ReflectionTestUtils.setField(withdrawnCounterPart, "id", counterPartId);
+
+            ChatRoom chatRoom = ChatFixture.createDirectChatRoom();
+            ReflectionTestUtils.setField(chatRoom, "id", roomId);
+
+            ChatRoomMember myMembership = ChatFixture.createJoinedMember(chatRoom, me);
+            ReflectionTestUtils.setField(myMembership, "id", 1L);
+
+            ChatRoomMember withdrawnMembership = ChatFixture.createJoinedMember(chatRoom, withdrawnCounterPart);
+            ReflectionTestUtils.setField(withdrawnMembership, "id", 2L);
+
+            List<ChatRoomMember> participants = List.of(myMembership, withdrawnMembership);
+
+            given(chatRoomRepository.findChatRoomWithPartyById(roomId)).willReturn(Optional.of(chatRoom));
+            given(chatRoomMemberRepository.findByChatRoomIdAndMemberId(roomId, memberId)).willReturn(Optional.of(myMembership));
+            given(chatRoomMemberRepository.findCounterPartWithMember(roomId, memberId)).willReturn(Optional.of(withdrawnMembership));
+            given(chatRoomMemberRepository.countByChatRoomId(roomId)).willReturn(2);
+            given(chatMessageRepository.findRecentMessagesWithImages(eq(roomId), any())).willReturn(List.of());
+            given(chatRoomMemberRepository.findChatRoomMembersWithMemberById(roomId)).willReturn(participants);
+
+            // when
+            ChatRoomDetailDTO.Response result = chatQueryService.getChatRoomDetail(roomId, memberId);
+
+            // then
+            assertThat(result.chatRoomInfo().isCounterPartWithdrawn()).isTrue();
+        }
+
+        @Test
+        @DisplayName("메시지가 DB에서 최신순으로 반환되면, 최종 응답에서는 오래된 순으로 뒤집혀야 한다")
+        void messages_areReversedToChronologicalOrder() {
+            // given
+            Long roomId = 1L;
+            Long memberId = 10L;
+
+            Member me = MemberFixture.createMemberWithName("홍길동", "길동", Gender.MALE, Level.A, 1001L);
+            ReflectionTestUtils.setField(me, "id", memberId);
+
+            Party party = PartyFixture.createParty("모임", memberId, PartyFixture.createPartyAddr("서울", "강남구"));
+            ReflectionTestUtils.setField(party, "id", 100L);
+
+            ChatRoom chatRoom = ChatFixture.createPartyChatRoom(party);
+            ReflectionTestUtils.setField(chatRoom, "id", roomId);
+
+            ChatRoomMember myMembership = ChatFixture.createJoinedMember(chatRoom, me);
+            ReflectionTestUtils.setField(myMembership, "id", 1L);
+
+            // DB는 최신순(id: 3→2→1)으로 반환
+            ChatMessage msg1 = ChatFixture.createTextMessage(chatRoom, me, "첫 번째 메시지");
+            ReflectionTestUtils.setField(msg1, "id", 1L);
+            ChatMessage msg2 = ChatFixture.createTextMessage(chatRoom, me, "두 번째 메시지");
+            ReflectionTestUtils.setField(msg2, "id", 2L);
+            ChatMessage msg3 = ChatFixture.createTextMessage(chatRoom, me, "세 번째 메시지");
+            ReflectionTestUtils.setField(msg3, "id", 3L);
+
+            given(chatRoomRepository.findChatRoomWithPartyById(roomId)).willReturn(Optional.of(chatRoom));
+            given(chatRoomMemberRepository.findByChatRoomIdAndMemberId(roomId, memberId)).willReturn(Optional.of(myMembership));
+            given(chatMessageRepository.findRecentMessagesWithImages(eq(roomId), any())).willReturn(List.of(msg3, msg2, msg1));
+            given(chatRoomMemberRepository.findChatRoomMembersWithMemberById(roomId)).willReturn(List.of(myMembership));
+            given(chatRoomMemberRepository.countByChatRoomId(roomId)).willReturn(1);
+
+            // when
+            ChatRoomDetailDTO.Response result = chatQueryService.getChatRoomDetail(roomId, memberId);
+
+            // then: 응답 메시지는 오래된 순(1→2→3)
+            List<ChatRoomDetailDTO.MessageInfo> messages = result.messages();
+            assertThat(messages).hasSize(3);
+            assertThat(messages.get(0).messageId()).isEqualTo(1L);
+            assertThat(messages.get(1).messageId()).isEqualTo(2L);
+            assertThat(messages.get(2).messageId()).isEqualTo(3L);
+        }
+
+        @Test
+        @DisplayName("메시지 발신자가 나(memberId)이면 isMyMessage가 true이다")
+        void message_isMyMessage_true_whenSenderIsMe() {
+            // given
+            Long roomId = 1L;
+            Long memberId = 10L;
+
+            Member me = MemberFixture.createMemberWithName("홍길동", "길동", Gender.MALE, Level.A, 1001L);
+            ReflectionTestUtils.setField(me, "id", memberId);
+
+            Party party = PartyFixture.createParty("모임", memberId, PartyFixture.createPartyAddr("서울", "강남구"));
+            ReflectionTestUtils.setField(party, "id", 100L);
+
+            ChatRoom chatRoom = ChatFixture.createPartyChatRoom(party);
+            ReflectionTestUtils.setField(chatRoom, "id", roomId);
+
+            ChatRoomMember myMembership = ChatFixture.createJoinedMember(chatRoom, me);
+            ReflectionTestUtils.setField(myMembership, "id", 1L);
+
+            ChatMessage myMessage = ChatFixture.createTextMessage(chatRoom, me, "내 메시지");
+            ReflectionTestUtils.setField(myMessage, "id", 1L);
+
+            given(chatRoomRepository.findChatRoomWithPartyById(roomId)).willReturn(Optional.of(chatRoom));
+            given(chatRoomMemberRepository.findByChatRoomIdAndMemberId(roomId, memberId)).willReturn(Optional.of(myMembership));
+            given(chatMessageRepository.findRecentMessagesWithImages(eq(roomId), any())).willReturn(List.of(myMessage));
+            given(chatRoomMemberRepository.findChatRoomMembersWithMemberById(roomId)).willReturn(List.of(myMembership));
+            given(chatRoomMemberRepository.countByChatRoomId(roomId)).willReturn(1);
+
+            // when
+            ChatRoomDetailDTO.Response result = chatQueryService.getChatRoomDetail(roomId, memberId);
+
+            // then
+            assertThat(result.messages().get(0).isMyMessage()).isTrue();
+            assertThat(result.messages().get(0).content()).isEqualTo("내 메시지");
+            assertThat(result.messages().get(0).senderName()).isEqualTo("홍길동");
+        }
+
+        @Test
+        @DisplayName("메시지 발신자가 상대방이면 isMyMessage가 false이다")
+        void message_isMyMessage_false_whenSenderIsOther() {
+            // given
+            Long roomId = 1L;
+            Long memberId = 10L;
+            Long otherId = 20L;
+
+            Member me = MemberFixture.createMemberWithName("홍길동", "길동", Gender.MALE, Level.A, 1001L);
+            ReflectionTestUtils.setField(me, "id", memberId);
+
+            Member other = MemberFixture.createMemberWithName("김철수", "철수", Gender.MALE, Level.B, 2002L);
+            ReflectionTestUtils.setField(other, "id", otherId);
+
+            Party party = PartyFixture.createParty("모임", memberId, PartyFixture.createPartyAddr("서울", "강남구"));
+            ReflectionTestUtils.setField(party, "id", 100L);
+
+            ChatRoom chatRoom = ChatFixture.createPartyChatRoom(party);
+            ReflectionTestUtils.setField(chatRoom, "id", roomId);
+
+            ChatRoomMember myMembership = ChatFixture.createJoinedMember(chatRoom, me);
+            ReflectionTestUtils.setField(myMembership, "id", 1L);
+
+            ChatRoomMember otherMembership = ChatFixture.createJoinedMember(chatRoom, other);
+            ReflectionTestUtils.setField(otherMembership, "id", 2L);
+
+            ChatMessage otherMessage = ChatFixture.createTextMessage(chatRoom, other, "상대방 메시지");
+            ReflectionTestUtils.setField(otherMessage, "id", 1L);
+
+            given(chatRoomRepository.findChatRoomWithPartyById(roomId)).willReturn(Optional.of(chatRoom));
+            given(chatRoomMemberRepository.findByChatRoomIdAndMemberId(roomId, memberId)).willReturn(Optional.of(myMembership));
+            given(chatMessageRepository.findRecentMessagesWithImages(eq(roomId), any())).willReturn(List.of(otherMessage));
+            given(chatRoomMemberRepository.findChatRoomMembersWithMemberById(roomId)).willReturn(List.of(myMembership, otherMembership));
+            given(chatRoomMemberRepository.countByChatRoomId(roomId)).willReturn(2);
+
+            // when
+            ChatRoomDetailDTO.Response result = chatQueryService.getChatRoomDetail(roomId, memberId);
+
+            // then
+            assertThat(result.messages().get(0).isMyMessage()).isFalse();
+            assertThat(result.messages().get(0).isSenderWithdrawn()).isFalse();
+        }
+
+        @Test
+        @DisplayName("탈퇴한 사용자가 보낸 메시지는 isSenderWithdrawn이 true이다")
+        void message_isSenderWithdrawn_true() {
+            // given
+            Long roomId = 1L;
+            Long memberId = 10L;
+            Long withdrawnId = 30L;
+
+            Member me = MemberFixture.createMemberWithName("홍길동", "길동", Gender.MALE, Level.A, 1001L);
+            ReflectionTestUtils.setField(me, "id", memberId);
+
+            Member withdrawn = MemberFixture.createWithdrawnMember("탈퇴한사용자", "탈퇴", 3003L);
+            ReflectionTestUtils.setField(withdrawn, "id", withdrawnId);
+
+            Party party = PartyFixture.createParty("모임", memberId, PartyFixture.createPartyAddr("서울", "강남구"));
+            ReflectionTestUtils.setField(party, "id", 100L);
+
+            ChatRoom chatRoom = ChatFixture.createPartyChatRoom(party);
+            ReflectionTestUtils.setField(chatRoom, "id", roomId);
+
+            ChatRoomMember myMembership = ChatFixture.createJoinedMember(chatRoom, me);
+            ReflectionTestUtils.setField(myMembership, "id", 1L);
+
+            ChatRoomMember withdrawnMembership = ChatFixture.createJoinedMember(chatRoom, withdrawn);
+            ReflectionTestUtils.setField(withdrawnMembership, "id", 2L);
+
+            ChatMessage withdrawnMessage = ChatFixture.createTextMessage(chatRoom, withdrawn, "탈퇴자 메시지");
+            ReflectionTestUtils.setField(withdrawnMessage, "id", 1L);
+
+            given(chatRoomRepository.findChatRoomWithPartyById(roomId)).willReturn(Optional.of(chatRoom));
+            given(chatRoomMemberRepository.findByChatRoomIdAndMemberId(roomId, memberId)).willReturn(Optional.of(myMembership));
+            given(chatMessageRepository.findRecentMessagesWithImages(eq(roomId), any())).willReturn(List.of(withdrawnMessage));
+            given(chatRoomMemberRepository.findChatRoomMembersWithMemberById(roomId)).willReturn(List.of(myMembership, withdrawnMembership));
+            given(chatRoomMemberRepository.countByChatRoomId(roomId)).willReturn(2);
+
+            // when
+            ChatRoomDetailDTO.Response result = chatQueryService.getChatRoomDetail(roomId, memberId);
+
+            // then
+            assertThat(result.messages().get(0).isSenderWithdrawn()).isTrue();
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 채팅방 조회 시 ChatException(CHAT_ROOM_NOT_FOUND)을 던진다")
+        void fail_chatRoomNotFound() {
+            // given
+            given(chatRoomRepository.findChatRoomWithPartyById(999L)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> chatQueryService.getChatRoomDetail(999L, 10L))
+                    .isInstanceOf(ChatException.class)
+                    .satisfies(e -> assertThat(((ChatException) e).getCode()).isEqualTo(ChatErrorCode.CHAT_ROOM_NOT_FOUND));
+        }
+
+        @Test
+        @DisplayName("채팅방 멤버가 아닌 사용자가 조회하면 ChatException(CHAT_ROOM_ACCESS_DENIED)을 던진다")
+        void fail_notChatRoomMember() {
+            // given
+            Long roomId = 1L;
+            Long outsiderId = 99L;
+
+            Party party = PartyFixture.createParty("모임", 1L, PartyFixture.createPartyAddr("서울", "강남구"));
+            ReflectionTestUtils.setField(party, "id", 100L);
+
+            ChatRoom chatRoom = ChatFixture.createPartyChatRoom(party);
+            ReflectionTestUtils.setField(chatRoom, "id", roomId);
+
+            given(chatRoomRepository.findChatRoomWithPartyById(roomId)).willReturn(Optional.of(chatRoom));
+            given(chatRoomMemberRepository.findByChatRoomIdAndMemberId(roomId, outsiderId)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> chatQueryService.getChatRoomDetail(roomId, outsiderId))
+                    .isInstanceOf(ChatException.class)
+                    .satisfies(e -> assertThat(((ChatException) e).getCode()).isEqualTo(ChatErrorCode.CHAT_ROOM_ACCESS_DENIED));
+
+            verify(chatRoomRepository).findChatRoomWithPartyById(roomId);
+        }
+    }
+}

--- a/src/test/java/umc/cockple/demo/support/fixture/ChatFixture.java
+++ b/src/test/java/umc/cockple/demo/support/fixture/ChatFixture.java
@@ -1,0 +1,43 @@
+package umc.cockple.demo.support.fixture;
+
+import umc.cockple.demo.domain.chat.domain.ChatMessage;
+import umc.cockple.demo.domain.chat.domain.ChatRoom;
+import umc.cockple.demo.domain.chat.domain.ChatRoomMember;
+import umc.cockple.demo.domain.chat.enums.ChatRoomMemberStatus;
+import umc.cockple.demo.domain.chat.enums.ChatRoomType;
+import umc.cockple.demo.domain.chat.enums.MessageType;
+import umc.cockple.demo.domain.member.domain.Member;
+import umc.cockple.demo.domain.party.domain.Party;
+
+public class ChatFixture {
+
+    public static ChatRoom createPartyChatRoom(Party party) {
+        return ChatRoom.builder()
+                .type(ChatRoomType.PARTY)
+                .party(party)
+                .build();
+    }
+
+    public static ChatRoom createDirectChatRoom() {
+        return ChatRoom.builder()
+                .type(ChatRoomType.DIRECT)
+                .build();
+    }
+
+    public static ChatRoomMember createJoinedMember(ChatRoom chatRoom, Member member) {
+        return ChatRoomMember.create(chatRoom, member);
+    }
+
+    public static ChatRoomMember createJoinedMemberWithLastRead(ChatRoom chatRoom, Member member, Long lastReadMessageId) {
+        return ChatRoomMember.builder()
+                .chatRoom(chatRoom)
+                .member(member)
+                .lastReadMessageId(lastReadMessageId)
+                .status(ChatRoomMemberStatus.JOINED)
+                .build();
+    }
+
+    public static ChatMessage createTextMessage(ChatRoom chatRoom, Member sender, String content) {
+        return ChatMessage.create(chatRoom, sender, content, MessageType.TEXT);
+    }
+}

--- a/src/test/java/umc/cockple/demo/support/fixture/MemberFixture.java
+++ b/src/test/java/umc/cockple/demo/support/fixture/MemberFixture.java
@@ -27,6 +27,26 @@ public class MemberFixture {
                 .build();
     }
 
+    public static Member createMemberWithName(String memberName, String nickname, Gender gender, Level level, Long socialId) {
+        return Member.builder()
+                .memberName(memberName)
+                .nickname(nickname)
+                .gender(gender)
+                .level(level)
+                .isActive(MemberStatus.ACTIVE)
+                .socialId(socialId)
+                .build();
+    }
+
+    public static Member createWithdrawnMember(String memberName, String nickname, Long socialId) {
+        return Member.builder()
+                .memberName(memberName)
+                .nickname(nickname)
+                .isActive(MemberStatus.INACTIVE)
+                .socialId(socialId)
+                .build();
+    }
+
     public static MemberParty createMemberParty(Party party, Member member, Role role) {
         return MemberParty.builder()
                 .party(party)


### PR DESCRIPTION
## ❤️ 기능 설명
초기 채팅방 조회 및 과거 메시지 조회 API 응답의 메시지 항목에
탈퇴한 사용자 여부를 나타내는 `isSenderWithdrawn` 필드를 추가했습니다.

<img width="824" height="545" alt="image" src="https://github.com/user-attachments/assets/f4e9fd80-54e0-4962-9b18-0555f3c4ced9" />
<img width="792" height="424" alt="image" src="https://github.com/user-attachments/assets/24e57d92-9a97-4798-89b0-d5295def11a4" />
<img width="830" height="490" alt="image" src="https://github.com/user-attachments/assets/4cbf6ba0-ebff-43a7-b213-715cf1013390" />

<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #512 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 통합 테스트 중 1개의 성공 시나리오에서는 전체 필드를 검증하면 좋겠습니다.
- [ ] 채팅방에 있던 도중 상대방이 탈퇴할 경우의 시나리오는 instagram DM도 실시간 반영을 하지 않으므로 일단 배제하기로 프론트분과 상의하였습니다.

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
