### PR TITLE
[docs/#554] Opencode CLI 사용을 위한 AGENTS.md 문서 추가

### DIFF
--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -1,0 +1,28 @@
+# WORKFLOWS GUIDE
+
+Apply root `AGENTS.md` first. This file only applies to `.github/workflows/*` edits.
+
+## OVERVIEW
+This directory drives CI on pull requests and CD on pushes to `develop` and `main`.
+
+## WHERE TO LOOK
+| Task | Location | Notes |
+|------|----------|-------|
+| PR build/test | `ci.yml` | writes `application.yml`, creates Firebase key, runs `./gradlew build` |
+| Image build + deploy | `cd.yml` | builds on push, tags by branch, then copies compose/nginx/scripts to server |
+
+## CONVENTIONS
+- `develop` and `main` are the only workflow branches here.
+- `ci.yml` chooses `APPLICATION` vs `APPLICATION_STAGING` by `github.base_ref`.
+- `cd.yml` chooses Docker tag `latest` for `main`, `staging` otherwise.
+- Deploy step assumes `/home/ubuntu/cockple` and hands off to `scripts/deploy.sh`.
+
+## ANTI-PATTERNS
+- Do not hardcode secrets into workflow YAML.
+- Do not change copied deploy assets in `cd.yml` without matching script/compose expectations.
+- Do not make `main` and `develop` diverge silently; branch-specific behavior is intentionally small and explicit.
+
+## COMMANDS
+```bash
+./gradlew.bat build
+```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,84 @@
+# PROJECT KNOWLEDGE BASE
+
+**Generated:** 2026-03-23 20:04 KST
+**Commit:** 5af1ffe6
+**Branch:** develop
+
+## OVERVIEW
+Cockple_BE is a single-module Spring Boot 3.5.9 backend for the Cockple badminton platform. Core stack: Java 17, JPA + QueryDSL, MySQL, Redis, JWT/Kakao OAuth, WebSocket chat, Firebase FCM, Flyway, Docker Compose, and Terraform-managed GCP/Cloudflare infra.
+
+Nearest `AGENTS.md` wins. Read this file first, then the closest child file for the area you are changing.
+
+## STRUCTURE
+```text
+./
+├── .github/workflows/                         # CI/CD entrypoint
+├── scripts/                                   # deploy and SSH tunnel helpers
+├── terraform/                                 # GCP + Cloudflare infra
+├── nginx/                                     # reverse proxy for prod/staging apps
+├── src/main/java/umc/cockple/demo/domain/     # business slices
+├── src/main/java/umc/cockple/demo/global/     # cross-cutting infra
+├── src/main/resources/                        # Spring profiles + Flyway
+├── src/main/generated/                        # generated QueryDSL Q-types
+└── src/test/java/umc/cockple/demo/            # integration/service tests + fixtures
+```
+
+## WHERE TO LOOK
+| Task | Location | Notes |
+|------|----------|-------|
+| App bootstrap | `src/main/java/umc/cockple/demo/Application.java` | Enables JPA auditing and caching |
+| Runtime config | `src/main/resources/application*.yml` | `local` is default; `staging` and `prod` override DB/Redis |
+| Security/websocket ingress | `src/main/java/umc/cockple/demo/global/config/` | JWT, CORS, WebSocket handler registration |
+| Business APIs | `src/main/java/umc/cockple/demo/domain/` | Vertical slices by feature |
+| Exercise hotspot | `src/main/java/umc/cockple/demo/domain/exercise/` | Largest converter/query/test surface |
+| Chat hotspot | `src/main/java/umc/cockple/demo/domain/chat/` | REST + WebSocket + cache/event flow |
+| Shared infra | `src/main/java/umc/cockple/demo/global/` | response, exception, jwt, oauth2, config |
+| Test conventions | `src/test/java/umc/cockple/demo/` | shared fixtures + integration base live here |
+| Local stack | `docker-compose.yml`, `nginx/`, `scripts/` | prod/staging services share one compose file |
+| CI/CD | `.github/workflows/` | PR builds on `develop`/`main`; push deploys by branch |
+| Infra changes | `terraform/` | GCP compute/network/storage + Cloudflare |
+
+## CONVENTIONS
+- Domain code is organized as feature slices, not horizontal layers across the repo.
+- Controllers usually return `BaseResponse` or `ResponseEntity<BaseResponse<...>>`.
+- Error codes are per-domain enums and use a documented `1xx/2xx/3xx/4xx` meaning split.
+- `application.yml` enforces `ddl-auto: validate`; schema changes belong in Flyway under `src/main/resources/db/migration/`.
+- QueryDSL generated sources are wired through Gradle; handwritten code lives under `src/main/java`, generated code under `src/main/generated` or `build/generated/...`.
+- Tests split into integration (`MockMvc` + Testcontainers profile) and service/unit (`MockitoExtension`) styles.
+
+## ANTI-PATTERNS (THIS PROJECT)
+- Do not edit generated QueryDSL Q-types.
+- Do not widen security whitelist or CORS origins casually; both are explicit in `SecurityConfig` and `WebSocketConfig`.
+- Do not rely on JPA auto-DDL for schema work; startup uses validation only.
+- Do not scatter test fixtures inside feature test packages; shared fixtures already live under `src/test/java/umc/cockple/demo/support/fixture/`.
+- Do not assume everything under `global/` is generic; JWT/OAuth code is coupled to member/auth flows.
+
+## UNIQUE STYLES
+- `domain/chat` has extra realtime sublayers: `handler/`, `interceptor/`, `events/`, `service/websocket/`.
+- `domain/exercise` is the densest slice: large converter, query service, command internals, and the biggest integration tests.
+- `domain/party` and `domain/notification` use events/notification wiring more than simpler slices like `bookmark` or `terms`.
+
+## COMMANDS
+```bash
+./gradlew.bat build
+./gradlew.bat test
+./gradlew.bat bootRun
+docker compose config --services
+bash scripts/tunnel.sh <GCP_IP>
+```
+
+## CHILD GUIDES
+- `.github/workflows/AGENTS.md`
+- `scripts/AGENTS.md`
+- `terraform/AGENTS.md`
+- `src/main/java/umc/cockple/demo/domain/AGENTS.md`
+- `src/main/java/umc/cockple/demo/domain/chat/AGENTS.md`
+- `src/main/java/umc/cockple/demo/domain/exercise/AGENTS.md`
+- `src/main/java/umc/cockple/demo/global/AGENTS.md`
+- `src/main/java/umc/cockple/demo/global/config/AGENTS.md`
+- `src/test/java/umc/cockple/demo/AGENTS.md`
+
+## NOTES
+- CI writes `src/main/resources/application.yml` from GitHub secrets before building.
+- CD copies only `docker-compose.yml`, `init-db.sql`, `nginx/`, and `scripts/` to the server; deploy behavior lives in both workflow and shell script.
+- Local profile expects MySQL on `3307` and Redis on `6380`; `scripts/tunnel.sh` exposes those ports through SSH forwarding.

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -1,0 +1,28 @@
+# SCRIPTS GUIDE
+
+Apply root `AGENTS.md` first. This file only applies to `scripts/*`.
+
+## OVERVIEW
+Shell scripts handle server deployment and local SSH tunneling into the remote stack.
+
+## WHERE TO LOOK
+| Task | Location | Notes |
+|------|----------|-------|
+| Branch-aware deploy | `deploy.sh` | writes `.env`, pulls image tag, restarts one app service |
+| Remote DB/Redis access | `tunnel.sh` | forwards MySQL to `3307`, Redis to `6380` |
+
+## CONVENTIONS
+- `deploy.sh` treats `main` as `cockple-app:latest`; any other branch path becomes `cockple-app-staging:staging`.
+- Deploy always starts `mysql`, `redis`, and `nginx` before replacing the app container.
+- Health checks are part of the script, not just Docker Compose.
+
+## ANTI-PATTERNS
+- Do not change forwarded local ports without matching `application-local.yml`.
+- Do not add new required env vars in scripts without updating workflow `envs` and compose.
+- Do not bypass the health-check loop when changing deploy behavior.
+
+## COMMANDS
+```bash
+bash scripts/deploy.sh <docker_repo> <branch>
+bash scripts/tunnel.sh <GCP_IP>
+```

--- a/src/main/java/umc/cockple/demo/domain/AGENTS.md
+++ b/src/main/java/umc/cockple/demo/domain/AGENTS.md
@@ -1,0 +1,32 @@
+# DOMAIN GUIDE
+
+Apply root `AGENTS.md` first. This file covers feature slices under `domain/`.
+
+## OVERVIEW
+Business logic is organized by feature slice, usually with `controller`, `converter`, `domain`, `dto`, `enums`, `exception`, `repository`, and `service` subpackages.
+
+## WHERE TO LOOK
+| Task | Location | Notes |
+|------|----------|-------|
+| Member/account flows | `member/` | auth-adjacent domain code |
+| Party lifecycle | `party/` | joins, invitations, roles, events |
+| Exercise lifecycle | `exercise/` | largest slice; read child guide |
+| Chat realtime flows | `chat/` | read child guide |
+| Notifications | `notification/` | FCM-backed notifications |
+| Simpler slices | `bookmark/`, `contest/`, `file/`, `terms/` | mostly standard pattern |
+
+## CONVENTIONS
+- Domain-specific errors live in each slice’s `exception/*ErrorCode.java`.
+- Controllers expose `/api/...` endpoints and use global response wrappers.
+- Shared enums/base entities come from `global/`; slice-specific rules stay here.
+- `party/` and `chat/` add `events/`; `party/` also has `utils/`.
+- QueryDSL generated code mirrors entity packages elsewhere; do not mix handwritten logic into generated folders.
+
+## ANTI-PATTERNS
+- Do not move business rules into `global/` just because multiple slices depend on them.
+- Do not bypass slice error codes with ad hoc strings or generic exceptions.
+- Do not edit generated Q-types to “fix” repository behavior.
+
+## CHILD GUIDES
+- `chat/AGENTS.md`
+- `exercise/AGENTS.md`

--- a/src/main/java/umc/cockple/demo/domain/chat/AGENTS.md
+++ b/src/main/java/umc/cockple/demo/domain/chat/AGENTS.md
@@ -1,0 +1,27 @@
+# CHAT GUIDE
+
+Apply parent guides first. This file only covers `domain/chat/`.
+
+## OVERVIEW
+Chat mixes REST queries with WebSocket transport, Redis-backed subscription/cache behavior, and domain events.
+
+## WHERE TO LOOK
+| Task | Location | Notes |
+|------|----------|-------|
+| WebSocket ingress | `handler/ChatWebSocketHandler.java` | handles connect/message/close/error |
+| Auth for sockets | `interceptor/` | JWT auth is enforced before handler logic |
+| Realtime services | `service/websocket/` | subscription, room list cache, message fanout |
+| Read/query flows | `service/ChatQueryServiceImpl.java` | room lists, unread counts, history |
+| Events | `events/` | send/subscription events bridge transport and async handlers |
+| DTO conversion | `converter/ChatConverter.java` | shapes REST/socket payloads |
+
+## CONVENTIONS
+- `WebSocketConfig` registers `/ws/chats` and wires the JWT interceptor.
+- Request `type()` drives socket branching: send, subscribe, unsubscribe, and chat-list variants.
+- Party chat and direct chat share the slice but differ in display-name/image/read-status logic.
+- Room list freshness depends on `service/websocket/ChatRoomListCacheService`.
+
+## ANTI-PATTERNS
+- Do not treat chat as HTTP-only; transport, cache, and event flow are part of the slice.
+- Do not bypass membership/access validation before room or message operations.
+- Do not mix socket session bookkeeping into controllers or converters.

--- a/src/main/java/umc/cockple/demo/domain/exercise/AGENTS.md
+++ b/src/main/java/umc/cockple/demo/domain/exercise/AGENTS.md
@@ -1,0 +1,27 @@
+# EXERCISE GUIDE
+
+Apply parent guides first. This file only covers `domain/exercise/`.
+
+## OVERVIEW
+Exercise is the densest feature slice: scheduling, guests, participation, waiting lists, recommendations, map/calendar queries, and the largest integration/service tests.
+
+## WHERE TO LOOK
+| Task | Location | Notes |
+|------|----------|-------|
+| Read-heavy hotspot | `service/ExerciseQueryService.java` | calendar/detail/recommendation/building/map queries |
+| Command internals | `service/command/internal/` | guest, lifecycle, participation subflows |
+| DTO mapping hotspot | `converter/ExerciseConverter.java` | very large conversion surface |
+| HTTP surface | `controller/ExerciseController.java` | CRUD + guests + calendars |
+| Error rules | `exception/ExerciseErrorCode.java` | started/past-time/permission constraints |
+| Integration coverage | `src/test/java/umc/cockple/demo/domain/exercise/` | biggest test package in repo |
+
+## CONVENTIONS
+- Time/date/location validation is centralized and reused through service methods and error codes.
+- Participation logic distinguishes confirmed participants from waiting members/guests.
+- Guest invitation rules depend on both party membership and exercise flags.
+- Converter growth is already high; new mapping code should stay tightly scoped to one flow.
+
+## ANTI-PATTERNS
+- Do not bypass `EXERCISE4xx` guardrails for past/start-state checks.
+- Do not duplicate participant/waiting-list logic in controllers or tests.
+- Do not spread unrelated conversions into `ExerciseConverter` without checking for an existing narrower path first.

--- a/src/main/java/umc/cockple/demo/global/AGENTS.md
+++ b/src/main/java/umc/cockple/demo/global/AGENTS.md
@@ -1,0 +1,29 @@
+# GLOBAL GUIDE
+
+Apply root `AGENTS.md` first. This file covers `global/` cross-cutting code.
+
+## OVERVIEW
+`global/` holds shared framework glue: response/exception handling, infra config, security, JWT, OAuth, shared enums, and the common base entity.
+
+## WHERE TO LOOK
+| Task | Location | Notes |
+|------|----------|-------|
+| Bootstrap/config wiring | `config/` | see child guide |
+| Response wrapper | `response/` | `BaseResponse`, code DTOs, success/error codes |
+| Exception handling | `exception/` | global handler + shared exception base |
+| Security/JWT | `security/`, `jwt/` | auth filter + token creation/parsing |
+| OAuth | `oauth2/` | Kakao-specific login flow |
+| Shared types | `common/BaseEntity.java`, `enums/` | audit fields and shared enums |
+
+## CONVENTIONS
+- API success/error formatting is centralized here; slices should plug into it rather than invent local wrappers.
+- `jwt/` and `oauth2/` are cross-cutting in placement but still coupled to member/auth flows.
+- `common/BaseEntity` and shared enums are the stable lowest-level shared types.
+
+## ANTI-PATTERNS
+- Do not put feature-specific business rules here unless they are truly shared.
+- Do not assume JWT/OAuth classes are provider-agnostic; this repo is Kakao-specific.
+- Do not bypass shared response/error abstractions from controllers.
+
+## CHILD GUIDES
+- `config/AGENTS.md`

--- a/src/main/java/umc/cockple/demo/global/config/AGENTS.md
+++ b/src/main/java/umc/cockple/demo/global/config/AGENTS.md
@@ -1,0 +1,25 @@
+# CONFIG GUIDE
+
+Apply parent guides first. This file only covers `global/config/`.
+
+## OVERVIEW
+This package is the runtime bootstrap surface for security, WebSocket, Redis/cache, Firebase, Swagger, QueryDSL, async work, and external storage wiring.
+
+## WHERE TO LOOK
+| Task | Location | Notes |
+|------|----------|-------|
+| Security whitelist + CORS | `SecurityConfig.java` | explicit public endpoints and allowed origins |
+| WebSocket bootstrap | `WebSocketConfig.java` | binds `/ws/chats` to handler + JWT interceptor |
+| Redis/cache serialization | `RedisConfig.java` | connection factory, templates, cache manager |
+| Firebase init | `FirebaseConfig.java` | disabled for `integrationtest` profile |
+
+## CONVENTIONS
+- Runtime values belong in `application*.yml`; config classes wire beans around those values.
+- `SecurityConfig` and `WebSocketConfig` both carry explicit frontend origin lists.
+- Firebase is suppressed during integration tests and mocked from test config.
+- Redis serialization uses a permissive polymorphic JSON serializer; cache/template behavior lives here, not in slices.
+
+## ANTI-PATTERNS
+- Do not widen public endpoints or origins without understanding auth and deployment impact.
+- Do not embed feature logic in config beans.
+- Do not duplicate profile gating from `application*.yml` inside random services.

--- a/src/test/java/umc/cockple/demo/AGENTS.md
+++ b/src/test/java/umc/cockple/demo/AGENTS.md
@@ -1,0 +1,27 @@
+# TEST GUIDE
+
+Apply root `AGENTS.md` first. This file covers `src/test/java/umc/cockple/demo/`.
+
+## OVERVIEW
+Tests mirror production domains and split into integration tests with Testcontainers/MockMvc and service tests with Mockito. Shared support code lives under `support/`.
+
+## WHERE TO LOOK
+| Task | Location | Notes |
+|------|----------|-------|
+| Integration base | `support/IntegrationTestBase.java` | `@SpringBootTest`, `MockMvc`, `integrationtest` profile |
+| Testcontainers + mocks | `support/IntegrationTestConfig.java` | MySQL, Redis, mocked FirebaseMessaging |
+| Auth helpers | `support/SecurityContextHelper.java` | sets and clears security context |
+| Shared fixtures | `support/fixture/` | static factories for member/party/exercise/chat/etc. |
+| Feature integration tests | `domain/*/integration/` | HTTP-level assertions and manual cleanup |
+| Feature service tests | `domain/*/service/` | Mockito-based isolated logic tests |
+
+## CONVENTIONS
+- Integration tests extend `IntegrationTestBase` and usually clear repositories in `@AfterEach`.
+- Service tests use `@ExtendWith(MockitoExtension.class)` and shared fixtures.
+- `application.yml` in test resources uses H2; `application-integrationtest.yml` switches to MySQL/Redis Testcontainers.
+- Large exercise/member/chat tests follow the same nested-class style; keep new tests aligned with that structure.
+
+## ANTI-PATTERNS
+- Do not create per-feature fixture factories when an existing shared fixture can be extended.
+- Do not mix Mockito-style unit tests and full integration setup in the same class.
+- Do not forget `SecurityContextHelper.clearAuthentication()` in integration teardown paths.

--- a/terraform/AGENTS.md
+++ b/terraform/AGENTS.md
@@ -1,0 +1,31 @@
+# TERRAFORM GUIDE
+
+Apply root `AGENTS.md` first. This file only applies to `terraform/*`.
+
+## OVERVIEW
+Terraform provisions the Cockple GCP network/compute/storage stack and Cloudflare DNS integration.
+
+## WHERE TO LOOK
+| Task | Location | Notes |
+|------|----------|-------|
+| Providers | `main.tf` | Google + Cloudflare providers |
+| Network/firewall | `network.tf` | VPC, subnet, Cloudflare-only HTTP ingress, open SSH |
+| Compute bootstrap | `compute.tf` | VM, static IP, Docker install via startup script |
+| Storage/IAM | `storage.tf` | GCS bucket + service account + public read |
+| Inputs/outputs | `variables.tf`, `outputs.tf` | secret vars and exported IP/bucket/account |
+
+## CONVENTIONS
+- Region defaults to `asia-northeast3`.
+- HTTP ingress is intentionally restricted to Cloudflare IP ranges.
+- Bucket CORS is pinned to Cockple prod/staging domains.
+
+## ANTI-PATTERNS
+- Do not weaken firewall or bucket exposure without touching the matching runtime assumptions.
+- Do not move secrets out of sensitive variables into plain values.
+- Do not duplicate Docker/bootstrap logic here and in scripts without keeping them aligned.
+
+## COMMANDS
+```bash
+terraform plan
+terraform apply
+```


### PR DESCRIPTION
## ❤️ 기능 설명

- Opencode CLI가 저장소 구조와 작업 규칙을 빠르게 파악할 수 있도록 `AGENTS.md` 문서를 추가했습니다.
- 루트 가이드에는 프로젝트 개요, 구조, 주요 진입점, 관례, 안티패턴, 자주 쓰는 명령어를 정리했습니다.
- 하위 가이드에는 `.github/workflows`, `scripts`, `terraform`, `domain`, `chat`, `exercise`, `global`, `global/config`, `test` 영역별 참고 위치와 작업 시 주의사항을 정리했습니다.

## 연결된 issue

close #554

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?

## 테스트

- 문서 추가 작업으로 별도 테스트는 실행하지 않았습니다.