### PR TITLE
[test/#565] Contest 도메인 테스트 코드 작성

### DIFF
--- a/src/main/java/umc/cockple/demo/domain/contest/controller/ContestController.java
+++ b/src/main/java/umc/cockple/demo/domain/contest/controller/ContestController.java
@@ -121,7 +121,7 @@ public class ContestController {
     @Operation(summary = "다른 사람의 대회 기록 리스트 조회", description = "회원이 다른 사람의 전체 또는 미입상(NONE) 대회 기록 리스트를 조회합니다.")
     @ApiResponse(responseCode = "200", description = "조회 성공")
     public BaseResponse<List<ContestRecordSimpleDTO.Response>> getOtherMemberContestRecord(
-            @RequestParam Long memeberId,
+            @PathVariable Long memberId,
             @Parameter(
                     name = "medalType",
                     description = "전체 or NONE",
@@ -129,7 +129,7 @@ public class ContestController {
             )
             @RequestParam(required = false) MedalType medalType
     ) {
-        List<ContestRecordSimpleDTO.Response> response = contestQueryService.getMyContestRecordsByMedalType(memeberId, medalType);
+        List<ContestRecordSimpleDTO.Response> response = contestQueryService.getMyContestRecordsByMedalType(memberId, medalType);
         return BaseResponse.success(CommonSuccessCode.OK, response);
     }
 
@@ -137,7 +137,7 @@ public class ContestController {
     @Operation(summary = "다른 사람의 대회 메달 조회", description = "회원이 다른 사람의 메달 개수를 조회합니다.")
     @ApiResponse(responseCode = "200", description = "조회 성공")
     public BaseResponse<ContestMedalSummaryDTO.Response> getOtherMemberMedals(
-            @RequestParam Long memberId
+            @PathVariable Long memberId
     ) {
         ContestMedalSummaryDTO.Response response = contestQueryService.getMyMedalSummary(memberId);
         return BaseResponse.success(CommonSuccessCode.OK,response);

--- a/src/main/java/umc/cockple/demo/domain/contest/converter/ContestConverter.java
+++ b/src/main/java/umc/cockple/demo/domain/contest/converter/ContestConverter.java
@@ -65,7 +65,7 @@ public class ContestConverter {
                 .contestId(contest.getId())
                 .contestImgs(imgResponses)
                 .contestVideos(videoResponses)
-                .UpdatedAt(contest.getUpdatedAt())
+                .updatedAt(contest.getUpdatedAt())
                 .build();
     }
 

--- a/src/main/java/umc/cockple/demo/domain/contest/dto/ContestRecordUpdateDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/contest/dto/ContestRecordUpdateDTO.java
@@ -52,7 +52,7 @@ public class ContestRecordUpdateDTO {
             Long contestId,
             List<ContestImgResponse> contestImgs,
             List<ContestVideoResponse> contestVideos,
-            LocalDateTime UpdatedAt
+            LocalDateTime updatedAt
     ) {
     }
 }

--- a/src/main/java/umc/cockple/demo/domain/contest/exception/ContestErrorCode.java
+++ b/src/main/java/umc/cockple/demo/domain/contest/exception/ContestErrorCode.java
@@ -10,8 +10,6 @@ import umc.cockple.demo.global.response.dto.ErrorReasonDTO;
 @RequiredArgsConstructor
 public enum ContestErrorCode implements BaseErrorCode {
 
-    IMAGE_UPLOAD_LIMIT_EXCEEDED(HttpStatus.BANDWIDTH_LIMIT_EXCEEDED, "CONTEST101", "이미지가 3개를 초과했습니다."),
-
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "CONTEST201", "존재하지 않는 회원입니다."),
     CONTEST_NOT_FOUND(HttpStatus.NOT_FOUND, "CONTEST202", "존재하지 않는 대회기록입니다."),
     CONTEST_IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "CONTEST203", "존재하지 않는 대회 이미지입니다."),

--- a/src/main/java/umc/cockple/demo/domain/contest/service/ContestCommandServiceImpl.java
+++ b/src/main/java/umc/cockple/demo/domain/contest/service/ContestCommandServiceImpl.java
@@ -116,6 +116,28 @@ public class ContestCommandServiceImpl implements ContestCommandService {
         return contestConverter.toUpdateResponseDTO(contest);
     }
 
+
+    // 삭제
+    @Override
+    public ContestRecordDeleteDTO.Response deleteContestRecord(Long memberId, Long contestId) {
+
+        log.info("[대회 기록 삭제 시작] - memberId: {}, contestId: {}", memberId, contestId);
+
+        // 1. 대회 조회
+        Contest contest = contestRepository.findByIdAndMember_Id(contestId, memberId)
+                .orElseThrow(() -> new ContestException(ContestErrorCode.CONTEST_NOT_FOUND));
+
+        // 2. 연관관계 해제 (양방향)
+        contest.removeMember();
+
+        // 3. 삭제
+        contestRepository.delete(contest);
+
+        log.info("대회 기록 삭제 완료 - contestId: {}", contestId);
+
+        return contestConverter.toDeleteResponseDTO(contest);
+    }
+
     private void updateContestImages(Contest contest, List<ContestImgUpdateRequest> requestImgs) {
         if (requestImgs == null) {
             requestImgs = List.of();
@@ -200,27 +222,6 @@ public class ContestCommandServiceImpl implements ContestCommandService {
                 contest.getContestVideos().add(newVideo);
             }
         }
-    }
-
-    // 삭제
-    @Override
-    public ContestRecordDeleteDTO.Response deleteContestRecord(Long memberId, Long contestId) {
-
-        log.info("[대회 기록 삭제 시작] - memberId: {}, contestId: {}", memberId, contestId);
-
-        // 1. 대회 조회
-        Contest contest = contestRepository.findByIdAndMember_Id(contestId, memberId)
-                .orElseThrow(() -> new ContestException(ContestErrorCode.CONTEST_NOT_FOUND));
-
-        // 2. 연관관계 해제 (양방향)
-        contest.removeMember();
-
-        // 3. 삭제
-        contestRepository.delete(contest);
-
-        log.info("대회 기록 삭제 완료 - contestId: {}", contestId);
-
-        return contestConverter.toDeleteResponseDTO(contest);
     }
 
     private void extractedImgsWithOrder(List<AddContestImgRequest> imgs, Contest contest) {

--- a/src/main/java/umc/cockple/demo/domain/contest/service/ContestCommandServiceImpl.java
+++ b/src/main/java/umc/cockple/demo/domain/contest/service/ContestCommandServiceImpl.java
@@ -218,8 +218,7 @@ public class ContestCommandServiceImpl implements ContestCommandService {
                 }
             } else {
                 // 신규 항목 추가
-                ContestVideo newVideo = ContestVideo.of(contest, reqVideo.videoKey(), reqVideo.videoOrder());
-                contest.getContestVideos().add(newVideo);
+                ContestVideo.of(contest, reqVideo.videoKey(), reqVideo.videoOrder());
             }
         }
     }
@@ -239,8 +238,7 @@ public class ContestCommandServiceImpl implements ContestCommandService {
     private void extractedVideoWithOrder(List<AddContestVideoRequest> videos, Contest contest) {
         if (videos != null && !videos.isEmpty()) {
             for (AddContestVideoRequest video : videos) {
-                ContestVideo contestVideo = ContestVideo.of(contest, video.videoKey(), video.videoOrder());
-                contest.getContestVideos().add(contestVideo);
+                ContestVideo.of(contest, video.videoKey(), video.videoOrder());
             }
         }
     }

--- a/src/main/java/umc/cockple/demo/domain/contest/service/ContestCommandServiceImpl.java
+++ b/src/main/java/umc/cockple/demo/domain/contest/service/ContestCommandServiceImpl.java
@@ -143,11 +143,6 @@ public class ContestCommandServiceImpl implements ContestCommandService {
             requestImgs = List.of();
         }
 
-        if (requestImgs.size() > 3) {
-            log.error("이미지 개수 초과: {}", requestImgs.size());
-            throw new ContestException(ContestErrorCode.IMAGE_UPLOAD_LIMIT_EXCEEDED);
-        }
-
         // 요청에 포함된 기존 이미지 ID 목록
         Set<Long> requestImgIds = requestImgs.stream()
                 .map(ContestImgUpdateRequest::id)
@@ -224,11 +219,6 @@ public class ContestCommandServiceImpl implements ContestCommandService {
     }
 
     private void extractedImgsWithOrder(List<AddContestImgRequest> imgs, Contest contest) {
-        int total = contest.getContestImgs().size() + imgs.size();
-        if (total > 3) {
-            log.error("이미지 개수 초과: 기존 {}, 추가 {}", contest.getContestImgs().size(), imgs.size());
-            throw new ContestException(ContestErrorCode.IMAGE_UPLOAD_LIMIT_EXCEEDED);
-        }
         for (AddContestImgRequest img : imgs) {
             ContestImg contestImg = ContestImg.of(contest, img.imgKey(), img.imgOrder());
             contest.addContestImg(contestImg);

--- a/src/main/java/umc/cockple/demo/domain/contest/service/ContestQueryServiceImpl.java
+++ b/src/main/java/umc/cockple/demo/domain/contest/service/ContestQueryServiceImpl.java
@@ -139,7 +139,7 @@ public class ContestQueryServiceImpl implements ContestQueryService {
                 : "";
     }
 
-    public String getMedalImgUrl(Contest contest) {
+    private String getMedalImgUrl(Contest contest) {
         String baseKey = "contest/";
         String key = switch (contest.getMedalType()) {
             case GOLD   -> baseKey + "b0ac9ac7-169a-40de-aeb3-a8572bc91506.svg";

--- a/src/test/java/umc/cockple/demo/domain/contest/integration/ContestIntegrationTest.java
+++ b/src/test/java/umc/cockple/demo/domain/contest/integration/ContestIntegrationTest.java
@@ -89,8 +89,8 @@ class ContestIntegrationTest extends IntegrationTestBase {
                 mockMvc.perform(post("/api/contests/my")
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(objectMapper.writeValueAsString(request)))
-                        .andExpect(status().isCreated())
-                        .andExpect(jsonPath("$.isSuccess").value(true))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.success").value(true))
                         .andExpect(jsonPath("$.code").value("COMMON201"))
                         .andExpect(jsonPath("$.data.contestId").isNumber())
                         .andExpect(jsonPath("$.data.createdAt").isNotEmpty())
@@ -117,7 +117,7 @@ class ContestIntegrationTest extends IntegrationTestBase {
                 mockMvc.perform(post("/api/contests/my")
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(objectMapper.writeValueAsString(request)))
-                        .andExpect(status().isCreated())
+                        .andExpect(status().isOk())
                         .andExpect(jsonPath("$.data.contestId").isNumber())
                         .andExpect(jsonPath("$.data.contestImgIds", hasSize(0)))
                         .andExpect(jsonPath("$.data.contestVideoIds", hasSize(0)));
@@ -266,8 +266,8 @@ class ContestIntegrationTest extends IntegrationTestBase {
                 mockMvc.perform(patch("/api/contests/my/{contestId}", myContest.getId())
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(objectMapper.writeValueAsString(request)))
-                        .andExpect(status().isCreated())
-                        .andExpect(jsonPath("$.isSuccess").value(true))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.success").value(true))
                         .andExpect(jsonPath("$.code").value("COMMON201"))
                         .andExpect(jsonPath("$.data.contestId").value(myContest.getId()))
                         .andExpect(jsonPath("$.data.contestImgs").isArray())
@@ -346,7 +346,7 @@ class ContestIntegrationTest extends IntegrationTestBase {
 
                 mockMvc.perform(delete("/api/contests/my/{contestId}", myContest.getId()))
                         .andExpect(status().isOk())
-                        .andExpect(jsonPath("$.isSuccess").value(true))
+                        .andExpect(jsonPath("$.success").value(true))
                         .andExpect(jsonPath("$.code").value("COMMON200"))
                         .andExpect(jsonPath("$.data.deleteContestId").value(myContest.getId()));
             }
@@ -402,11 +402,11 @@ class ContestIntegrationTest extends IntegrationTestBase {
 
                 mockMvc.perform(get("/api/contests/my/{contestId}", myContest.getId()))
                         .andExpect(status().isOk())
-                        .andExpect(jsonPath("$.isSuccess").value(true))
+                        .andExpect(jsonPath("$.success").value(true))
                         .andExpect(jsonPath("$.code").value("COMMON200"))
                         .andExpect(jsonPath("$.data.contestId").value(myContest.getId()))
                         .andExpect(jsonPath("$.data.contestName").value("내 대회 기록"))
-                        .andExpect(jsonPath("$.data.date").value("2026-06-15"))
+                        .andExpect(jsonPath("$.data.date").value("2024-06-15"))
                         .andExpect(jsonPath("$.data.medalType").value("GOLD"))
                         .andExpect(jsonPath("$.data.type").value("SINGLE"))
                         .andExpect(jsonPath("$.data.level").value("A"))
@@ -472,7 +472,7 @@ class ContestIntegrationTest extends IntegrationTestBase {
 
                 mockMvc.perform(get("/api/contests/my"))
                         .andExpect(status().isOk())
-                        .andExpect(jsonPath("$.isSuccess").value(true))
+                        .andExpect(jsonPath("$.success").value(true))
                         .andExpect(jsonPath("$.code").value("COMMON200"))
                         .andExpect(jsonPath("$.data", hasSize(4)))
                         .andExpect(jsonPath("$.data[0].contestId").isNumber())
@@ -566,7 +566,7 @@ class ContestIntegrationTest extends IntegrationTestBase {
 
                 mockMvc.perform(get("/api/contests/my/medals"))
                         .andExpect(status().isOk())
-                        .andExpect(jsonPath("$.isSuccess").value(true))
+                        .andExpect(jsonPath("$.success").value(true))
                         .andExpect(jsonPath("$.code").value("COMMON200"))
                         .andExpect(jsonPath("$.data.myMedalTotal").value(4))
                         .andExpect(jsonPath("$.data.goldCount").value(2))
@@ -600,7 +600,7 @@ class ContestIntegrationTest extends IntegrationTestBase {
         void setUpContest() {
             otherContest = contestRepository.save(ContestFixture.createPrivateContest(
                     otherMember, "타인의 대회", MedalType.BRONZE,
-                    LocalDate.of(2025, 3, 10), ParticipationType.WOMEN_DOUBLES, Level.C, "비공개 후기"
+                    LocalDate.of(2026, 3, 10), ParticipationType.WOMEN_DOUBLES, Level.C, "비공개 후기"
             ));
         }
 
@@ -616,11 +616,11 @@ class ContestIntegrationTest extends IntegrationTestBase {
                 mockMvc.perform(get("/api/members/{memberId}/contests/{contestId}",
                                 otherMember.getId(), otherContest.getId()))
                         .andExpect(status().isOk())
-                        .andExpect(jsonPath("$.isSuccess").value(true))
+                        .andExpect(jsonPath("$.success").value(true))
                         .andExpect(jsonPath("$.code").value("COMMON200"))
                         .andExpect(jsonPath("$.data.contestId").value(otherContest.getId()))
                         .andExpect(jsonPath("$.data.contestName").value("타인의 대회"))
-                        .andExpect(jsonPath("$.data.date").value("2024-03-10"))
+                        .andExpect(jsonPath("$.data.date").value("2026-03-10"))
                         .andExpect(jsonPath("$.data.medalType").value("BRONZE"))
                         .andExpect(jsonPath("$.data.type").value("WOMEN_DOUBLES"))
                         .andExpect(jsonPath("$.data.level").value("C"))
@@ -676,7 +676,7 @@ class ContestIntegrationTest extends IntegrationTestBase {
                 mockMvc.perform(get("/api/members/{memberId}/contests", otherMember.getId())
                                 .param("memeberId", String.valueOf(otherMember.getId())))
                         .andExpect(status().isOk())
-                        .andExpect(jsonPath("$.isSuccess").value(true))
+                        .andExpect(jsonPath("$.success").value(true))
                         .andExpect(jsonPath("$.code").value("COMMON200"))
                         .andExpect(jsonPath("$.data", hasSize(2)));
             }
@@ -719,7 +719,7 @@ class ContestIntegrationTest extends IntegrationTestBase {
                 mockMvc.perform(get("/api/members/{memberId}/medals", otherMember.getId())
                                 .param("memberId", String.valueOf(otherMember.getId())))
                         .andExpect(status().isOk())
-                        .andExpect(jsonPath("$.isSuccess").value(true))
+                        .andExpect(jsonPath("$.success").value(true))
                         .andExpect(jsonPath("$.code").value("COMMON200"))
                         .andExpect(jsonPath("$.data.myMedalTotal").value(2))
                         .andExpect(jsonPath("$.data.goldCount").value(1))

--- a/src/test/java/umc/cockple/demo/domain/contest/integration/ContestIntegrationTest.java
+++ b/src/test/java/umc/cockple/demo/domain/contest/integration/ContestIntegrationTest.java
@@ -276,7 +276,7 @@ class ContestIntegrationTest extends IntegrationTestBase {
                         .andExpect(jsonPath("$.data.contestImgs[0].imgOrder").value(1))
                         .andExpect(jsonPath("$.data.contestVideos").isArray())
                         .andExpect(jsonPath("$.data.contestVideos", hasSize(1)))
-                        .andExpect(jsonPath("$.data.UpdatedAt").isNotEmpty());
+                        .andExpect(jsonPath("$.data.updatedAt").isNotEmpty());
             }
         }
 

--- a/src/test/java/umc/cockple/demo/domain/contest/integration/ContestIntegrationTest.java
+++ b/src/test/java/umc/cockple/demo/domain/contest/integration/ContestIntegrationTest.java
@@ -673,8 +673,7 @@ class ContestIntegrationTest extends IntegrationTestBase {
             void getOtherContestList_all() throws Exception {
                 SecurityContextHelper.setAuthentication(member.getId(), member.getNickname());
 
-                mockMvc.perform(get("/api/members/{memberId}/contests", otherMember.getId())
-                                .param("memeberId", String.valueOf(otherMember.getId())))
+                mockMvc.perform(get("/api/members/{memberId}/contests", otherMember.getId()))
                         .andExpect(status().isOk())
                         .andExpect(jsonPath("$.success").value(true))
                         .andExpect(jsonPath("$.code").value("COMMON200"))
@@ -687,7 +686,6 @@ class ContestIntegrationTest extends IntegrationTestBase {
                 SecurityContextHelper.setAuthentication(member.getId(), member.getNickname());
 
                 mockMvc.perform(get("/api/members/{memberId}/contests", otherMember.getId())
-                                .param("memeberId", String.valueOf(otherMember.getId()))
                                 .param("medalType", "NONE"))
                         .andExpect(status().isOk())
                         .andExpect(jsonPath("$.data", hasSize(1)))
@@ -716,8 +714,7 @@ class ContestIntegrationTest extends IntegrationTestBase {
             void getOtherMemberMedals_allFields() throws Exception {
                 SecurityContextHelper.setAuthentication(member.getId(), member.getNickname());
 
-                mockMvc.perform(get("/api/members/{memberId}/medals", otherMember.getId())
-                                .param("memberId", String.valueOf(otherMember.getId())))
+                mockMvc.perform(get("/api/members/{memberId}/medals", otherMember.getId()))
                         .andExpect(status().isOk())
                         .andExpect(jsonPath("$.success").value(true))
                         .andExpect(jsonPath("$.code").value("COMMON200"))
@@ -732,8 +729,7 @@ class ContestIntegrationTest extends IntegrationTestBase {
             void getOtherMemberMedals_noMedals() throws Exception {
                 SecurityContextHelper.setAuthentication(otherMember.getId(), otherMember.getNickname());
 
-                mockMvc.perform(get("/api/members/{memberId}/medals", member.getId())
-                                .param("memberId", String.valueOf(member.getId())))
+                mockMvc.perform(get("/api/members/{memberId}/medals", member.getId()))
                         .andExpect(status().isOk())
                         .andExpect(jsonPath("$.data.myMedalTotal").value(0))
                         .andExpect(jsonPath("$.data.goldCount").value(0))

--- a/src/test/java/umc/cockple/demo/domain/contest/integration/ContestIntegrationTest.java
+++ b/src/test/java/umc/cockple/demo/domain/contest/integration/ContestIntegrationTest.java
@@ -1,0 +1,745 @@
+package umc.cockple.demo.domain.contest.integration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import umc.cockple.demo.domain.contest.domain.Contest;
+import umc.cockple.demo.domain.contest.dto.*;
+import umc.cockple.demo.domain.contest.enums.MedalType;
+import umc.cockple.demo.domain.contest.exception.ContestErrorCode;
+import umc.cockple.demo.domain.contest.repository.ContestRepository;
+import umc.cockple.demo.domain.member.domain.Member;
+import umc.cockple.demo.domain.member.repository.MemberRepository;
+import umc.cockple.demo.domain.party.enums.ParticipationType;
+import umc.cockple.demo.global.enums.Gender;
+import umc.cockple.demo.global.enums.Level;
+import umc.cockple.demo.support.IntegrationTestBase;
+import umc.cockple.demo.support.SecurityContextHelper;
+import umc.cockple.demo.support.fixture.ContestFixture;
+import umc.cockple.demo.support.fixture.MemberFixture;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.hamcrest.Matchers.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+class ContestIntegrationTest extends IntegrationTestBase {
+
+    @Autowired MockMvc mockMvc;
+    @Autowired ObjectMapper objectMapper;
+    @Autowired MemberRepository memberRepository;
+    @Autowired ContestRepository contestRepository;
+
+    private Member member;
+    private Member otherMember;
+
+    @BeforeEach
+    void setUp() {
+        member = memberRepository.save(MemberFixture.createMember("테스터", Gender.MALE, Level.A, 1001L));
+        otherMember = memberRepository.save(MemberFixture.createMember("다른회원", Gender.FEMALE, Level.B, 2002L));
+    }
+
+    @AfterEach
+    void tearDown() {
+        contestRepository.deleteAll();
+        memberRepository.deleteAll();
+        SecurityContextHelper.clearAuthentication();
+    }
+
+    private Contest createContest(Member m, String name, MedalType medalType) {
+        return contestRepository.save(ContestFixture.createContest(m, name, medalType));
+    }
+
+
+    @Nested
+    @DisplayName("POST /api/contests/my - 대회 기록 등록")
+    class CreateContest {
+
+        @Nested
+        @DisplayName("성공 케이스")
+        class Success {
+
+            @Test
+            @DisplayName("201 - 대회 기록을 등록하면 contestId, createdAt, 이미지/영상 ID 목록을 반환한다")
+            void createContest_allFields() throws Exception {
+                SecurityContextHelper.setAuthentication(member.getId(), member.getNickname());
+
+                ContestRecordCreateDTO.Request request = ContestRecordCreateDTO.Request.builder()
+                        .contestName("2026 전국 배드민턴 오픈 대회")
+                        .date(LocalDate.of(2026, 6, 15))
+                        .medalType(MedalType.GOLD)
+                        .type(ParticipationType.SINGLE)
+                        .level(Level.A)
+                        .content("결승에서 승리했습니다.")
+                        .contentIsOpen(true)
+                        .videoIsOpen(true)
+                        .contestImgs(List.of(
+                                new AddContestImgRequest("images/contest1.jpg", 1),
+                                new AddContestImgRequest("images/contest2.jpg", 2)
+                        ))
+                        .contestVideos(List.of(
+                                new AddContestVideoRequest("videos/match.mp4", 1)
+                        ))
+                        .build();
+
+                mockMvc.perform(post("/api/contests/my")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request)))
+                        .andExpect(status().isCreated())
+                        .andExpect(jsonPath("$.isSuccess").value(true))
+                        .andExpect(jsonPath("$.code").value("COMMON201"))
+                        .andExpect(jsonPath("$.data.contestId").isNumber())
+                        .andExpect(jsonPath("$.data.createdAt").isNotEmpty())
+                        .andExpect(jsonPath("$.data.contestImgIds").isArray())
+                        .andExpect(jsonPath("$.data.contestImgIds", hasSize(2)))
+                        .andExpect(jsonPath("$.data.contestVideoIds").isArray())
+                        .andExpect(jsonPath("$.data.contestVideoIds", hasSize(1)));
+            }
+
+            @Test
+            @DisplayName("201 - 이미지/영상 없이 필수 필드만으로 대회 기록을 등록하면 성공한다")
+            void createContest_minimalFields() throws Exception {
+                SecurityContextHelper.setAuthentication(member.getId(), member.getNickname());
+
+                ContestRecordCreateDTO.Request request = ContestRecordCreateDTO.Request.builder()
+                        .contestName("한강 배드민턴 클럽 대회")
+                        .medalType(MedalType.NONE)
+                        .type(ParticipationType.MEN_DOUBLES)
+                        .level(Level.B)
+                        .contentIsOpen(false)
+                        .videoIsOpen(false)
+                        .build();
+
+                mockMvc.perform(post("/api/contests/my")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request)))
+                        .andExpect(status().isCreated())
+                        .andExpect(jsonPath("$.data.contestId").isNumber())
+                        .andExpect(jsonPath("$.data.contestImgIds", hasSize(0)))
+                        .andExpect(jsonPath("$.data.contestVideoIds", hasSize(0)));
+            }
+        }
+
+        @Nested
+        @DisplayName("실패 케이스")
+        class Failure {
+
+            @Test
+            @DisplayName("400 - contestName이 없으면 에러를 반환한다")
+            void createContest_missingContestName() throws Exception {
+                SecurityContextHelper.setAuthentication(member.getId(), member.getNickname());
+
+                ContestRecordCreateDTO.Request request = ContestRecordCreateDTO.Request.builder()
+                        .type(ParticipationType.SINGLE)
+                        .level(Level.A)
+                        .contentIsOpen(true)
+                        .videoIsOpen(false)
+                        .build();
+
+                mockMvc.perform(post("/api/contests/my")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request)))
+                        .andExpect(status().isBadRequest());
+            }
+
+            @Test
+            @DisplayName("400 - 이미지가 3개를 초과하면 에러를 반환한다")
+            void createContest_imageLimitExceeded() throws Exception {
+                SecurityContextHelper.setAuthentication(member.getId(), member.getNickname());
+
+                ContestRecordCreateDTO.Request request = ContestRecordCreateDTO.Request.builder()
+                        .contestName("테스트 대회")
+                        .type(ParticipationType.SINGLE)
+                        .level(Level.A)
+                        .contentIsOpen(true)
+                        .videoIsOpen(false)
+                        .contestImgs(List.of(
+                                new AddContestImgRequest("img1.jpg", 1),
+                                new AddContestImgRequest("img2.jpg", 2),
+                                new AddContestImgRequest("img3.jpg", 3),
+                                new AddContestImgRequest("img4.jpg", 4)
+                        ))
+                        .build();
+
+                mockMvc.perform(post("/api/contests/my")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request)))
+                        .andExpect(status().isBadRequest());
+            }
+
+            @Test
+            @DisplayName("400 - ParticipationType이 없으면 에러를 반환한다")
+            void createContest_missingType() throws Exception {
+                SecurityContextHelper.setAuthentication(member.getId(), member.getNickname());
+
+                ContestRecordCreateDTO.Request request = ContestRecordCreateDTO.Request.builder()
+                        .contestName("테스트 대회")
+                        .level(Level.A)
+                        .contentIsOpen(true)
+                        .videoIsOpen(false)
+                        .build();
+
+                mockMvc.perform(post("/api/contests/my")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request)))
+                        .andExpect(status().isBadRequest());
+            }
+
+            @Test
+            @DisplayName("400 - content가 100자를 초과하면 에러를 반환한다")
+            void createContest_contentTooLong() throws Exception {
+                SecurityContextHelper.setAuthentication(member.getId(), member.getNickname());
+
+                ContestRecordCreateDTO.Request request = ContestRecordCreateDTO.Request.builder()
+                        .contestName("테스트 대회")
+                        .type(ParticipationType.SINGLE)
+                        .level(Level.A)
+                        .content("a".repeat(101))
+                        .contentIsOpen(true)
+                        .videoIsOpen(false)
+                        .build();
+
+                mockMvc.perform(post("/api/contests/my")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request)))
+                        .andExpect(status().isBadRequest());
+            }
+
+            @Test
+            @DisplayName("400 - level이 없으면 에러를 반환한다")
+            void createContest_missingLevel() throws Exception {
+                SecurityContextHelper.setAuthentication(member.getId(), member.getNickname());
+
+                ContestRecordCreateDTO.Request request = ContestRecordCreateDTO.Request.builder()
+                        .contestName("테스트 대회")
+                        .type(ParticipationType.SINGLE)
+                        .contentIsOpen(true)
+                        .videoIsOpen(false)
+                        .build();
+
+                mockMvc.perform(post("/api/contests/my")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request)))
+                        .andExpect(status().isBadRequest());
+            }
+        }
+    }
+
+
+    @Nested
+    @DisplayName("PATCH /api/contests/my/{contestId} - 대회 기록 수정")
+    class UpdateContest {
+
+        private Contest myContest;
+
+        @BeforeEach
+        void setUpContest() {
+            myContest = createContest(member, "원래 대회 이름", MedalType.NONE);
+        }
+
+        @Nested
+        @DisplayName("성공 케이스")
+        class Success {
+
+            @Test
+            @DisplayName("201 - 대회 기록을 수정하면 contestId, 이미지/영상 목록, updatedAt을 반환한다")
+            void updateContest_allFields() throws Exception {
+                SecurityContextHelper.setAuthentication(member.getId(), member.getNickname());
+
+                ContestRecordUpdateDTO.Request request = new ContestRecordUpdateDTO.Request(
+                        "수정된 대회 이름",
+                        LocalDate.of(2026, 9, 20),
+                        MedalType.SILVER,
+                        ParticipationType.MIX_DOUBLES,
+                        Level.B,
+                        "수정된 대회 후기",
+                        true,
+                        false,
+                        List.of(new ContestImgUpdateRequest(null, "new-img.jpg", 1)),
+                        List.of(new ContestVideoUpdateRequest(null, "new-video.mp4", 1))
+                );
+
+                mockMvc.perform(patch("/api/contests/my/{contestId}", myContest.getId())
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request)))
+                        .andExpect(status().isCreated())
+                        .andExpect(jsonPath("$.isSuccess").value(true))
+                        .andExpect(jsonPath("$.code").value("COMMON201"))
+                        .andExpect(jsonPath("$.data.contestId").value(myContest.getId()))
+                        .andExpect(jsonPath("$.data.contestImgs").isArray())
+                        .andExpect(jsonPath("$.data.contestImgs", hasSize(1)))
+                        .andExpect(jsonPath("$.data.contestImgs[0].imgKey").value("new-img.jpg"))
+                        .andExpect(jsonPath("$.data.contestImgs[0].imgOrder").value(1))
+                        .andExpect(jsonPath("$.data.contestVideos").isArray())
+                        .andExpect(jsonPath("$.data.contestVideos", hasSize(1)))
+                        .andExpect(jsonPath("$.data.UpdatedAt").isNotEmpty());
+            }
+        }
+
+        @Nested
+        @DisplayName("실패 케이스")
+        class Failure {
+
+            @Test
+            @DisplayName("404 - 존재하지 않는 대회 기록을 수정하려 하면 에러를 반환한다")
+            void updateContest_notFound() throws Exception {
+                SecurityContextHelper.setAuthentication(member.getId(), member.getNickname());
+
+                ContestRecordUpdateDTO.Request request = new ContestRecordUpdateDTO.Request(
+                        "수정된 이름", null, MedalType.GOLD,
+                        ParticipationType.SINGLE, Level.A, null, true, false,
+                        null, null
+                );
+
+                mockMvc.perform(patch("/api/contests/my/{contestId}", 9999L)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request)))
+                        .andExpect(status().isNotFound())
+                        .andExpect(jsonPath("$.code").value(ContestErrorCode.CONTEST_NOT_FOUND.getCode()))
+                        .andExpect(jsonPath("$.message").value(ContestErrorCode.CONTEST_NOT_FOUND.getMessage()));
+            }
+
+            @Test
+            @DisplayName("404 - 다른 사람의 대회 기록을 수정하려 하면 에러를 반환한다")
+            void updateContest_notOwner() throws Exception {
+                SecurityContextHelper.setAuthentication(otherMember.getId(), otherMember.getNickname());
+
+                ContestRecordUpdateDTO.Request request = new ContestRecordUpdateDTO.Request(
+                        "수정된 이름", null, MedalType.GOLD,
+                        ParticipationType.SINGLE, Level.A, null, true, false,
+                        null, null
+                );
+
+                mockMvc.perform(patch("/api/contests/my/{contestId}", myContest.getId())
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request)))
+                        .andExpect(status().isNotFound())
+                        .andExpect(jsonPath("$.code").value(ContestErrorCode.CONTEST_NOT_FOUND.getCode()));
+            }
+        }
+    }
+
+
+    @Nested
+    @DisplayName("DELETE /api/contests/my/{contestId} - 대회 기록 삭제")
+    class DeleteContest {
+
+        private Contest myContest;
+
+        @BeforeEach
+        void setUpContest() {
+            myContest = createContest(member, "삭제할 대회", MedalType.BRONZE);
+        }
+
+        @Nested
+        @DisplayName("성공 케이스")
+        class Success {
+
+            @Test
+            @DisplayName("200 - 자신의 대회 기록을 삭제하면 삭제된 contestId를 반환한다")
+            void deleteContest_success() throws Exception {
+                SecurityContextHelper.setAuthentication(member.getId(), member.getNickname());
+
+                mockMvc.perform(delete("/api/contests/my/{contestId}", myContest.getId()))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.isSuccess").value(true))
+                        .andExpect(jsonPath("$.code").value("COMMON200"))
+                        .andExpect(jsonPath("$.data.deleteContestId").value(myContest.getId()));
+            }
+        }
+
+        @Nested
+        @DisplayName("실패 케이스")
+        class Failure {
+
+            @Test
+            @DisplayName("404 - 존재하지 않는 대회 기록을 삭제하려 하면 에러를 반환한다")
+            void deleteContest_notFound() throws Exception {
+                SecurityContextHelper.setAuthentication(member.getId(), member.getNickname());
+
+                mockMvc.perform(delete("/api/contests/my/{contestId}", 9999L))
+                        .andExpect(status().isNotFound())
+                        .andExpect(jsonPath("$.code").value(ContestErrorCode.CONTEST_NOT_FOUND.getCode()))
+                        .andExpect(jsonPath("$.message").value(ContestErrorCode.CONTEST_NOT_FOUND.getMessage()));
+            }
+
+            @Test
+            @DisplayName("404 - 다른 사람의 대회 기록을 삭제하려 하면 에러를 반환한다")
+            void deleteContest_notOwner() throws Exception {
+                SecurityContextHelper.setAuthentication(otherMember.getId(), otherMember.getNickname());
+
+                mockMvc.perform(delete("/api/contests/my/{contestId}", myContest.getId()))
+                        .andExpect(status().isNotFound())
+                        .andExpect(jsonPath("$.code").value(ContestErrorCode.CONTEST_NOT_FOUND.getCode()));
+            }
+        }
+    }
+
+
+    @Nested
+    @DisplayName("GET /api/contests/my/{contestId} - 내 대회 기록 상세 조회")
+    class GetMyContestRecordDetail {
+
+        private Contest myContest;
+
+        @BeforeEach
+        void setUpContest() {
+            myContest = createContest(member, "내 대회 기록", MedalType.GOLD);
+        }
+
+        @Nested
+        @DisplayName("성공 케이스")
+        class Success {
+
+            @Test
+            @DisplayName("200 - 자신의 대회 기록을 상세 조회하면 모든 필드를 반환한다")
+            void getMyContestRecordDetail_allFields() throws Exception {
+                SecurityContextHelper.setAuthentication(member.getId(), member.getNickname());
+
+                mockMvc.perform(get("/api/contests/my/{contestId}", myContest.getId()))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.isSuccess").value(true))
+                        .andExpect(jsonPath("$.code").value("COMMON200"))
+                        .andExpect(jsonPath("$.data.contestId").value(myContest.getId()))
+                        .andExpect(jsonPath("$.data.contestName").value("내 대회 기록"))
+                        .andExpect(jsonPath("$.data.date").value("2026-06-15"))
+                        .andExpect(jsonPath("$.data.medalType").value("GOLD"))
+                        .andExpect(jsonPath("$.data.type").value("SINGLE"))
+                        .andExpect(jsonPath("$.data.level").value("A"))
+                        .andExpect(jsonPath("$.data.content").value("대회 후기입니다."))
+                        .andExpect(jsonPath("$.data.contentIsOpen").value(true))
+                        .andExpect(jsonPath("$.data.videoIsOpen").value(true))
+                        .andExpect(jsonPath("$.data.contestImgIds").isArray())
+                        .andExpect(jsonPath("$.data.contestImgUrls").isArray())
+                        .andExpect(jsonPath("$.data.contestVideoIds").isArray())
+                        .andExpect(jsonPath("$.data.contestVideoUrls").isArray());
+            }
+        }
+
+        @Nested
+        @DisplayName("실패 케이스")
+        class Failure {
+
+            @Test
+            @DisplayName("404 - 존재하지 않는 대회 기록을 조회하면 에러를 반환한다")
+            void getMyContestRecordDetail_notFound() throws Exception {
+                SecurityContextHelper.setAuthentication(member.getId(), member.getNickname());
+
+                mockMvc.perform(get("/api/contests/my/{contestId}", 9999L))
+                        .andExpect(status().isNotFound())
+                        .andExpect(jsonPath("$.code").value(ContestErrorCode.CONTEST_NOT_FOUND.getCode()))
+                        .andExpect(jsonPath("$.message").value(ContestErrorCode.CONTEST_NOT_FOUND.getMessage()));
+            }
+
+            @Test
+            @DisplayName("404 - 다른 사람의 대회 기록을 내 기록으로 조회하면 에러를 반환한다")
+            void getMyContestRecordDetail_othersMember() throws Exception {
+                Contest otherContest = createContest(otherMember, "타인의 대회", MedalType.SILVER);
+                SecurityContextHelper.setAuthentication(member.getId(), member.getNickname());
+
+                mockMvc.perform(get("/api/contests/my/{contestId}", otherContest.getId()))
+                        .andExpect(status().isNotFound())
+                        .andExpect(jsonPath("$.code").value(ContestErrorCode.CONTEST_NOT_FOUND.getCode()));
+            }
+        }
+    }
+
+
+    @Nested
+    @DisplayName("GET /api/contests/my - 내 대회 기록 리스트 조회")
+    class GetMyContestRecordList {
+
+        @BeforeEach
+        void setUpContests() {
+            createContest(member, "금메달 대회", MedalType.GOLD);
+            createContest(member, "은메달 대회", MedalType.SILVER);
+            createContest(member, "동메달 대회", MedalType.BRONZE);
+            createContest(member, "미입상 대회", MedalType.NONE);
+        }
+
+        @Nested
+        @DisplayName("성공 케이스")
+        class Success {
+
+            @Test
+            @DisplayName("200 - medalType 없이 조회하면 전체 대회 기록 리스트와 모든 필드를 반환한다")
+            void getMyContestRecords_allFields() throws Exception {
+                SecurityContextHelper.setAuthentication(member.getId(), member.getNickname());
+
+                mockMvc.perform(get("/api/contests/my"))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.isSuccess").value(true))
+                        .andExpect(jsonPath("$.code").value("COMMON200"))
+                        .andExpect(jsonPath("$.data", hasSize(4)))
+                        .andExpect(jsonPath("$.data[0].contestId").isNumber())
+                        .andExpect(jsonPath("$.data[0].contestName").isString())
+                        .andExpect(jsonPath("$.data[0].type").value("SINGLE"))
+                        .andExpect(jsonPath("$.data[0].level").value("A"))
+                        .andExpect(jsonPath("$.data[0].date").value("2024-06-15"))
+                        .andExpect(jsonPath("$.data[0].medalImgUrl").isString());
+            }
+
+            @Test
+            @DisplayName("200 - medalType=GOLD로 조회하면 NONE 필터링 없이 전체를 반환한다")
+            void getMyContestRecords_withGold() throws Exception {
+                SecurityContextHelper.setAuthentication(member.getId(), member.getNickname());
+
+                mockMvc.perform(get("/api/contests/my")
+                                .param("medalType", "GOLD"))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.data", hasSize(4)));
+            }
+
+            @Test
+            @DisplayName("200 - medalType=SILVER로 조회하면 NONE 필터링 없이 전체를 반환한다")
+            void getMyContestRecords_withSilver() throws Exception {
+                SecurityContextHelper.setAuthentication(member.getId(), member.getNickname());
+
+                mockMvc.perform(get("/api/contests/my")
+                                .param("medalType", "SILVER"))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.data", hasSize(4)));
+            }
+
+            @Test
+            @DisplayName("200 - medalType=BRONZE로 조회하면 NONE 필터링 없이 전체를 반환한다")
+            void getMyContestRecords_withBronze() throws Exception {
+                SecurityContextHelper.setAuthentication(member.getId(), member.getNickname());
+
+                mockMvc.perform(get("/api/contests/my")
+                                .param("medalType", "BRONZE"))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.data", hasSize(4)));
+            }
+
+            @Test
+            @DisplayName("200 - medalType=NONE으로 조회하면 미입상 대회 기록만 반환한다")
+            void getMyContestRecords_filterByNone() throws Exception {
+                SecurityContextHelper.setAuthentication(member.getId(), member.getNickname());
+
+                mockMvc.perform(get("/api/contests/my")
+                                .param("medalType", "NONE"))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.data", hasSize(1)))
+                        .andExpect(jsonPath("$.data[0].contestName").value("미입상 대회"));
+            }
+
+            @Test
+            @DisplayName("200 - 대회 기록이 없으면 빈 리스트를 반환한다")
+            void getMyContestRecords_empty() throws Exception {
+                SecurityContextHelper.setAuthentication(otherMember.getId(), otherMember.getNickname());
+
+                mockMvc.perform(get("/api/contests/my"))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.data", hasSize(0)));
+            }
+        }
+    }
+
+
+
+    @Nested
+    @DisplayName("GET /api/contests/my/medals - 내 메달 조회")
+    class GetMyMedals {
+
+        @BeforeEach
+        void setUpContests() {
+            createContest(member, "금메달 대회1", MedalType.GOLD);
+            createContest(member, "금메달 대회2", MedalType.GOLD);
+            createContest(member, "은메달 대회", MedalType.SILVER);
+            createContest(member, "동메달 대회", MedalType.BRONZE);
+            createContest(member, "미입상 대회", MedalType.NONE);
+        }
+
+        @Nested
+        @DisplayName("성공 케이스")
+        class Success {
+
+            @Test
+            @DisplayName("200 - 메달 현황을 조회하면 총 개수(NONE 제외)와 종류별 개수를 반환한다")
+            void getMyMedals_allFields() throws Exception {
+                SecurityContextHelper.setAuthentication(member.getId(), member.getNickname());
+
+                mockMvc.perform(get("/api/contests/my/medals"))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.isSuccess").value(true))
+                        .andExpect(jsonPath("$.code").value("COMMON200"))
+                        .andExpect(jsonPath("$.data.myMedalTotal").value(4))
+                        .andExpect(jsonPath("$.data.goldCount").value(2))
+                        .andExpect(jsonPath("$.data.silverCount").value(1))
+                        .andExpect(jsonPath("$.data.bronzeCount").value(1));
+            }
+
+            @Test
+            @DisplayName("200 - 메달이 없으면 모두 0을 반환한다")
+            void getMyMedals_noMedals() throws Exception {
+                SecurityContextHelper.setAuthentication(otherMember.getId(), otherMember.getNickname());
+
+                mockMvc.perform(get("/api/contests/my/medals"))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.data.myMedalTotal").value(0))
+                        .andExpect(jsonPath("$.data.goldCount").value(0))
+                        .andExpect(jsonPath("$.data.silverCount").value(0))
+                        .andExpect(jsonPath("$.data.bronzeCount").value(0));
+            }
+        }
+    }
+
+
+    @Nested
+    @DisplayName("GET /api/members/{memberId}/contests/{contestId} - 다른 사람의 대회 기록 상세 조회")
+    class GetOtherMemberContestRecordDetail {
+
+        private Contest otherContest;
+
+        @BeforeEach
+        void setUpContest() {
+            otherContest = contestRepository.save(ContestFixture.createPrivateContest(
+                    otherMember, "타인의 대회", MedalType.BRONZE,
+                    LocalDate.of(2025, 3, 10), ParticipationType.WOMEN_DOUBLES, Level.C, "비공개 후기"
+            ));
+        }
+
+        @Nested
+        @DisplayName("성공 케이스")
+        class Success {
+
+            @Test
+            @DisplayName("200 - 비공개 설정 시 content와 영상은 숨기고 다른 사람의 대회 기록 상세를 반환한다")
+            void getOtherContestDetail_allFields() throws Exception {
+                SecurityContextHelper.setAuthentication(member.getId(), member.getNickname());
+
+                mockMvc.perform(get("/api/members/{memberId}/contests/{contestId}",
+                                otherMember.getId(), otherContest.getId()))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.isSuccess").value(true))
+                        .andExpect(jsonPath("$.code").value("COMMON200"))
+                        .andExpect(jsonPath("$.data.contestId").value(otherContest.getId()))
+                        .andExpect(jsonPath("$.data.contestName").value("타인의 대회"))
+                        .andExpect(jsonPath("$.data.date").value("2024-03-10"))
+                        .andExpect(jsonPath("$.data.medalType").value("BRONZE"))
+                        .andExpect(jsonPath("$.data.type").value("WOMEN_DOUBLES"))
+                        .andExpect(jsonPath("$.data.level").value("C"))
+                        .andExpect(jsonPath("$.data.contentIsOpen").value(false))
+                        .andExpect(jsonPath("$.data.videoIsOpen").value(false))
+                        .andExpect(jsonPath("$.data.content").value(""))
+                        .andExpect(jsonPath("$.data.contestImgIds").isArray())
+                        .andExpect(jsonPath("$.data.contestImgUrls").isArray())
+                        .andExpect(jsonPath("$.data.contestVideoIds").isArray())
+                        .andExpect(jsonPath("$.data.contestVideoUrls").isArray());
+            }
+        }
+
+        @Nested
+        @DisplayName("실패 케이스")
+        class Failure {
+
+            @Test
+            @DisplayName("404 - 존재하지 않는 대회 기록을 조회하면 에러를 반환한다")
+            void getOtherContestDetail_notFound() throws Exception {
+                SecurityContextHelper.setAuthentication(member.getId(), member.getNickname());
+
+                mockMvc.perform(get("/api/members/{memberId}/contests/{contestId}",
+                                otherMember.getId(), 9999L))
+                        .andExpect(status().isNotFound())
+                        .andExpect(jsonPath("$.code").value(ContestErrorCode.CONTEST_NOT_FOUND.getCode()))
+                        .andExpect(jsonPath("$.message").value(ContestErrorCode.CONTEST_NOT_FOUND.getMessage()));
+            }
+        }
+    }
+
+
+
+    @Nested
+    @DisplayName("GET /api/members/{memberId}/contests - 다른 사람의 대회 기록 리스트 조회")
+    class GetOtherMemberContestList {
+
+        @BeforeEach
+        void setUpContests() {
+            createContest(otherMember, "타인의 금메달 대회", MedalType.GOLD);
+            createContest(otherMember, "타인의 미입상 대회", MedalType.NONE);
+        }
+
+        @Nested
+        @DisplayName("성공 케이스")
+        class Success {
+
+            @Test
+            @DisplayName("200 - 다른 사람의 전체 대회 기록 리스트를 조회하면 성공한다")
+            void getOtherContestList_all() throws Exception {
+                SecurityContextHelper.setAuthentication(member.getId(), member.getNickname());
+
+                mockMvc.perform(get("/api/members/{memberId}/contests", otherMember.getId())
+                                .param("memeberId", String.valueOf(otherMember.getId())))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.isSuccess").value(true))
+                        .andExpect(jsonPath("$.code").value("COMMON200"))
+                        .andExpect(jsonPath("$.data", hasSize(2)));
+            }
+
+            @Test
+            @DisplayName("200 - medalType=NONE으로 조회하면 다른 사람의 미입상 기록만 반환한다")
+            void getOtherContestList_filterByNone() throws Exception {
+                SecurityContextHelper.setAuthentication(member.getId(), member.getNickname());
+
+                mockMvc.perform(get("/api/members/{memberId}/contests", otherMember.getId())
+                                .param("memeberId", String.valueOf(otherMember.getId()))
+                                .param("medalType", "NONE"))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.data", hasSize(1)))
+                        .andExpect(jsonPath("$.data[0].contestName").value("타인의 미입상 대회"));
+            }
+        }
+    }
+
+
+    @Nested
+    @DisplayName("GET /api/members/{memberId}/medals - 다른 사람의 메달 조회")
+    class GetOtherMemberMedals {
+
+        @BeforeEach
+        void setUpContests() {
+            createContest(otherMember, "타인의 금메달", MedalType.GOLD);
+            createContest(otherMember, "타인의 은메달", MedalType.SILVER);
+        }
+
+        @Nested
+        @DisplayName("성공 케이스")
+        class Success {
+
+            @Test
+            @DisplayName("200 - 다른 사람의 메달 현황을 조회하면 종류별 개수를 반환한다")
+            void getOtherMemberMedals_allFields() throws Exception {
+                SecurityContextHelper.setAuthentication(member.getId(), member.getNickname());
+
+                mockMvc.perform(get("/api/members/{memberId}/medals", otherMember.getId())
+                                .param("memberId", String.valueOf(otherMember.getId())))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.isSuccess").value(true))
+                        .andExpect(jsonPath("$.code").value("COMMON200"))
+                        .andExpect(jsonPath("$.data.myMedalTotal").value(2))
+                        .andExpect(jsonPath("$.data.goldCount").value(1))
+                        .andExpect(jsonPath("$.data.silverCount").value(1))
+                        .andExpect(jsonPath("$.data.bronzeCount").value(0));
+            }
+
+            @Test
+            @DisplayName("200 - 메달이 없는 회원을 조회하면 모두 0을 반환한다")
+            void getOtherMemberMedals_noMedals() throws Exception {
+                SecurityContextHelper.setAuthentication(otherMember.getId(), otherMember.getNickname());
+
+                mockMvc.perform(get("/api/members/{memberId}/medals", member.getId())
+                                .param("memberId", String.valueOf(member.getId())))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.data.myMedalTotal").value(0))
+                        .andExpect(jsonPath("$.data.goldCount").value(0))
+                        .andExpect(jsonPath("$.data.silverCount").value(0))
+                        .andExpect(jsonPath("$.data.bronzeCount").value(0));
+            }
+        }
+    }
+}

--- a/src/test/java/umc/cockple/demo/domain/contest/service/ContestCommandServiceTest.java
+++ b/src/test/java/umc/cockple/demo/domain/contest/service/ContestCommandServiceTest.java
@@ -1,0 +1,451 @@
+package umc.cockple.demo.domain.contest.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import umc.cockple.demo.domain.contest.converter.ContestConverter;
+import umc.cockple.demo.domain.contest.domain.Contest;
+import umc.cockple.demo.domain.contest.dto.*;
+import umc.cockple.demo.domain.contest.enums.MedalType;
+import umc.cockple.demo.domain.contest.exception.ContestErrorCode;
+import umc.cockple.demo.domain.contest.exception.ContestException;
+import umc.cockple.demo.domain.contest.repository.ContestRepository;
+import umc.cockple.demo.domain.file.service.FileService;
+import umc.cockple.demo.domain.member.domain.Member;
+import umc.cockple.demo.domain.member.repository.MemberRepository;
+import umc.cockple.demo.domain.party.enums.ParticipationType;
+import umc.cockple.demo.global.enums.Gender;
+import umc.cockple.demo.global.enums.Level;
+import umc.cockple.demo.support.fixture.ContestFixture;
+import umc.cockple.demo.support.fixture.MemberFixture;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ContestCommandService")
+class ContestCommandServiceTest {
+
+    @InjectMocks
+    private ContestCommandServiceImpl contestCommandService;
+
+    @Mock private ContestRepository contestRepository;
+    @Mock private MemberRepository memberRepository;
+    @Mock private ContestConverter contestConverter;
+
+    private Member member;
+
+    @BeforeEach
+    void setUp() {
+        member = MemberFixture.createMember("테스터", Gender.MALE, Level.A, 1001L);
+        ReflectionTestUtils.setField(member, "id", 1L);
+    }
+
+
+    @Nested
+    @DisplayName("createContestRecord - 대회 기록 등록")
+    class CreateContestRecord {
+
+        private ContestRecordCreateDTO.Request request;
+        private ContestRecordCreateDTO.Command command;
+
+        @BeforeEach
+        void setUp() {
+            request = ContestRecordCreateDTO.Request.builder()
+                    .contestName("2024 전국 배드민턴 오픈 대회")
+                    .date(LocalDate.of(2024, 6, 15))
+                    .medalType(MedalType.GOLD)
+                    .type(ParticipationType.SINGLE)
+                    .level(Level.A)
+                    .content("결승에서 승리했습니다.")
+                    .contentIsOpen(true)
+                    .videoIsOpen(true)
+                    .build();
+
+            command = ContestRecordCreateDTO.Command.builder()
+                    .memberId(member.getId())
+                    .contestName("2024 전국 배드민턴 오픈 대회")
+                    .date(LocalDate.of(2024, 6, 15))
+                    .medalType(MedalType.GOLD)
+                    .type(ParticipationType.SINGLE)
+                    .level(Level.A)
+                    .content("결승에서 승리했습니다.")
+                    .contentIsOpen(true)
+                    .videoIsOpen(true)
+                    .build();
+        }
+
+        @Nested
+        @DisplayName("성공 케이스")
+        class Success {
+
+            @Test
+            @DisplayName("회원이 존재하면 대회 기록을 저장하고 응답을 반환한다")
+            void createContestRecord_success() {
+                // given
+                Contest savedContest = ContestFixture.createContest(member, "2024 전국 배드민턴 오픈 대회", MedalType.GOLD);
+                ReflectionTestUtils.setField(savedContest, "id", 10L);
+
+                ContestRecordCreateDTO.Response expectedResponse = ContestRecordCreateDTO.Response.builder()
+                        .contestId(10L)
+                        .createdAt(LocalDateTime.now())
+                        .contestImgIds(List.of())
+                        .contestVideoIds(List.of())
+                        .build();
+
+                given(memberRepository.findById(member.getId())).willReturn(Optional.of(member));
+                given(contestConverter.toCreateCommand(request, member.getId())).willReturn(command);
+                given(contestRepository.save(any())).willReturn(savedContest);
+                given(contestConverter.toCreateResponseDTO(savedContest)).willReturn(expectedResponse);
+
+                // when
+                ContestRecordCreateDTO.Response response =
+                        contestCommandService.createContestRecord(member.getId(), request);
+
+                // then
+                assertThat(response.contestId()).isEqualTo(10L);
+                then(contestRepository).should().save(any());
+                then(contestConverter).should().toCreateResponseDTO(savedContest);
+            }
+
+            @Test
+            @DisplayName("이미지를 포함하면 contestImgIds 목록을 반환한다")
+            void createContestRecord_withImages() {
+                // given
+                ContestRecordCreateDTO.Request requestWithImgs = ContestRecordCreateDTO.Request.builder()
+                        .contestName("이미지 포함 대회")
+                        .type(ParticipationType.SINGLE)
+                        .level(Level.A)
+                        .contentIsOpen(true)
+                        .videoIsOpen(false)
+                        .contestImgs(List.of(
+                                new AddContestImgRequest("img1.jpg", 1),
+                                new AddContestImgRequest("img2.jpg", 2)
+                        ))
+                        .build();
+
+                ContestRecordCreateDTO.Command commandWithImgs = ContestRecordCreateDTO.Command.builder()
+                        .memberId(member.getId())
+                        .contestName("이미지 포함 대회")
+                        .type(ParticipationType.SINGLE)
+                        .level(Level.A)
+                        .contentIsOpen(true)
+                        .videoIsOpen(false)
+                        .contestImgs(List.of(
+                                new AddContestImgRequest("img1.jpg", 1),
+                                new AddContestImgRequest("img2.jpg", 2)
+                        ))
+                        .build();
+
+                Contest savedContest = ContestFixture.createContest(member, "이미지 포함 대회", MedalType.NONE);
+                ReflectionTestUtils.setField(savedContest, "id", 20L);
+
+                ContestRecordCreateDTO.Response expectedResponse = ContestRecordCreateDTO.Response.builder()
+                        .contestId(20L)
+                        .createdAt(LocalDateTime.now())
+                        .contestImgIds(List.of(1L, 2L))
+                        .contestVideoIds(List.of())
+                        .build();
+
+                given(memberRepository.findById(member.getId())).willReturn(Optional.of(member));
+                given(contestConverter.toCreateCommand(requestWithImgs, member.getId())).willReturn(commandWithImgs);
+                given(contestRepository.save(any())).willReturn(savedContest);
+                given(contestConverter.toCreateResponseDTO(savedContest)).willReturn(expectedResponse);
+
+                // when
+                ContestRecordCreateDTO.Response response =
+                        contestCommandService.createContestRecord(member.getId(), requestWithImgs);
+
+                // then
+                assertThat(response.contestImgIds()).hasSize(2);
+            }
+
+            @Test
+            @DisplayName("영상을 포함하면 contestVideoIds 목록을 반환한다")
+            void createContestRecord_withVideos() {
+                // given
+                ContestRecordCreateDTO.Request requestWithVideos = ContestRecordCreateDTO.Request.builder()
+                        .contestName("영상 포함 대회")
+                        .type(ParticipationType.SINGLE)
+                        .level(Level.A)
+                        .contentIsOpen(true)
+                        .videoIsOpen(true)
+                        .contestVideos(List.of(
+                                new AddContestVideoRequest("videos/match1.mp4", 1),
+                                new AddContestVideoRequest("videos/match2.mp4", 2)
+                        ))
+                        .build();
+
+                ContestRecordCreateDTO.Command commandWithVideos = ContestRecordCreateDTO.Command.builder()
+                        .memberId(member.getId())
+                        .contestName("영상 포함 대회")
+                        .type(ParticipationType.SINGLE)
+                        .level(Level.A)
+                        .contentIsOpen(true)
+                        .videoIsOpen(true)
+                        .contestVideos(List.of(
+                                new AddContestVideoRequest("videos/match1.mp4", 1),
+                                new AddContestVideoRequest("videos/match2.mp4", 2)
+                        ))
+                        .build();
+
+                Contest savedContest = ContestFixture.createContest(member, "영상 포함 대회", MedalType.NONE);
+                ReflectionTestUtils.setField(savedContest, "id", 30L);
+
+                ContestRecordCreateDTO.Response expectedResponse = ContestRecordCreateDTO.Response.builder()
+                        .contestId(30L)
+                        .createdAt(LocalDateTime.now())
+                        .contestImgIds(List.of())
+                        .contestVideoIds(List.of(1L, 2L))
+                        .build();
+
+                given(memberRepository.findById(member.getId())).willReturn(Optional.of(member));
+                given(contestConverter.toCreateCommand(requestWithVideos, member.getId())).willReturn(commandWithVideos);
+                given(contestRepository.save(any())).willReturn(savedContest);
+                given(contestConverter.toCreateResponseDTO(savedContest)).willReturn(expectedResponse);
+
+                // when
+                ContestRecordCreateDTO.Response response =
+                        contestCommandService.createContestRecord(member.getId(), requestWithVideos);
+
+                // then
+                assertThat(response.contestVideoIds()).hasSize(2);
+                assertThat(response.contestImgIds()).isEmpty();
+            }
+        }
+
+        @Nested
+        @DisplayName("실패 케이스")
+        class Failure {
+
+            @Test
+            @DisplayName("존재하지 않는 회원이면 ContestException(MEMBER_NOT_FOUND)을 던진다")
+            void createContestRecord_memberNotFound() {
+                // given
+                given(memberRepository.findById(999L)).willReturn(Optional.empty());
+
+                // when & then
+                assertThatThrownBy(() ->
+                        contestCommandService.createContestRecord(999L, request))
+                        .isInstanceOf(ContestException.class)
+                        .satisfies(e -> assertThat(((ContestException) e).getCode())
+                                .isEqualTo(ContestErrorCode.MEMBER_NOT_FOUND));
+            }
+
+            @Test
+            @DisplayName("이미지가 3개를 초과하면 ContestException(IMAGE_UPLOAD_LIMIT_EXCEEDED)을 던진다")
+            void createContestRecord_imageLimitExceeded() {
+                // given
+                ContestRecordCreateDTO.Command commandWith4Imgs = ContestRecordCreateDTO.Command.builder()
+                        .memberId(member.getId())
+                        .contestName("테스트 대회")
+                        .type(ParticipationType.SINGLE)
+                        .level(Level.A)
+                        .contentIsOpen(true)
+                        .videoIsOpen(false)
+                        .contestImgs(List.of(
+                                new AddContestImgRequest("img1.jpg", 1),
+                                new AddContestImgRequest("img2.jpg", 2),
+                                new AddContestImgRequest("img3.jpg", 3),
+                                new AddContestImgRequest("img4.jpg", 4)
+                        ))
+                        .build();
+
+                given(memberRepository.findById(member.getId())).willReturn(Optional.of(member));
+                given(contestConverter.toCreateCommand(any(), any())).willReturn(commandWith4Imgs);
+
+                // when & then
+                assertThatThrownBy(() ->
+                        contestCommandService.createContestRecord(member.getId(), request))
+                        .isInstanceOf(ContestException.class)
+                        .satisfies(e -> assertThat(((ContestException) e).getCode())
+                                .isEqualTo(ContestErrorCode.IMAGE_UPLOAD_LIMIT_EXCEEDED));
+            }
+        }
+    }
+
+    // =========================================================
+    // updateContestRecord
+    // =========================================================
+
+    @Nested
+    @DisplayName("updateContestRecord - 대회 기록 수정")
+    class UpdateContestRecord {
+
+        private Contest contest;
+        private ContestRecordUpdateDTO.Request request;
+
+        @BeforeEach
+        void setUp() {
+            contest = ContestFixture.createContest(member, "원래 대회 이름", MedalType.NONE);
+            ReflectionTestUtils.setField(contest, "id", 10L);
+
+            request = new ContestRecordUpdateDTO.Request(
+                    "수정된 대회 이름",
+                    LocalDate.of(2024, 9, 20),
+                    MedalType.SILVER,
+                    ParticipationType.MIX_DOUBLES,
+                    Level.B,
+                    "수정된 후기",
+                    true,
+                    false,
+                    null,
+                    null
+            );
+        }
+
+        @Nested
+        @DisplayName("성공 케이스")
+        class Success {
+
+            @Test
+            @DisplayName("대회 기록이 존재하면 수정 후 응답을 반환한다")
+            void updateContestRecord_success() {
+                // given
+                ContestRecordUpdateDTO.Response expectedResponse = ContestRecordUpdateDTO.Response.builder()
+                        .contestId(10L)
+                        .contestImgs(List.of())
+                        .contestVideos(List.of())
+                        .UpdatedAt(LocalDateTime.now())
+                        .build();
+
+                given(contestRepository.findByIdAndMember_Id(10L, member.getId()))
+                        .willReturn(Optional.of(contest));
+                given(contestRepository.save(contest)).willReturn(contest);
+                given(contestConverter.toUpdateResponseDTO(contest)).willReturn(expectedResponse);
+
+                // when
+                ContestRecordUpdateDTO.Response response =
+                        contestCommandService.updateContestRecord(member.getId(), 10L, request);
+
+                // then
+                assertThat(response.contestId()).isEqualTo(10L);
+                then(contestRepository).should().save(contest);
+            }
+        }
+
+        @Nested
+        @DisplayName("실패 케이스")
+        class Failure {
+
+            @Test
+            @DisplayName("존재하지 않거나 본인 소유가 아닌 대회 기록이면 ContestException(CONTEST_NOT_FOUND)을 던진다")
+            void updateContestRecord_contestNotFound() {
+                // given
+                given(contestRepository.findByIdAndMember_Id(999L, member.getId()))
+                        .willReturn(Optional.empty());
+
+                // when & then
+                assertThatThrownBy(() ->
+                        contestCommandService.updateContestRecord(member.getId(), 999L, request))
+                        .isInstanceOf(ContestException.class)
+                        .satisfies(e -> assertThat(((ContestException) e).getCode())
+                                .isEqualTo(ContestErrorCode.CONTEST_NOT_FOUND));
+            }
+
+            @Test
+            @DisplayName("수정 요청 이미지가 3개를 초과하면 ContestException(IMAGE_UPLOAD_LIMIT_EXCEEDED)을 던진다")
+            void updateContestRecord_imageLimitExceeded() {
+                // given
+                ContestRecordUpdateDTO.Request requestWith4Imgs = new ContestRecordUpdateDTO.Request(
+                        "수정된 이름", null, MedalType.GOLD, ParticipationType.SINGLE, Level.A,
+                        null, true, false,
+                        List.of(
+                                new ContestImgUpdateRequest(null, "img1.jpg", 1),
+                                new ContestImgUpdateRequest(null, "img2.jpg", 2),
+                                new ContestImgUpdateRequest(null, "img3.jpg", 3),
+                                new ContestImgUpdateRequest(null, "img4.jpg", 4)
+                        ),
+                        null
+                );
+
+                given(contestRepository.findByIdAndMember_Id(10L, member.getId()))
+                        .willReturn(Optional.of(contest));
+
+                // when & then
+                assertThatThrownBy(() ->
+                        contestCommandService.updateContestRecord(member.getId(), 10L, requestWith4Imgs))
+                        .isInstanceOf(ContestException.class)
+                        .satisfies(e -> assertThat(((ContestException) e).getCode())
+                                .isEqualTo(ContestErrorCode.IMAGE_UPLOAD_LIMIT_EXCEEDED));
+            }
+        }
+    }
+
+    // =========================================================
+    // deleteContestRecord
+    // =========================================================
+
+    @Nested
+    @DisplayName("deleteContestRecord - 대회 기록 삭제")
+    class DeleteContestRecord {
+
+        private Contest contest;
+
+        @BeforeEach
+        void setUp() {
+            contest = ContestFixture.createContest(member, "삭제할 대회", MedalType.BRONZE);
+            ReflectionTestUtils.setField(contest, "id", 10L);
+        }
+
+        @Nested
+        @DisplayName("성공 케이스")
+        class Success {
+
+            @Test
+            @DisplayName("대회 기록이 존재하면 삭제 후 deleteContestId를 반환한다")
+            void deleteContestRecord_success() {
+                // given
+                ContestRecordDeleteDTO.Response expectedResponse = ContestRecordDeleteDTO.Response.builder()
+                        .deleteContestId(10L)
+                        .build();
+
+                given(contestRepository.findByIdAndMember_Id(10L, member.getId()))
+                        .willReturn(Optional.of(contest));
+                given(contestConverter.toDeleteResponseDTO(contest)).willReturn(expectedResponse);
+
+                // when
+                ContestRecordDeleteDTO.Response response =
+                        contestCommandService.deleteContestRecord(member.getId(), 10L);
+
+                // then
+                assertThat(response.deleteContestId()).isEqualTo(10L);
+                then(contestRepository).should().delete(contest);
+            }
+        }
+
+        @Nested
+        @DisplayName("실패 케이스")
+        class Failure {
+
+            @Test
+            @DisplayName("존재하지 않거나 본인 소유가 아닌 대회 기록이면 ContestException(CONTEST_NOT_FOUND)을 던진다")
+            void deleteContestRecord_contestNotFound() {
+                // given
+                given(contestRepository.findByIdAndMember_Id(999L, member.getId()))
+                        .willReturn(Optional.empty());
+
+                // when & then
+                assertThatThrownBy(() ->
+                        contestCommandService.deleteContestRecord(member.getId(), 999L))
+                        .isInstanceOf(ContestException.class)
+                        .satisfies(e -> assertThat(((ContestException) e).getCode())
+                                .isEqualTo(ContestErrorCode.CONTEST_NOT_FOUND));
+            }
+        }
+    }
+}

--- a/src/test/java/umc/cockple/demo/domain/contest/service/ContestCommandServiceTest.java
+++ b/src/test/java/umc/cockple/demo/domain/contest/service/ContestCommandServiceTest.java
@@ -46,6 +46,7 @@ class ContestCommandServiceTest {
     @Mock private ContestRepository contestRepository;
     @Mock private MemberRepository memberRepository;
     @Mock private ContestConverter contestConverter;
+    @Mock private FileService fileService;
 
     private Member member;
 
@@ -291,7 +292,7 @@ class ContestCommandServiceTest {
                         .contestId(10L)
                         .contestImgs(List.of())
                         .contestVideos(List.of())
-                        .UpdatedAt(LocalDateTime.now())
+                        .updatedAt(LocalDateTime.now())
                         .build();
 
                 given(contestRepository.findByIdAndMember_Id(10L, member.getId()))

--- a/src/test/java/umc/cockple/demo/domain/contest/service/ContestCommandServiceTest.java
+++ b/src/test/java/umc/cockple/demo/domain/contest/service/ContestCommandServiceTest.java
@@ -246,35 +246,6 @@ class ContestCommandServiceTest {
                                 .isEqualTo(ContestErrorCode.MEMBER_NOT_FOUND));
             }
 
-            @Test
-            @DisplayName("이미지가 3개를 초과하면 ContestException(IMAGE_UPLOAD_LIMIT_EXCEEDED)을 던진다")
-            void createContestRecord_imageLimitExceeded() {
-                // given
-                ContestRecordCreateDTO.Command commandWith4Imgs = ContestRecordCreateDTO.Command.builder()
-                        .memberId(member.getId())
-                        .contestName("테스트 대회")
-                        .type(ParticipationType.SINGLE)
-                        .level(Level.A)
-                        .contentIsOpen(true)
-                        .videoIsOpen(false)
-                        .contestImgs(List.of(
-                                new AddContestImgRequest("img1.jpg", 1),
-                                new AddContestImgRequest("img2.jpg", 2),
-                                new AddContestImgRequest("img3.jpg", 3),
-                                new AddContestImgRequest("img4.jpg", 4)
-                        ))
-                        .build();
-
-                given(memberRepository.findById(member.getId())).willReturn(Optional.of(member));
-                given(contestConverter.toCreateCommand(any(), any())).willReturn(commandWith4Imgs);
-
-                // when & then
-                assertThatThrownBy(() ->
-                        contestCommandService.createContestRecord(member.getId(), request))
-                        .isInstanceOf(ContestException.class)
-                        .satisfies(e -> assertThat(((ContestException) e).getCode())
-                                .isEqualTo(ContestErrorCode.IMAGE_UPLOAD_LIMIT_EXCEEDED));
-            }
         }
     }
 
@@ -357,32 +328,6 @@ class ContestCommandServiceTest {
                                 .isEqualTo(ContestErrorCode.CONTEST_NOT_FOUND));
             }
 
