### PR TITLE
Release 1.1.2V

### DIFF
--- a/src/main/java/umc/cockple/demo/domain/member/controller/MemberController.java
+++ b/src/main/java/umc/cockple/demo/domain/member/controller/MemberController.java
@@ -53,6 +53,7 @@ public class MemberController {
                 .path("/")
                 .maxAge(Duration.ofDays(7))
                 .sameSite("None")
+                .domain(".cockple.store")
                 .build()
                 ;
 


### PR DESCRIPTION
## ❤️ 기능 설명
사파리에서 쿠키를 받지 못하는 문제를 해결하기 위해, 쿠키를 넘길 때 서브도메인을 지정하여 해결합니다.
- [chore/#528] 서브도메인 명시 (#529) (#530)