### PR TITLE
[fix/#552] 모임 채팅방 멤버 누락 데이터 보정

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     command:
       - --character-set-server=utf8mb4
       - --collation-server=utf8mb4_unicode_ci
-      - --innodb-buffer-pool-size=256M
+      - --innodb-buffer-pool-size=512M
     volumes:
       - mysql-data:/var/lib/mysql
       - ./init-db.sql:/docker-entrypoint-initdb.d/init-db.sql:ro
@@ -22,8 +22,8 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
-    mem_limit: 512m
-    memswap_limit: 768m
+    mem_limit: 1g
+    memswap_limit: 1536m
 
   redis:
     image: redis:7-alpine

--- a/src/main/resources/db/migration/V2026.03.24.16.00__backfill_missing_party_chat_room_members.sql
+++ b/src/main/resources/db/migration/V2026.03.24.16.00__backfill_missing_party_chat_room_members.sql
@@ -1,0 +1,28 @@
+INSERT INTO chat_room_member (
+    created_at,
+    updated_at,
+    chat_room_id,
+    member_id,
+    display_name,
+    last_read_message_id,
+    status
+)
+SELECT
+    NOW(6),
+    NOW(6),
+    cr.id,
+    mp.member_id,
+    NULL,
+    NULL,
+    'JOINED'
+FROM member_party mp
+JOIN party p
+    ON p.id = mp.party_id
+JOIN chat_room cr
+    ON cr.party_id = mp.party_id
+LEFT JOIN chat_room_member crm
+    ON crm.chat_room_id = cr.id
+   AND crm.member_id = mp.member_id
+WHERE mp.status = 'ACTIVE'
+  AND p.status = 'ACTIVE'
+  AND crm.id IS NULL;


### PR DESCRIPTION
## ❤️ 기능 설명

- 누락된 모임 채팅방 멤버를 복구하기 위한 Flyway 마이그레이션을 추가했습니다.
- `member_party`, `party`, `chat_room`을 기준으로 ACTIVE 상태의 참가자 중 `chat_room_member`에 없는 레코드만 백필합니다.
- MySQL이 두 개의 데이터베이스를 함께 커버할 때 메모리 부족이 발생하지 않도록 `docker-compose.yml`의 `innodb-buffer-pool-size`, `mem_limit`, `memswap_limit`을 상향했습니다.

## 연결된 issue

close #552

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 마이그레이션 적용 시점과 MySQL 메모리 상향 배포 영향도 함께 확인 부탁드립니다.

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?

## 테스트

- 별도 테스트는 실행하지 않았습니다.
- 데이터 보정용 SQL 마이그레이션과 MySQL 메모리 설정 변경을 포함합니다.