### PR TITLE
[chore/#531] Nginx 설정 파일 수정

### DIFF
--- a/nginx/conf.d/prod.conf
+++ b/nginx/conf.d/prod.conf
@@ -10,7 +10,7 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
     }
 
     location / {
@@ -18,6 +18,6 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
     }
 }

--- a/nginx/conf.d/prod.conf
+++ b/nginx/conf.d/prod.conf
@@ -11,6 +11,9 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
+
+        proxy_read_timeout 3600s;
+        proxy_send_timeout 3600s;
     }
 
     location / {

--- a/nginx/conf.d/staging.conf
+++ b/nginx/conf.d/staging.conf
@@ -11,6 +11,9 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
+
+        proxy_read_timeout 3600s;
+        proxy_send_timeout 3600s;
     }
 
     location / {

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -21,5 +21,9 @@ http {
     keepalive_timeout 65;
     client_max_body_size 30M;
 
+    gzip on;
+    gzip_types application/json application/javascript text/plain text/css;
+    gzip_min_length 256;
+
     include /etc/nginx/conf.d/*.conf;
 }


### PR DESCRIPTION
## ❤️ 기능 설명
기존에 Nginx 프로토콜 설정 부분에서 정상 작동함에도 https로 하드코딩이 되어있었습니다.
이를 cloudflare의 프로토콜을 사용하도록 변경하였습니다. 8320156

웹소켓의 타임아웃 설정값이 누락되어 기본값인 1분으로 설정되어 있었습니다.
1분마다 연결이 끊기는 심각한 문제가 있어 이를 60분으로 설정하였습니다. 1c3c80f

json 응답에 대해서 gzip 설정을 통해 데이터 크기를 60~70% 감축하려고 하였습니다. 9f58ef0

<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #531 
<br>
<br>


## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
