### PR TITLE
[refactor/#571] 일반 알림 FCM 비동기 처리 전환

### DIFF
--- a/src/main/java/umc/cockple/demo/domain/member/domain/Member.java
+++ b/src/main/java/umc/cockple/demo/domain/member/domain/Member.java
@@ -173,6 +173,10 @@ public class Member extends BaseEntity {
                         );
     }
 
+    public boolean isWithdrawn() {
+        return this.isActive == MemberStatus.INACTIVE;
+    }
+
     public void withdraw() {
         this.isActive = MemberStatus.INACTIVE;
         this.refreshToken = null;

--- a/src/main/java/umc/cockple/demo/domain/notification/events/NotificationEvent.java
+++ b/src/main/java/umc/cockple/demo/domain/notification/events/NotificationEvent.java
@@ -1,9 +1,7 @@
 package umc.cockple.demo.domain.notification.events;
 
-import umc.cockple.demo.domain.member.domain.Member;
-
 public record NotificationEvent(
-        Member member,
+        Long memberId,
         String title,
         String content
 ) {

--- a/src/main/java/umc/cockple/demo/domain/notification/events/NotificationEvent.java
+++ b/src/main/java/umc/cockple/demo/domain/notification/events/NotificationEvent.java
@@ -1,0 +1,10 @@
+package umc.cockple.demo.domain.notification.events;
+
+import umc.cockple.demo.domain.member.domain.Member;
+
+public record NotificationEvent(
+        Member member,
+        String title,
+        String content
+) {
+}

--- a/src/main/java/umc/cockple/demo/domain/notification/events/NotificationEventListener.java
+++ b/src/main/java/umc/cockple/demo/domain/notification/events/NotificationEventListener.java
@@ -4,8 +4,12 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
+import umc.cockple.demo.domain.member.domain.Member;
+import umc.cockple.demo.domain.member.repository.MemberRepository;
 import umc.cockple.demo.domain.notification.fcm.FcmService;
 
 @Component
@@ -14,15 +18,28 @@ import umc.cockple.demo.domain.notification.fcm.FcmService;
 public class NotificationEventListener {
 
     private final FcmService fcmService;
+    private final MemberRepository memberRepository;
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     @Async
+    @Transactional(readOnly = true, propagation = Propagation.REQUIRES_NEW)
     public void handleNotification(NotificationEvent event) {
-        log.info("[NOTIFICATION] FCM 전송 이벤트 처리 - memberId: {}", event.member().getId());
+        log.info("[NOTIFICATION] FCM 전송 이벤트 처리 - memberId: {}", event.memberId());
+        memberRepository.findById(event.memberId()).ifPresentOrElse(
+                member -> sendFcm(member, event),
+                () -> log.warn("[NOTIFICATION] FCM 전송 대상 멤버 없음 - memberId: {}", event.memberId())
+        );
+    }
+
+    private void sendFcm(Member member, NotificationEvent event) {
+        if (member.isWithdrawn()) {
+            log.info("[NOTIFICATION] 탈퇴 회원 FCM 전송 생략 - memberId: {}", event.memberId());
+            return;
+        }
         try {
-            fcmService.sendNotification(event.member(), event.title(), event.content());
+            fcmService.sendNotification(member, event.title(), event.content());
         } catch (Exception e) {
-            log.error("[NOTIFICATION] FCM 전송 실패 - memberId: {}", event.member().getId(), e);
+            log.error("[NOTIFICATION] FCM 전송 실패 - memberId: {}", event.memberId(), e);
         }
     }
 }

--- a/src/main/java/umc/cockple/demo/domain/notification/events/NotificationEventListener.java
+++ b/src/main/java/umc/cockple/demo/domain/notification/events/NotificationEventListener.java
@@ -1,0 +1,28 @@
+package umc.cockple.demo.domain.notification.events;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+import umc.cockple.demo.domain.notification.fcm.FcmService;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class NotificationEventListener {
+
+    private final FcmService fcmService;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Async
+    public void handleNotification(NotificationEvent event) {
+        log.info("[NOTIFICATION] FCM 전송 이벤트 처리 - memberId: {}", event.member().getId());
+        try {
+            fcmService.sendNotification(event.member(), event.title(), event.content());
+        } catch (Exception e) {
+            log.error("[NOTIFICATION] FCM 전송 실패 - memberId: {}", event.member().getId(), e);
+        }
+    }
+}

--- a/src/main/java/umc/cockple/demo/domain/notification/service/NotificationCommandService.java
+++ b/src/main/java/umc/cockple/demo/domain/notification/service/NotificationCommandService.java
@@ -7,14 +7,14 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import umc.cockple.demo.domain.member.domain.Member;
-import umc.cockple.demo.domain.member.repository.MemberRepository;
 import umc.cockple.demo.domain.notification.domain.Notification;
 import umc.cockple.demo.domain.notification.dto.CreateNotificationRequestDTO;
 import umc.cockple.demo.domain.notification.enums.NotificationTarget;
+import umc.cockple.demo.domain.notification.events.NotificationEvent;
 import umc.cockple.demo.domain.notification.exception.NotificationErrorCode;
 import umc.cockple.demo.domain.notification.exception.NotificationException;
-import umc.cockple.demo.domain.notification.fcm.FcmService;
 import umc.cockple.demo.domain.notification.repository.NotificationRepository;
+import org.springframework.context.ApplicationEventPublisher;
 import umc.cockple.demo.domain.notification.enums.NotificationType;
 import umc.cockple.demo.domain.party.domain.Party;
 import umc.cockple.demo.domain.party.exception.PartyErrorCode;
@@ -37,11 +37,10 @@ import static umc.cockple.demo.domain.notification.dto.MarkAsReadDTO.*;
 public class NotificationCommandService {
 
     private final NotificationRepository notificationRepository;
-    private final MemberRepository memberRepository;
     private final PartyRepository partyRepository;
     private final NotificationMessageGenerator notificationMessageGenerator;
     private final ObjectMapper objectMapper;
-    private final FcmService fcmService;
+    private final ApplicationEventPublisher eventPublisher;
 
     // 알림 타입 변경 (초대 수락, 거절에 사용)
     public Response markAsReadNotification(Long memberId, Long notificationId, NotificationType type) {
@@ -120,13 +119,8 @@ public class NotificationCommandService {
             long dbTime = System.currentTimeMillis() - start;
             log.info("[NOTIFICATION] DB 저장 완료 - memberId: {}, 소요시간: {}ms", member.getId(), dbTime);
 
-            // [부하테스트용 FCM 시뮬레이션] 실제 FCM 평균 응답시간 836ms 재현 - 비동기 전환 전 baseline 측정용
-            try {
-                Thread.sleep(800);
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-            }
-            log.info("[NOTIFICATION] 전체 알림 생성 완료 - memberId: {}, 총 소요시간: {}ms", member.getId(), System.currentTimeMillis() - start);
+            eventPublisher.publishEvent(new NotificationEvent(member, title, content));
+            log.info("[NOTIFICATION] 알림 이벤트 발행 완료 - memberId: {}, 총 소요시간: {}ms", member.getId(), System.currentTimeMillis() - start);
 
         } catch (JsonProcessingException e) {
             throw new NotificationException(NotificationErrorCode.INVALID_NOTIFICATION_DATA);

--- a/src/main/java/umc/cockple/demo/domain/notification/service/NotificationCommandService.java
+++ b/src/main/java/umc/cockple/demo/domain/notification/service/NotificationCommandService.java
@@ -119,7 +119,7 @@ public class NotificationCommandService {
             long dbTime = System.currentTimeMillis() - start;
             log.info("[NOTIFICATION] DB 저장 완료 - memberId: {}, 소요시간: {}ms", member.getId(), dbTime);
 
-            eventPublisher.publishEvent(new NotificationEvent(member, title, content));
+            eventPublisher.publishEvent(new NotificationEvent(member.getId(), title, content));
             log.info("[NOTIFICATION] 알림 이벤트 발행 완료 - memberId: {}, 총 소요시간: {}ms", member.getId(), System.currentTimeMillis() - start);
 
         } catch (JsonProcessingException e) {

--- a/src/test/java/umc/cockple/demo/domain/notification/events/NotificationEventListenerTest.java
+++ b/src/test/java/umc/cockple/demo/domain/notification/events/NotificationEventListenerTest.java
@@ -1,0 +1,113 @@
+package umc.cockple.demo.domain.notification.events;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.core.task.SyncTaskExecutor;
+import org.springframework.core.task.TaskExecutor;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.support.TransactionTemplate;
+import umc.cockple.demo.domain.member.domain.Member;
+import umc.cockple.demo.domain.member.repository.MemberRepository;
+import umc.cockple.demo.domain.notification.fcm.FcmService;
+import umc.cockple.demo.global.enums.Gender;
+import umc.cockple.demo.global.enums.Level;
+import umc.cockple.demo.support.IntegrationTestBase;
+import umc.cockple.demo.support.fixture.MemberFixture;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+@DisplayName("NotificationEventListener")
+class NotificationEventListenerTest extends IntegrationTestBase {
+
+    // @Async를 동기로 실행해 테스트 스레드와 타이밍 문제를 제거
+    @TestConfiguration
+    static class SyncAsyncConfig {
+        @Bean
+        @Primary
+        public TaskExecutor taskExecutor() {
+            return new SyncTaskExecutor();
+        }
+    }
+
+    @Autowired
+    private ApplicationEventPublisher eventPublisher;
+
+    @Autowired
+    private TransactionTemplate transactionTemplate;
+
+    // FcmService를 Mock으로 대체해 실제 FCM 전송 없이 호출 여부만 검증
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @MockitoBean
+    private FcmService fcmService;
+
+    private Member member;
+
+    @AfterEach
+    void tearDown() {
+        memberRepository.deleteAll();
+    }
+
+    @BeforeEach
+    void setUp() {
+        Member unsaved = MemberFixture.createMember("테스터", Gender.MALE, Level.A, 1001L);
+        ReflectionTestUtils.setField(unsaved, "fcmToken", "valid-fcm-token");
+        member = memberRepository.save(unsaved);
+    }
+
+    @Test
+    @DisplayName("트랜잭션이 커밋되면 FCM 전송이 실행된다")
+    void 트랜잭션_커밋_후_FCM_전송이_실행된다() {
+        // when
+        transactionTemplate.execute(status -> {
+            eventPublisher.publishEvent(new NotificationEvent(member.getId(), "제목", "내용"));
+            return null;
+        });
+
+        // then
+        then(fcmService).should().sendNotification(any(Member.class), any(), any());
+    }
+
+    @Test
+    @DisplayName("트랜잭션이 롤백되면 FCM 전송이 실행되지 않는다")
+    void 트랜잭션_롤백_시_FCM_전송이_실행되지_않는다() {
+        // when
+        transactionTemplate.execute(status -> {
+            eventPublisher.publishEvent(new NotificationEvent(member.getId(), "제목", "내용"));
+            status.setRollbackOnly();
+            return null;
+        });
+
+        // then
+        then(fcmService).should(never()).sendNotification(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("탈퇴 회원에게는 FCM 전송이 실행되지 않는다")
+    void 탈퇴_회원에게는_FCM_전송이_실행되지_않는다() {
+        // given - FCM 토큰이 있더라도 탈퇴 상태면 전송하지 않아야 함
+        Member withdrawnMember = MemberFixture.createWithdrawnMember("탈퇴자", "탈퇴자", 2002L);
+        ReflectionTestUtils.setField(withdrawnMember, "fcmToken", "valid-fcm-token");
+        Member saved = memberRepository.save(withdrawnMember);
+
+        // when
+        transactionTemplate.execute(status -> {
+            eventPublisher.publishEvent(new NotificationEvent(saved.getId(), "제목", "내용"));
+            return null;
+        });
+
+        // then
+        then(fcmService).should(never()).sendNotification(any(), any(), any());
+    }
+}

--- a/src/test/java/umc/cockple/demo/domain/notification/service/NotificationCommandServiceTest.java
+++ b/src/test/java/umc/cockple/demo/domain/notification/service/NotificationCommandServiceTest.java
@@ -10,15 +10,15 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.context.ApplicationEventPublisher;
 import umc.cockple.demo.domain.member.domain.Member;
-import umc.cockple.demo.domain.member.repository.MemberRepository;
 import umc.cockple.demo.domain.notification.domain.Notification;
 import umc.cockple.demo.domain.notification.dto.CreateNotificationRequestDTO;
 import umc.cockple.demo.domain.notification.enums.NotificationTarget;
 import umc.cockple.demo.domain.notification.enums.NotificationType;
+import umc.cockple.demo.domain.notification.events.NotificationEvent;
 import umc.cockple.demo.domain.notification.exception.NotificationErrorCode;
 import umc.cockple.demo.domain.notification.exception.NotificationException;
-import umc.cockple.demo.domain.notification.fcm.FcmService;
 import umc.cockple.demo.domain.notification.repository.NotificationRepository;
 import umc.cockple.demo.domain.party.domain.Party;
 import umc.cockple.demo.domain.party.exception.PartyErrorCode;
@@ -37,7 +37,6 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.never;
@@ -51,11 +50,10 @@ class NotificationCommandServiceTest {
     private NotificationCommandService notificationCommandService;
 
     @Mock private NotificationRepository notificationRepository;
-    @Mock private MemberRepository memberRepository;
     @Mock private PartyRepository partyRepository;
     @Mock private NotificationMessageGenerator notificationMessageGenerator;
     @Mock private ObjectMapper objectMapper;
-    @Mock private FcmService fcmService;
+    @Mock private ApplicationEventPublisher eventPublisher;
 
     private Member member;
     private Party party;
@@ -217,10 +215,11 @@ class NotificationCommandServiceTest {
 
                 // then
                 then(notificationRepository).should().save(any(Notification.class));
+                then(eventPublisher).should().publishEvent(any(NotificationEvent.class));
             }
 
             @Test
-            @DisplayName("PARTY_INVITE 알림을 생성하면 title이 '새로운 모임'으로 FCM이 전송된다")
+            @DisplayName("PARTY_INVITE 알림을 생성하면 title이 '새로운 모임'으로 이벤트가 발행된다")
             void createNotification_partyInvite_usesTitleNewParty() throws Exception {
                 // given
                 CreateNotificationRequestDTO dto = CreateNotificationRequestDTO.builder()
@@ -242,6 +241,7 @@ class NotificationCommandServiceTest {
 
                 // then
                 then(notificationRepository).should().save(any(Notification.class));
+                then(eventPublisher).should().publishEvent(any(NotificationEvent.class));
             }
 
             @Test
@@ -268,6 +268,7 @@ class NotificationCommandServiceTest {
 
                 // then
                 then(notificationRepository).should().save(any(Notification.class));
+                then(eventPublisher).should().publishEvent(any(NotificationEvent.class));
             }
 
             @Test
@@ -284,6 +285,7 @@ class NotificationCommandServiceTest {
                 Notification oldestNonInvite = Notification.builder()
                         .member(member).partyId(100L).title("오래된 알림").content("c")
                         .type(NotificationType.SIMPLE).isRead(true).imageKey(null).data("{}").build();
+                ReflectionTestUtils.setField(oldestNonInvite, "id", 50L);
 
                 CreateNotificationRequestDTO dto = CreateNotificationRequestDTO.builder()
                         .member(member)
@@ -305,7 +307,7 @@ class NotificationCommandServiceTest {
                 notificationCommandService.createNotification(dto);
 
                 // then
-                then(notificationRepository).should().delete(oldestNonInvite);
+                then(notificationRepository).should().deleteByIdQuery(50L);
                 then(notificationRepository).should().save(any(Notification.class));
             }
 
@@ -337,7 +339,7 @@ class NotificationCommandServiceTest {
                 notificationCommandService.createNotification(dto);
 
                 // then
-                then(notificationRepository).should(never()).delete(any());
+                then(notificationRepository).should(never()).deleteByIdQuery(any(Long.class));
                 then(notificationRepository).should().save(any(Notification.class));
             }
         }


### PR DESCRIPTION
## ❤️ 기능 설명
채팅 알림과 마찬가지로 FCM 일반 알림을 비동기로 변경하고, 트랜잭션을 분리합니다.

<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #571 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [ ] 이슈넘버를 적었는가?