-            @Test
-            @DisplayName("수정 요청 이미지가 3개를 초과하면 ContestException(IMAGE_UPLOAD_LIMIT_EXCEEDED)을 던진다")
-            void updateContestRecord_imageLimitExceeded() {
-                // given
-                ContestRecordUpdateDTO.Request requestWith4Imgs = new ContestRecordUpdateDTO.Request(
-                        "수정된 이름", null, MedalType.GOLD, ParticipationType.SINGLE, Level.A,
-                        null, true, false,
-                        List.of(
-                                new ContestImgUpdateRequest(null, "img1.jpg", 1),
-                                new ContestImgUpdateRequest(null, "img2.jpg", 2),
-                                new ContestImgUpdateRequest(null, "img3.jpg", 3),
-                                new ContestImgUpdateRequest(null, "img4.jpg", 4)
-                        ),
-                        null
-                );
-
-                given(contestRepository.findByIdAndMember_Id(10L, member.getId()))
-                        .willReturn(Optional.of(contest));
-
-                // when & then
-                assertThatThrownBy(() ->
-                        contestCommandService.updateContestRecord(member.getId(), 10L, requestWith4Imgs))
-                        .isInstanceOf(ContestException.class)
-                        .satisfies(e -> assertThat(((ContestException) e).getCode())
-                                .isEqualTo(ContestErrorCode.IMAGE_UPLOAD_LIMIT_EXCEEDED));
-            }
         }
     }
 

