### PR TITLE
[debug/#575] 동시 알림이 같은 알림 삭제하려는 경쟁조건 해결

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,5 @@ src/main/resources/firebase/*.json
 .omx/
 
 cockple_dump.sql
+
+k6

--- a/src/main/java/umc/cockple/demo/domain/notification/service/NotificationCommandService.java
+++ b/src/main/java/umc/cockple/demo/domain/notification/service/NotificationCommandService.java
@@ -28,6 +28,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
 
 import static umc.cockple.demo.domain.notification.dto.MarkAsReadDTO.*;
 
@@ -65,9 +66,12 @@ public class NotificationCommandService {
             Member member = dto.member();
             List<Notification> bookmarks = notificationRepository.findAllByMemberOrderByCreatedAtDesc(member);
             if (bookmarks.size() >= 50) {
-                // INVITE타입이 아니면서 가장 오래된 거 삭제
-                notificationRepository.findFirstByMemberAndTypeNotOrderByCreatedAtAsc(member, NotificationType.INVITE)
-                        .ifPresent(notificationRepository::delete);
+                try {
+                    notificationRepository.findFirstByMemberAndTypeNotOrderByCreatedAtAsc(member, NotificationType.INVITE)
+                            .ifPresent(notificationRepository::delete);
+                } catch (ObjectOptimisticLockingFailureException e) {
+                    log.warn("알림 삭제 충돌 - 다른 트랜잭션에서 이미 삭제됨 - memberId: {}", member.getId());
+                }
             }
 
             Party party = partyRepository.findById(dto.partyId())


### PR DESCRIPTION
## ❤️ 기능 설명
기존에 알림 50개를 유지하기 위해서 걸어두었던 예외가 동시에 여러 알림이 들어올 때, 같은 알림을 삭제하려는 race condition으로 인해 이미 없는 알림을 삭제하려는 오류가 발생

50개라는 제한이 사실 ux를 위한 soft limit이기 때문에 락을 걸기보다는 예외를 무시하게 두고, 추후 스케줄러를 구현하는 방식으로 해결합니다.

<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #575 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [ ] 이슈넘버를 적었는가?
