### PR TITLE
[chore/#524] 서버 운영 서버의 주소를 api.cockple.store로 변경

### DIFF
--- a/nginx/conf.d/prod.conf
+++ b/nginx/conf.d/prod.conf
@@ -1,6 +1,6 @@
 server {
     listen 80;
-    server_name cockple.store;
+    server_name api.cockple.store;
 
     location /ws/ {
         proxy_pass http://cockple-app:8080;

--- a/src/main/java/umc/cockple/demo/global/config/SecurityConfig.java
+++ b/src/main/java/umc/cockple/demo/global/config/SecurityConfig.java
@@ -66,7 +66,7 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration config = new CorsConfiguration();
-        config.setAllowedOrigins(List.of("http://localhost:5173", "https://cockple.store", "https://staging.cockple.store", "https://cockple-fe.vercel.app")); // 배포 시에는 도메인 지정 권장
+        config.setAllowedOrigins(List.of("http://localhost:5173", "https://cockple.store", "https://www.cockple.store", "https://staging.cockple.store", "https://cockple-fe.vercel.app")); // 배포 시에는 도메인 지정 권장
         config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
         config.setAllowedHeaders(List.of("*"));
         config.setAllowCredentials(true);

--- a/src/main/java/umc/cockple/demo/global/config/WebSocketConfig.java
+++ b/src/main/java/umc/cockple/demo/global/config/WebSocketConfig.java
@@ -21,7 +21,7 @@ public class WebSocketConfig implements WebSocketConfigurer {
         registry
                 .addHandler(chatWebSocketHandler, "/ws/chats")
                 .addInterceptors(jwtWebSocketAuthInterceptor)
-                .setAllowedOrigins("http://localhost:5173", "https://cockple.store", "https://cockple-fe.vercel.app/", "https://staging.cockple.store")
+                .setAllowedOrigins("http://localhost:5173", "https://cockple.store", "https://www.cockple.store", "https://cockple-fe.vercel.app/", "https://staging.cockple.store")
                 .withSockJS(); // 브라우저 호환성
     }
 }


### PR DESCRIPTION
## ❤️ 기능 설명
프론트와 서버의 도메인을 맞추기 위해 서버는 api.cockple.store로 변경하였고,
www.cockple.store로 오는 요청의 CORS와 웹소켓을 허용하도록 하였습니다.

<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #524 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] cockple.store -> www.cockple.store로 리다이렉트 되도록 할 예정 (최종 프론트 도메인: www.cockple.store)
- [ ] 서버 도메인: api.cockple.store(운영), staging.cockple.store(테스트)
- [ ] 기존 경로는 혹시 몰라서 일단 허용하도록 유지하였습니다.

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
