### PR TITLE
[fix/#515] 회원 탈퇴 시 미래 운동만 취소 및 운동 상세 조회 탈퇴 여부 필드 추가

### DIFF
--- a/src/main/java/umc/cockple/demo/domain/exercise/converter/ExerciseConverter.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/converter/ExerciseConverter.java
@@ -13,6 +13,7 @@ import umc.cockple.demo.domain.member.domain.Member;
 import umc.cockple.demo.domain.member.domain.MemberAddr;
 import umc.cockple.demo.domain.member.domain.MemberExercise;
 import umc.cockple.demo.domain.member.domain.ProfileImg;
+import umc.cockple.demo.domain.member.enums.MemberStatus;
 import umc.cockple.demo.domain.party.domain.Party;
 import umc.cockple.demo.domain.party.domain.PartyImg;
 import umc.cockple.demo.global.enums.Gender;
@@ -406,6 +407,7 @@ public class ExerciseConverter {
                 .partyPosition(role.name())
                 .inviterName(null)
                 .joinedAt(memberParticipant.getCreatedAt())
+                .isWithdrawn(member.getIsActive() == MemberStatus.INACTIVE)
                 .build();
     }
 
@@ -423,6 +425,7 @@ public class ExerciseConverter {
                 .partyPosition(null)
                 .inviterName(null)
                 .joinedAt(memberParticipant.getCreatedAt())
+                .isWithdrawn(member.getIsActive() == MemberStatus.INACTIVE)
                 .build();
     }
 
@@ -439,6 +442,7 @@ public class ExerciseConverter {
                 .partyPosition(null)
                 .inviterName(inviterName)
                 .joinedAt(guest.getCreatedAt())
+                .isWithdrawn(false)
                 .build();
     }
 

--- a/src/main/java/umc/cockple/demo/domain/exercise/dto/ExerciseDetailDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/dto/ExerciseDetailDTO.java
@@ -54,7 +54,8 @@ public class ExerciseDetailDTO {
             String participantType,
             String partyPosition,
             String inviterName,
-            LocalDateTime joinedAt
+            LocalDateTime joinedAt,
+            boolean isWithdrawn
     ) {
     }
 }

--- a/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseQueryService.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseQueryService.java
@@ -26,7 +26,6 @@ import umc.cockple.demo.domain.member.domain.Member;
 import umc.cockple.demo.domain.member.domain.MemberAddr;
 import umc.cockple.demo.domain.member.domain.MemberExercise;
 import umc.cockple.demo.domain.member.domain.MemberParty;
-import umc.cockple.demo.domain.member.enums.MemberStatus;
 import umc.cockple.demo.domain.member.repository.MemberExerciseRepository;
 import umc.cockple.demo.domain.member.repository.MemberPartyRepository;
 import umc.cockple.demo.domain.member.repository.MemberRepository;
@@ -688,6 +687,7 @@ public class ExerciseQueryService {
                 .partyPosition(original.partyPosition())
                 .inviterName(original.inviterName())
                 .joinedAt(original.joinedAt())
+                .isWithdrawn(original.isWithdrawn())
                 .build();
     }
 
