### PR TITLE
[debug/#547] 프로필 이름 변경 시 내 채팅방 목록이 전부 내 이름으로 변경되는 버그

### DIFF
--- a/src/main/java/umc/cockple/demo/domain/chat/repository/ChatRoomMemberRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/repository/ChatRoomMemberRepository.java
@@ -1,6 +1,7 @@
 package umc.cockple.demo.domain.chat.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import umc.cockple.demo.domain.chat.domain.ChatRoomMember;
@@ -25,8 +26,6 @@ public interface ChatRoomMemberRepository extends JpaRepository<ChatRoomMember, 
     );
 
     List<ChatRoomMember> findByChatRoomId(Long id);
-
-    List<ChatRoomMember> findAllByMemberId(Long id);
 
     @Query("""
             SELECT crm FROM ChatRoomMember crm
@@ -62,5 +61,15 @@ public interface ChatRoomMemberRepository extends JpaRepository<ChatRoomMember, 
 
     @Query("SELECT crm.member.id FROM ChatRoomMember crm WHERE crm.chatRoom.id = :chatRoomId")
     List<Long> findMemberIdsByChatRoomId(Long chatRoomId);
+
+    @Query("""
+            SELECT counterPart FROM ChatRoomMember counterPart
+            WHERE counterPart.chatRoom.type = 'DIRECT'
+            AND counterPart.member.id != :memberId
+            AND counterPart.chatRoom.id IN (
+                SELECT mine.chatRoom.id FROM ChatRoomMember mine WHERE mine.member.id = :memberId
+            )
+            """)
+    List<ChatRoomMember> findDirectChatCounterParts(@Param("memberId") Long memberId);
 }
 

--- a/src/main/java/umc/cockple/demo/domain/member/repository/MemberKeywordRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/member/repository/MemberKeywordRepository.java
@@ -4,7 +4,11 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import umc.cockple.demo.domain.member.domain.Member;
 import umc.cockple.demo.domain.member.domain.MemberKeyword;
 
+import java.util.List;
+
 public interface MemberKeywordRepository extends JpaRepository<MemberKeyword, Long> {
 
     void deleteAllByMember(Member member);
+
+    List<MemberKeyword> findAllByMemberId(Long memberId);
 }

--- a/src/main/java/umc/cockple/demo/domain/member/service/MemberCommandService.java
+++ b/src/main/java/umc/cockple/demo/domain/member/service/MemberCommandService.java
@@ -5,7 +5,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
-import umc.cockple.demo.domain.chat.domain.ChatRoomMember;
 import umc.cockple.demo.domain.chat.repository.ChatRoomMemberRepository;
 import umc.cockple.demo.domain.member.domain.*;
 import umc.cockple.demo.domain.member.dto.MemberDetailInfoRequestDTO;
@@ -158,9 +157,8 @@ public class MemberCommandService {
             }
         }
 
-        //chatRoomMember의 displayName도 같이 업데이트
-        List<ChatRoomMember> chatRoomMembers = chatRoomMemberRepository.findAllByMemberId(member.getId());
-        chatRoomMembers.forEach(crm -> crm.updateDisplayName(requestDto.memberName()));
+        chatRoomMemberRepository.findDirectChatCounterParts(member.getId())
+                .forEach(crm -> crm.updateDisplayName(requestDto.memberName()));
 
     }
 

--- a/src/test/java/umc/cockple/demo/domain/member/integration/MemberIntegrationTest.java
+++ b/src/test/java/umc/cockple/demo/domain/member/integration/MemberIntegrationTest.java
@@ -6,6 +6,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
+import umc.cockple.demo.domain.chat.domain.ChatRoom;
+import umc.cockple.demo.domain.chat.domain.ChatRoomMember;
+import umc.cockple.demo.domain.chat.repository.ChatRoomMemberRepository;
+import umc.cockple.demo.domain.chat.repository.ChatRoomRepository;
 import umc.cockple.demo.domain.contest.domain.Contest;
 import umc.cockple.demo.domain.contest.enums.MedalType;
 import umc.cockple.demo.domain.contest.repository.ContestRepository;
@@ -13,6 +17,7 @@ import umc.cockple.demo.domain.exercise.enums.ExerciseMemberShipStatus;
 import umc.cockple.demo.domain.file.service.FileService;
 import umc.cockple.demo.domain.member.domain.*;
 import umc.cockple.demo.domain.member.dto.CreateMemberAddrDTO;
+import umc.cockple.demo.domain.member.dto.UpdateProfileRequestDTO;
 import umc.cockple.demo.domain.member.enums.MemberStatus;
 import umc.cockple.demo.domain.member.exception.MemberErrorCode;
 import umc.cockple.demo.domain.member.repository.*;
@@ -28,12 +33,15 @@ import umc.cockple.demo.global.enums.Role;
 import umc.cockple.demo.global.oauth2.service.KakaoOauthService;
 import umc.cockple.demo.support.IntegrationTestBase;
 import umc.cockple.demo.support.SecurityContextHelper;
+import umc.cockple.demo.support.fixture.ChatFixture;
 import umc.cockple.demo.support.fixture.MemberAddrFixture;
 import umc.cockple.demo.support.fixture.MemberFixture;
 import umc.cockple.demo.support.fixture.PartyFixture;
 
 import java.time.LocalDate;
+import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
@@ -56,6 +64,8 @@ class MemberIntegrationTest extends IntegrationTestBase {
     @Autowired ContestRepository contestRepository;
     @Autowired MemberExerciseRepository memberExerciseRepository;
     @Autowired MemberKeywordRepository memberKeywordRepository;
+    @Autowired ChatRoomRepository chatRoomRepository;
+    @Autowired ChatRoomMemberRepository chatRoomMemberRepository;
 
     private Member member;
 
@@ -66,6 +76,7 @@ class MemberIntegrationTest extends IntegrationTestBase {
 
     @AfterEach
     void tearDown() {
+        chatRoomRepository.deleteAll(); // cascade: ChatRoomMember 함께 삭제
         memberPartyRepository.deleteAll();
         partyRepository.deleteAll();
         partyAddrRepository.deleteAll();
@@ -369,6 +380,183 @@ class MemberIntegrationTest extends IntegrationTestBase {
                         .andExpect(status().isBadRequest())
                         .andExpect(jsonPath("$.code").value(MemberErrorCode.MAIN_ADDRESS_NULL.getCode()))
                         .andExpect(jsonPath("$.message").value(MemberErrorCode.MAIN_ADDRESS_NULL.getMessage()));
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("PATCH /api/my/profile - 프로필 수정")
+    class UpdateProfile {
+
+        @Nested
+        @DisplayName("성공")
+        class Success {
+
+            @Test
+            @DisplayName("200 - 모든 필드가 정상 업데이트된다")
+            void 모든_필드가_정상_업데이트된다() throws Exception {
+                // given - 기존 키워드 등록
+                memberKeywordRepository.save(MemberKeyword.builder()
+                        .member(member).keyword(Keyword.FREE).build());
+
+                UpdateProfileRequestDTO request = new UpdateProfileRequestDTO(
+                        "김길동", LocalDate.of(1995, 6, 15), Level.B,
+                        List.of(Keyword.FRIENDSHIP, Keyword.MANAGER_MATCH), "profile/new-key.jpg");
+
+                SecurityContextHelper.setAuthentication(member.getId(), member.getNickname());
+
+                // when
+                mockMvc.perform(patch("/api/my/profile")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request)))
+                        .andExpect(status().isOk());
+
+                // then - DB에서 모든 필드 검증
+                Member updated = memberRepository.findMemberWithProfileById(member.getId()).orElseThrow();
+                assertThat(updated.getMemberName()).isEqualTo("김길동");
+                assertThat(updated.getBirth()).isEqualTo(LocalDate.of(1995, 6, 15));
+                assertThat(updated.getLevel()).isEqualTo(Level.B);
+                assertThat(updated.getProfileImg()).isNotNull();
+                assertThat(updated.getProfileImg().getImgKey()).isEqualTo("profile/new-key.jpg");
+
+                List<MemberKeyword> keywords = memberKeywordRepository.findAllByMemberId(member.getId());
+                assertThat(keywords).hasSize(2);
+                assertThat(keywords.stream().map(MemberKeyword::getKeyword).toList())
+                        .containsExactlyInAnyOrder(Keyword.FRIENDSHIP, Keyword.MANAGER_MATCH);
+            }
+
+            @Test
+            @DisplayName("200 - imgKey가 없으면 이미지 없이 프로필이 업데이트된다")
+            void imgKey가_없으면_이미지_없이_프로필이_업데이트된다() throws Exception {
+                // given
+                UpdateProfileRequestDTO request = new UpdateProfileRequestDTO(
+                        "김길동", LocalDate.of(1990, 1, 1), Level.A,
+                        List.of(Keyword.FRIENDSHIP), null);
+
+                SecurityContextHelper.setAuthentication(member.getId(), member.getNickname());
+
+                // when
+                mockMvc.perform(patch("/api/my/profile")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request)))
+                        .andExpect(status().isOk());
+
+                // then
+                Member updated = memberRepository.findMemberWithProfileById(member.getId()).orElseThrow();
+                assertThat(updated.getMemberName()).isEqualTo("김길동");
+                assertThat(updated.getProfileImg()).isNull();
+            }
+
+            @Test
+            @DisplayName("200 - 기존 이미지가 있고 imgKey가 다르면 이미지가 변경된다")
+            void 기존_이미지가_있고_imgKey가_다르면_이미지가_변경된다() throws Exception {
+                // given - 기존 프로필 이미지 설정
+                ProfileImg existingImg = ProfileImg.builder()
+                        .member(member).imgKey("profile/old-key.jpg").build();
+                member.updateProfileImg(existingImg);
+                memberRepository.save(member);
+
+                UpdateProfileRequestDTO request = new UpdateProfileRequestDTO(
+                        "김길동", LocalDate.of(1990, 1, 1), Level.A,
+                        List.of(Keyword.FRIENDSHIP), "profile/new-key.jpg");
+
+                SecurityContextHelper.setAuthentication(member.getId(), member.getNickname());
+
+                // when
+                mockMvc.perform(patch("/api/my/profile")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request)))
+                        .andExpect(status().isOk());
+
+                // then
+                Member updated = memberRepository.findMemberWithProfileById(member.getId()).orElseThrow();
+                assertThat(updated.getProfileImg().getImgKey()).isEqualTo("profile/new-key.jpg");
+            }
+
+            @Test
+            @DisplayName("200 - DIRECT 채팅방 상대방의 displayName이 업데이트된다")
+            void DIRECT_채팅방_상대방의_displayName이_업데이트된다() throws Exception {
+                // given
+                Member counterPart = memberRepository.save(
+                        MemberFixture.createMember("상대방", Gender.FEMALE, Level.B, 2001L));
+
+                ChatRoom directRoom = ChatRoom.createDirectChatRoom();
+                directRoom.addChatRoomMember(
+                        ChatFixture.createJoinedMember(directRoom, member, "홍길동"));
+                directRoom.addChatRoomMember(
+                        ChatFixture.createJoinedMember(directRoom, counterPart, "홍길동"));
+                chatRoomRepository.save(directRoom);
+
+                UpdateProfileRequestDTO request = new UpdateProfileRequestDTO(
+                        "김길동", LocalDate.of(1990, 1, 1), Level.A,
+                        List.of(Keyword.FRIENDSHIP), null);
+
+                SecurityContextHelper.setAuthentication(member.getId(), member.getNickname());
+
+                // when
+                mockMvc.perform(patch("/api/my/profile")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request)))
+                        .andExpect(status().isOk());
+
+                // then - 상대방의 ChatRoomMember displayName이 업데이트되었는지 검증
+                ChatRoomMember updatedCounterPart = chatRoomMemberRepository
+                        .findByChatRoomIdAndMemberId(directRoom.getId(), counterPart.getId())
+                        .orElseThrow();
+                assertThat(updatedCounterPart.getDisplayName()).isEqualTo("김길동");
+            }
+
+            @Test
+            @DisplayName("200 - PARTY 채팅방의 displayName은 변경되지 않는다")
+            void PARTY_채팅방의_displayName은_변경되지_않는다() throws Exception {
+                // given
+                PartyAddr addr = partyAddrRepository.save(PartyFixture.createPartyAddr("서울특별시", "강남구"));
+                Party party = partyRepository.save(PartyFixture.createParty("테스트 모임", member.getId(), addr));
+
+                ChatRoom partyRoom = ChatRoom.createPartyChatRoom(party);
+                partyRoom.addChatRoomMember(
+                        ChatFixture.createJoinedMember(partyRoom, member, "홍길동"));
+                chatRoomRepository.save(partyRoom);
+
+                UpdateProfileRequestDTO request = new UpdateProfileRequestDTO(
+                        "김길동", LocalDate.of(1990, 1, 1), Level.A,
+                        List.of(Keyword.FRIENDSHIP), null);
+
+                SecurityContextHelper.setAuthentication(member.getId(), member.getNickname());
+
+                // when
+                mockMvc.perform(patch("/api/my/profile")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request)))
+                        .andExpect(status().isOk());
+
+                // then - PARTY 채팅방의 ChatRoomMember displayName은 변경되지 않아야 한다
+                ChatRoomMember partyChatMember = chatRoomMemberRepository
+                        .findByChatRoomIdAndMemberId(partyRoom.getId(), member.getId())
+                        .orElseThrow();
+                assertThat(partyChatMember.getDisplayName()).isEqualTo("홍길동");
+            }
+        }
+
+        @Nested
+        @DisplayName("실패")
+        class Failure {
+
+            @Test
+            @DisplayName("404 - 존재하지 않는 회원이면 MEMBER_NOT_FOUND 에러를 반환한다")
+            void 존재하지_않는_회원이면_MEMBER_NOT_FOUND_에러를_반환한다() throws Exception {
+                UpdateProfileRequestDTO request = new UpdateProfileRequestDTO(
+                        "김길동", LocalDate.of(1990, 1, 1), Level.A,
+                        List.of(Keyword.FRIENDSHIP), null);
+
+                SecurityContextHelper.setAuthentication(999L, "없는회원");
+
+                mockMvc.perform(patch("/api/my/profile")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request)))
+                        .andExpect(status().isNotFound())
+                        .andExpect(jsonPath("$.code").value(MemberErrorCode.MEMBER_NOT_FOUND.getCode()))
+                        .andExpect(jsonPath("$.message").value(MemberErrorCode.MEMBER_NOT_FOUND.getMessage()));
             }
         }
     }

--- a/src/test/java/umc/cockple/demo/domain/member/integration/MemberIntegrationTest.java
+++ b/src/test/java/umc/cockple/demo/domain/member/integration/MemberIntegrationTest.java
@@ -9,22 +9,15 @@ import org.springframework.test.web.servlet.MockMvc;
 import umc.cockple.demo.domain.contest.domain.Contest;
 import umc.cockple.demo.domain.contest.enums.MedalType;
 import umc.cockple.demo.domain.contest.repository.ContestRepository;
-import umc.cockple.demo.domain.member.domain.Member;
-import umc.cockple.demo.domain.member.domain.MemberAddr;
-import umc.cockple.demo.domain.member.domain.MemberExercise;
-import umc.cockple.demo.domain.member.domain.MemberKeyword;
-import umc.cockple.demo.domain.member.domain.ProfileImg;
+import umc.cockple.demo.domain.exercise.enums.ExerciseMemberShipStatus;
+import umc.cockple.demo.domain.file.service.FileService;
+import umc.cockple.demo.domain.member.domain.*;
 import umc.cockple.demo.domain.member.dto.CreateMemberAddrDTO;
 import umc.cockple.demo.domain.member.enums.MemberStatus;
 import umc.cockple.demo.domain.member.exception.MemberErrorCode;
-import umc.cockple.demo.domain.member.repository.MemberAddrRepository;
-import umc.cockple.demo.domain.member.repository.MemberExerciseRepository;
-import umc.cockple.demo.domain.member.repository.MemberKeywordRepository;
-import umc.cockple.demo.domain.member.repository.MemberPartyRepository;
-import umc.cockple.demo.domain.member.repository.MemberRepository;
+import umc.cockple.demo.domain.member.repository.*;
 import umc.cockple.demo.domain.party.domain.Party;
 import umc.cockple.demo.domain.party.domain.PartyAddr;
-import umc.cockple.demo.domain.exercise.enums.ExerciseMemberShipStatus;
 import umc.cockple.demo.domain.party.enums.ParticipationType;
 import umc.cockple.demo.domain.party.repository.PartyAddrRepository;
 import umc.cockple.demo.domain.party.repository.PartyRepository;
@@ -42,8 +35,10 @@ import umc.cockple.demo.support.fixture.PartyFixture;
 import java.time.LocalDate;
 
 import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 class MemberIntegrationTest extends IntegrationTestBase {
 
@@ -55,9 +50,8 @@ class MemberIntegrationTest extends IntegrationTestBase {
     @Autowired PartyRepository partyRepository;
     @Autowired PartyAddrRepository partyAddrRepository;
 
-    // withdrawMember에서 카카오 연결 끊기 API 호출을 막기 위해 Mock 처리
-    @MockitoBean
-    KakaoOauthService kakaoOauthService;
+    @MockitoBean KakaoOauthService kakaoOauthService;
+    @MockitoBean FileService fileService;
 
     @Autowired ContestRepository contestRepository;
     @Autowired MemberExerciseRepository memberExerciseRepository;
@@ -134,7 +128,6 @@ class MemberIntegrationTest extends IntegrationTestBase {
         }
     }
 
-
     @Nested
     @DisplayName("GET /api/profile/{memberId} - 타인 프로필 조회")
     class GetProfile {
@@ -147,6 +140,9 @@ class MemberIntegrationTest extends IntegrationTestBase {
             @DisplayName("200 - 모든 필드가 정상 반환된다")
             void getProfile_모든_필드가_정상_반환된다() throws Exception {
                 // given
+                given(fileService.getUrlFromKey("profile/test-key.jpg"))
+                        .willReturn("https://storage.googleapis.com/test-bucket/profile/test-key.jpg");
+
                 Member freshMember = memberRepository.save(Member.builder()
                         .memberName("홍길동")
                         .nickname("홍길동")
@@ -260,6 +256,9 @@ class MemberIntegrationTest extends IntegrationTestBase {
             @DisplayName("200 - 모든 필드가 정상 반환된다")
             void getMyProfile_모든_필드가_정상_반환된다() throws Exception {
                 // given
+                given(fileService.getUrlFromKey("profile/test-key.jpg"))
+                        .willReturn("https://storage.googleapis.com/test-bucket/profile/test-key.jpg");
+
                 Member freshMember = memberRepository.save(Member.builder()
                         .memberName("홍길동")
                         .nickname("홍길동")
@@ -373,7 +372,6 @@ class MemberIntegrationTest extends IntegrationTestBase {
             }
         }
     }
-
 
     @Nested
     @DisplayName("POST /api/my/profile/locations - 주소 추가")

--- a/src/test/java/umc/cockple/demo/domain/member/service/MemberCommandServiceTest.java
+++ b/src/test/java/umc/cockple/demo/domain/member/service/MemberCommandServiceTest.java
@@ -9,7 +9,9 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
+import umc.cockple.demo.domain.chat.domain.ChatRoomMember;
 import umc.cockple.demo.domain.chat.repository.ChatRoomMemberRepository;
+import umc.cockple.demo.support.fixture.ChatFixture;
 import umc.cockple.demo.domain.file.service.FileService;
 import umc.cockple.demo.domain.member.domain.Member;
 import umc.cockple.demo.domain.member.domain.MemberAddr;
@@ -204,8 +206,6 @@ class MemberCommandServiceTest {
                 // given
                 given(memberRepository.findMemberWithProfileById(normalMember.getId()))
                         .willReturn(Optional.of(normalMember));
-                given(chatRoomMemberRepository.findAllByMemberId(normalMember.getId()))
-                        .willReturn(List.of());
 
                 // when
                 memberCommandService.updateProfile(requestWithoutImg, normalMember.getId());
@@ -223,8 +223,6 @@ class MemberCommandServiceTest {
                 // given
                 given(memberRepository.findMemberWithProfileById(normalMember.getId()))
                         .willReturn(Optional.of(normalMember));
-                given(chatRoomMemberRepository.findAllByMemberId(normalMember.getId()))
-                        .willReturn(List.of());
 
                 // when
                 memberCommandService.updateProfile(requestWithImg, normalMember.getId());
@@ -246,8 +244,6 @@ class MemberCommandServiceTest {
 
                 given(memberRepository.findMemberWithProfileById(normalMember.getId()))
                         .willReturn(Optional.of(normalMember));
-                given(chatRoomMemberRepository.findAllByMemberId(normalMember.getId()))
-                        .willReturn(List.of());
 
                 // when
                 memberCommandService.updateProfile(requestWithImg, normalMember.getId());
@@ -272,8 +268,6 @@ class MemberCommandServiceTest {
 
                 given(memberRepository.findMemberWithProfileById(normalMember.getId()))
                         .willReturn(Optional.of(normalMember));
-                given(chatRoomMemberRepository.findAllByMemberId(normalMember.getId()))
-                        .willReturn(List.of());
 
                 // when
                 memberCommandService.updateProfile(sameImgRequest, normalMember.getId());
@@ -288,8 +282,6 @@ class MemberCommandServiceTest {
                 // given
                 given(memberRepository.findMemberWithProfileById(normalMember.getId()))
                         .willReturn(Optional.of(normalMember));
-                given(chatRoomMemberRepository.findAllByMemberId(normalMember.getId()))
-                        .willReturn(List.of());
 
                 // when
                 memberCommandService.updateProfile(requestWithImg, normalMember.getId());
@@ -298,6 +290,24 @@ class MemberCommandServiceTest {
                 then(memberKeywordRepository).should().deleteAllByMember(normalMember);
                 then(memberKeywordRepository).should().saveAll(any());
                 assertThat(normalMember.getKeywords()).hasSize(requestWithImg.keywords().size());
+            }
+
+            @Test
+            @DisplayName("프로필_수정_시_DIRECT_채팅방_상대방의_displayName이_업데이트된다")
+            void 프로필_수정_시_DIRECT_채팅방_상대방의_displayName이_업데이트된다() {
+                // given
+                ChatRoomMember counterPartCrm = ChatFixture.createChatRoomMemberWithDisplayName("홍길동");
+
+                given(memberRepository.findMemberWithProfileById(normalMember.getId()))
+                        .willReturn(Optional.of(normalMember));
+                given(chatRoomMemberRepository.findDirectChatCounterParts(normalMember.getId()))
+                        .willReturn(List.of(counterPartCrm));
+
+                // when
+                memberCommandService.updateProfile(requestWithoutImg, normalMember.getId());
+
+                // then
+                assertThat(counterPartCrm.getDisplayName()).isEqualTo(requestWithoutImg.memberName());
             }
         }
 

--- a/src/test/java/umc/cockple/demo/support/fixture/ChatFixture.java
+++ b/src/test/java/umc/cockple/demo/support/fixture/ChatFixture.java
@@ -31,6 +31,12 @@ public class ChatFixture {
         return ChatRoomMember.create(chatRoom, member);
     }
 
+    public static ChatRoomMember createChatRoomMemberWithDisplayName(String displayName) {
+        return ChatRoomMember.builder()
+                .displayName(displayName)
+                .build();
+    }
+
     public static ChatRoomMember createJoinedMemberWithLastRead(ChatRoom chatRoom, Member member, Long lastReadMessageId) {
         return ChatRoomMember.builder()
                 .chatRoom(chatRoom)

--- a/src/test/java/umc/cockple/demo/support/fixture/ChatFixture.java
+++ b/src/test/java/umc/cockple/demo/support/fixture/ChatFixture.java
@@ -31,6 +31,10 @@ public class ChatFixture {
         return ChatRoomMember.create(chatRoom, member);
     }
 
+    public static ChatRoomMember createJoinedMember(ChatRoom chatRoom, Member member, String displayName) {
+        return ChatRoomMember.createJoined(chatRoom, member, displayName);
+    }
+
     public static ChatRoomMember createChatRoomMemberWithDisplayName(String displayName) {
         return ChatRoomMember.builder()
                 .displayName(displayName)


### PR DESCRIPTION
## ❤️ 기능 설명
프로필 수정 시 DIRECT 채팅방 상대방의 displayName이 정상적으로 업데이트되도록 수정했습니다.

**버그 수정 (d084f42)**
- `findAllByMemberId()`로 본인의 모든 ChatRoomMember를 업데이트하던 로직을 `findDirectChatCounterParts()`로 DIRECT 채팅방의 상대방만 조회 후 `updateDisplayName()` 호출하도록 변경
- ChatRoomMemberRepository에 `findDirectChatCounterParts` 쿼리 메서드 추가

**단위 테스트 (21efbe6)**
- 프로필 수정 시 `findDirectChatCounterParts` 호출 및 displayName 변경 검증 테스트 추가
- ChatFixture에 `createChatRoomMemberWithDisplayName`, `createJoinedMember(displayName)` 팩토리 메서드 추가

**통합 테스트 환경 개선 (12d5856)**
- FileService를 @MockitoBean으로 mock 처리하여 실제 스토리지 의존 제거
- profileImgUrl을 검증하는 기존 테스트에 stub 추가

**통합 테스트 작성 (88e6f96)**
- PATCH /api/my/profile 통합 테스트 6개 추가
  - 모든 필드(memberName, birth, level, keywords, imgKey) 정상 업데이트 검증
  - imgKey 없이 프로필 업데이트
  - 기존 이미지가 있고 imgKey가 다르면 이미지 변경
  - DIRECT 채팅방 상대방 displayName 업데이트 검증
  - PARTY 채팅방 displayName 미변경 검증
  - 존재하지 않는 회원 시 404 에러
- MemberKeywordRepository에 `findAllByMemberId` 추가

<br>
테스트 성공 결과 스크린샷 첨부
<br>

<img width="564" height="242" alt="image" src="https://github.com/user-attachments/assets/a00cf5bf-f0cb-4739-af69-d6b5b8cc8ec7" />

<img width="538" height="222" alt="image" src="https://github.com/user-attachments/assets/15a3da6f-e26a-4384-87d9-542cf67d43f5" />


<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #547 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] @kanghana1 멤버 통합테스트에서 파일서비스 로직을 호출하던 것을 mock + stub으로 처리하였습니다. 테스트의 데이터가 스토리지에 저장될 이유가 없으므로 개선하였습니다!

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