--- a/src/test/java/umc/cockple/demo/domain/contest/service/ContestQueryServiceTest.java
+++ b/src/test/java/umc/cockple/demo/domain/contest/service/ContestQueryServiceTest.java
@@ -263,8 +263,6 @@ class ContestQueryServiceTest {
 
             noneContest = ContestFixture.createContest(member, "미입상 대회", MedalType.NONE);
             ReflectionTestUtils.setField(noneContest, "id", 3L);
-
-            given(fileService.getUrlFromKey(anyString())).willReturn("https://cdn.example.com/medal.svg");
         }
 
         @Nested
@@ -275,6 +273,7 @@ class ContestQueryServiceTest {
             @DisplayName("medalType=null이면 전체 대회 기록을 반환한다")
             void getList_noFilter() {
                 // given
+                given(fileService.getUrlFromKey(anyString())).willReturn("https://cdn.example.com/medal.svg");
                 given(contestRepository.findAllByMember_Id(member.getId()))
                         .willReturn(List.of(goldContest, silverContest, noneContest));
 
@@ -290,6 +289,7 @@ class ContestQueryServiceTest {
             @DisplayName("medalType=NONE이면 미입상 대회 기록만 반환한다")
             void getList_filterByNone() {
                 // given
+                given(fileService.getUrlFromKey(anyString())).willReturn("https://cdn.example.com/medal.svg");
                 given(contestRepository.findAllByMember_Id(member.getId()))
                         .willReturn(List.of(goldContest, silverContest, noneContest));
 
@@ -306,6 +306,7 @@ class ContestQueryServiceTest {
             @DisplayName("medalType=GOLD이면 NONE 필터링 없이 전체를 반환한다")
             void getList_filterByGold_returnsAll() {
                 // given
+                given(fileService.getUrlFromKey(anyString())).willReturn("https://cdn.example.com/medal.svg");
                 given(contestRepository.findAllByMember_Id(member.getId()))
                         .willReturn(List.of(goldContest, silverContest, noneContest));
 
@@ -321,6 +322,7 @@ class ContestQueryServiceTest {
             @DisplayName("medalType=SILVER이면 NONE 필터링 없이 전체를 반환한다")
             void getList_filterBySilver_returnsAll() {
                 // given
+                given(fileService.getUrlFromKey(anyString())).willReturn("https://cdn.example.com/medal.svg");
                 given(contestRepository.findAllByMember_Id(member.getId()))
                         .willReturn(List.of(goldContest, silverContest, noneContest));
 
@@ -336,6 +338,7 @@ class ContestQueryServiceTest {
             @DisplayName("medalType=BRONZE이면 NONE 필터링 없이 전체를 반환한다")
             void getList_filterByBronze_returnsAll() {
                 // given
+                given(fileService.getUrlFromKey(anyString())).willReturn("https://cdn.example.com/medal.svg");
                 given(contestRepository.findAllByMember_Id(member.getId()))
                         .willReturn(List.of(goldContest, silverContest, noneContest));
 

--- a/src/test/java/umc/cockple/demo/domain/contest/service/ContestQueryServiceTest.java
+++ b/src/test/java/umc/cockple/demo/domain/contest/service/ContestQueryServiceTest.java
@@ -1,0 +1,432 @@
+package umc.cockple.demo.domain.contest.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import umc.cockple.demo.domain.contest.converter.ContestConverter;
+import umc.cockple.demo.domain.contest.domain.Contest;
+import umc.cockple.demo.domain.contest.domain.ContestVideo;
+import umc.cockple.demo.domain.contest.dto.ContestMedalSummaryDTO;
+import umc.cockple.demo.domain.contest.dto.ContestRecordDetailDTO;
+import umc.cockple.demo.domain.contest.dto.ContestRecordSimpleDTO;
+import umc.cockple.demo.domain.contest.enums.MedalType;
+import umc.cockple.demo.domain.contest.exception.ContestErrorCode;
+import umc.cockple.demo.domain.contest.exception.ContestException;
+import umc.cockple.demo.domain.contest.repository.ContestRepository;
+import umc.cockple.demo.domain.file.service.FileService;
+import umc.cockple.demo.domain.member.domain.Member;
+import umc.cockple.demo.domain.party.enums.ParticipationType;
+import umc.cockple.demo.global.enums.Gender;
+import umc.cockple.demo.global.enums.Level;
+import umc.cockple.demo.support.fixture.ContestFixture;
+import umc.cockple.demo.support.fixture.MemberFixture;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ContestQueryService")
+class ContestQueryServiceTest {
+
+    @InjectMocks
+    private ContestQueryServiceImpl contestQueryService;
+
+    @Mock private ContestRepository contestRepository;
+    @Mock private ContestConverter contestConverter;
+    @Mock private FileService fileService;
+
+    private Member member;
+    private Member otherMember;
+
+    @BeforeEach
+    void setUp() {
+        member = MemberFixture.createMember("테스터", Gender.MALE, Level.A, 1001L);
+        ReflectionTestUtils.setField(member, "id", 1L);
+
+        otherMember = MemberFixture.createMember("다른회원", Gender.FEMALE, Level.B, 2002L);
+        ReflectionTestUtils.setField(otherMember, "id", 2L);
+    }
+
+
+    @Nested
+    @DisplayName("getContestRecordDetail - 대회 기록 상세 조회")
+    class GetContestRecordDetail {
+
+        private Contest publicContest;
+        private Contest privateContest;
+        private Contest publicVideoContest;
+
+        @BeforeEach
+        void setUp() {
+            publicContest = ContestFixture.createContest(member, "공개 대회", MedalType.GOLD);
+            ReflectionTestUtils.setField(publicContest, "id", 10L);
+
+            privateContest = ContestFixture.createPrivateContest(
+                    member, "비공개 대회", MedalType.SILVER,
+                    LocalDate.of(2024, 3, 10), ParticipationType.SINGLE, Level.A, "비공개 후기"
+            );
+            ReflectionTestUtils.setField(privateContest, "id", 20L);
+
+            // videoIsOpen=true, 영상 1개 포함
+            publicVideoContest = ContestFixture.createContest(member, "영상 공개 대회", MedalType.BRONZE);
+            ReflectionTestUtils.setField(publicVideoContest, "id", 30L);
+            ContestVideo video = ContestVideo.of(publicVideoContest, "https://cdn.example.com/match.mp4", 1);
+            ReflectionTestUtils.setField(video, "id", 100L);
+        }
+
+        @Nested
+        @DisplayName("성공 케이스")
+        class Success {
+
+            @Test
+            @DisplayName("본인 조회 시 content와 영상 목록을 그대로 반환한다")
+            void getDetail_owner() {
+                // given
+                ContestRecordDetailDTO.Response expectedResponse = ContestRecordDetailDTO.Response.builder()
+                        .contestId(20L)
+                        .content("비공개 후기")
+                        .contestVideoIds(List.of())
+                        .contestVideoUrls(List.of())
+                        .build();
+
+                given(contestRepository.findByIdAndMember_Id(20L, member.getId()))
+                        .willReturn(Optional.of(privateContest));
+                given(contestConverter.toDetailResponseDTO(eq(privateContest), any(), any(), any(), any(), eq("비공개 후기")))
+                        .willReturn(expectedResponse);
+
+                // when
+                ContestRecordDetailDTO.Response response =
+                        contestQueryService.getContestRecordDetail(member.getId(), member.getId(), 20L);
+
+                // then
+                assertThat(response.content()).isEqualTo("비공개 후기");
+                assertThat(response.contestVideoIds()).isEmpty();
+            }
+
+            @Test
+            @DisplayName("타인 조회 + contentIsOpen=true이면 content를 반환한다")
+            void getDetail_otherMember_publicContent() {
+                // given
+                ContestRecordDetailDTO.Response expectedResponse = ContestRecordDetailDTO.Response.builder()
+                        .contestId(10L)
+                        .content("대회 후기입니다.")
+                        .build();
+
+                given(contestRepository.findByIdAndMember_Id(10L, member.getId()))
+                        .willReturn(Optional.of(publicContest));
+                given(contestConverter.toDetailResponseDTO(eq(publicContest), any(), any(), any(), any(), eq("대회 후기입니다.")))
+                        .willReturn(expectedResponse);
+
+                // when
+                ContestRecordDetailDTO.Response response =
+                        contestQueryService.getContestRecordDetail(otherMember.getId(), member.getId(), 10L);
+
+                // then
+                assertThat(response.content()).isEqualTo("대회 후기입니다.");
+            }
+
+            @Test
+            @DisplayName("타인 조회 + contentIsOpen=false이면 content를 빈 문자열로 반환한다")
+            void getDetail_otherMember_privateContent() {
+                // given
+                ContestRecordDetailDTO.Response expectedResponse = ContestRecordDetailDTO.Response.builder()
+                        .contestId(20L)
+                        .content("")
+                        .contestVideoIds(List.of())
+                        .contestVideoUrls(List.of())
+                        .build();
+
+                given(contestRepository.findByIdAndMember_Id(20L, member.getId()))
+                        .willReturn(Optional.of(privateContest));
+                given(contestConverter.toDetailResponseDTO(eq(privateContest), any(), any(), any(), any(), eq("")))
+                        .willReturn(expectedResponse);
+
+                // when
+                ContestRecordDetailDTO.Response response =
+                        contestQueryService.getContestRecordDetail(otherMember.getId(), member.getId(), 20L);
+
+                // then
+                assertThat(response.content()).isEmpty();
+                assertThat(response.contestVideoIds()).isEmpty();
+            }
+
+            @Test
+            @DisplayName("타인 조회 + videoIsOpen=true이면 영상 ID와 URL 목록이 converter에 전달된다")
+            void getDetail_otherMember_publicVideo() {
+                // given
+                ContestRecordDetailDTO.Response expectedResponse = ContestRecordDetailDTO.Response.builder()
+                        .contestId(30L)
+                        .contestVideoIds(List.of(100L))
+                        .contestVideoUrls(List.of("https://cdn.example.com/match.mp4"))
+                        .build();
+
+                given(contestRepository.findByIdAndMember_Id(30L, member.getId()))
+                        .willReturn(Optional.of(publicVideoContest));
+                given(contestConverter.toDetailResponseDTO(
+                        eq(publicVideoContest), any(), any(),
+                        eq(List.of(100L)),
+                        eq(List.of("https://cdn.example.com/match.mp4")),
+                        any()))
+                        .willReturn(expectedResponse);
+
+                // when
+                ContestRecordDetailDTO.Response response =
+                        contestQueryService.getContestRecordDetail(otherMember.getId(), member.getId(), 30L);
+
+                // then
+                assertThat(response.contestVideoIds()).containsExactly(100L);
+                assertThat(response.contestVideoUrls()).containsExactly("https://cdn.example.com/match.mp4");
+            }
+
+            @Test
+            @DisplayName("타인 조회 + videoIsOpen=false이면 빈 영상 목록이 converter에 전달된다")
+            void getDetail_otherMember_privateVideo() {
+                // given
+                ContestRecordDetailDTO.Response expectedResponse = ContestRecordDetailDTO.Response.builder()
+                        .contestId(20L)
+                        .content("")
+                        .contestVideoIds(List.of())
+                        .contestVideoUrls(List.of())
+                        .build();
+
+                given(contestRepository.findByIdAndMember_Id(20L, member.getId()))
+                        .willReturn(Optional.of(privateContest));
+                given(contestConverter.toDetailResponseDTO(
+                        eq(privateContest), any(), any(),
+                        eq(List.of()),
+                        eq(List.of()),
+                        any()))
+                        .willReturn(expectedResponse);
+
+                // when
+                ContestRecordDetailDTO.Response response =
+                        contestQueryService.getContestRecordDetail(otherMember.getId(), member.getId(), 20L);
+
+                // then
+                then(contestConverter).should().toDetailResponseDTO(
+                        eq(privateContest), any(), any(),
+                        eq(List.of()), eq(List.of()), any());
+                assertThat(response.contestVideoIds()).isEmpty();
+            }
+        }
+
+        @Nested
+        @DisplayName("실패 케이스")
+        class Failure {
+
+            @Test
+            @DisplayName("존재하지 않는 대회 기록이면 ContestException(CONTEST_NOT_FOUND)을 던진다")
+            void getDetail_notFound() {
+                // given
+                given(contestRepository.findByIdAndMember_Id(999L, member.getId()))
+                        .willReturn(Optional.empty());
+
+                // when & then
+                assertThatThrownBy(() ->
+                        contestQueryService.getContestRecordDetail(member.getId(), member.getId(), 999L))
+                        .isInstanceOf(ContestException.class)
+                        .satisfies(e -> assertThat(((ContestException) e).getCode())
+                                .isEqualTo(ContestErrorCode.CONTEST_NOT_FOUND));
+            }
+        }
+    }
+
+
+    @Nested
+    @DisplayName("getMyContestRecordsByMedalType - 내 대회 기록 리스트 조회 (전체, 미입상)")
+    class GetMyContestRecordsByMedalType {
+
+        private Contest goldContest;
+        private Contest silverContest;
+        private Contest noneContest;
+
+        @BeforeEach
+        void setUp() {
+            goldContest = ContestFixture.createContest(member, "금메달 대회", MedalType.GOLD);
+            ReflectionTestUtils.setField(goldContest, "id", 1L);
+
+            silverContest = ContestFixture.createContest(member, "은메달 대회", MedalType.SILVER);
+            ReflectionTestUtils.setField(silverContest, "id", 2L);
+
+            noneContest = ContestFixture.createContest(member, "미입상 대회", MedalType.NONE);
+            ReflectionTestUtils.setField(noneContest, "id", 3L);
+
+            given(fileService.getUrlFromKey(anyString())).willReturn("https://cdn.example.com/medal.svg");
+        }
+
+        @Nested
+        @DisplayName("성공 케이스")
+        class Success {
+
+            @Test
+            @DisplayName("medalType=null이면 전체 대회 기록을 반환한다")
+            void getList_noFilter() {
+                // given
+                given(contestRepository.findAllByMember_Id(member.getId()))
+                        .willReturn(List.of(goldContest, silverContest, noneContest));
+
+                // when
+                List<ContestRecordSimpleDTO.Response> result =
+                        contestQueryService.getMyContestRecordsByMedalType(member.getId(), null);
+
+                // then
+                assertThat(result).hasSize(3);
+            }
+
+            @Test
+            @DisplayName("medalType=NONE이면 미입상 대회 기록만 반환한다")
+            void getList_filterByNone() {
+                // given
+                given(contestRepository.findAllByMember_Id(member.getId()))
+                        .willReturn(List.of(goldContest, silverContest, noneContest));
+
+                // when
+                List<ContestRecordSimpleDTO.Response> result =
+                        contestQueryService.getMyContestRecordsByMedalType(member.getId(), MedalType.NONE);
+
+                // then
+                assertThat(result).hasSize(1);
+                assertThat(result.get(0).contestName()).isEqualTo("미입상 대회");
+            }
+
+            @Test
+            @DisplayName("medalType=GOLD이면 NONE 필터링 없이 전체를 반환한다")
+            void getList_filterByGold_returnsAll() {
+                // given
+                given(contestRepository.findAllByMember_Id(member.getId()))
+                        .willReturn(List.of(goldContest, silverContest, noneContest));
+
+                // when
+                List<ContestRecordSimpleDTO.Response> result =
+                        contestQueryService.getMyContestRecordsByMedalType(member.getId(), MedalType.GOLD);
+
+                // then
+                assertThat(result).hasSize(3);
+            }
+
+            @Test
+            @DisplayName("medalType=SILVER이면 NONE 필터링 없이 전체를 반환한다")
+            void getList_filterBySilver_returnsAll() {
+                // given
+                given(contestRepository.findAllByMember_Id(member.getId()))
+                        .willReturn(List.of(goldContest, silverContest, noneContest));
+
+                // when
+                List<ContestRecordSimpleDTO.Response> result =
+                        contestQueryService.getMyContestRecordsByMedalType(member.getId(), MedalType.SILVER);
+
+                // then
+                assertThat(result).hasSize(3);
+            }
+
+            @Test
+            @DisplayName("medalType=BRONZE이면 NONE 필터링 없이 전체를 반환한다")
+            void getList_filterByBronze_returnsAll() {
+                // given
+                given(contestRepository.findAllByMember_Id(member.getId()))
+                        .willReturn(List.of(goldContest, silverContest, noneContest));
+
+                // when
+                List<ContestRecordSimpleDTO.Response> result =
+                        contestQueryService.getMyContestRecordsByMedalType(member.getId(), MedalType.BRONZE);
+
+                // then
+                assertThat(result).hasSize(3);
+            }
+
+            @Test
+            @DisplayName("대회 기록이 없으면 빈 리스트를 반환한다")
+            void getList_empty() {
+                // given
+                given(contestRepository.findAllByMember_Id(member.getId()))
+                        .willReturn(List.of());
+
+                // when
+                List<ContestRecordSimpleDTO.Response> result =
+                        contestQueryService.getMyContestRecordsByMedalType(member.getId(), null);
+
+                // then
+                assertThat(result).isEmpty();
+                then(fileService).shouldHaveNoInteractions();
+            }
+        }
+    }
+
+
+    @Nested
+    @DisplayName("getMyMedalSummary - 내 대회 메달 조회")
+    class GetMyMedalSummary {
+
+        @Nested
+        @DisplayName("성공 케이스")
+        class Success {
+
+            @Test
+            @DisplayName("메달이 있으면 종류별 개수와 합계를 반환한다")
+            void getMedalSummary_hasMedals() {
+                // given
+                ContestMedalSummaryDTO.Response expectedResponse = ContestMedalSummaryDTO.Response.builder()
+                        .myMedalTotal(4)
+                        .goldCount(2)
+                        .silverCount(1)
+                        .bronzeCount(1)
+                        .build();
+
+                given(contestRepository.countGoldMedalsByMemberId(member.getId())).willReturn(2);
+                given(contestRepository.countSilverMedalsByMemberId(member.getId())).willReturn(1);
+                given(contestRepository.countBronzeMedalsByMemberId(member.getId())).willReturn(1);
+                given(contestConverter.toMedalSummaryResponseDTO(2, 1, 1)).willReturn(expectedResponse);
+
+                // when
+                ContestMedalSummaryDTO.Response response =
+                        contestQueryService.getMyMedalSummary(member.getId());
+
+                // then
+                assertThat(response.myMedalTotal()).isEqualTo(4);
+                assertThat(response.goldCount()).isEqualTo(2);
+                assertThat(response.silverCount()).isEqualTo(1);
+                assertThat(response.bronzeCount()).isEqualTo(1);
+            }
+
+            @Test
+            @DisplayName("메달이 없으면 모두 0을 반환한다")
+            void getMedalSummary_noMedals() {
+                // given
+                ContestMedalSummaryDTO.Response expectedResponse = ContestMedalSummaryDTO.Response.builder()
+                        .myMedalTotal(0)
+                        .goldCount(0)
+                        .silverCount(0)
+                        .bronzeCount(0)
+                        .build();
+
+                given(contestRepository.countGoldMedalsByMemberId(member.getId())).willReturn(0);
+                given(contestRepository.countSilverMedalsByMemberId(member.getId())).willReturn(0);
+                given(contestRepository.countBronzeMedalsByMemberId(member.getId())).willReturn(0);
+                given(contestConverter.toMedalSummaryResponseDTO(0, 0, 0)).willReturn(expectedResponse);
+
+                // when
+                ContestMedalSummaryDTO.Response response =
+                        contestQueryService.getMyMedalSummary(member.getId());
+
+                // then
+                assertThat(response.myMedalTotal()).isEqualTo(0);
+                assertThat(response.goldCount()).isEqualTo(0);
+                assertThat(response.silverCount()).isEqualTo(0);
+                assertThat(response.bronzeCount()).isEqualTo(0);
+            }
+        }
+    }
+}

--- a/src/test/java/umc/cockple/demo/support/fixture/ContestFixture.java
+++ b/src/test/java/umc/cockple/demo/support/fixture/ContestFixture.java
@@ -1,0 +1,64 @@
+package umc.cockple.demo.support.fixture;
+
+import umc.cockple.demo.domain.contest.domain.Contest;
+import umc.cockple.demo.domain.contest.enums.MedalType;
+import umc.cockple.demo.domain.member.domain.Member;
+import umc.cockple.demo.domain.party.enums.ParticipationType;
+import umc.cockple.demo.global.enums.Level;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+
+public class ContestFixture {
+
+    public static Contest createContest(Member member, String contestName, MedalType medalType) {
+        return Contest.builder()
+                .member(member)
+                .contestName(contestName)
+                .medalType(medalType)
+                .date(LocalDate.of(2024, 6, 15))
+                .type(ParticipationType.SINGLE)
+                .level(Level.A)
+                .content("대회 후기입니다.")
+                .contentIsOpen(true)
+                .videoIsOpen(true)
+                .contestImgs(new ArrayList<>())
+                .contestVideos(new ArrayList<>())
+                .build();
+    }
+
+    public static Contest createContest(Member member, String contestName, MedalType medalType,
+                                        LocalDate date, ParticipationType type, Level level) {
+        return Contest.builder()
+                .member(member)
+                .contestName(contestName)
+                .medalType(medalType)
+                .date(date)
+                .type(type)
+                .level(level)
+                .content("대회 후기입니다.")
+                .contentIsOpen(true)
+                .videoIsOpen(true)
+                .contestImgs(new ArrayList<>())
+                .contestVideos(new ArrayList<>())
+                .build();
+    }
+
+    public static Contest createPrivateContest(Member member, String contestName, MedalType medalType,
+                                               LocalDate date, ParticipationType type, Level level,
+                                               String content) {
+        return Contest.builder()
+                .member(member)
+                .contestName(contestName)
+                .medalType(medalType)
+                .date(date)
+                .type(type)
+                .level(level)
+                .content(content)
+                .contentIsOpen(false)
+                .videoIsOpen(false)
+                .contestImgs(new ArrayList<>())
+                .contestVideos(new ArrayList<>())
+                .build();
+    }
+}


### PR DESCRIPTION
## ❤️ 기능 설명
- Contest 도메인의 단위테스트와 통합테스트를 작성합니다.
- 작성과정에서 대회기록 영상을 중복 저장하는 로직상 오류가 있어서 수정을 진행했습니다. 

단위테스트 - command
<img width="514" height="577" alt="스크린샷 2026-04-04 002159" src="https://github.com/user-attachments/assets/9015512e-260f-498e-8518-105146b1df74" />

단위테스트 - query
<img width="496" height="648" alt="스크린샷 2026-04-04 002509" src="https://github.com/user-attachments/assets/44c882ba-fc24-46fc-b70d-8f94e7bf172e" />

통합테스트
<img width="518" height="1047" alt="스크린샷 2026-04-04 003840" src="https://github.com/user-attachments/assets/45b381d7-9e6e-442a-b00a-277abccaa9e4" />



추후 별도의 이슈로 코드 리팩토링(함수명이 의미에 맞지 않는 부분, dto를 과도하게 사용하는 부분) 을 진행하겠습니다.

<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #565 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [ ] 이슈넘버를 적었는가?