@@ -832,7 +832,7 @@ public class ExerciseQueryService {
     }
 
     private List<MemberExercise> findMemberExercisesWithMemberAndProfile(Long exerciseId) {
-        return memberExerciseRepository.findByExerciseIdWithMemberAndProfile(exerciseId, MemberStatus.ACTIVE);
+        return memberExerciseRepository.findByExerciseIdWithMemberAndProfile(exerciseId);
     }
 
     private List<Guest> findGuests(Long exerciseId) {

--- a/src/main/java/umc/cockple/demo/domain/member/repository/MemberExerciseRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/member/repository/MemberExerciseRepository.java
@@ -1,14 +1,15 @@
 package umc.cockple.demo.domain.member.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import umc.cockple.demo.domain.exercise.domain.Exercise;
 import umc.cockple.demo.domain.member.domain.Member;
 import umc.cockple.demo.domain.member.domain.MemberExercise;
-import umc.cockple.demo.domain.member.enums.MemberStatus;
 
 import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -23,13 +24,24 @@ public interface MemberExerciseRepository extends JpaRepository<MemberExercise, 
             JOIN FETCH me.member m
             LEFT JOIN FETCH m.profileImg mp
             WHERE me.exercise.id = :exerciseId
-            AND m.isActive = :memberStatus
             ORDER BY me.createdAt ASC
             """)
     List<MemberExercise> findByExerciseIdWithMemberAndProfile(
-            @Param("exerciseId") Long exerciseId, @Param("memberStatus") MemberStatus memberStatus);
+            @Param("exerciseId") Long exerciseId);
 
-    void deleteAllByMember(Member member);
+    @Modifying
+    @Query("""
+            DELETE FROM MemberExercise me
+            WHERE me.member = :member
+            AND (
+                me.exercise.date > :today
+                OR (me.exercise.date = :today AND me.exercise.startTime > :now)
+            )
+            """)
+    void deleteFutureExercisesByMember(
+            @Param("member") Member member,
+            @Param("today") LocalDate today,
+            @Param("now") LocalTime now);
 
     @Query("select me.exercise.id " +
             "from MemberExercise me " +

--- a/src/main/java/umc/cockple/demo/domain/member/service/MemberCommandService.java
+++ b/src/main/java/umc/cockple/demo/domain/member/service/MemberCommandService.java
@@ -17,6 +17,8 @@ import umc.cockple.demo.domain.member.repository.*;
 import umc.cockple.demo.domain.member.enums.MemberStatus;
 import umc.cockple.demo.domain.image.service.ImageService;
 
+import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.List;
 import umc.cockple.demo.global.oauth2.service.KakaoOauthService;
 
@@ -82,8 +84,8 @@ public class MemberCommandService {
         // 탈퇴 가능여부 검증
         validateCanWithdraw(member);
 
-        // 참여중인 운동, 모임에서 나가기, keyword 삭제
-        memberExerciseRepository.deleteAllByMember(member);
+        // 참여중인 미래 운동, 모임에서 나가기, keyword 삭제
+        memberExerciseRepository.deleteFutureExercisesByMember(member, LocalDate.now(), LocalTime.now());
         memberPartyRepository.deleteAllByMember(member);
         memberKeywordRepository.deleteAllByMember(member);
 

--- a/src/test/java/umc/cockple/demo/domain/exercise/integration/ExerciseIntegrationTest.java
+++ b/src/test/java/umc/cockple/demo/domain/exercise/integration/ExerciseIntegrationTest.java
@@ -753,6 +753,22 @@ class ExerciseIntegrationTest extends IntegrationTestBase {
                         .andExpect(jsonPath("$.data.participants.list[0].name").value(normalMember.getMemberName()))
                         .andExpect(jsonPath("$.data.participants.list[1].name").value(subManager.getMemberName()));
             }
+
+            @Test
+            @DisplayName("남성과 여성 참가자가 있을 때 성별 카운트가 올바르게 반환된다")
+            void 남성과_여성_참가자가_있을_때_성별_카운트가_올바르게_반환된다() throws Exception {
+                SecurityContextHelper.setAuthentication(manager.getId(), manager.getNickname());
+
+                // normalMember: MALE, subManager: FEMALE
+                memberExerciseRepository.save(MemberFixture.createMemberExercise(normalMember, exercise));
+                memberExerciseRepository.save(MemberFixture.createMemberExercise(subManager, exercise));
+
+                mockMvc.perform(get("/api/exercises/{exerciseId}", exercise.getId()))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.data.participants.currentParticipantCount").value(2))
+                        .andExpect(jsonPath("$.data.participants.manCount").value(1))
+                        .andExpect(jsonPath("$.data.participants.womenCount").value(1));
+            }
         }
 
         @Nested

--- a/src/test/java/umc/cockple/demo/domain/exercise/integration/ExerciseIntegrationTest.java
+++ b/src/test/java/umc/cockple/demo/domain/exercise/integration/ExerciseIntegrationTest.java
@@ -36,6 +36,7 @@ import umc.cockple.demo.support.fixture.GuestFixture;
 import java.time.LocalDate;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -615,6 +616,46 @@ class ExerciseIntegrationTest extends IntegrationTestBase {
                         .andExpect(jsonPath("$.code").value(ExerciseErrorCode.EXERCISE_ALREADY_STARTED_CANCEL.getCode()))
                         .andExpect(jsonPath("$.message").value(ExerciseErrorCode.EXERCISE_ALREADY_STARTED_CANCEL.getMessage()));
             }
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /api/exercises/{exerciseId} - 운동 상세 조회")
+    class GetExerciseDetail {
+
+        private Exercise exercise;
+
+        @BeforeEach
+        void setUp() {
+            exercise = exerciseRepository.save(
+                    ExerciseFixture.createExerciseWithAddr(party, LocalDate.now().minusDays(1)));
+        }
+
+        @Test
+        @DisplayName("200 - 활성_회원_참가자는_isWithdrawn_false로_반환된다")
+        void 활성_회원_참가자는_isWithdrawn_false로_반환된다() throws Exception {
+            SecurityContextHelper.setAuthentication(manager.getId(), manager.getNickname());
+
+            memberExerciseRepository.save(MemberFixture.createMemberExercise(normalMember, exercise));
+
+            mockMvc.perform(get("/api/exercises/{exerciseId}", exercise.getId()))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.participants.list[0].isWithdrawn").value(false));
+        }
+
+        @Test
+        @DisplayName("200 - 탈퇴_회원_참가자는_isWithdrawn_true로_반환된다")
+        void 탈퇴_회원_참가자는_isWithdrawn_true로_반환된다() throws Exception {
+            SecurityContextHelper.setAuthentication(manager.getId(), manager.getNickname());
+
+            Member withdrawnMember = memberRepository.save(
+                    MemberFixture.createWithdrawnMember("탈퇴회원", "탈퇴닉네임", 8888L));
+
+            memberExerciseRepository.save(MemberFixture.createMemberExercise(withdrawnMember, exercise));
+
+            mockMvc.perform(get("/api/exercises/{exerciseId}", exercise.getId()))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.participants.list[0].isWithdrawn").value(true));
         }
     }
 }

--- a/src/test/java/umc/cockple/demo/domain/exercise/integration/ExerciseIntegrationTest.java
+++ b/src/test/java/umc/cockple/demo/domain/exercise/integration/ExerciseIntegrationTest.java
@@ -755,6 +755,28 @@ class ExerciseIntegrationTest extends IntegrationTestBase {
             }
 
             @Test
+            @DisplayName("대기자의 성별 카운트가 올바르게 반환된다")
+            void 대기자의_성별_카운트가_올바르게_반환된다() throws Exception {
+                SecurityContextHelper.setAuthentication(manager.getId(), manager.getNickname());
+
+                // 정원 1명짜리 운동: normalMember(MALE) 참가, subManager(FEMALE) 대기
+                Exercise smallExercise = exerciseRepository.save(
+                        ExerciseFixture.createExerciseWithAddr(party, LocalDate.now().minusDays(1), 1));
+
+                memberExerciseRepository.save(MemberFixture.createMemberExercise(normalMember, smallExercise));
+                memberExerciseRepository.save(MemberFixture.createMemberExercise(subManager, smallExercise));
+
+                mockMvc.perform(get("/api/exercises/{exerciseId}", smallExercise.getId()))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.data.participants.currentParticipantCount").value(1))
+                        .andExpect(jsonPath("$.data.participants.manCount").value(1))
+                        .andExpect(jsonPath("$.data.participants.womenCount").value(0))
+                        .andExpect(jsonPath("$.data.waiting.currentWaitingCount").value(1))
+                        .andExpect(jsonPath("$.data.waiting.manCount").value(0))
+                        .andExpect(jsonPath("$.data.waiting.womenCount").value(1));
+            }
+
+            @Test
             @DisplayName("남성과 여성 참가자가 있을 때 성별 카운트가 올바르게 반환된다")
             void 남성과_여성_참가자가_있을_때_성별_카운트가_올바르게_반환된다() throws Exception {
                 SecurityContextHelper.setAuthentication(manager.getId(), manager.getNickname());

--- a/src/test/java/umc/cockple/demo/domain/exercise/integration/ExerciseIntegrationTest.java
+++ b/src/test/java/umc/cockple/demo/domain/exercise/integration/ExerciseIntegrationTest.java
@@ -631,31 +631,155 @@ class ExerciseIntegrationTest extends IntegrationTestBase {
                     ExerciseFixture.createExerciseWithAddr(party, LocalDate.now().minusDays(1)));
         }
 
-        @Test
-        @DisplayName("200 - 활성_회원_참가자는_isWithdrawn_false로_반환된다")
-        void 활성_회원_참가자는_isWithdrawn_false로_반환된다() throws Exception {
-            SecurityContextHelper.setAuthentication(manager.getId(), manager.getNickname());
+        @Nested
+        @DisplayName("성공 케이스")
+        class Success {
 
-            memberExerciseRepository.save(MemberFixture.createMemberExercise(normalMember, exercise));
+            @Test
+            @DisplayName("응답의 모든 주요 필드가 올바르게 반환된다")
+            void 응답의_모든_주요_필드가_올바르게_반환된다() throws Exception {
+                SecurityContextHelper.setAuthentication(manager.getId(), manager.getNickname());
 
-            mockMvc.perform(get("/api/exercises/{exerciseId}", exercise.getId()))
-                    .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.data.participants.list[0].isWithdrawn").value(false));
+                memberExerciseRepository.save(MemberFixture.createMemberExercise(normalMember, exercise));
+
+                mockMvc.perform(get("/api/exercises/{exerciseId}", exercise.getId()))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.data.isManager").value(true))
+                        .andExpect(jsonPath("$.data.info.buildingName").value("테스트 체육관"))
+                        .andExpect(jsonPath("$.data.info.location").value("서울특별시 강남구 테헤란로 1"))
+                        .andExpect(jsonPath("$.data.participants.currentParticipantCount").value(1))
+                        .andExpect(jsonPath("$.data.participants.totalCount").value(10))
+                        .andExpect(jsonPath("$.data.participants.manCount").value(1))
+                        .andExpect(jsonPath("$.data.participants.womenCount").value(0))
+                        .andExpect(jsonPath("$.data.participants.list[0].participantNumber").value(1))
+                        .andExpect(jsonPath("$.data.participants.list[0].name").isString())
+                        .andExpect(jsonPath("$.data.participants.list[0].gender").value("MALE"))
+                        .andExpect(jsonPath("$.data.participants.list[0].level").isString())
+                        .andExpect(jsonPath("$.data.participants.list[0].participantType").isString())
+                        .andExpect(jsonPath("$.data.participants.list[0].isWithdrawn").value(false))
+                        .andExpect(jsonPath("$.data.waiting.currentWaitingCount").value(0));
+            }
+
+            @Test
+            @DisplayName("활성 회원 참가자는 isWithdrawn false로 반환된다")
+            void 활성_회원_참가자는_isWithdrawn_false로_반환된다() throws Exception {
+                SecurityContextHelper.setAuthentication(manager.getId(), manager.getNickname());
+
+                memberExerciseRepository.save(MemberFixture.createMemberExercise(normalMember, exercise));
+
+                mockMvc.perform(get("/api/exercises/{exerciseId}", exercise.getId()))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.data.participants.list[0].isWithdrawn").value(false));
+            }
+
+            @Test
+            @DisplayName("탈퇴 회원 참가자는 isWithdrawn true로 반환된다")
+            void 탈퇴_회원_참가자는_isWithdrawn_true로_반환된다() throws Exception {
+                SecurityContextHelper.setAuthentication(manager.getId(), manager.getNickname());
+
+                Member withdrawnMember = memberRepository.save(
+                        MemberFixture.createWithdrawnMember("탈퇴회원", "탈퇴닉네임", 8888L));
+
+                memberExerciseRepository.save(MemberFixture.createMemberExercise(withdrawnMember, exercise));
+
+                mockMvc.perform(get("/api/exercises/{exerciseId}", exercise.getId()))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.data.participants.list[0].isWithdrawn").value(true));
+            }
+
+            @Test
+            @DisplayName("모임장이 조회하면 isManager true로 반환된다")
+            void 모임장이_조회하면_isManager_true로_반환된다() throws Exception {
+                SecurityContextHelper.setAuthentication(manager.getId(), manager.getNickname());
+
+                mockMvc.perform(get("/api/exercises/{exerciseId}", exercise.getId()))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.data.isManager").value(true));
+            }
+
+            @Test
+            @DisplayName("일반 멤버가 조회하면 isManager false로 반환된다")
+            void 일반_멤버가_조회하면_isManager_false로_반환된다() throws Exception {
+                SecurityContextHelper.setAuthentication(normalMember.getId(), normalMember.getNickname());
+
+                mockMvc.perform(get("/api/exercises/{exerciseId}", exercise.getId()))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.data.isManager").value(false));
+            }
+
+            @Test
+            @DisplayName("정원 초과 참가자는 대기자로 반환된다")
+            void 정원_초과_참가자는_대기자로_반환된다() throws Exception {
+                SecurityContextHelper.setAuthentication(manager.getId(), manager.getNickname());
+
+                Exercise smallExercise = exerciseRepository.save(
+                        ExerciseFixture.createExerciseWithAddr(party, LocalDate.now().minusDays(1), 1));
+
+                memberExerciseRepository.save(MemberFixture.createMemberExercise(normalMember, smallExercise));
+                memberExerciseRepository.save(MemberFixture.createMemberExercise(subManager, smallExercise));
+
+                mockMvc.perform(get("/api/exercises/{exerciseId}", smallExercise.getId()))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.data.participants.currentParticipantCount").value(1))
+                        .andExpect(jsonPath("$.data.waiting.currentWaitingCount").value(1));
+            }
+
+            @Test
+            @DisplayName("게스트 참가자는 inviterName이 반환된다")
+            void 게스트_참가자는_inviterName이_반환된다() throws Exception {
+                SecurityContextHelper.setAuthentication(manager.getId(), manager.getNickname());
+
+                guestRepository.save(GuestFixture.createGuest(exercise, manager.getId()));
+
+                mockMvc.perform(get("/api/exercises/{exerciseId}", exercise.getId()))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.data.participants.list[0].participantType").value("GUEST"))
+                        .andExpect(jsonPath("$.data.participants.list[0].inviterName").isString());
+            }
+
+            @Test
+            @DisplayName("먼저 가입한 참가자가 더 낮은 participantNumber를 받는다")
+            void 먼저_가입한_참가자가_더_낮은_participantNumber를_받는다() throws Exception {
+                SecurityContextHelper.setAuthentication(manager.getId(), manager.getNickname());
+
+                memberExerciseRepository.save(MemberFixture.createMemberExercise(normalMember, exercise));
+                memberExerciseRepository.save(MemberFixture.createMemberExercise(subManager, exercise));
+
+                mockMvc.perform(get("/api/exercises/{exerciseId}", exercise.getId()))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.data.participants.currentParticipantCount").value(2))
+                        .andExpect(jsonPath("$.data.participants.list[0].participantNumber").value(1))
+                        .andExpect(jsonPath("$.data.participants.list[1].participantNumber").value(2))
+                        .andExpect(jsonPath("$.data.participants.list[0].name").value(normalMember.getMemberName()))
+                        .andExpect(jsonPath("$.data.participants.list[1].name").value(subManager.getMemberName()));
+            }
         }
 
-        @Test
-        @DisplayName("200 - 탈퇴_회원_참가자는_isWithdrawn_true로_반환된다")
-        void 탈퇴_회원_참가자는_isWithdrawn_true로_반환된다() throws Exception {
-            SecurityContextHelper.setAuthentication(manager.getId(), manager.getNickname());
+        @Nested
+        @DisplayName("실패 케이스")
+        class Failure {
 
-            Member withdrawnMember = memberRepository.save(
-                    MemberFixture.createWithdrawnMember("탈퇴회원", "탈퇴닉네임", 8888L));
+            @Test
+            @DisplayName("존재하지 않는 운동이면 에러를 반환한다")
+            void 존재하지_않는_운동이면_에러를_반환한다() throws Exception {
+                SecurityContextHelper.setAuthentication(manager.getId(), manager.getNickname());
 
-            memberExerciseRepository.save(MemberFixture.createMemberExercise(withdrawnMember, exercise));
+                mockMvc.perform(get("/api/exercises/{exerciseId}", 999L))
+                        .andExpect(status().isNotFound())
+                        .andExpect(jsonPath("$.code").value(ExerciseErrorCode.EXERCISE_NOT_FOUND.getCode()))
+                        .andExpect(jsonPath("$.message").value(ExerciseErrorCode.EXERCISE_NOT_FOUND.getMessage()));
+            }
 
-            mockMvc.perform(get("/api/exercises/{exerciseId}", exercise.getId()))
-                    .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.data.participants.list[0].isWithdrawn").value(true));
+            @Test
+            @DisplayName("존재하지 않는 멤버면 에러를 반환한다")
+            void 존재하지_않는_멤버면_에러를_반환한다() throws Exception {
+                SecurityContextHelper.setAuthentication(999L, "없는멤버");
+
+                mockMvc.perform(get("/api/exercises/{exerciseId}", exercise.getId()))
+                        .andExpect(status().isNotFound())
+                        .andExpect(jsonPath("$.code").value(ExerciseErrorCode.MEMBER_NOT_FOUND.getCode()))
+                        .andExpect(jsonPath("$.message").value(ExerciseErrorCode.MEMBER_NOT_FOUND.getMessage()));
+            }
         }
     }
 }

--- a/src/test/java/umc/cockple/demo/domain/exercise/service/ExerciseQueryServiceTest.java
+++ b/src/test/java/umc/cockple/demo/domain/exercise/service/ExerciseQueryServiceTest.java
@@ -1,0 +1,200 @@
+package umc.cockple.demo.domain.exercise.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import umc.cockple.demo.domain.bookmark.repository.ExerciseBookmarkRepository;
+import umc.cockple.demo.domain.exercise.converter.ExerciseConverter;
+import umc.cockple.demo.domain.exercise.domain.Exercise;
+import umc.cockple.demo.domain.exercise.domain.ExerciseAddr;
+import umc.cockple.demo.domain.exercise.dto.ExerciseDetailDTO;
+import umc.cockple.demo.domain.exercise.repository.ExerciseRepository;
+import umc.cockple.demo.domain.exercise.repository.GuestRepository;
+import umc.cockple.demo.domain.image.service.ImageService;
+import umc.cockple.demo.domain.member.domain.Member;
+import umc.cockple.demo.domain.member.domain.MemberExercise;
+import umc.cockple.demo.domain.member.domain.MemberParty;
+import umc.cockple.demo.domain.member.enums.MemberStatus;
+import umc.cockple.demo.domain.member.repository.MemberExerciseRepository;
+import umc.cockple.demo.domain.member.repository.MemberPartyRepository;
+import umc.cockple.demo.domain.member.repository.MemberRepository;
+import umc.cockple.demo.domain.party.domain.Party;
+import umc.cockple.demo.domain.party.repository.PartyRepository;
+import umc.cockple.demo.global.enums.Gender;
+import umc.cockple.demo.global.enums.Level;
+import umc.cockple.demo.global.enums.Role;
+import umc.cockple.demo.support.fixture.ExerciseFixture;
+import umc.cockple.demo.support.fixture.MemberFixture;
+import umc.cockple.demo.support.fixture.PartyFixture;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ExerciseQueryService")
+class ExerciseQueryServiceTest {
+
+    @InjectMocks
+    private ExerciseQueryService exerciseQueryService;
+
+    @Mock private ExerciseRepository exerciseRepository;
+    @Mock private MemberRepository memberRepository;
+    @Mock private MemberPartyRepository memberPartyRepository;
+    @Mock private MemberExerciseRepository memberExerciseRepository;
+    @Mock private GuestRepository guestRepository;
+    @Mock private PartyRepository partyRepository;
+    @Mock private ExerciseBookmarkRepository exerciseBookmarkRepository;
+    @Mock private ImageService imageService;
+
+    private ExerciseConverter exerciseConverter;
+
+    private Member manager;
+    private Party party;
+    private Exercise exercise;
+
+    @BeforeEach
+    void setUp() {
+        exerciseConverter = new ExerciseConverter(imageService);
+        ReflectionTestUtils.setField(exerciseQueryService, "exerciseConverter", exerciseConverter);
+
+        manager = MemberFixture.createMember("모임장", Gender.MALE, Level.A, 1001L);
+        ReflectionTestUtils.setField(manager, "id", 1L);
+
+        party = PartyFixture.createParty("테스트 모임", manager.getId(),
+                PartyFixture.createPartyAddr("서울특별시", "강남구"));
+        ReflectionTestUtils.setField(party, "id", 10L);
+
+        exercise = ExerciseFixture.createExercise(party, LocalDate.now().minusDays(1));
+        ReflectionTestUtils.setField(exercise, "id", 100L);
+
+        ExerciseAddr exerciseAddr = ExerciseAddr.builder()
+                .addr1("서울특별시")
+                .addr2("강남구")
+                .streetAddr("서울특별시 강남구 테헤란로 1")
+                .buildingName("테스트 체육관")
+                .latitude(37.5)
+                .longitude(127.0)
+                .build();
+        ReflectionTestUtils.setField(exercise, "exerciseAddr", exerciseAddr);
+    }
+
+    @Nested
+    @DisplayName("getExerciseDetail - 탈퇴 회원")
+    class GetExerciseDetailWithdrawn {
+
+        @Test
+        @DisplayName("탈퇴_회원은_isWithdrawn_true로_반환된다")
+        void 탈퇴_회원은_isWithdrawn_true로_반환된다() {
+            // given
+            Member withdrawnMember = Member.builder()
+                    .memberName("탈퇴회원")
+                    .nickname("탈퇴닉네임")
+                    .gender(Gender.MALE)
+                    .level(Level.C)
+                    .isActive(MemberStatus.INACTIVE)
+                    .socialId(9999L)
+                    .build();
+            ReflectionTestUtils.setField(withdrawnMember, "id", 99L);
+
+            MemberExercise memberExercise = MemberFixture.createMemberExercise(withdrawnMember, exercise);
+            ReflectionTestUtils.setField(memberExercise, "createdAt", LocalDateTime.now());
+
+            given(exerciseRepository.findExerciseWithBasicInfo(exercise.getId()))
+                    .willReturn(Optional.of(exercise));
+            given(memberRepository.findById(manager.getId()))
+                    .willReturn(Optional.of(manager));
+            given(memberExerciseRepository.findByExerciseIdWithMemberAndProfile(exercise.getId()))
+                    .willReturn(List.of(memberExercise));
+            given(guestRepository.findByExerciseId(exercise.getId()))
+                    .willReturn(List.of());
+            given(memberPartyRepository.existsByPartyIdAndMemberIdAndRole(
+                    party.getId(), manager.getId(), Role.party_MANAGER))
+                    .willReturn(true);
+            given(memberPartyRepository.findMemberRolesByPartyAndMembers(
+                    party.getId(), List.of(withdrawnMember.getId())))
+                    .willReturn(List.of());
+
+            // when
+            ExerciseDetailDTO.Response response = exerciseQueryService.getExerciseDetail(
+                    exercise.getId(), manager.getId());
+
+            // then
+            List<ExerciseDetailDTO.ParticipantInfo> participants = response.participants().list();
+            assertThat(participants).hasSize(1);
+            assertThat(participants.get(0).isWithdrawn()).isTrue();
+        }
+
+        @Test
+        @DisplayName("활성_회원은_isWithdrawn_false로_반환된다")
+        void 활성_회원은_isWithdrawn_false로_반환된다() {
+            // given
+            Member activeMember = MemberFixture.createMember("활성회원", Gender.FEMALE, Level.B, 2002L);
+            ReflectionTestUtils.setField(activeMember, "id", 2L);
+
+            MemberExercise memberExercise = MemberFixture.createMemberExercise(activeMember, exercise);
+            ReflectionTestUtils.setField(memberExercise, "createdAt", LocalDateTime.now());
+
+            MemberParty memberParty = MemberFixture.createMemberParty(party, activeMember, Role.party_MEMBER);
+
+            given(exerciseRepository.findExerciseWithBasicInfo(exercise.getId()))
+                    .willReturn(Optional.of(exercise));
+            given(memberRepository.findById(manager.getId()))
+                    .willReturn(Optional.of(manager));
+            given(memberExerciseRepository.findByExerciseIdWithMemberAndProfile(exercise.getId()))
+                    .willReturn(List.of(memberExercise));
+            given(guestRepository.findByExerciseId(exercise.getId()))
+                    .willReturn(List.of());
+            given(memberPartyRepository.existsByPartyIdAndMemberIdAndRole(
+                    party.getId(), manager.getId(), Role.party_MANAGER))
+                    .willReturn(true);
+            given(memberPartyRepository.findMemberRolesByPartyAndMembers(
+                    party.getId(), List.of(activeMember.getId())))
+                    .willReturn(List.of(memberParty));
+
+            // when
+            ExerciseDetailDTO.Response response = exerciseQueryService.getExerciseDetail(
+                    exercise.getId(), manager.getId());
+
+            // then
+            List<ExerciseDetailDTO.ParticipantInfo> participants = response.participants().list();
+            assertThat(participants).hasSize(1);
+            assertThat(participants.get(0).isWithdrawn()).isFalse();
+        }
+
+        @Test
+        @DisplayName("게스트는_isWithdrawn_false로_반환된다")
+        void 게스트는_isWithdrawn_false로_반환된다() {
+            // given
+            given(exerciseRepository.findExerciseWithBasicInfo(exercise.getId()))
+                    .willReturn(Optional.of(exercise));
+            given(memberRepository.findById(manager.getId()))
+                    .willReturn(Optional.of(manager));
+            given(memberExerciseRepository.findByExerciseIdWithMemberAndProfile(exercise.getId()))
+                    .willReturn(List.of());
+            given(guestRepository.findByExerciseId(exercise.getId()))
+                    .willReturn(List.of());
+            given(memberPartyRepository.existsByPartyIdAndMemberIdAndRole(
+                    party.getId(), manager.getId(), Role.party_MANAGER))
+                    .willReturn(true);
+
+            // when
+            ExerciseDetailDTO.Response response = exerciseQueryService.getExerciseDetail(
+                    exercise.getId(), manager.getId());
+
+            // then
+            List<ExerciseDetailDTO.ParticipantInfo> participants = response.participants().list();
+            assertThat(participants).isEmpty();
+        }
+    }
+}

--- a/src/test/java/umc/cockple/demo/domain/exercise/service/ExerciseQueryServiceTest.java
+++ b/src/test/java/umc/cockple/demo/domain/exercise/service/ExerciseQueryServiceTest.java
@@ -386,6 +386,53 @@ class ExerciseQueryServiceTest {
             }
 
             @Test
+            @DisplayName("대기자_성별_카운트가_올바르게_계산된다")
+            void 대기자_성별_카운트가_올바르게_계산된다() {
+                // given
+                ReflectionTestUtils.setField(exercise, "maxCapacity", 1);
+
+                Member maleMember = MemberFixture.createMember("남성", Gender.MALE, Level.A, 6001L);
+                ReflectionTestUtils.setField(maleMember, "id", 11L);
+
+                Member femaleMember = MemberFixture.createMember("여성", Gender.FEMALE, Level.B, 6002L);
+                ReflectionTestUtils.setField(femaleMember, "id", 12L);
+
+                MemberExercise first = MemberFixture.createMemberExercise(maleMember, exercise);
+                ReflectionTestUtils.setField(first, "createdAt", LocalDateTime.now().minusMinutes(10));
+
+                MemberExercise second = MemberFixture.createMemberExercise(femaleMember, exercise);
+                ReflectionTestUtils.setField(second, "createdAt", LocalDateTime.now());
+
+                MemberParty maleParty = MemberFixture.createMemberParty(party, maleMember, Role.party_MEMBER);
+                MemberParty femaleParty = MemberFixture.createMemberParty(party, femaleMember, Role.party_MEMBER);
+
+                given(exerciseRepository.findExerciseWithBasicInfo(exercise.getId()))
+                        .willReturn(Optional.of(exercise));
+                given(memberRepository.findById(manager.getId()))
+                        .willReturn(Optional.of(manager));
+                given(memberExerciseRepository.findByExerciseIdWithMemberAndProfile(exercise.getId()))
+                        .willReturn(List.of(first, second));
+                given(guestRepository.findByExerciseId(exercise.getId()))
+                        .willReturn(List.of());
+                given(memberPartyRepository.existsByPartyIdAndMemberIdAndRole(
+                        party.getId(), manager.getId(), Role.party_MANAGER))
+                        .willReturn(true);
+                given(memberPartyRepository.findMemberRolesByPartyAndMembers(
+                        party.getId(), List.of(maleMember.getId(), femaleMember.getId())))
+                        .willReturn(List.of(maleParty, femaleParty));
+
+                // when
+                ExerciseDetailDTO.Response response = exerciseQueryService.getExerciseDetail(
+                        exercise.getId(), manager.getId());
+
+                // then
+                assertThat(response.participants().manCount()).isEqualTo(1);
+                assertThat(response.participants().womenCount()).isZero();
+                assertThat(response.waiting().manCount()).isZero();
+                assertThat(response.waiting().womenCount()).isEqualTo(1);
+            }
+
+            @Test
             @DisplayName("참가자_성별_카운트가_올바르게_계산된다")
             void 참가자_성별_카운트가_올바르게_계산된다() {
                 // given

--- a/src/test/java/umc/cockple/demo/domain/exercise/service/ExerciseQueryServiceTest.java
+++ b/src/test/java/umc/cockple/demo/domain/exercise/service/ExerciseQueryServiceTest.java
@@ -13,7 +13,10 @@ import umc.cockple.demo.domain.bookmark.repository.ExerciseBookmarkRepository;
 import umc.cockple.demo.domain.exercise.converter.ExerciseConverter;
 import umc.cockple.demo.domain.exercise.domain.Exercise;
 import umc.cockple.demo.domain.exercise.domain.ExerciseAddr;
+import umc.cockple.demo.domain.exercise.domain.Guest;
 import umc.cockple.demo.domain.exercise.dto.ExerciseDetailDTO;
+import umc.cockple.demo.domain.exercise.exception.ExerciseErrorCode;
+import umc.cockple.demo.domain.exercise.exception.ExerciseException;
 import umc.cockple.demo.domain.exercise.repository.ExerciseRepository;
 import umc.cockple.demo.domain.exercise.repository.GuestRepository;
 import umc.cockple.demo.domain.image.service.ImageService;
@@ -30,15 +33,19 @@ import umc.cockple.demo.global.enums.Gender;
 import umc.cockple.demo.global.enums.Level;
 import umc.cockple.demo.global.enums.Role;
 import umc.cockple.demo.support.fixture.ExerciseFixture;
+import umc.cockple.demo.support.fixture.GuestFixture;
 import umc.cockple.demo.support.fixture.MemberFixture;
 import umc.cockple.demo.support.fixture.PartyFixture;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 
 @ExtendWith(MockitoExtension.class)
@@ -90,111 +97,369 @@ class ExerciseQueryServiceTest {
     }
 
     @Nested
-    @DisplayName("getExerciseDetail - 탈퇴 회원")
-    class GetExerciseDetailWithdrawn {
+    @DisplayName("getExerciseDetail")
+    class GetExerciseDetail {
 
-        @Test
-        @DisplayName("탈퇴_회원은_isWithdrawn_true로_반환된다")
-        void 탈퇴_회원은_isWithdrawn_true로_반환된다() {
-            // given
-            Member withdrawnMember = Member.builder()
-                    .memberName("탈퇴회원")
-                    .nickname("탈퇴닉네임")
-                    .gender(Gender.MALE)
-                    .level(Level.C)
-                    .isActive(MemberStatus.INACTIVE)
-                    .socialId(9999L)
-                    .build();
-            ReflectionTestUtils.setField(withdrawnMember, "id", 99L);
+        @Nested
+        @DisplayName("성공 케이스")
+        class Success {
 
-            MemberExercise memberExercise = MemberFixture.createMemberExercise(withdrawnMember, exercise);
-            ReflectionTestUtils.setField(memberExercise, "createdAt", LocalDateTime.now());
+            @Test
+            @DisplayName("모임장이면_isManager_true로_반환된다")
+            void 모임장이면_isManager_true로_반환된다() {
+                // given
+                given(exerciseRepository.findExerciseWithBasicInfo(exercise.getId()))
+                        .willReturn(Optional.of(exercise));
+                given(memberRepository.findById(manager.getId()))
+                        .willReturn(Optional.of(manager));
+                given(memberExerciseRepository.findByExerciseIdWithMemberAndProfile(exercise.getId()))
+                        .willReturn(List.of());
+                given(guestRepository.findByExerciseId(exercise.getId()))
+                        .willReturn(List.of());
+                given(memberPartyRepository.existsByPartyIdAndMemberIdAndRole(
+                        party.getId(), manager.getId(), Role.party_MANAGER))
+                        .willReturn(true);
 
-            given(exerciseRepository.findExerciseWithBasicInfo(exercise.getId()))
-                    .willReturn(Optional.of(exercise));
-            given(memberRepository.findById(manager.getId()))
-                    .willReturn(Optional.of(manager));
-            given(memberExerciseRepository.findByExerciseIdWithMemberAndProfile(exercise.getId()))
-                    .willReturn(List.of(memberExercise));
-            given(guestRepository.findByExerciseId(exercise.getId()))
-                    .willReturn(List.of());
-            given(memberPartyRepository.existsByPartyIdAndMemberIdAndRole(
-                    party.getId(), manager.getId(), Role.party_MANAGER))
-                    .willReturn(true);
-            given(memberPartyRepository.findMemberRolesByPartyAndMembers(
-                    party.getId(), List.of(withdrawnMember.getId())))
-                    .willReturn(List.of());
+                // when
+                ExerciseDetailDTO.Response response = exerciseQueryService.getExerciseDetail(
+                        exercise.getId(), manager.getId());
 
-            // when
-            ExerciseDetailDTO.Response response = exerciseQueryService.getExerciseDetail(
-                    exercise.getId(), manager.getId());
+                // then
+                assertThat(response.isManager()).isTrue();
+            }
 
-            // then
-            List<ExerciseDetailDTO.ParticipantInfo> participants = response.participants().list();
-            assertThat(participants).hasSize(1);
-            assertThat(participants.get(0).isWithdrawn()).isTrue();
+            @Test
+            @DisplayName("일반_멤버면_isManager_false로_반환된다")
+            void 일반_멤버면_isManager_false로_반환된다() {
+                // given
+                Member normalMember = MemberFixture.createMember("일반멤버", Gender.FEMALE, Level.B, 2002L);
+                ReflectionTestUtils.setField(normalMember, "id", 2L);
+
+                given(exerciseRepository.findExerciseWithBasicInfo(exercise.getId()))
+                        .willReturn(Optional.of(exercise));
+                given(memberRepository.findById(normalMember.getId()))
+                        .willReturn(Optional.of(normalMember));
+                given(memberExerciseRepository.findByExerciseIdWithMemberAndProfile(exercise.getId()))
+                        .willReturn(List.of());
+                given(guestRepository.findByExerciseId(exercise.getId()))
+                        .willReturn(List.of());
+                given(memberPartyRepository.existsByPartyIdAndMemberIdAndRole(
+                        party.getId(), normalMember.getId(), Role.party_MANAGER))
+                        .willReturn(false);
+
+                // when
+                ExerciseDetailDTO.Response response = exerciseQueryService.getExerciseDetail(
+                        exercise.getId(), normalMember.getId());
+
+                // then
+                assertThat(response.isManager()).isFalse();
+            }
+
+            @Test
+            @DisplayName("탈퇴_회원은_isWithdrawn_true로_반환된다")
+            void 탈퇴_회원은_isWithdrawn_true로_반환된다() {
+                // given
+                Member withdrawnMember = Member.builder()
+                        .memberName("탈퇴회원")
+                        .nickname("탈퇴닉네임")
+                        .gender(Gender.MALE)
+                        .level(Level.C)
+                        .isActive(MemberStatus.INACTIVE)
+                        .socialId(9999L)
+                        .build();
+                ReflectionTestUtils.setField(withdrawnMember, "id", 99L);
+
+                MemberExercise memberExercise = MemberFixture.createMemberExercise(withdrawnMember, exercise);
+                ReflectionTestUtils.setField(memberExercise, "createdAt", LocalDateTime.now());
+
+                given(exerciseRepository.findExerciseWithBasicInfo(exercise.getId()))
+                        .willReturn(Optional.of(exercise));
+                given(memberRepository.findById(manager.getId()))
+                        .willReturn(Optional.of(manager));
+                given(memberExerciseRepository.findByExerciseIdWithMemberAndProfile(exercise.getId()))
+                        .willReturn(List.of(memberExercise));
+                given(guestRepository.findByExerciseId(exercise.getId()))
+                        .willReturn(List.of());
+                given(memberPartyRepository.existsByPartyIdAndMemberIdAndRole(
+                        party.getId(), manager.getId(), Role.party_MANAGER))
+                        .willReturn(true);
+                given(memberPartyRepository.findMemberRolesByPartyAndMembers(
+                        party.getId(), List.of(withdrawnMember.getId())))
+                        .willReturn(List.of());
+
+                // when
+                ExerciseDetailDTO.Response response = exerciseQueryService.getExerciseDetail(
+                        exercise.getId(), manager.getId());
+
+                // then
+                List<ExerciseDetailDTO.ParticipantInfo> participants = response.participants().list();
+                assertThat(participants).hasSize(1);
+                assertThat(participants.get(0).isWithdrawn()).isTrue();
+            }
+
+            @Test
+            @DisplayName("활성_회원은_isWithdrawn_false로_반환된다")
+            void 활성_회원은_isWithdrawn_false로_반환된다() {
+                // given
+                Member activeMember = MemberFixture.createMember("활성회원", Gender.FEMALE, Level.B, 2002L);
+                ReflectionTestUtils.setField(activeMember, "id", 2L);
+
+                MemberExercise memberExercise = MemberFixture.createMemberExercise(activeMember, exercise);
+                ReflectionTestUtils.setField(memberExercise, "createdAt", LocalDateTime.now());
+
+                MemberParty memberParty = MemberFixture.createMemberParty(party, activeMember, Role.party_MEMBER);
+
+                given(exerciseRepository.findExerciseWithBasicInfo(exercise.getId()))
+                        .willReturn(Optional.of(exercise));
+                given(memberRepository.findById(manager.getId()))
+                        .willReturn(Optional.of(manager));
+                given(memberExerciseRepository.findByExerciseIdWithMemberAndProfile(exercise.getId()))
+                        .willReturn(List.of(memberExercise));
+                given(guestRepository.findByExerciseId(exercise.getId()))
+                        .willReturn(List.of());
+                given(memberPartyRepository.existsByPartyIdAndMemberIdAndRole(
+                        party.getId(), manager.getId(), Role.party_MANAGER))
+                        .willReturn(true);
+                given(memberPartyRepository.findMemberRolesByPartyAndMembers(
+                        party.getId(), List.of(activeMember.getId())))
+                        .willReturn(List.of(memberParty));
+
+                // when
+                ExerciseDetailDTO.Response response = exerciseQueryService.getExerciseDetail(
+                        exercise.getId(), manager.getId());
+
+                // then
+                List<ExerciseDetailDTO.ParticipantInfo> participants = response.participants().list();
+                assertThat(participants).hasSize(1);
+                assertThat(participants.get(0).isWithdrawn()).isFalse();
+            }
+
+            @Test
+            @DisplayName("게스트는_isWithdrawn_false로_반환된다")
+            void 게스트는_isWithdrawn_false로_반환된다() {
+                // given
+                given(exerciseRepository.findExerciseWithBasicInfo(exercise.getId()))
+                        .willReturn(Optional.of(exercise));
+                given(memberRepository.findById(manager.getId()))
+                        .willReturn(Optional.of(manager));
+                given(memberExerciseRepository.findByExerciseIdWithMemberAndProfile(exercise.getId()))
+                        .willReturn(List.of());
+                given(guestRepository.findByExerciseId(exercise.getId()))
+                        .willReturn(List.of());
+                given(memberPartyRepository.existsByPartyIdAndMemberIdAndRole(
+                        party.getId(), manager.getId(), Role.party_MANAGER))
+                        .willReturn(true);
+
+                // when
+                ExerciseDetailDTO.Response response = exerciseQueryService.getExerciseDetail(
+                        exercise.getId(), manager.getId());
+
+                // then
+                List<ExerciseDetailDTO.ParticipantInfo> participants = response.participants().list();
+                assertThat(participants).isEmpty();
+            }
+
+            @Test
+            @DisplayName("정원_초과_참가자는_대기자_목록으로_반환된다")
+            void 정원_초과_참가자는_대기자_목록으로_반환된다() {
+                // given
+                ReflectionTestUtils.setField(exercise, "maxCapacity", 1);
+
+                Member firstMember = MemberFixture.createMember("첫번째", Gender.MALE, Level.A, 3001L);
+                ReflectionTestUtils.setField(firstMember, "id", 3L);
+
+                Member secondMember = MemberFixture.createMember("두번째", Gender.FEMALE, Level.B, 3002L);
+                ReflectionTestUtils.setField(secondMember, "id", 4L);
+
+                MemberExercise first = MemberFixture.createMemberExercise(firstMember, exercise);
+                ReflectionTestUtils.setField(first, "createdAt", LocalDateTime.now().minusMinutes(10));
+
+                MemberExercise second = MemberFixture.createMemberExercise(secondMember, exercise);
+                ReflectionTestUtils.setField(second, "createdAt", LocalDateTime.now());
+
+                MemberParty firstParty = MemberFixture.createMemberParty(party, firstMember, Role.party_MEMBER);
+                MemberParty secondParty = MemberFixture.createMemberParty(party, secondMember, Role.party_MEMBER);
+
+                given(exerciseRepository.findExerciseWithBasicInfo(exercise.getId()))
+                        .willReturn(Optional.of(exercise));
+                given(memberRepository.findById(manager.getId()))
+                        .willReturn(Optional.of(manager));
+                given(memberExerciseRepository.findByExerciseIdWithMemberAndProfile(exercise.getId()))
+                        .willReturn(List.of(first, second));
+                given(guestRepository.findByExerciseId(exercise.getId()))
+                        .willReturn(List.of());
+                given(memberPartyRepository.existsByPartyIdAndMemberIdAndRole(
+                        party.getId(), manager.getId(), Role.party_MANAGER))
+                        .willReturn(true);
+                given(memberPartyRepository.findMemberRolesByPartyAndMembers(
+                        party.getId(), List.of(firstMember.getId(), secondMember.getId())))
+                        .willReturn(List.of(firstParty, secondParty));
+
+                // when
+                ExerciseDetailDTO.Response response = exerciseQueryService.getExerciseDetail(
+                        exercise.getId(), manager.getId());
+
+                // then
+                assertThat(response.participants().list()).hasSize(1);
+                assertThat(response.waiting().list()).hasSize(1);
+                assertThat(response.waiting().currentWaitingCount()).isEqualTo(1);
+            }
+
+            @Test
+            @DisplayName("게스트_참가자는_participantType이_GUEST이고_inviterName이_반환된다")
+            void 게스트_참가자는_participantType이_GUEST이고_inviterName이_반환된다() {
+                // given
+                Guest guest = GuestFixture.createGuest(exercise, manager.getId());
+                ReflectionTestUtils.setField(guest, "id", 50L);
+                ReflectionTestUtils.setField(guest, "createdAt", LocalDateTime.now());
+
+                given(exerciseRepository.findExerciseWithBasicInfo(exercise.getId()))
+                        .willReturn(Optional.of(exercise));
+                given(memberRepository.findById(manager.getId()))
+                        .willReturn(Optional.of(manager));
+                given(memberExerciseRepository.findByExerciseIdWithMemberAndProfile(exercise.getId()))
+                        .willReturn(List.of());
+                given(guestRepository.findByExerciseId(exercise.getId()))
+                        .willReturn(List.of(guest));
+                given(memberPartyRepository.existsByPartyIdAndMemberIdAndRole(
+                        party.getId(), manager.getId(), Role.party_MANAGER))
+                        .willReturn(true);
+                given(memberRepository.findMemberNamesByIds(any()))
+                        .willReturn(Map.of(manager.getId(), "모임장"));
+
+                // when
+                ExerciseDetailDTO.Response response = exerciseQueryService.getExerciseDetail(
+                        exercise.getId(), manager.getId());
+
+                // then
+                List<ExerciseDetailDTO.ParticipantInfo> participants = response.participants().list();
+                assertThat(participants).hasSize(1);
+                assertThat(participants.get(0).participantType()).isEqualTo("GUEST");
+                assertThat(participants.get(0).inviterName()).isEqualTo("모임장");
+            }
+
+            @Test
+            @DisplayName("먼저_가입한_참가자가_더_낮은_participantNumber를_받는다")
+            void 먼저_가입한_참가자가_더_낮은_participantNumber를_받는다() {
+                // given
+                Member firstMember = MemberFixture.createMember("첫번째", Gender.MALE, Level.A, 5001L);
+                ReflectionTestUtils.setField(firstMember, "id", 7L);
+
+                Member secondMember = MemberFixture.createMember("두번째", Gender.FEMALE, Level.B, 5002L);
+                ReflectionTestUtils.setField(secondMember, "id", 8L);
+
+                MemberExercise first = MemberFixture.createMemberExercise(firstMember, exercise);
+                ReflectionTestUtils.setField(first, "createdAt", LocalDateTime.now().minusMinutes(10));
+
+                MemberExercise second = MemberFixture.createMemberExercise(secondMember, exercise);
+                ReflectionTestUtils.setField(second, "createdAt", LocalDateTime.now());
+
+                MemberParty firstParty = MemberFixture.createMemberParty(party, firstMember, Role.party_MEMBER);
+                MemberParty secondParty = MemberFixture.createMemberParty(party, secondMember, Role.party_MEMBER);
+
+                given(exerciseRepository.findExerciseWithBasicInfo(exercise.getId()))
+                        .willReturn(Optional.of(exercise));
+                given(memberRepository.findById(manager.getId()))
+                        .willReturn(Optional.of(manager));
+                given(memberExerciseRepository.findByExerciseIdWithMemberAndProfile(exercise.getId()))
+                        .willReturn(List.of(first, second));
+                given(guestRepository.findByExerciseId(exercise.getId()))
+                        .willReturn(List.of());
+                given(memberPartyRepository.existsByPartyIdAndMemberIdAndRole(
+                        party.getId(), manager.getId(), Role.party_MANAGER))
+                        .willReturn(true);
+                given(memberPartyRepository.findMemberRolesByPartyAndMembers(
+                        party.getId(), List.of(firstMember.getId(), secondMember.getId())))
+                        .willReturn(List.of(firstParty, secondParty));
+
+                // when
+                ExerciseDetailDTO.Response response = exerciseQueryService.getExerciseDetail(
+                        exercise.getId(), manager.getId());
+
+                // then
+                List<ExerciseDetailDTO.ParticipantInfo> participants = response.participants().list();
+                assertThat(participants).hasSize(2);
+                assertThat(participants.get(0).participantNumber()).isEqualTo(1);
+                assertThat(participants.get(0).name()).isEqualTo("첫번째");
+                assertThat(participants.get(1).participantNumber()).isEqualTo(2);
+                assertThat(participants.get(1).name()).isEqualTo("두번째");
+            }
+
+            @Test
+            @DisplayName("참가자_성별_카운트가_올바르게_계산된다")
+            void 참가자_성별_카운트가_올바르게_계산된다() {
+                // given
+                Member maleMember = MemberFixture.createMember("남성", Gender.MALE, Level.A, 4001L);
+                ReflectionTestUtils.setField(maleMember, "id", 5L);
+
+                Member femaleMember = MemberFixture.createMember("여성", Gender.FEMALE, Level.B, 4002L);
+                ReflectionTestUtils.setField(femaleMember, "id", 6L);
+
+                MemberExercise maleExercise = MemberFixture.createMemberExercise(maleMember, exercise);
+                ReflectionTestUtils.setField(maleExercise, "createdAt", LocalDateTime.now().minusMinutes(5));
+
+                MemberExercise femaleExercise = MemberFixture.createMemberExercise(femaleMember, exercise);
+                ReflectionTestUtils.setField(femaleExercise, "createdAt", LocalDateTime.now());
+
+                MemberParty maleParty = MemberFixture.createMemberParty(party, maleMember, Role.party_MEMBER);
+                MemberParty femaleParty = MemberFixture.createMemberParty(party, femaleMember, Role.party_MEMBER);
+
+                given(exerciseRepository.findExerciseWithBasicInfo(exercise.getId()))
+                        .willReturn(Optional.of(exercise));
+                given(memberRepository.findById(manager.getId()))
+                        .willReturn(Optional.of(manager));
+                given(memberExerciseRepository.findByExerciseIdWithMemberAndProfile(exercise.getId()))
+                        .willReturn(List.of(maleExercise, femaleExercise));
+                given(guestRepository.findByExerciseId(exercise.getId()))
+                        .willReturn(List.of());
+                given(memberPartyRepository.existsByPartyIdAndMemberIdAndRole(
+                        party.getId(), manager.getId(), Role.party_MANAGER))
+                        .willReturn(true);
+                given(memberPartyRepository.findMemberRolesByPartyAndMembers(
+                        party.getId(), List.of(maleMember.getId(), femaleMember.getId())))
+                        .willReturn(List.of(maleParty, femaleParty));
+
+                // when
+                ExerciseDetailDTO.Response response = exerciseQueryService.getExerciseDetail(
+                        exercise.getId(), manager.getId());
+
+                // then
+                assertThat(response.participants().manCount()).isEqualTo(1);
+                assertThat(response.participants().womenCount()).isEqualTo(1);
+            }
         }
 
-        @Test
-        @DisplayName("활성_회원은_isWithdrawn_false로_반환된다")
-        void 활성_회원은_isWithdrawn_false로_반환된다() {
-            // given
-            Member activeMember = MemberFixture.createMember("활성회원", Gender.FEMALE, Level.B, 2002L);
-            ReflectionTestUtils.setField(activeMember, "id", 2L);
+        @Nested
+        @DisplayName("실패 케이스")
+        class Failure {
 
-            MemberExercise memberExercise = MemberFixture.createMemberExercise(activeMember, exercise);
-            ReflectionTestUtils.setField(memberExercise, "createdAt", LocalDateTime.now());
+            @Test
+            @DisplayName("존재하지_않는_운동이면_예외를_던진다")
+            void 존재하지_않는_운동이면_예외를_던진다() {
+                // given
+                given(exerciseRepository.findExerciseWithBasicInfo(999L))
+                        .willReturn(Optional.empty());
 
-            MemberParty memberParty = MemberFixture.createMemberParty(party, activeMember, Role.party_MEMBER);
+                // when & then
+                assertThatThrownBy(() -> exerciseQueryService.getExerciseDetail(999L, manager.getId()))
+                        .isInstanceOf(ExerciseException.class)
+                        .hasFieldOrPropertyWithValue("code", ExerciseErrorCode.EXERCISE_NOT_FOUND);
+            }
 
-            given(exerciseRepository.findExerciseWithBasicInfo(exercise.getId()))
-                    .willReturn(Optional.of(exercise));
-            given(memberRepository.findById(manager.getId()))
-                    .willReturn(Optional.of(manager));
-            given(memberExerciseRepository.findByExerciseIdWithMemberAndProfile(exercise.getId()))
-                    .willReturn(List.of(memberExercise));
-            given(guestRepository.findByExerciseId(exercise.getId()))
-                    .willReturn(List.of());
-            given(memberPartyRepository.existsByPartyIdAndMemberIdAndRole(
-                    party.getId(), manager.getId(), Role.party_MANAGER))
-                    .willReturn(true);
-            given(memberPartyRepository.findMemberRolesByPartyAndMembers(
-                    party.getId(), List.of(activeMember.getId())))
-                    .willReturn(List.of(memberParty));
+            @Test
+            @DisplayName("존재하지_않는_멤버면_예외를_던진다")
+            void 존재하지_않는_멤버면_예외를_던진다() {
+                // given
+                given(exerciseRepository.findExerciseWithBasicInfo(exercise.getId()))
+                        .willReturn(Optional.of(exercise));
+                given(memberRepository.findById(999L))
+                        .willReturn(Optional.empty());
 
-            // when
-            ExerciseDetailDTO.Response response = exerciseQueryService.getExerciseDetail(
-                    exercise.getId(), manager.getId());
-
-            // then
-            List<ExerciseDetailDTO.ParticipantInfo> participants = response.participants().list();
-            assertThat(participants).hasSize(1);
-            assertThat(participants.get(0).isWithdrawn()).isFalse();
-        }
-
-        @Test
-        @DisplayName("게스트는_isWithdrawn_false로_반환된다")
-        void 게스트는_isWithdrawn_false로_반환된다() {
-            // given
-            given(exerciseRepository.findExerciseWithBasicInfo(exercise.getId()))
-                    .willReturn(Optional.of(exercise));
-            given(memberRepository.findById(manager.getId()))
-                    .willReturn(Optional.of(manager));
-            given(memberExerciseRepository.findByExerciseIdWithMemberAndProfile(exercise.getId()))
-                    .willReturn(List.of());
-            given(guestRepository.findByExerciseId(exercise.getId()))
-                    .willReturn(List.of());
-            given(memberPartyRepository.existsByPartyIdAndMemberIdAndRole(
-                    party.getId(), manager.getId(), Role.party_MANAGER))
-                    .willReturn(true);
-
-            // when
-            ExerciseDetailDTO.Response response = exerciseQueryService.getExerciseDetail(
-                    exercise.getId(), manager.getId());
-
-            // then
-            List<ExerciseDetailDTO.ParticipantInfo> participants = response.participants().list();
-            assertThat(participants).isEmpty();
+                // when & then
+                assertThatThrownBy(() -> exerciseQueryService.getExerciseDetail(exercise.getId(), 999L))
+                        .isInstanceOf(ExerciseException.class)
+                        .hasFieldOrPropertyWithValue("code", ExerciseErrorCode.MEMBER_NOT_FOUND);
+            }
         }
     }
 }

--- a/src/test/java/umc/cockple/demo/domain/member/service/MemberCommandServiceTest.java
+++ b/src/test/java/umc/cockple/demo/domain/member/service/MemberCommandServiceTest.java
@@ -1,0 +1,73 @@
+package umc.cockple.demo.domain.member.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import umc.cockple.demo.domain.chat.repository.ChatRoomMemberRepository;
+import umc.cockple.demo.domain.image.service.ImageService;
+import umc.cockple.demo.domain.member.domain.Member;
+import umc.cockple.demo.domain.member.repository.*;
+import umc.cockple.demo.global.enums.Gender;
+import umc.cockple.demo.global.enums.Level;
+import umc.cockple.demo.global.oauth2.service.KakaoOauthService;
+import umc.cockple.demo.support.fixture.MemberFixture;
+
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("MemberCommandService")
+class MemberCommandServiceTest {
+
+    @InjectMocks
+    private MemberCommandService memberCommandService;
+
+    @Mock private MemberRepository memberRepository;
+    @Mock private MemberExerciseRepository memberExerciseRepository;
+    @Mock private MemberPartyRepository memberPartyRepository;
+    @Mock private MemberKeywordRepository memberKeywordRepository;
+    @Mock private MemberAddrRepository memberAddrRepository;
+    @Mock private ChatRoomMemberRepository chatRoomMemberRepository;
+    @Mock private KakaoOauthService kakaoOauthService;
+    @Mock private ImageService imageService;
+
+    private Member normalMember;
+
+    @BeforeEach
+    void setUp() {
+        normalMember = MemberFixture.createMember("일반멤버", Gender.MALE, Level.C, 9001L);
+        ReflectionTestUtils.setField(normalMember, "id", 1L);
+    }
+
+    @Nested
+    @DisplayName("withdrawMember")
+    class WithdrawMember {
+
+        @Test
+        @DisplayName("과거_운동은_삭제되지_않고_미래_운동만_삭제한다")
+        void 과거_운동은_삭제되지_않고_미래_운동만_삭제한다() {
+            // given
+            given(memberRepository.findById(normalMember.getId())).willReturn(Optional.of(normalMember));
+
+            // when
+            memberCommandService.withdrawMember(normalMember.getId());
+
+            // then
+            then(memberExerciseRepository).should()
+                    .deleteFutureExercisesByMember(eq(normalMember), any(), any());
+            then(memberExerciseRepository).should(never())
+                    .deleteAll();
+        }
+    }
+}

--- a/src/test/java/umc/cockple/demo/support/fixture/ExerciseFixture.java
+++ b/src/test/java/umc/cockple/demo/support/fixture/ExerciseFixture.java
@@ -21,6 +21,10 @@ public class ExerciseFixture {
     }
 
     public static Exercise createExerciseWithAddr(Party party, LocalDate date) {
+        return createExerciseWithAddr(party, date, 10);
+    }
+
+    public static Exercise createExerciseWithAddr(Party party, LocalDate date, int maxCapacity) {
         ExerciseAddr addr = ExerciseAddr.builder()
                 .addr1("서울특별시")
                 .addr2("강남구")
@@ -34,7 +38,7 @@ public class ExerciseFixture {
                 .party(party)
                 .date(date)
                 .startTime(LocalTime.of(10, 0))
-                .maxCapacity(10)
+                .maxCapacity(maxCapacity)
                 .partyGuestAccept(true)
                 .outsideGuestAccept(false)
                 .exerciseAddr(addr)

--- a/src/test/java/umc/cockple/demo/support/fixture/ExerciseFixture.java
+++ b/src/test/java/umc/cockple/demo/support/fixture/ExerciseFixture.java
@@ -1,6 +1,7 @@
 package umc.cockple.demo.support.fixture;
 
 import umc.cockple.demo.domain.exercise.domain.Exercise;
+import umc.cockple.demo.domain.exercise.domain.ExerciseAddr;
 import umc.cockple.demo.domain.party.domain.Party;
 
 import java.time.LocalDate;
@@ -16,6 +17,27 @@ public class ExerciseFixture {
                 .maxCapacity(10)
                 .partyGuestAccept(true)
                 .outsideGuestAccept(false)
+                .build();
+    }
+
+    public static Exercise createExerciseWithAddr(Party party, LocalDate date) {
+        ExerciseAddr addr = ExerciseAddr.builder()
+                .addr1("서울특별시")
+                .addr2("강남구")
+                .streetAddr("서울특별시 강남구 테헤란로 1")
+                .buildingName("테스트 체육관")
+                .latitude(37.5)
+                .longitude(127.0)
+                .build();
+
+        return Exercise.builder()
+                .party(party)
+                .date(date)
+                .startTime(LocalTime.of(10, 0))
+                .maxCapacity(10)
+                .partyGuestAccept(true)
+                .outsideGuestAccept(false)
+                .exerciseAddr(addr)
                 .build();
     }
 }

--- a/src/test/java/umc/cockple/demo/support/fixture/MemberFixture.java
+++ b/src/test/java/umc/cockple/demo/support/fixture/MemberFixture.java
@@ -42,6 +42,8 @@ public class MemberFixture {
         return Member.builder()
                 .memberName(memberName)
                 .nickname(nickname)
+                .gender(Gender.MALE)
+                .level(Level.C)
                 .isActive(MemberStatus.INACTIVE)
                 .socialId(socialId)
                 .build();


### PR DESCRIPTION
## ❤️ 기능 설명
### 1. 회원 탈퇴 시 미래 운동만 취소되도록 수정
기존에는 탈퇴 시 `deleteAllByMember`로 과거 운동 참여 기록까지 전부 삭제되었습니다.
탈퇴 이후의 미래 운동에서만 삭제하도록 `deleteFutureExercisesByMember` 쿼리로 변경했습니다.

- `MemberExerciseRepository`: `deleteAllByMember` → `deleteFutureExercisesByMember` (오늘 이후 날짜, 또는 오늘이면 현재 시간 이후 운동만 삭제)
- `MemberCommandService`: 위 메서드 호출 시 `LocalDate.now()`, `LocalTime.now()` 전달

### 2. 운동 상세 조회 API에 참가자 탈퇴 여부 필드 추가
탈퇴한 회원도 과거 운동에 참가자로 남아있을 수 있으므로, 조회 시 탈퇴 여부를 구분할 수 있도록 `isWithdrawn` 필드를 추가했습니다.

- `ExerciseDetailDTO.ParticipantInfo`: `isWithdrawn` 필드 추가
- `MemberExerciseRepository.findByExerciseIdWithMemberAndProfile`: 활성 회원 필터(`memberStatus` 조건) 제거 — 탈퇴 회원도 포함하여 조회
- `ExerciseConverter`: 참가자 빌드 시 `member.getIsActive() == INACTIVE` 여부를 `isWithdrawn`으로 세팅
- `ExerciseQueryService`: `getAllSortedParticipants`에서 탈퇴 여부 포함한 참가자 목록 반환

### 3. 테스트 코드 작성
**단위 테스트 (`ExerciseQueryServiceTest`)**
- 탈퇴 회원 `isWithdrawn = true` / 활성 회원 `isWithdrawn = false`
- `isManager` true/false, 정원 초과 대기자, 게스트 participantType/inviterName, 성별 카운트
- 먼저 가입한 참가자가 낮은 `participantNumber`를 받는 순서 로직
- 존재하지 않는 운동/멤버 예외

**통합 테스트 (`ExerciseIntegrationTest`)**
- `GetExerciseDetail`을 `Success` / `Failure` nested class 구조로 재구성
- 응답 주요 필드 전체 검증 (`buildingName`, `location`, `manCount`, `womenCount`, `participantNumber`, `gender`, `level` 등)
- `isManager` true/false, 정원 초과 대기자, 게스트 participantType/inviterName, 성별 카운트
- 먼저 가입한 참가자 → 낮은 번호 순서 검증
- 존재하지 않는 운동/멤버(404) 실패 케이스

**단위 테스트 (`MemberCommandServiceTest`)**
- 탈퇴 시 미래 운동만 삭제 호출됨을 검증


swagger 테스트 성공 결과 스크린샷 첨부
<img width="846" height="607" alt="image" src="https://github.com/user-attachments/assets/ccc2d7c4-e390-4521-8fca-397e0879f96e" />

<img width="855" height="567" alt="image" src="https://github.com/user-attachments/assets/19df6179-fe84-4931-9475-3376cbb93ec6" />

<img width="866" height="172" alt="image" src="https://github.com/user-attachments/assets/92163f04-d015-411c-b252-7081cfd318b8" />

<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #515 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 회원 탈퇴 시 미래 운동만 삭제하기로 PM님과 상의하였습니다.
- [ ] 멤버 도메인에 관련 단위 테스트를 작성하였으므로 코드 충돌이 예상됩니다. 꼭 풀 받고 작업해주세요! @kanghana1 

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
