### PR TITLE
[feat/#569] 채팅 푸시알림 기능 추가 및 테스트코드 작성

### DIFF
--- a/src/main/java/umc/cockple/demo/domain/chat/events/ChatEventListener.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/events/ChatEventListener.java
@@ -13,6 +13,8 @@ import umc.cockple.demo.domain.chat.service.websocket.ChatListSubscriptionServic
 import umc.cockple.demo.domain.chat.service.websocket.ChatRoomListCacheService;
 import umc.cockple.demo.domain.chat.service.websocket.ChatSendService;
 import umc.cockple.demo.domain.chat.service.websocket.SubscriptionService;
+import umc.cockple.demo.domain.notification.events.ChatNotificationEvent;
+import umc.cockple.demo.domain.notification.service.ChatPushNotificationService;
 import umc.cockple.demo.domain.party.events.PartyMemberJoinedEvent;
 
 import java.util.HashMap;
@@ -27,6 +29,7 @@ public class ChatEventListener {
     private final SubscriptionService subscriptionService;
     private final ChatRoomListCacheService chatRoomListCacheService;
     private final ChatListSubscriptionService chatListSubscriptionService;
+    private final ChatPushNotificationService chatPushNotificationService;
 
 
     @EventListener
@@ -39,6 +42,17 @@ public class ChatEventListener {
                     .sendMessage(event.chatRoomId(), event.content(), event.files(), event.senderId());
         } catch (Exception e) {
             log.error("메시지 전송 이벤트 처리 중 오류 발생", e);
+        }
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Async
+    public void handleChatNotification(ChatNotificationEvent event) {
+        log.info("채팅 알림 이벤트 처리 - 채팅방: {}, 발신자: {}", event.chatRoomId(), event.senderId());
+        try {
+            chatPushNotificationService.sendPush(event);
+        } catch (Exception e) {
+            log.error("채팅 알림 이벤트 처리 중 오류 발생 - 채팅방: {}", event.chatRoomId(), e);
         }
     }
 

--- a/src/main/java/umc/cockple/demo/domain/chat/repository/ChatRoomMemberRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/repository/ChatRoomMemberRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import umc.cockple.demo.domain.chat.domain.ChatRoomMember;
+import umc.cockple.demo.domain.chat.enums.ChatRoomMemberStatus;
 
 import java.util.List;
 import java.util.Optional;
@@ -61,6 +62,17 @@ public interface ChatRoomMemberRepository extends JpaRepository<ChatRoomMember, 
 
     @Query("SELECT crm.member.id FROM ChatRoomMember crm WHERE crm.chatRoom.id = :chatRoomId")
     List<Long> findMemberIdsByChatRoomId(Long chatRoomId);
+
+    @Query("""
+            SELECT crm FROM ChatRoomMember crm
+            JOIN FETCH crm.member m
+            WHERE crm.chatRoom.id = :chatRoomId
+            AND crm.status = :status
+            """)
+    List<ChatRoomMember> findByChatRoomIdAndStatusWithMember(
+            @Param("chatRoomId") Long chatRoomId,
+            @Param("status") ChatRoomMemberStatus status
+    );
 
     @Query("""
             SELECT counterPart FROM ChatRoomMember counterPart

--- a/src/main/java/umc/cockple/demo/domain/chat/service/websocket/ChatSendService.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/websocket/ChatSendService.java
@@ -22,7 +22,7 @@ import umc.cockple.demo.domain.chat.repository.MessageReadStatusRepository;
 import umc.cockple.demo.domain.chat.service.ChatProcessor;
 import umc.cockple.demo.domain.member.domain.Member;
 import umc.cockple.demo.domain.member.repository.MemberRepository;
-import umc.cockple.demo.domain.notification.service.ChatPushNotificationService;
+import umc.cockple.demo.domain.notification.events.ChatNotificationEvent;
 
 import java.util.HashMap;
 import java.util.List;
@@ -46,8 +46,6 @@ public class ChatSendService {
     private final ChatProcessor chatProcessor;
     private final ChatConverter chatConverter;
     private final ChatReadService chatReadService;
-    private final ChatPushNotificationService chatPushNotificationService;
-
     private final ApplicationEventPublisher eventPublisher;
 
     public void sendMessage(Long chatRoomId, String content, List<WebSocketMessageDTO.Request.FileInfo> files, Long senderId) {
@@ -78,7 +76,8 @@ public class ChatSendService {
         subscriptionService.broadcastMessage(chatRoomId, response, senderId);
         log.info("메시지 브로드캐스트 완료 - 채팅방 ID: {}", chatRoomId);
 
-        chatPushNotificationService.sendPush(chatRoom, savedMessage, sender, activeSubscribers);
+        // 알림 이벤트 발행
+        publishChatNotificationEvent(chatRoom, savedMessage, sender, activeSubscribers);
 
         publishChatRoomListUpdateEvent(chatRoom, savedMessage);
     }
@@ -201,6 +200,26 @@ public class ChatSendService {
         }
 
         return unreadCounts;
+    }
+
+    // 채팅 알림 이벤트 발행
+    private void publishChatNotificationEvent(ChatRoom chatRoom, ChatMessage savedMessage,
+                                              Member sender, List<Long> activeSubscribers) {
+        String notificationTitle = chatRoom.getType() == ChatRoomType.PARTY
+                ? chatRoom.getParty().getPartyName()
+                : sender.getNickname();
+        String notificationContent = chatRoom.getType() == ChatRoomType.PARTY
+                ? sender.getNickname() + ": " + savedMessage.getDisplayContent()
+                : savedMessage.getDisplayContent();
+
+        eventPublisher.publishEvent(ChatNotificationEvent.create(
+                chatRoom.getId(),
+                chatRoom.getType(),
+                notificationTitle,
+                notificationContent,
+                sender.getId(),
+                activeSubscribers
+        ));
     }
 
     private ChatRoom findChatRoom(Long chatRoomId) {

--- a/src/main/java/umc/cockple/demo/domain/chat/service/websocket/ChatSendService.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/websocket/ChatSendService.java
@@ -22,6 +22,7 @@ import umc.cockple.demo.domain.chat.repository.MessageReadStatusRepository;
 import umc.cockple.demo.domain.chat.service.ChatProcessor;
 import umc.cockple.demo.domain.member.domain.Member;
 import umc.cockple.demo.domain.member.repository.MemberRepository;
+import umc.cockple.demo.domain.notification.service.ChatPushNotificationService;
 
 import java.util.HashMap;
 import java.util.List;
@@ -45,6 +46,7 @@ public class ChatSendService {
     private final ChatProcessor chatProcessor;
     private final ChatConverter chatConverter;
     private final ChatReadService chatReadService;
+    private final ChatPushNotificationService chatPushNotificationService;
 
     private final ApplicationEventPublisher eventPublisher;
 
@@ -75,6 +77,8 @@ public class ChatSendService {
                 chatConverter.toSendMessageResponse(chatRoomId, content, responseFiles, savedMessage, sender, profileImageUrl, unreadCount);
         subscriptionService.broadcastMessage(chatRoomId, response, senderId);
         log.info("메시지 브로드캐스트 완료 - 채팅방 ID: {}", chatRoomId);
+
+        chatPushNotificationService.sendPush(chatRoom, savedMessage, sender, activeSubscribers);
 
         publishChatRoomListUpdateEvent(chatRoom, savedMessage);
     }

--- a/src/main/java/umc/cockple/demo/domain/notification/enums/NotificationTarget.java
+++ b/src/main/java/umc/cockple/demo/domain/notification/enums/NotificationTarget.java
@@ -10,9 +10,7 @@ public enum NotificationTarget {
     PARTY_INVITE_APPROVED(NotificationType.SIMPLE),
     PARTY_JOINREQUEST_APPROVED(NotificationType.CHANGE),
     PARTY_SUBOWNER_ASSIGNED(NotificationType.SIMPLE),
-    PARTY_SUBOWNER_RELEASED(NotificationType.SIMPLE),
-    CHAT_MESSAGE_RECEIVED(NotificationType.CHAT),
-    GROUP_CHAT_MESSAGE_RECEIVED(NotificationType.CHAT)
+    PARTY_SUBOWNER_RELEASED(NotificationType.SIMPLE)
 
     ;
 

--- a/src/main/java/umc/cockple/demo/domain/notification/enums/NotificationTarget.java
+++ b/src/main/java/umc/cockple/demo/domain/notification/enums/NotificationTarget.java
@@ -10,7 +10,12 @@ public enum NotificationTarget {
     PARTY_INVITE_APPROVED(NotificationType.SIMPLE),
     PARTY_JOINREQUEST_APPROVED(NotificationType.CHANGE),
     PARTY_SUBOWNER_ASSIGNED(NotificationType.SIMPLE),
-    PARTY_SUBOWNER_RELEASED(NotificationType.SIMPLE);
+    PARTY_SUBOWNER_RELEASED(NotificationType.SIMPLE),
+    CHAT_MESSAGE_RECEIVED(NotificationType.CHAT),
+    GROUP_CHAT_MESSAGE_RECEIVED(NotificationType.CHAT)
+
+    ;
+
 
     private final NotificationType defaultType;
 

--- a/src/main/java/umc/cockple/demo/domain/notification/enums/NotificationType.java
+++ b/src/main/java/umc/cockple/demo/domain/notification/enums/NotificationType.java
@@ -6,5 +6,7 @@ public enum NotificationType {
     INVITE_REJECT, // 초대 버튼 있는 알림이고 거절한 경우
 
     CHANGE, // 눌렀을 떄 운동 / 모임 상세 페이지로 가는 알림
-    SIMPLE // 읽기 전용 단순 알림
+    SIMPLE, // 읽기 전용 단순 알림
+    CHAT // 채팅 메시지 수신 알림
+     ;
 }

--- a/src/main/java/umc/cockple/demo/domain/notification/enums/NotificationType.java
+++ b/src/main/java/umc/cockple/demo/domain/notification/enums/NotificationType.java
@@ -6,7 +6,7 @@ public enum NotificationType {
     INVITE_REJECT, // 초대 버튼 있는 알림이고 거절한 경우
 
     CHANGE, // 눌렀을 떄 운동 / 모임 상세 페이지로 가는 알림
-    SIMPLE, // 읽기 전용 단순 알림
-    CHAT // 채팅 메시지 수신 알림
+    SIMPLE // 읽기 전용 단순 알림
+
      ;
 }

--- a/src/main/java/umc/cockple/demo/domain/notification/events/ChatNotificationEvent.java
+++ b/src/main/java/umc/cockple/demo/domain/notification/events/ChatNotificationEvent.java
@@ -1,0 +1,33 @@
+package umc.cockple.demo.domain.notification.events;
+
+import lombok.Builder;
+import umc.cockple.demo.domain.chat.enums.ChatRoomType;
+
+import java.util.List;
+
+@Builder
+public record ChatNotificationEvent(
+        Long chatRoomId,
+        ChatRoomType chatRoomType,
+        String notificationTitle,
+        String notificationContent,
+        Long senderId,
+        List<Long> activeSubscriberIds
+) {
+    public static ChatNotificationEvent create(
+            Long chatRoomId,
+            ChatRoomType chatRoomType,
+            String notificationTitle,
+            String notificationContent,
+            Long senderId,
+            List<Long> activeSubscriberIds) {
+        return ChatNotificationEvent.builder()
+                .chatRoomId(chatRoomId)
+                .chatRoomType(chatRoomType)
+                .notificationTitle(notificationTitle)
+                .notificationContent(notificationContent)
+                .senderId(senderId)
+                .activeSubscriberIds(activeSubscriberIds)
+                .build();
+    }
+}

--- a/src/main/java/umc/cockple/demo/domain/notification/fcm/FcmService.java
+++ b/src/main/java/umc/cockple/demo/domain/notification/fcm/FcmService.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import umc.cockple.demo.domain.chat.enums.ChatRoomType;
 import umc.cockple.demo.domain.member.domain.Member;
 import umc.cockple.demo.domain.member.exception.MemberErrorCode;
 import umc.cockple.demo.domain.member.exception.MemberException;
@@ -49,6 +50,32 @@ public class FcmService {
             log.info("FCM 전송 완료 - memberId: {}", member.getId());
         } catch (FirebaseMessagingException e) {
             log.error("FCM 전송 실패 - memberId: {}, error: {}", member.getId(), e.getMessage());
+        }
+    }
+
+    public void sendChatNotification(Member member, String title, String content,
+                                     Long chatRoomId, ChatRoomType chatRoomType) {
+        String fcmToken = member.getFcmToken();
+        if (fcmToken == null || fcmToken.isBlank()) {
+            log.info("FCM 토큰 없음 - memberId: {}, 채팅 알림 전송 생략", member.getId());
+            return;
+        }
+
+        Message message = Message.builder()
+                .setToken(fcmToken)
+                .setNotification(Notification.builder()
+                        .setTitle(title)
+                        .setBody(content)
+                        .build())
+                .putData("chatRoomId", chatRoomId.toString())
+                .putData("chatRoomType", chatRoomType.name())
+                .build();
+
+        try {
+            firebaseMessaging.send(message);
+            log.info("채팅 FCM 전송 완료 - memberId: {}, chatRoomId: {}", member.getId(), chatRoomId);
+        } catch (FirebaseMessagingException e) {
+            log.error("채팅 FCM 전송 실패 - memberId: {}, error: {}", member.getId(), e.getMessage());
         }
     }
 }

--- a/src/main/java/umc/cockple/demo/domain/notification/service/ChatPushNotificationService.java
+++ b/src/main/java/umc/cockple/demo/domain/notification/service/ChatPushNotificationService.java
@@ -3,15 +3,11 @@ package umc.cockple.demo.domain.notification.service;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-import umc.cockple.demo.domain.chat.domain.ChatMessage;
-import umc.cockple.demo.domain.chat.domain.ChatRoom;
+import org.springframework.transaction.annotation.Transactional;
 import umc.cockple.demo.domain.chat.enums.ChatRoomMemberStatus;
-import umc.cockple.demo.domain.chat.enums.ChatRoomType;
+import umc.cockple.demo.domain.notification.events.ChatNotificationEvent;
 import umc.cockple.demo.domain.chat.repository.ChatRoomMemberRepository;
-import umc.cockple.demo.domain.member.domain.Member;
 import umc.cockple.demo.domain.notification.fcm.FcmService;
-
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -21,31 +17,16 @@ public class ChatPushNotificationService {
     private final FcmService fcmService;
     private final ChatRoomMemberRepository chatRoomMemberRepository;
 
-    public void sendPush(ChatRoom chatRoom, ChatMessage message, Member sender, List<Long> activeSubscriberIds) {
-        String title = buildTitle(chatRoom, sender);
-        String content = buildContent(chatRoom, sender, message);
-
+    @Transactional(readOnly = true)
+    public void sendPush(ChatNotificationEvent event) {
         chatRoomMemberRepository
-                .findByChatRoomIdAndStatusWithMember(chatRoom.getId(), ChatRoomMemberStatus.JOINED)
+                .findByChatRoomIdAndStatusWithMember(event.chatRoomId(), ChatRoomMemberStatus.JOINED)
                 .stream()
-                .filter(crm -> !crm.getMember().getId().equals(sender.getId()))
-                .filter(crm -> !activeSubscriberIds.contains(crm.getMember().getId()))
+                .filter(crm -> !crm.getMember().getId().equals(event.senderId()))
+                .filter(crm -> !event.activeSubscriberIds().contains(crm.getMember().getId()))
                 .forEach(crm -> fcmService.sendChatNotification(
-                        crm.getMember(), title, content, chatRoom.getId(), chatRoom.getType()
+                        crm.getMember(), event.notificationTitle(), event.notificationContent(),
+                        event.chatRoomId(), event.chatRoomType()
                 ));
-    }
-
-    private String buildTitle(ChatRoom chatRoom, Member sender) {
-        if (chatRoom.getType() == ChatRoomType.PARTY) {
-            return chatRoom.getParty().getPartyName();
-        }
-        return sender.getNickname();
-    }
-
-    private String buildContent(ChatRoom chatRoom, Member sender, ChatMessage message) {
-        if (chatRoom.getType() == ChatRoomType.PARTY) {
-            return sender.getNickname() + ": " + message.getDisplayContent();
-        }
-        return message.getDisplayContent();
     }
 }

--- a/src/main/java/umc/cockple/demo/domain/notification/service/ChatPushNotificationService.java
+++ b/src/main/java/umc/cockple/demo/domain/notification/service/ChatPushNotificationService.java
@@ -1,0 +1,51 @@
+package umc.cockple.demo.domain.notification.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import umc.cockple.demo.domain.chat.domain.ChatMessage;
+import umc.cockple.demo.domain.chat.domain.ChatRoom;
+import umc.cockple.demo.domain.chat.enums.ChatRoomMemberStatus;
+import umc.cockple.demo.domain.chat.enums.ChatRoomType;
+import umc.cockple.demo.domain.chat.repository.ChatRoomMemberRepository;
+import umc.cockple.demo.domain.member.domain.Member;
+import umc.cockple.demo.domain.notification.fcm.FcmService;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ChatPushNotificationService {
+
+    private final FcmService fcmService;
+    private final ChatRoomMemberRepository chatRoomMemberRepository;
+
+    public void sendPush(ChatRoom chatRoom, ChatMessage message, Member sender, List<Long> activeSubscriberIds) {
+        String title = buildTitle(chatRoom, sender);
+        String content = buildContent(chatRoom, sender, message);
+
+        chatRoomMemberRepository
+                .findByChatRoomIdAndStatusWithMember(chatRoom.getId(), ChatRoomMemberStatus.JOINED)
+                .stream()
+                .filter(crm -> !crm.getMember().getId().equals(sender.getId()))
+                .filter(crm -> !activeSubscriberIds.contains(crm.getMember().getId()))
+                .forEach(crm -> fcmService.sendChatNotification(
+                        crm.getMember(), title, content, chatRoom.getId(), chatRoom.getType()
+                ));
+    }
+
+    private String buildTitle(ChatRoom chatRoom, Member sender) {
+        if (chatRoom.getType() == ChatRoomType.PARTY) {
+            return chatRoom.getParty().getPartyName();
+        }
+        return sender.getNickname();
+    }
+
+    private String buildContent(ChatRoom chatRoom, Member sender, ChatMessage message) {
+        if (chatRoom.getType() == ChatRoomType.PARTY) {
+            return sender.getNickname() + ": " + message.getDisplayContent();
+        }
+        return message.getDisplayContent();
+    }
+}

--- a/src/test/java/umc/cockple/demo/domain/notification/service/ChatPushNotificationServiceTest.java
+++ b/src/test/java/umc/cockple/demo/domain/notification/service/ChatPushNotificationServiceTest.java
@@ -1,0 +1,273 @@
+package umc.cockple.demo.domain.notification.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import umc.cockple.demo.domain.chat.domain.ChatMessage;
+import umc.cockple.demo.domain.chat.domain.ChatRoom;
+import umc.cockple.demo.domain.chat.domain.ChatRoomMember;
+import umc.cockple.demo.domain.chat.enums.ChatRoomMemberStatus;
+import umc.cockple.demo.domain.chat.enums.ChatRoomType;
+import umc.cockple.demo.domain.chat.repository.ChatRoomMemberRepository;
+import umc.cockple.demo.domain.member.domain.Member;
+import umc.cockple.demo.domain.notification.fcm.FcmService;
+import umc.cockple.demo.domain.party.domain.Party;
+import umc.cockple.demo.global.enums.Gender;
+import umc.cockple.demo.global.enums.Level;
+import umc.cockple.demo.support.fixture.ChatFixture;
+import umc.cockple.demo.support.fixture.MemberFixture;
+import umc.cockple.demo.support.fixture.PartyFixture;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ChatPushNotificationService")
+class ChatPushNotificationServiceTest {
+
+    @InjectMocks
+    private ChatPushNotificationService chatPushNotificationService;
+
+    @Mock
+    private FcmService fcmService;
+
+    @Mock
+    private ChatRoomMemberRepository chatRoomMemberRepository;
+
+    private Member sender;
+    private Member activeSubscriber;
+    private Member offlineMember;
+
+    @BeforeEach
+    void setUp() {
+        sender = MemberFixture.createMember("발신자", Gender.MALE, Level.A, 1001L);
+        ReflectionTestUtils.setField(sender, "id", 1L);
+
+        activeSubscriber = MemberFixture.createMember("활성구독자", Gender.FEMALE, Level.B, 1002L);
+        ReflectionTestUtils.setField(activeSubscriber, "id", 2L);
+
+        offlineMember = MemberFixture.createMember("오프라인멤버", Gender.MALE, Level.C, 1003L);
+        ReflectionTestUtils.setField(offlineMember, "id", 3L);
+    }
+
+    @Nested
+    @DisplayName("단체채팅")
+    class PartyChatRoom {
+
+        private Party party;
+        private ChatRoom chatRoom;
+
+        @BeforeEach
+        void setUp() {
+            party = PartyFixture.createParty("테스트모임", sender.getId(),
+                    PartyFixture.createPartyAddr("서울", "강남구"));
+            chatRoom = ChatFixture.createPartyChatRoom(party);
+            ReflectionTestUtils.setField(chatRoom, "id", 10L);
+        }
+
+        @Test
+        @DisplayName("오프라인 멤버에게 FCM을 전송한다")
+        void sendPush_toOfflineMember() {
+            // given
+            ChatMessage message = ChatFixture.createTextMessage(chatRoom, sender, "안녕하세요!");
+            List<Long> activeSubscriberIds = List.of(sender.getId(), activeSubscriber.getId());
+
+            ChatRoomMember offlineCrm = ChatFixture.createJoinedMember(chatRoom, offlineMember);
+            given(chatRoomMemberRepository.findByChatRoomIdAndStatusWithMember(chatRoom.getId(), ChatRoomMemberStatus.JOINED))
+                    .willReturn(List.of(
+                            ChatFixture.createJoinedMember(chatRoom, sender),
+                            ChatFixture.createJoinedMember(chatRoom, activeSubscriber),
+                            offlineCrm
+                    ));
+
+            // when
+            chatPushNotificationService.sendPush(chatRoom, message, sender, activeSubscriberIds);
+
+            // then
+            then(fcmService).should(times(1)).sendChatNotification(
+                    any(), any(), any(), any(), any()
+            );
+        }
+
+        @Test
+        @DisplayName("title은 모임 이름, content는 '닉네임: 메시지내용' 형식이다")
+        void sendPush_partyChatFormat() {
+            // given
+            ChatMessage message = ChatFixture.createTextMessage(chatRoom, sender, "안녕하세요!");
+            List<Long> activeSubscriberIds = List.of(sender.getId());
+
+            given(chatRoomMemberRepository.findByChatRoomIdAndStatusWithMember(chatRoom.getId(), ChatRoomMemberStatus.JOINED))
+                    .willReturn(List.of(
+                            ChatFixture.createJoinedMember(chatRoom, sender),
+                            ChatFixture.createJoinedMember(chatRoom, offlineMember)
+                    ));
+
+            ArgumentCaptor<String> titleCaptor = ArgumentCaptor.forClass(String.class);
+            ArgumentCaptor<String> contentCaptor = ArgumentCaptor.forClass(String.class);
+
+            // when
+            chatPushNotificationService.sendPush(chatRoom, message, sender, activeSubscriberIds);
+
+            // then
+            then(fcmService).should().sendChatNotification(
+                    any(), titleCaptor.capture(), contentCaptor.capture(), any(), any()
+            );
+            assertThat(titleCaptor.getValue()).isEqualTo("테스트모임");
+            assertThat(contentCaptor.getValue()).isEqualTo("발신자: 안녕하세요!");
+        }
+
+        @Test
+        @DisplayName("sender는 FCM 대상에서 제외된다")
+        void sendPush_excludesSender() {
+            // given
+            ChatMessage message = ChatFixture.createTextMessage(chatRoom, sender, "안녕하세요!");
+            List<Long> activeSubscriberIds = List.of();
+
+            given(chatRoomMemberRepository.findByChatRoomIdAndStatusWithMember(chatRoom.getId(), ChatRoomMemberStatus.JOINED))
+                    .willReturn(List.of(ChatFixture.createJoinedMember(chatRoom, sender)));
+
+            // when
+            chatPushNotificationService.sendPush(chatRoom, message, sender, activeSubscriberIds);
+
+            // then
+            then(fcmService).should(never()).sendChatNotification(any(), any(), any(), any(), any());
+        }
+
+        @Test
+        @DisplayName("활성 구독자는 FCM 대상에서 제외된다")
+        void sendPush_excludesActiveSubscribers() {
+            // given
+            ChatMessage message = ChatFixture.createTextMessage(chatRoom, sender, "안녕하세요!");
+            List<Long> activeSubscriberIds = List.of(activeSubscriber.getId());
+
+            given(chatRoomMemberRepository.findByChatRoomIdAndStatusWithMember(chatRoom.getId(), ChatRoomMemberStatus.JOINED))
+                    .willReturn(List.of(
+                            ChatFixture.createJoinedMember(chatRoom, sender),
+                            ChatFixture.createJoinedMember(chatRoom, activeSubscriber)
+                    ));
+
+            // when
+            chatPushNotificationService.sendPush(chatRoom, message, sender, activeSubscriberIds);
+
+            // then
+            then(fcmService).should(never()).sendChatNotification(any(), any(), any(), any(), any());
+        }
+
+        @Test
+        @DisplayName("오프라인 멤버가 여러 명이면 모두에게 FCM을 전송한다")
+        void sendPush_toMultipleOfflineMembers() {
+            // given
+            Member anotherOffline = MemberFixture.createMember("또다른오프라인", Gender.FEMALE, Level.A, 1004L);
+            ReflectionTestUtils.setField(anotherOffline, "id", 4L);
+
+            ChatMessage message = ChatFixture.createTextMessage(chatRoom, sender, "공지사항입니다");
+            List<Long> activeSubscriberIds = List.of(sender.getId());
+
+            given(chatRoomMemberRepository.findByChatRoomIdAndStatusWithMember(chatRoom.getId(), ChatRoomMemberStatus.JOINED))
+                    .willReturn(List.of(
+                            ChatFixture.createJoinedMember(chatRoom, sender),
+                            ChatFixture.createJoinedMember(chatRoom, offlineMember),
+                            ChatFixture.createJoinedMember(chatRoom, anotherOffline)
+                    ));
+
+            // when
+            chatPushNotificationService.sendPush(chatRoom, message, sender, activeSubscriberIds);
+
+            // then
+            then(fcmService).should(times(2)).sendChatNotification(any(), any(), any(), any(), any());
+        }
+    }
+
+    @Nested
+    @DisplayName("개인채팅")
+    class DirectChatRoom {
+
+        private ChatRoom chatRoom;
+
+        @BeforeEach
+        void setUp() {
+            chatRoom = ChatFixture.createDirectChatRoom();
+            ReflectionTestUtils.setField(chatRoom, "id", 20L);
+        }
+
+        @Test
+        @DisplayName("오프라인 상대방에게 FCM을 전송한다")
+        void sendPush_toOfflineCounterPart() {
+            // given
+            ChatMessage message = ChatFixture.createTextMessage(chatRoom, sender, "안녕!");
+            List<Long> activeSubscriberIds = List.of(sender.getId());
+
+            given(chatRoomMemberRepository.findByChatRoomIdAndStatusWithMember(chatRoom.getId(), ChatRoomMemberStatus.JOINED))
+                    .willReturn(List.of(
+                            ChatFixture.createJoinedMember(chatRoom, sender),
+                            ChatFixture.createJoinedMember(chatRoom, offlineMember)
+                    ));
+
+            // when
+            chatPushNotificationService.sendPush(chatRoom, message, sender, activeSubscriberIds);
+
+            // then
+            then(fcmService).should(times(1)).sendChatNotification(any(), any(), any(), any(), any());
+        }
+
+        @Test
+        @DisplayName("title은 발신자 닉네임, content는 메시지 내용이다")
+        void sendPush_directChatFormat() {
+            // given
+            ChatMessage message = ChatFixture.createTextMessage(chatRoom, sender, "안녕!");
+            List<Long> activeSubscriberIds = List.of(sender.getId());
+
+            given(chatRoomMemberRepository.findByChatRoomIdAndStatusWithMember(chatRoom.getId(), ChatRoomMemberStatus.JOINED))
+                    .willReturn(List.of(
+                            ChatFixture.createJoinedMember(chatRoom, sender),
+                            ChatFixture.createJoinedMember(chatRoom, offlineMember)
+                    ));
+
+            ArgumentCaptor<String> titleCaptor = ArgumentCaptor.forClass(String.class);
+            ArgumentCaptor<String> contentCaptor = ArgumentCaptor.forClass(String.class);
+
+            // when
+            chatPushNotificationService.sendPush(chatRoom, message, sender, activeSubscriberIds);
+
+            // then
+            then(fcmService).should().sendChatNotification(
+                    any(), titleCaptor.capture(), contentCaptor.capture(), any(), any()
+            );
+            assertThat(titleCaptor.getValue()).isEqualTo("발신자");
+            assertThat(contentCaptor.getValue()).isEqualTo("안녕!");
+        }
+
+        @Test
+        @DisplayName("상대방이 활성 구독자면 FCM을 전송하지 않는다")
+        void sendPush_excludesActiveCounterPart() {
+            // given
+            ChatMessage message = ChatFixture.createTextMessage(chatRoom, sender, "안녕!");
+            List<Long> activeSubscriberIds = List.of(offlineMember.getId());
+
+            given(chatRoomMemberRepository.findByChatRoomIdAndStatusWithMember(chatRoom.getId(), ChatRoomMemberStatus.JOINED))
+                    .willReturn(List.of(
+                            ChatFixture.createJoinedMember(chatRoom, sender),
+                            ChatFixture.createJoinedMember(chatRoom, offlineMember)
+                    ));
+
+            // when
+            chatPushNotificationService.sendPush(chatRoom, message, sender, activeSubscriberIds);
+
+            // then
+            then(fcmService).should(never()).sendChatNotification(any(), any(), any(), any(), any());
+        }
+    }
+}

--- a/src/test/java/umc/cockple/demo/domain/notification/service/ChatPushNotificationServiceTest.java
+++ b/src/test/java/umc/cockple/demo/domain/notification/service/ChatPushNotificationServiceTest.java
@@ -10,13 +10,12 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
-import umc.cockple.demo.domain.chat.domain.ChatMessage;
 import umc.cockple.demo.domain.chat.domain.ChatRoom;
-import umc.cockple.demo.domain.chat.domain.ChatRoomMember;
 import umc.cockple.demo.domain.chat.enums.ChatRoomMemberStatus;
 import umc.cockple.demo.domain.chat.enums.ChatRoomType;
 import umc.cockple.demo.domain.chat.repository.ChatRoomMemberRepository;
 import umc.cockple.demo.domain.member.domain.Member;
+import umc.cockple.demo.domain.notification.events.ChatNotificationEvent;
 import umc.cockple.demo.domain.notification.fcm.FcmService;
 import umc.cockple.demo.domain.party.domain.Party;
 import umc.cockple.demo.global.enums.Gender;
@@ -67,12 +66,11 @@ class ChatPushNotificationServiceTest {
     @DisplayName("단체채팅")
     class PartyChatRoom {
 
-        private Party party;
         private ChatRoom chatRoom;
 
         @BeforeEach
         void setUp() {
-            party = PartyFixture.createParty("테스트모임", sender.getId(),
+            Party party = PartyFixture.createParty("테스트모임", sender.getId(),
                     PartyFixture.createPartyAddr("서울", "강남구"));
             chatRoom = ChatFixture.createPartyChatRoom(party);
             ReflectionTestUtils.setField(chatRoom, "id", 10L);
@@ -82,33 +80,34 @@ class ChatPushNotificationServiceTest {
         @DisplayName("오프라인 멤버에게 FCM을 전송한다")
         void sendPush_toOfflineMember() {
             // given
-            ChatMessage message = ChatFixture.createTextMessage(chatRoom, sender, "안녕하세요!");
-            List<Long> activeSubscriberIds = List.of(sender.getId(), activeSubscriber.getId());
-
-            ChatRoomMember offlineCrm = ChatFixture.createJoinedMember(chatRoom, offlineMember);
+            ChatNotificationEvent event = ChatNotificationEvent.create(
+                    chatRoom.getId(), ChatRoomType.PARTY,
+                    "테스트모임", "발신자: 안녕하세요!",
+                    sender.getId(), List.of(sender.getId(), activeSubscriber.getId())
+            );
             given(chatRoomMemberRepository.findByChatRoomIdAndStatusWithMember(chatRoom.getId(), ChatRoomMemberStatus.JOINED))
                     .willReturn(List.of(
                             ChatFixture.createJoinedMember(chatRoom, sender),
                             ChatFixture.createJoinedMember(chatRoom, activeSubscriber),
-                            offlineCrm
+                            ChatFixture.createJoinedMember(chatRoom, offlineMember)
                     ));
 
             // when
-            chatPushNotificationService.sendPush(chatRoom, message, sender, activeSubscriberIds);
+            chatPushNotificationService.sendPush(event);
 
             // then
-            then(fcmService).should(times(1)).sendChatNotification(
-                    any(), any(), any(), any(), any()
-            );
+            then(fcmService).should(times(1)).sendChatNotification(any(), any(), any(), any(), any());
         }
 
         @Test
-        @DisplayName("title은 모임 이름, content는 '닉네임: 메시지내용' 형식이다")
-        void sendPush_partyChatFormat() {
+        @DisplayName("이벤트의 title과 content를 FCM에 그대로 전달한다")
+        void sendPush_forwardsEventTitleAndContent() {
             // given
-            ChatMessage message = ChatFixture.createTextMessage(chatRoom, sender, "안녕하세요!");
-            List<Long> activeSubscriberIds = List.of(sender.getId());
-
+            ChatNotificationEvent event = ChatNotificationEvent.create(
+                    chatRoom.getId(), ChatRoomType.PARTY,
+                    "테스트모임", "발신자: 안녕하세요!",
+                    sender.getId(), List.of(sender.getId())
+            );
             given(chatRoomMemberRepository.findByChatRoomIdAndStatusWithMember(chatRoom.getId(), ChatRoomMemberStatus.JOINED))
                     .willReturn(List.of(
                             ChatFixture.createJoinedMember(chatRoom, sender),
@@ -119,7 +118,7 @@ class ChatPushNotificationServiceTest {
             ArgumentCaptor<String> contentCaptor = ArgumentCaptor.forClass(String.class);
 
             // when
-            chatPushNotificationService.sendPush(chatRoom, message, sender, activeSubscriberIds);
+            chatPushNotificationService.sendPush(event);
 
             // then
             then(fcmService).should().sendChatNotification(
@@ -133,14 +132,16 @@ class ChatPushNotificationServiceTest {
         @DisplayName("sender는 FCM 대상에서 제외된다")
         void sendPush_excludesSender() {
             // given
-            ChatMessage message = ChatFixture.createTextMessage(chatRoom, sender, "안녕하세요!");
-            List<Long> activeSubscriberIds = List.of();
-
+            ChatNotificationEvent event = ChatNotificationEvent.create(
+                    chatRoom.getId(), ChatRoomType.PARTY,
+                    "테스트모임", "발신자: 안녕하세요!",
+                    sender.getId(), List.of()
+            );
             given(chatRoomMemberRepository.findByChatRoomIdAndStatusWithMember(chatRoom.getId(), ChatRoomMemberStatus.JOINED))
                     .willReturn(List.of(ChatFixture.createJoinedMember(chatRoom, sender)));
 
             // when
-            chatPushNotificationService.sendPush(chatRoom, message, sender, activeSubscriberIds);
+            chatPushNotificationService.sendPush(event);
 
             // then
             then(fcmService).should(never()).sendChatNotification(any(), any(), any(), any(), any());
@@ -150,9 +151,11 @@ class ChatPushNotificationServiceTest {
         @DisplayName("활성 구독자는 FCM 대상에서 제외된다")
         void sendPush_excludesActiveSubscribers() {
             // given
-            ChatMessage message = ChatFixture.createTextMessage(chatRoom, sender, "안녕하세요!");
-            List<Long> activeSubscriberIds = List.of(activeSubscriber.getId());
-
+            ChatNotificationEvent event = ChatNotificationEvent.create(
+                    chatRoom.getId(), ChatRoomType.PARTY,
+                    "테스트모임", "발신자: 안녕하세요!",
+                    sender.getId(), List.of(activeSubscriber.getId())
+            );
             given(chatRoomMemberRepository.findByChatRoomIdAndStatusWithMember(chatRoom.getId(), ChatRoomMemberStatus.JOINED))
                     .willReturn(List.of(
                             ChatFixture.createJoinedMember(chatRoom, sender),
@@ -160,7 +163,7 @@ class ChatPushNotificationServiceTest {
                     ));
 
             // when
-            chatPushNotificationService.sendPush(chatRoom, message, sender, activeSubscriberIds);
+            chatPushNotificationService.sendPush(event);
 
             // then
             then(fcmService).should(never()).sendChatNotification(any(), any(), any(), any(), any());
@@ -173,9 +176,11 @@ class ChatPushNotificationServiceTest {
             Member anotherOffline = MemberFixture.createMember("또다른오프라인", Gender.FEMALE, Level.A, 1004L);
             ReflectionTestUtils.setField(anotherOffline, "id", 4L);
 
-            ChatMessage message = ChatFixture.createTextMessage(chatRoom, sender, "공지사항입니다");
-            List<Long> activeSubscriberIds = List.of(sender.getId());
-
+            ChatNotificationEvent event = ChatNotificationEvent.create(
+                    chatRoom.getId(), ChatRoomType.PARTY,
+                    "테스트모임", "발신자: 공지사항입니다",
+                    sender.getId(), List.of(sender.getId())
+            );
             given(chatRoomMemberRepository.findByChatRoomIdAndStatusWithMember(chatRoom.getId(), ChatRoomMemberStatus.JOINED))
                     .willReturn(List.of(
                             ChatFixture.createJoinedMember(chatRoom, sender),
@@ -184,7 +189,7 @@ class ChatPushNotificationServiceTest {
                     ));
 
             // when
-            chatPushNotificationService.sendPush(chatRoom, message, sender, activeSubscriberIds);
+            chatPushNotificationService.sendPush(event);
 
             // then
             then(fcmService).should(times(2)).sendChatNotification(any(), any(), any(), any(), any());
@@ -207,9 +212,11 @@ class ChatPushNotificationServiceTest {
         @DisplayName("오프라인 상대방에게 FCM을 전송한다")
         void sendPush_toOfflineCounterPart() {
             // given
-            ChatMessage message = ChatFixture.createTextMessage(chatRoom, sender, "안녕!");
-            List<Long> activeSubscriberIds = List.of(sender.getId());
-
+            ChatNotificationEvent event = ChatNotificationEvent.create(
+                    chatRoom.getId(), ChatRoomType.DIRECT,
+                    "발신자", "안녕!",
+                    sender.getId(), List.of(sender.getId())
+            );
             given(chatRoomMemberRepository.findByChatRoomIdAndStatusWithMember(chatRoom.getId(), ChatRoomMemberStatus.JOINED))
                     .willReturn(List.of(
                             ChatFixture.createJoinedMember(chatRoom, sender),
@@ -217,19 +224,21 @@ class ChatPushNotificationServiceTest {
                     ));
 
             // when
-            chatPushNotificationService.sendPush(chatRoom, message, sender, activeSubscriberIds);
+            chatPushNotificationService.sendPush(event);
 
             // then
             then(fcmService).should(times(1)).sendChatNotification(any(), any(), any(), any(), any());
         }
 
         @Test
-        @DisplayName("title은 발신자 닉네임, content는 메시지 내용이다")
-        void sendPush_directChatFormat() {
+        @DisplayName("이벤트의 title과 content를 FCM에 그대로 전달한다")
+        void sendPush_forwardsEventTitleAndContent() {
             // given
-            ChatMessage message = ChatFixture.createTextMessage(chatRoom, sender, "안녕!");
-            List<Long> activeSubscriberIds = List.of(sender.getId());
-
+            ChatNotificationEvent event = ChatNotificationEvent.create(
+                    chatRoom.getId(), ChatRoomType.DIRECT,
+                    "발신자", "안녕!",
+                    sender.getId(), List.of(sender.getId())
+            );
             given(chatRoomMemberRepository.findByChatRoomIdAndStatusWithMember(chatRoom.getId(), ChatRoomMemberStatus.JOINED))
                     .willReturn(List.of(
                             ChatFixture.createJoinedMember(chatRoom, sender),
@@ -240,7 +249,7 @@ class ChatPushNotificationServiceTest {
             ArgumentCaptor<String> contentCaptor = ArgumentCaptor.forClass(String.class);
 
             // when
-            chatPushNotificationService.sendPush(chatRoom, message, sender, activeSubscriberIds);
+            chatPushNotificationService.sendPush(event);
 
             // then
             then(fcmService).should().sendChatNotification(
@@ -254,9 +263,11 @@ class ChatPushNotificationServiceTest {
         @DisplayName("상대방이 활성 구독자면 FCM을 전송하지 않는다")
         void sendPush_excludesActiveCounterPart() {
             // given
-            ChatMessage message = ChatFixture.createTextMessage(chatRoom, sender, "안녕!");
-            List<Long> activeSubscriberIds = List.of(offlineMember.getId());
-
+            ChatNotificationEvent event = ChatNotificationEvent.create(
+                    chatRoom.getId(), ChatRoomType.DIRECT,
+                    "발신자", "안녕!",
+                    sender.getId(), List.of(offlineMember.getId())
+            );
             given(chatRoomMemberRepository.findByChatRoomIdAndStatusWithMember(chatRoom.getId(), ChatRoomMemberStatus.JOINED))
                     .willReturn(List.of(
                             ChatFixture.createJoinedMember(chatRoom, sender),
@@ -264,7 +275,7 @@ class ChatPushNotificationServiceTest {
                     ));
 
             // when
-            chatPushNotificationService.sendPush(chatRoom, message, sender, activeSubscriberIds);
+            chatPushNotificationService.sendPush(event);
 
             // then
             then(fcmService).should(never()).sendChatNotification(any(), any(), any(), any(), any());


### PR DESCRIPTION
## ❤️ 기능 설명
기획단 요청에 따라 채팅 푸시알림 기능을 추가합니다.
- 개인 채팅, 단체 채팅 알림을 추가하였습니다.
- 기존 알림들은 notification 테이블에 저장했으나, 채팅의 경우 채팅이 쌓였을 때 그 외 알림들이 밀리는 것을 우려하여 해당 테이블에 저장하지 않습니다. 따라서 별도의 Service를 추가하여 로직을 분리했습니다.
- 채팅 알림은 채팅을 보낸 사람, 앱 활성화 상태인 사람에게는 전송되지 않도록 구현하였습니다.

<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #569 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [ ] 이슈넘버를 적었는가?
