### PR TITLE
[refactor/#598] 월간 운동 지도 조회 공간 검색 최적화

### DIFF
--- a/src/main/java/umc/cockple/demo/domain/exercise/controller/ExerciseController.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/controller/ExerciseController.java
@@ -368,9 +368,10 @@ public class ExerciseController {
             @RequestParam(defaultValue = "3.0") Double radiusKm
     ) {
         Long memberId = SecurityUtil.getCurrentMemberId();
+        ExerciseMapBuildingsDTO.Query query = ExerciseMapBuildingsDTO.Query.of(date, latitude, longitude, radiusKm);
 
         ExerciseMapBuildingsDTO.Response response = exerciseQueryService
-                .getExerciseMapCalendarSummary(date, latitude, longitude, radiusKm, memberId);
+                .getExerciseMapCalendarSummary(query, memberId);
 
         return BaseResponse.success(CommonSuccessCode.OK, response);
     }

--- a/src/main/java/umc/cockple/demo/domain/exercise/dto/ExerciseMapBuildingsDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/dto/ExerciseMapBuildingsDTO.java
@@ -1,12 +1,101 @@
 package umc.cockple.demo.domain.exercise.dto;
 
 import lombok.Builder;
+import umc.cockple.demo.domain.exercise.exception.ExerciseErrorCode;
+import umc.cockple.demo.domain.exercise.exception.ExerciseException;
 
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
 
 public class ExerciseMapBuildingsDTO {
+
+    private static final double KILOMETERS_PER_LATITUDE_DEGREE = 111.045;
+    private static final double MIN_LONGITUDE_COSINE = 1.0e-12;
+    private static final double MIN_LATITUDE = -90.0;
+    private static final double MAX_LATITUDE = 90.0;
+    private static final double MIN_LONGITUDE = -180.0;
+    private static final double MAX_LONGITUDE = 180.0;
+
+    public record Query(
+            LocalDate date,
+            Double latitude,
+            Double longitude,
+            Double radiusKm
+    ) {
+        public Query {
+            validateLocationCompleteness(latitude, longitude);
+            validateCoordinate(latitude, longitude);
+            validateRadius(radiusKm);
+            validateBoundingBox(latitude, longitude, radiusKm);
+        }
+
+        public static Query of(LocalDate date, Double latitude, Double longitude, Double radiusKm) {
+            return new Query(date, latitude, longitude, radiusKm);
+        }
+
+        public Query withFallbackLocation(Double fallbackLatitude, Double fallbackLongitude) {
+            if (latitude != null && longitude != null) {
+                return this;
+            }
+
+            return new Query(date, fallbackLatitude, fallbackLongitude, radiusKm);
+        }
+
+        private static void validateLocationCompleteness(Double latitude, Double longitude) {
+            if ((latitude == null) != (longitude == null)) {
+                throw new ExerciseException(ExerciseErrorCode.INCOMPLETE_LOCATION_INFO);
+            }
+        }
+
+        private static void validateCoordinate(Double latitude, Double longitude) {
+            if (latitude == null && longitude == null) {
+                return;
+            }
+
+            if (!isValidLatitude(latitude) || !isValidLongitude(longitude)) {
+                throw new ExerciseException(ExerciseErrorCode.INVALID_LOCATION_INFO);
+            }
+        }
+
+        private static void validateRadius(Double radiusKm) {
+            if (radiusKm == null || !Double.isFinite(radiusKm) || radiusKm <= 0) {
+                throw new ExerciseException(ExerciseErrorCode.INVALID_LOCATION_INFO);
+            }
+        }
+
+        private static void validateBoundingBox(Double latitude, Double longitude, Double radiusKm) {
+            if (latitude == null && longitude == null) {
+                return;
+            }
+
+            double deltaLatitude = radiusKm / KILOMETERS_PER_LATITUDE_DEGREE;
+            double latitudeCosine = Math.cos(Math.toRadians(latitude));
+            double safeLatitudeCosine = Math.max(Math.abs(latitudeCosine), MIN_LONGITUDE_COSINE);
+            double deltaLongitude = radiusKm / (KILOMETERS_PER_LATITUDE_DEGREE * safeLatitudeCosine);
+
+            if (!isValidLatitude(latitude - deltaLatitude)
+                    || !isValidLatitude(latitude + deltaLatitude)
+                    || !isValidLongitude(longitude - deltaLongitude)
+                    || !isValidLongitude(longitude + deltaLongitude)) {
+                throw new ExerciseException(ExerciseErrorCode.INVALID_LOCATION_INFO);
+            }
+        }
+
+        private static boolean isValidLatitude(Double latitude) {
+            return latitude != null
+                    && Double.isFinite(latitude)
+                    && latitude >= MIN_LATITUDE
+                    && latitude <= MAX_LATITUDE;
+        }
+
+        private static boolean isValidLongitude(Double longitude) {
+            return longitude != null
+                    && Double.isFinite(longitude)
+                    && longitude >= MIN_LONGITUDE
+                    && longitude <= MAX_LONGITUDE;
+        }
+    }
 
     @Builder
     public record Response(

--- a/src/main/java/umc/cockple/demo/domain/exercise/dto/ExerciseMapBuildingsDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/dto/ExerciseMapBuildingsDTO.java
@@ -3,6 +3,7 @@ package umc.cockple.demo.domain.exercise.dto;
 import lombok.Builder;
 import umc.cockple.demo.domain.exercise.exception.ExerciseErrorCode;
 import umc.cockple.demo.domain.exercise.exception.ExerciseException;
+import umc.cockple.demo.domain.exercise.utils.ExerciseMapBoundingBox;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -10,8 +11,6 @@ import java.util.Map;
 
 public class ExerciseMapBuildingsDTO {
 
-    private static final double KILOMETERS_PER_LATITUDE_DEGREE = 111.045;
-    private static final double MIN_LONGITUDE_COSINE = 1.0e-12;
     private static final double MIN_LATITUDE = -90.0;
     private static final double MAX_LATITUDE = 90.0;
     private static final double MIN_LONGITUDE = -180.0;
@@ -69,15 +68,7 @@ public class ExerciseMapBuildingsDTO {
                 return;
             }
 
-            double deltaLatitude = radiusKm / KILOMETERS_PER_LATITUDE_DEGREE;
-            double latitudeCosine = Math.cos(Math.toRadians(latitude));
-            double safeLatitudeCosine = Math.max(Math.abs(latitudeCosine), MIN_LONGITUDE_COSINE);
-            double deltaLongitude = radiusKm / (KILOMETERS_PER_LATITUDE_DEGREE * safeLatitudeCosine);
-
-            if (!isValidLatitude(latitude - deltaLatitude)
-                    || !isValidLatitude(latitude + deltaLatitude)
-                    || !isValidLongitude(longitude - deltaLongitude)
-                    || !isValidLongitude(longitude + deltaLongitude)) {
+            if (!ExerciseMapBoundingBox.from(latitude, longitude, radiusKm).isWithinCoordinateRange()) {
                 throw new ExerciseException(ExerciseErrorCode.INVALID_LOCATION_INFO);
             }
         }

--- a/src/main/java/umc/cockple/demo/domain/exercise/exception/ExerciseErrorCode.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/exception/ExerciseErrorCode.java
@@ -23,6 +23,7 @@ public enum ExerciseErrorCode implements BaseErrorCode {
     INCOMPLETE_DATE_RANGE(HttpStatus.BAD_REQUEST, "EXERCISE105", "시작 날짜와 종료 날짜는 둘 다 null이거나 둘 다 null이 아니어야 합니다."),
     INVALID_DATE_RANGE(HttpStatus.BAD_REQUEST, "EXERCISE106", "종료 날짜는 시작 날짜보다 이후여야 합니다"),
     INCOMPLETE_LOCATION_INFO(HttpStatus.BAD_REQUEST, "EXERCISE107", "위도와 경도는 둘 다 null이거나 둘 다 null이 아니어야 합니다."),
+    INVALID_LOCATION_INFO(HttpStatus.BAD_REQUEST, "EXERCISE108", "위도, 경도 또는 반경 값이 유효하지 않습니다."),
 
     PARTY_NOT_FOUND(HttpStatus.NOT_FOUND, "EXERCISE201", "존재하지 않는 파티입니다."),
     EXERCISE_NOT_FOUND(HttpStatus.NOT_FOUND, "EXERCISE202", "존재하지 않는 운동입니다."),

--- a/src/main/java/umc/cockple/demo/domain/exercise/repository/ExerciseRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/repository/ExerciseRepository.java
@@ -221,6 +221,14 @@ public interface ExerciseRepository extends JpaRepository<Exercise, Long>, Exerc
             """)
     List<Exercise> findExercisesByBuildingAndDate(String buildingName, String streetAddr, LocalDate date);
 
+    /*
+     * 월간 지도 조회는 의도적으로 두 단계로 나눈다.
+     * 1. native spatial query로 조건에 맞는 Exercise ID 후보군만 먼저 조회한다.
+     * 2. 조회된 ID로 JPQL fetch join을 다시 수행해 실제 Exercise 엔티티를 로딩한다.
+     *
+     * native query에서 엔티티를 직접 조회하면 JPA fetch join과 연관 로딩 제어가 어려워지므로
+     * 공간 검색 조건과 엔티티 로딩 책임을 분리한다.
+     */
     default List<Exercise> findExercisesByMonthAndRadius(
             LocalDate startDate,
             LocalDate endDate,
@@ -238,6 +246,8 @@ public interface ExerciseRepository extends JpaRepository<Exercise, Long>, Exerc
     }
 
     /*
+     * 1단계 ID 후보군 조회 전용 쿼리다.
+     *
      * 좌표 순서 계약:
      * - API/DTO 필드는 latitude, longitude 순서다.
      * - MySQL spatial WKT는 axis-order=long-lat와 함께 POINT(longitude latitude) 순서로 만든다.
@@ -266,6 +276,10 @@ public interface ExerciseRepository extends JpaRepository<Exercise, Long>, Exerc
             @Param("boundingBoxWkt") String boundingBoxWkt,
             @Param("radiusKm") Double radiusKm);
 
+    /*
+     * 2단계 엔티티 조회 전용 쿼리다.
+     * 1단계에서 확정한 ID 후보군을 기준으로 Exercise와 월간 지도 응답에 필요한 주소를 로딩한다.
+     */
     @Query("""
             SELECT e FROM Exercise e
             JOIN FETCH e.exerciseAddr addr

--- a/src/main/java/umc/cockple/demo/domain/exercise/repository/ExerciseRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/repository/ExerciseRepository.java
@@ -221,26 +221,51 @@ public interface ExerciseRepository extends JpaRepository<Exercise, Long>, Exerc
             """)
     List<Exercise> findExercisesByBuildingAndDate(String buildingName, String streetAddr, LocalDate date);
 
+    default List<Exercise> findExercisesByMonthAndRadius(
+            LocalDate startDate,
+            LocalDate endDate,
+            String centerPointWkt,
+            String boundingBoxWkt,
+            Double radiusKm) {
+        List<Long> exerciseIds = findExerciseIdsByMonthAndRadius(
+                startDate, endDate, centerPointWkt, boundingBoxWkt, radiusKm);
+
+        if (exerciseIds.isEmpty()) {
+            return List.of();
+        }
+
+        return findExercisesByIdsForMonthlyMap(exerciseIds);
+    }
+
+    @Query(value = """
+            SELECT e.id
+            FROM exercise_addr addr
+            JOIN exercise e ON e.addr_id = addr.id
+            WHERE e.date BETWEEN :startDate AND :endDate
+            AND MBRWithin(
+                addr.location,
+                ST_GeomFromText(:boundingBoxWkt, 4326, 'axis-order=long-lat')
+            )
+            AND ST_Distance_Sphere(
+                addr.location,
+                ST_GeomFromText(:centerPointWkt, 4326, 'axis-order=long-lat')
+            ) <= (:radiusKm * 1000.0)
+            ORDER BY e.date ASC, e.start_time ASC
+            """, nativeQuery = true)
+    List<Long> findExerciseIdsByMonthAndRadius(
+            @Param("startDate") LocalDate startDate,
+            @Param("endDate") LocalDate endDate,
+            @Param("centerPointWkt") String centerPointWkt,
+            @Param("boundingBoxWkt") String boundingBoxWkt,
+            @Param("radiusKm") Double radiusKm);
+
     @Query("""
             SELECT e FROM Exercise e
             JOIN FETCH e.exerciseAddr addr
-            WHERE e.date BETWEEN :startDate AND :endDate
-            AND (
-                (6371 * acos(
-                    LEAST(1.0, cos(radians(:latitude)) * cos(radians(addr.latitude)) *
-                    cos(radians(addr.longitude) - radians(:longitude)) +
-                    sin(radians(:latitude)) * sin(radians(addr.latitude)))
-                )) <= :radiusKm
-                OR (addr.latitude = :latitude AND addr.longitude = :longitude)
-            )
+            WHERE e.id IN :exerciseIds
             ORDER BY e.date ASC, e.startTime ASC
             """)
-    List<Exercise> findExercisesByMonthAndRadius(
-            @Param("startDate") LocalDate startDate,
-            @Param("endDate") LocalDate end,
-            @Param("latitude") Double latitude,
-            @Param("longitude") Double longitude,
-            @Param("radiusKm") Integer radiusKm);
+    List<Exercise> findExercisesByIdsForMonthlyMap(@Param("exerciseIds") List<Long> exerciseIds);
 
 
     @Query("""

--- a/src/main/java/umc/cockple/demo/domain/exercise/repository/ExerciseRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/repository/ExerciseRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import umc.cockple.demo.domain.exercise.domain.Exercise;
+import umc.cockple.demo.domain.exercise.repository.support.ExerciseMapSpatialSearchCondition;
 import umc.cockple.demo.domain.party.dto.PartyExerciseInfoDTO;
 import umc.cockple.demo.global.enums.Gender;
 import umc.cockple.demo.global.enums.Level;
@@ -232,11 +233,18 @@ public interface ExerciseRepository extends JpaRepository<Exercise, Long>, Exerc
     default List<Exercise> findExercisesByMonthAndRadius(
             LocalDate startDate,
             LocalDate endDate,
-            String centerPointWkt,
-            String boundingBoxWkt,
+            Double latitude,
+            Double longitude,
             Double radiusKm) {
+        ExerciseMapSpatialSearchCondition searchCondition =
+                ExerciseMapSpatialSearchCondition.from(latitude, longitude, radiusKm);
+
         List<Long> exerciseIds = findExerciseIdsByMonthAndRadius(
-                startDate, endDate, centerPointWkt, boundingBoxWkt, radiusKm);
+                startDate,
+                endDate,
+                searchCondition.centerPointWkt(),
+                searchCondition.boundingBoxWkt(),
+                searchCondition.radiusKm());
 
         if (exerciseIds.isEmpty()) {
             return List.of();

--- a/src/main/java/umc/cockple/demo/domain/exercise/repository/ExerciseRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/repository/ExerciseRepository.java
@@ -237,6 +237,13 @@ public interface ExerciseRepository extends JpaRepository<Exercise, Long>, Exerc
         return findExercisesByIdsForMonthlyMap(exerciseIds);
     }
 
+    /*
+     * 좌표 순서 계약:
+     * - API/DTO 필드는 latitude, longitude 순서다.
+     * - MySQL spatial WKT는 axis-order=long-lat와 함께 POINT(longitude latitude) 순서로 만든다.
+     * - MBRWithin은 공간 인덱스를 타기 위한 bounding box 후보 필터다.
+     * - ST_Distance_Sphere는 최종 원형 반경을 보장하는 정밀 거리 필터다.
+     */
     @Query(value = """
             SELECT e.id
             FROM exercise_addr addr

--- a/src/main/java/umc/cockple/demo/domain/exercise/repository/support/ExerciseMapSpatialSearchCondition.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/repository/support/ExerciseMapSpatialSearchCondition.java
@@ -1,0 +1,75 @@
+package umc.cockple.demo.domain.exercise.repository.support;
+
+import java.util.Locale;
+
+/*
+ * 월간 지도 spatial 조회 조건 값 객체다.
+ *
+ * 입력 값 검증은 ExerciseMapBuildingsDTO.Query 책임이다.
+ * 이 객체는 검증이 끝난 좌표와 반경을 MySQL spatial query 파라미터로 변환하는 adapter 역할만 한다.
+ * MySQL ST_GeomFromText(..., 'axis-order=long-lat') 계약에 맞춰
+ * WKT는 항상 longitude latitude 순서로 생성한다.
+ */
+public record ExerciseMapSpatialSearchCondition(
+        double latitude,
+        double longitude,
+        double radiusKm,
+        String centerPointWkt,
+        String boundingBoxWkt
+) {
+
+    private static final double KILOMETERS_PER_LATITUDE_DEGREE = 111.045;
+    private static final double MIN_LONGITUDE_COSINE = 1.0e-12;
+
+    public static ExerciseMapSpatialSearchCondition from(double latitude, double longitude, double radiusKm) {
+        BoundingBox boundingBox = BoundingBox.from(latitude, longitude, radiusKm);
+
+        return new ExerciseMapSpatialSearchCondition(
+                latitude,
+                longitude,
+                radiusKm,
+                pointWkt(longitude, latitude),
+                polygonWkt(
+                        boundingBox.minLongitude(),
+                        boundingBox.minLatitude(),
+                        boundingBox.maxLongitude(),
+                        boundingBox.maxLatitude())
+        );
+    }
+
+    private static String pointWkt(double longitude, double latitude) {
+        return String.format(Locale.ROOT, "POINT(%s %s)", longitude, latitude);
+    }
+
+    private static String polygonWkt(double minLongitude, double minLatitude,
+                                     double maxLongitude, double maxLatitude) {
+        return String.format(Locale.ROOT,
+                "POLYGON((%s %s,%s %s,%s %s,%s %s,%s %s))",
+                minLongitude, minLatitude,
+                maxLongitude, minLatitude,
+                maxLongitude, maxLatitude,
+                minLongitude, maxLatitude,
+                minLongitude, minLatitude);
+    }
+
+    private record BoundingBox(
+            double minLatitude,
+            double maxLatitude,
+            double minLongitude,
+            double maxLongitude
+    ) {
+        private static BoundingBox from(double latitude, double longitude, double radiusKm) {
+            double deltaLatitude = radiusKm / KILOMETERS_PER_LATITUDE_DEGREE;
+            double latitudeCosine = Math.cos(Math.toRadians(latitude));
+            double safeLatitudeCosine = Math.max(Math.abs(latitudeCosine), MIN_LONGITUDE_COSINE);
+            double deltaLongitude = radiusKm / (KILOMETERS_PER_LATITUDE_DEGREE * safeLatitudeCosine);
+
+            return new BoundingBox(
+                    latitude - deltaLatitude,
+                    latitude + deltaLatitude,
+                    longitude - deltaLongitude,
+                    longitude + deltaLongitude
+            );
+        }
+    }
+}

--- a/src/main/java/umc/cockple/demo/domain/exercise/repository/support/ExerciseMapSpatialSearchCondition.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/repository/support/ExerciseMapSpatialSearchCondition.java
@@ -1,5 +1,7 @@
 package umc.cockple.demo.domain.exercise.repository.support;
 
+import umc.cockple.demo.domain.exercise.utils.ExerciseMapBoundingBox;
+
 import java.util.Locale;
 
 /*
@@ -18,11 +20,8 @@ public record ExerciseMapSpatialSearchCondition(
         String boundingBoxWkt
 ) {
 
-    private static final double KILOMETERS_PER_LATITUDE_DEGREE = 111.045;
-    private static final double MIN_LONGITUDE_COSINE = 1.0e-12;
-
     public static ExerciseMapSpatialSearchCondition from(double latitude, double longitude, double radiusKm) {
-        BoundingBox boundingBox = BoundingBox.from(latitude, longitude, radiusKm);
+        ExerciseMapBoundingBox boundingBox = ExerciseMapBoundingBox.from(latitude, longitude, radiusKm);
 
         return new ExerciseMapSpatialSearchCondition(
                 latitude,
@@ -50,26 +49,5 @@ public record ExerciseMapSpatialSearchCondition(
                 maxLongitude, maxLatitude,
                 minLongitude, maxLatitude,
                 minLongitude, minLatitude);
-    }
-
-    private record BoundingBox(
-            double minLatitude,
-            double maxLatitude,
-            double minLongitude,
-            double maxLongitude
-    ) {
-        private static BoundingBox from(double latitude, double longitude, double radiusKm) {
-            double deltaLatitude = radiusKm / KILOMETERS_PER_LATITUDE_DEGREE;
-            double latitudeCosine = Math.cos(Math.toRadians(latitude));
-            double safeLatitudeCosine = Math.max(Math.abs(latitudeCosine), MIN_LONGITUDE_COSINE);
-            double deltaLongitude = radiusKm / (KILOMETERS_PER_LATITUDE_DEGREE * safeLatitudeCosine);
-
-            return new BoundingBox(
-                    latitude - deltaLatitude,
-                    latitude + deltaLatitude,
-                    longitude - deltaLongitude,
-                    longitude + deltaLongitude
-            );
-        }
     }
 }

--- a/src/main/java/umc/cockple/demo/domain/exercise/repository/support/ExerciseMapSpatialSearchCondition.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/repository/support/ExerciseMapSpatialSearchCondition.java
@@ -2,6 +2,7 @@ package umc.cockple.demo.domain.exercise.repository.support;
 
 import umc.cockple.demo.domain.exercise.utils.ExerciseMapBoundingBox;
 
+import java.math.BigDecimal;
 import java.util.Locale;
 
 /*
@@ -37,17 +38,23 @@ public record ExerciseMapSpatialSearchCondition(
     }
 
     private static String pointWkt(double longitude, double latitude) {
-        return String.format(Locale.ROOT, "POINT(%s %s)", longitude, latitude);
+        return String.format(Locale.ROOT, "POINT(%s %s)", plain(longitude), plain(latitude));
     }
 
     private static String polygonWkt(double minLongitude, double minLatitude,
                                      double maxLongitude, double maxLatitude) {
         return String.format(Locale.ROOT,
                 "POLYGON((%s %s,%s %s,%s %s,%s %s,%s %s))",
-                minLongitude, minLatitude,
-                maxLongitude, minLatitude,
-                maxLongitude, maxLatitude,
-                minLongitude, maxLatitude,
-                minLongitude, minLatitude);
+                plain(minLongitude), plain(minLatitude),
+                plain(maxLongitude), plain(minLatitude),
+                plain(maxLongitude), plain(maxLatitude),
+                plain(minLongitude), plain(maxLatitude),
+                plain(minLongitude), plain(minLatitude));
+    }
+
+    private static String plain(double value) {
+        return BigDecimal.valueOf(value)
+                .stripTrailingZeros()
+                .toPlainString();
     }
 }

--- a/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseQueryService.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseQueryService.java
@@ -48,9 +48,6 @@ import java.util.stream.Collectors;
 @Slf4j
 public class ExerciseQueryService {
 
-    private static final double KILOMETERS_PER_LATITUDE_DEGREE = 111.045;
-    private static final double MIN_LONGITUDE_COSINE = 1.0e-12;
-
     private final ExerciseRepository exerciseRepository;
     private final MemberRepository memberRepository;
     private final MemberPartyRepository memberPartyRepository;
@@ -805,13 +802,11 @@ public class ExerciseQueryService {
 
     private List<Exercise> findExercisesByMonthAndRadius(
             DateRange dateRange, ExerciseMapBuildingsDTO.Query searchQuery) {
-        SpatialSearchBounds bounds = SpatialSearchBounds.from(searchQuery);
-
         return exerciseRepository.findExercisesByMonthAndRadius(
                 dateRange.start(),
                 dateRange.end(),
-                bounds.centerPointWkt(),
-                bounds.boundingBoxWkt(),
+                searchQuery.latitude(),
+                searchQuery.longitude(),
                 searchQuery.radiusKm()
         );
     }
@@ -954,40 +949,6 @@ public class ExerciseQueryService {
     }
 
     private record ExerciseWithDistance(Exercise exercise, double distance) {
-    }
-
-    private record SpatialSearchBounds(String centerPointWkt, String boundingBoxWkt) {
-        private static SpatialSearchBounds from(ExerciseMapBuildingsDTO.Query query) {
-            double deltaLatitude = query.radiusKm() / KILOMETERS_PER_LATITUDE_DEGREE;
-            double latitudeCosine = Math.cos(Math.toRadians(query.latitude()));
-            double safeLatitudeCosine = Math.max(Math.abs(latitudeCosine), MIN_LONGITUDE_COSINE);
-            double deltaLongitude = query.radiusKm() / (KILOMETERS_PER_LATITUDE_DEGREE * safeLatitudeCosine);
-
-            double minLatitude = query.latitude() - deltaLatitude;
-            double maxLatitude = query.latitude() + deltaLatitude;
-            double minLongitude = query.longitude() - deltaLongitude;
-            double maxLongitude = query.longitude() + deltaLongitude;
-
-            return new SpatialSearchBounds(
-                    pointWkt(query.longitude(), query.latitude()),
-                    polygonWkt(minLongitude, minLatitude, maxLongitude, maxLatitude)
-            );
-        }
-
-        private static String pointWkt(double longitude, double latitude) {
-            return String.format(Locale.ROOT, "POINT(%s %s)", longitude, latitude);
-        }
-
-        private static String polygonWkt(double minLongitude, double minLatitude,
-                                         double maxLongitude, double maxLatitude) {
-            return String.format(Locale.ROOT,
-                    "POLYGON((%s %s,%s %s,%s %s,%s %s,%s %s))",
-                    minLongitude, minLatitude,
-                    maxLongitude, minLatitude,
-                    maxLongitude, maxLatitude,
-                    minLongitude, maxLatitude,
-                    minLongitude, minLatitude);
-        }
     }
 
     private record BuildingKey(

--- a/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseQueryService.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseQueryService.java
@@ -294,18 +294,19 @@ public class ExerciseQueryService {
     }
 
     public ExerciseMapBuildingsDTO.Response getExerciseMapCalendarSummary(
-            LocalDate date, Double latitude, Double longitude, Double radiusKm, Long memberId) {
+            ExerciseMapBuildingsDTO.Query query, Long memberId) {
 
         log.info("월간 운동 캘린더 요약 조회 시작 - 날짜: {}, 중심: ({}, {}), 반경: {}km",
-                date, latitude, longitude, radiusKm);
+                query.date(), query.latitude(), query.longitude(), query.radiusKm());
 
         Member member = findMemberWithAddressesOrThrow(memberId);
         MemberAddr mainAddr = findMainAddrOrThrow(member);
+        ExerciseMapBuildingsDTO.Query searchQuery =
+                query.withFallbackLocation(mainAddr.getLatitude(), mainAddr.getLongitude());
 
-        DateRange dateRange = DateRange.calculateMonthlyStartAndEnd(date);
-        SearchLocation searchLocation = SearchLocation.createLocation(latitude, longitude, radiusKm, mainAddr);
+        DateRange dateRange = DateRange.calculateMonthlyStartAndEnd(query.date());
 
-        List<Exercise> exercises = findExercisesByMonthAndRadius(dateRange, searchLocation);
+        List<Exercise> exercises = findExercisesByMonthAndRadius(dateRange, searchQuery);
 
         Map<LocalDate, List<ExerciseMapBuildingsDTO.BuildingInfo>> dailyBuildings =
                 groupExercisesByDateAndBuilding(exercises);
@@ -314,7 +315,7 @@ public class ExerciseQueryService {
 
         return exerciseConverter.toMapCalendarSummaryResponse(
                 dateRange.start().getYear(), dateRange.start().getMonthValue(),
-                searchLocation.latitude(), searchLocation.longitude(), radiusKm, dailyBuildings);
+                searchQuery.latitude(), searchQuery.longitude(), searchQuery.radiusKm(), dailyBuildings);
     }
 
     public ExerciseRecommendationCalendarDTO.Response getRecommendedExerciseCalendar(
@@ -802,15 +803,16 @@ public class ExerciseQueryService {
                 .findExercisesByBuildingAndDate(buildingName, streetAddr, date);
     }
 
-    private List<Exercise> findExercisesByMonthAndRadius(DateRange dateRange, SearchLocation searchLocation) {
-        SpatialSearchBounds bounds = SpatialSearchBounds.from(searchLocation);
+    private List<Exercise> findExercisesByMonthAndRadius(
+            DateRange dateRange, ExerciseMapBuildingsDTO.Query searchQuery) {
+        SpatialSearchBounds bounds = SpatialSearchBounds.from(searchQuery);
 
         return exerciseRepository.findExercisesByMonthAndRadius(
                 dateRange.start(),
                 dateRange.end(),
                 bounds.centerPointWkt(),
                 bounds.boundingBoxWkt(),
-                searchLocation.radiusKm()
+                searchQuery.radiusKm()
         );
     }
 
@@ -954,34 +956,20 @@ public class ExerciseQueryService {
     private record ExerciseWithDistance(Exercise exercise, double distance) {
     }
 
-    private record SearchLocation(Double latitude, Double longitude, Double radiusKm) {
-        private static SearchLocation createLocation(Double latitude, Double longitude, Double radius, MemberAddr addr) {
-            if (latitude == null && longitude == null) {
-                return new SearchLocation(addr.getLatitude(), addr.getLongitude(), radius);
-            }
-
-            if (latitude == null || longitude == null) {
-                throw new ExerciseException(ExerciseErrorCode.INCOMPLETE_LOCATION_INFO);
-            }
-
-            return new SearchLocation(latitude, longitude, radius);
-        }
-    }
-
     private record SpatialSearchBounds(String centerPointWkt, String boundingBoxWkt) {
-        private static SpatialSearchBounds from(SearchLocation location) {
-            double deltaLatitude = location.radiusKm() / KILOMETERS_PER_LATITUDE_DEGREE;
-            double latitudeCosine = Math.cos(Math.toRadians(location.latitude()));
+        private static SpatialSearchBounds from(ExerciseMapBuildingsDTO.Query query) {
+            double deltaLatitude = query.radiusKm() / KILOMETERS_PER_LATITUDE_DEGREE;
+            double latitudeCosine = Math.cos(Math.toRadians(query.latitude()));
             double safeLatitudeCosine = Math.max(Math.abs(latitudeCosine), MIN_LONGITUDE_COSINE);
-            double deltaLongitude = location.radiusKm() / (KILOMETERS_PER_LATITUDE_DEGREE * safeLatitudeCosine);
+            double deltaLongitude = query.radiusKm() / (KILOMETERS_PER_LATITUDE_DEGREE * safeLatitudeCosine);
 
-            double minLatitude = location.latitude() - deltaLatitude;
-            double maxLatitude = location.latitude() + deltaLatitude;
-            double minLongitude = location.longitude() - deltaLongitude;
-            double maxLongitude = location.longitude() + deltaLongitude;
+            double minLatitude = query.latitude() - deltaLatitude;
+            double maxLatitude = query.latitude() + deltaLatitude;
+            double minLongitude = query.longitude() - deltaLongitude;
+            double maxLongitude = query.longitude() + deltaLongitude;
 
             return new SpatialSearchBounds(
-                    pointWkt(location.longitude(), location.latitude()),
+                    pointWkt(query.longitude(), query.latitude()),
                     polygonWkt(minLongitude, minLatitude, maxLongitude, maxLatitude)
             );
         }

--- a/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseQueryService.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/service/ExerciseQueryService.java
@@ -48,6 +48,9 @@ import java.util.stream.Collectors;
 @Slf4j
 public class ExerciseQueryService {
 
+    private static final double KILOMETERS_PER_LATITUDE_DEGREE = 111.045;
+    private static final double MIN_LONGITUDE_COSINE = 1.0e-12;
+
     private final ExerciseRepository exerciseRepository;
     private final MemberRepository memberRepository;
     private final MemberPartyRepository memberPartyRepository;
@@ -800,12 +803,14 @@ public class ExerciseQueryService {
     }
 
     private List<Exercise> findExercisesByMonthAndRadius(DateRange dateRange, SearchLocation searchLocation) {
+        SpatialSearchBounds bounds = SpatialSearchBounds.from(searchLocation);
+
         return exerciseRepository.findExercisesByMonthAndRadius(
                 dateRange.start(),
                 dateRange.end(),
-                searchLocation.latitude(),
-                searchLocation.longitude(),
-                searchLocation.radiusKm().intValue()
+                bounds.centerPointWkt(),
+                bounds.boundingBoxWkt(),
+                searchLocation.radiusKm()
         );
     }
 
@@ -960,6 +965,40 @@ public class ExerciseQueryService {
             }
 
             return new SearchLocation(latitude, longitude, radius);
+        }
+    }
+
+    private record SpatialSearchBounds(String centerPointWkt, String boundingBoxWkt) {
+        private static SpatialSearchBounds from(SearchLocation location) {
+            double deltaLatitude = location.radiusKm() / KILOMETERS_PER_LATITUDE_DEGREE;
+            double latitudeCosine = Math.cos(Math.toRadians(location.latitude()));
+            double safeLatitudeCosine = Math.max(Math.abs(latitudeCosine), MIN_LONGITUDE_COSINE);
+            double deltaLongitude = location.radiusKm() / (KILOMETERS_PER_LATITUDE_DEGREE * safeLatitudeCosine);
+
+            double minLatitude = location.latitude() - deltaLatitude;
+            double maxLatitude = location.latitude() + deltaLatitude;
+            double minLongitude = location.longitude() - deltaLongitude;
+            double maxLongitude = location.longitude() + deltaLongitude;
+
+            return new SpatialSearchBounds(
+                    pointWkt(location.longitude(), location.latitude()),
+                    polygonWkt(minLongitude, minLatitude, maxLongitude, maxLatitude)
+            );
+        }
+
+        private static String pointWkt(double longitude, double latitude) {
+            return String.format(Locale.ROOT, "POINT(%s %s)", longitude, latitude);
+        }
+
+        private static String polygonWkt(double minLongitude, double minLatitude,
+                                         double maxLongitude, double maxLatitude) {
+            return String.format(Locale.ROOT,
+                    "POLYGON((%s %s,%s %s,%s %s,%s %s,%s %s))",
+                    minLongitude, minLatitude,
+                    maxLongitude, minLatitude,
+                    maxLongitude, maxLatitude,
+                    minLongitude, maxLatitude,
+                    minLongitude, minLatitude);
         }
     }
 

--- a/src/main/java/umc/cockple/demo/domain/exercise/utils/ExerciseMapBoundingBox.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/utils/ExerciseMapBoundingBox.java
@@ -1,0 +1,53 @@
+package umc.cockple.demo.domain.exercise.utils;
+
+/*
+ * 월간 지도 반경 검색용 bounding box 계산 값 객체다.
+ * 입력 검증과 MySQL WKT 생성은 담당하지 않고, 중심 좌표와 반경으로 사각 후보 영역만 계산한다.
+ */
+public record ExerciseMapBoundingBox(
+        double minLatitude,
+        double maxLatitude,
+        double minLongitude,
+        double maxLongitude
+) {
+
+    private static final double KILOMETERS_PER_LATITUDE_DEGREE = 111.045;
+    private static final double MIN_LONGITUDE_COSINE = 1.0e-12;
+    private static final double MIN_LATITUDE = -90.0;
+    private static final double MAX_LATITUDE = 90.0;
+    private static final double MIN_LONGITUDE = -180.0;
+    private static final double MAX_LONGITUDE = 180.0;
+
+    public static ExerciseMapBoundingBox from(double latitude, double longitude, double radiusKm) {
+        double deltaLatitude = radiusKm / KILOMETERS_PER_LATITUDE_DEGREE;
+        double latitudeCosine = Math.cos(Math.toRadians(latitude));
+        double safeLatitudeCosine = Math.max(Math.abs(latitudeCosine), MIN_LONGITUDE_COSINE);
+        double deltaLongitude = radiusKm / (KILOMETERS_PER_LATITUDE_DEGREE * safeLatitudeCosine);
+
+        return new ExerciseMapBoundingBox(
+                latitude - deltaLatitude,
+                latitude + deltaLatitude,
+                longitude - deltaLongitude,
+                longitude + deltaLongitude
+        );
+    }
+
+    public boolean isWithinCoordinateRange() {
+        return isValidLatitude(minLatitude)
+                && isValidLatitude(maxLatitude)
+                && isValidLongitude(minLongitude)
+                && isValidLongitude(maxLongitude);
+    }
+
+    private static boolean isValidLatitude(double latitude) {
+        return Double.isFinite(latitude)
+                && latitude >= MIN_LATITUDE
+                && latitude <= MAX_LATITUDE;
+    }
+
+    private static boolean isValidLongitude(double longitude) {
+        return Double.isFinite(longitude)
+                && longitude >= MIN_LONGITUDE
+                && longitude <= MAX_LONGITUDE;
+    }
+}

--- a/src/main/resources/db/migration/V2026.05.31.00.00__add_exercise_addr_spatial_location.sql
+++ b/src/main/resources/db/migration/V2026.05.31.00.00__add_exercise_addr_spatial_location.sql
@@ -1,0 +1,15 @@
+ALTER TABLE exercise_addr
+    ADD COLUMN location POINT
+        GENERATED ALWAYS AS (
+            ST_GeomFromText(
+                CONCAT('POINT(', longitude, ' ', latitude, ')'),
+                4326,
+                'axis-order=long-lat'
+            )
+        ) STORED NOT NULL SRID 4326;
+
+CREATE SPATIAL INDEX idx_exercise_addr_location
+    ON exercise_addr (location);
+
+CREATE INDEX idx_exercise_date_addr
+    ON exercise (date, addr_id);

--- a/src/test/java/umc/cockple/demo/domain/exercise/dto/ExerciseMapBuildingsDTOTest.java
+++ b/src/test/java/umc/cockple/demo/domain/exercise/dto/ExerciseMapBuildingsDTOTest.java
@@ -1,0 +1,112 @@
+package umc.cockple.demo.domain.exercise.dto;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import umc.cockple.demo.domain.exercise.exception.ExerciseErrorCode;
+import umc.cockple.demo.domain.exercise.exception.ExerciseException;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("ExerciseMapBuildingsDTO")
+class ExerciseMapBuildingsDTOTest {
+
+    @Nested
+    @DisplayName("Query")
+    class QueryTest {
+
+        @Test
+        @DisplayName("좌표가 없으면 대표주소 fallback 전 상태로 생성된다")
+        void 좌표가_없으면_대표주소_fallback_전_상태로_생성된다() {
+            // when
+            ExerciseMapBuildingsDTO.Query query = ExerciseMapBuildingsDTO.Query.of(
+                    LocalDate.of(2026, 4, 1), null, null, 3.9);
+
+            // then
+            assertThat(query.latitude()).isNull();
+            assertThat(query.longitude()).isNull();
+            assertThat(query.radiusKm()).isEqualTo(3.9);
+        }
+
+        @Test
+        @DisplayName("명시 좌표와 반경이 유효하면 생성된다")
+        void 명시_좌표와_반경이_유효하면_생성된다() {
+            // when
+            ExerciseMapBuildingsDTO.Query query = ExerciseMapBuildingsDTO.Query.of(
+                    LocalDate.of(2026, 4, 1), 37.5, 127.0, 3.9);
+
+            // then
+            assertThat(query.latitude()).isEqualTo(37.5);
+            assertThat(query.longitude()).isEqualTo(127.0);
+            assertThat(query.radiusKm()).isEqualTo(3.9);
+        }
+
+        @Test
+        @DisplayName("대표주소 fallback 좌표가 유효하면 좌표가 채워진 Query를 반환한다")
+        void 대표주소_fallback_좌표가_유효하면_좌표가_채워진_query를_반환한다() {
+            // given
+            ExerciseMapBuildingsDTO.Query query = ExerciseMapBuildingsDTO.Query.of(
+                    LocalDate.of(2026, 4, 1), null, null, 3.9);
+
+            // when
+            ExerciseMapBuildingsDTO.Query fallbackQuery = query.withFallbackLocation(37.5, 127.0);
+
+            // then
+            assertThat(fallbackQuery.latitude()).isEqualTo(37.5);
+            assertThat(fallbackQuery.longitude()).isEqualTo(127.0);
+            assertThat(fallbackQuery.radiusKm()).isEqualTo(3.9);
+        }
+
+        @Test
+        @DisplayName("위도와 경도 중 하나만 있으면 예외를 던진다")
+        void 위도와_경도_중_하나만_있으면_예외를_던진다() {
+            assertThatThrownBy(() -> ExerciseMapBuildingsDTO.Query.of(
+                    LocalDate.of(2026, 4, 1), 37.5, null, 3.9))
+                    .isInstanceOf(ExerciseException.class)
+                    .hasFieldOrPropertyWithValue("code", ExerciseErrorCode.INCOMPLETE_LOCATION_INFO);
+        }
+
+        @Test
+        @DisplayName("좌표 범위를 벗어나면 예외를 던진다")
+        void 좌표_범위를_벗어나면_예외를_던진다() {
+            assertThatThrownBy(() -> ExerciseMapBuildingsDTO.Query.of(
+                    LocalDate.of(2026, 4, 1), 91.0, 127.0, 3.9))
+                    .isInstanceOf(ExerciseException.class)
+                    .hasFieldOrPropertyWithValue("code", ExerciseErrorCode.INVALID_LOCATION_INFO);
+        }
+
+        @Test
+        @DisplayName("반경이 양수가 아니면 예외를 던진다")
+        void 반경이_양수가_아니면_예외를_던진다() {
+            assertThatThrownBy(() -> ExerciseMapBuildingsDTO.Query.of(
+                    LocalDate.of(2026, 4, 1), 37.5, 127.0, 0.0))
+                    .isInstanceOf(ExerciseException.class)
+                    .hasFieldOrPropertyWithValue("code", ExerciseErrorCode.INVALID_LOCATION_INFO);
+        }
+
+        @Test
+        @DisplayName("반경 bounding box가 SRID 4326 좌표 범위를 벗어나면 예외를 던진다")
+        void 반경_bounding_box가_srid_4326_좌표_범위를_벗어나면_예외를_던진다() {
+            assertThatThrownBy(() -> ExerciseMapBuildingsDTO.Query.of(
+                    LocalDate.of(2026, 4, 1), 37.5, 127.0, 10_000.0))
+                    .isInstanceOf(ExerciseException.class)
+                    .hasFieldOrPropertyWithValue("code", ExerciseErrorCode.INVALID_LOCATION_INFO);
+        }
+
+        @Test
+        @DisplayName("대표주소 fallback 좌표가 유효하지 않으면 예외를 던진다")
+        void 대표주소_fallback_좌표가_유효하지_않으면_예외를_던진다() {
+            // given
+            ExerciseMapBuildingsDTO.Query query = ExerciseMapBuildingsDTO.Query.of(
+                    LocalDate.of(2026, 4, 1), null, null, 3.9);
+
+            // when & then
+            assertThatThrownBy(() -> query.withFallbackLocation(91.0, 127.0))
+                    .isInstanceOf(ExerciseException.class)
+                    .hasFieldOrPropertyWithValue("code", ExerciseErrorCode.INVALID_LOCATION_INFO);
+        }
+    }
+}

--- a/src/test/java/umc/cockple/demo/domain/exercise/integration/ExerciseQueryIntegrationTest.java
+++ b/src/test/java/umc/cockple/demo/domain/exercise/integration/ExerciseQueryIntegrationTest.java
@@ -1472,6 +1472,35 @@ class ExerciseQueryIntegrationTest extends IntegrationTestBase {
             }
 
             @Test
+            @DisplayName("좌표 범위를 벗어나면 400을 반환한다")
+            void 좌표_범위를_벗어나면_400을_반환한다() throws Exception {
+                SecurityContextHelper.setAuthentication(normalMember.getId(), normalMember.getNickname());
+
+                mockMvc.perform(get("/api/buildings/map/monthly")
+                                .param("date", targetDate.toString())
+                                .param("latitude", "91.0")
+                                .param("longitude", "127.0"))
+                        .andExpect(status().isBadRequest())
+                        .andExpect(jsonPath("$.code").value(ExerciseErrorCode.INVALID_LOCATION_INFO.getCode()))
+                        .andExpect(jsonPath("$.message").value(ExerciseErrorCode.INVALID_LOCATION_INFO.getMessage()));
+            }
+
+            @Test
+            @DisplayName("반경이 양수가 아니면 400을 반환한다")
+            void 반경이_양수가_아니면_400을_반환한다() throws Exception {
+                SecurityContextHelper.setAuthentication(normalMember.getId(), normalMember.getNickname());
+
+                mockMvc.perform(get("/api/buildings/map/monthly")
+                                .param("date", targetDate.toString())
+                                .param("latitude", "37.5")
+                                .param("longitude", "127.0")
+                                .param("radiusKm", "0"))
+                        .andExpect(status().isBadRequest())
+                        .andExpect(jsonPath("$.code").value(ExerciseErrorCode.INVALID_LOCATION_INFO.getCode()))
+                        .andExpect(jsonPath("$.message").value(ExerciseErrorCode.INVALID_LOCATION_INFO.getMessage()));
+            }
+
+            @Test
             @DisplayName("날짜 형식이 잘못되면 400을 반환한다")
             void 날짜_형식이_잘못되면_400을_반환한다() throws Exception {
                 SecurityContextHelper.setAuthentication(normalMember.getId(), normalMember.getNickname());

--- a/src/test/java/umc/cockple/demo/domain/exercise/integration/ExerciseQueryIntegrationTest.java
+++ b/src/test/java/umc/cockple/demo/domain/exercise/integration/ExerciseQueryIntegrationTest.java
@@ -1294,6 +1294,8 @@ class ExerciseQueryIntegrationTest extends IntegrationTestBase {
                     37.501, 127.001, LocalTime.of(13, 0));
             saveMapExercise(LocalDate.of(2026, 4, 4), "A빌딩", "서울특별시 강남구 테헤란로 10",
                     37.5005, 127.0005, LocalTime.of(10, 0));
+            saveMapExercise(LocalDate.of(2026, 4, 7), "소수반경빌딩", "서울특별시 강남구 테헤란로 390",
+                    37.535, 127.0, LocalTime.of(15, 0));
             saveMapExercise(LocalDate.of(2026, 4, 5), "반경밖빌딩", "부산광역시 해운대구 센텀로 1",
                     35.17, 129.13, LocalTime.of(12, 0));
             saveMapExercise(LocalDate.of(2026, 4, 6), "부산빌딩", "부산광역시 해운대구 센텀로 2",
@@ -1340,6 +1342,28 @@ class ExerciseQueryIntegrationTest extends IntegrationTestBase {
                         .andExpect(jsonPath("$.data.buildings['2026-04-04'].length()").value(1))
                         .andExpect(jsonPath("$.data.buildings['2026-04-04'][0].buildingName").value("A빌딩"))
                         .andExpect(jsonPath("$.data.buildings['2026-04-05']").doesNotExist());
+            }
+
+            @Test
+            @DisplayName("3.0km 밖이지만 3.9km 안인 건물은 소수 반경을 절사하지 않고 반환한다")
+            void 삼키로미터_밖_삼점구키로미터_안_건물은_소수_반경을_절사하지_않고_반환한다() throws Exception {
+                SecurityContextHelper.setAuthentication(normalMember.getId(), normalMember.getNickname());
+
+                mockMvc.perform(get("/api/buildings/map/monthly")
+                                .param("date", targetDate.toString())
+                                .param("latitude", "37.5")
+                                .param("longitude", "127.0")
+                                .param("radiusKm", "3.9"))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.data.buildings['2026-04-07'][0].buildingName").value("소수반경빌딩"));
+
+                mockMvc.perform(get("/api/buildings/map/monthly")
+                                .param("date", targetDate.toString())
+                                .param("latitude", "37.5")
+                                .param("longitude", "127.0")
+                                .param("radiusKm", "3.0"))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.data.buildings['2026-04-07']").doesNotExist());
             }
 
             @Test

--- a/src/test/java/umc/cockple/demo/domain/exercise/integration/ExerciseQueryIntegrationTest.java
+++ b/src/test/java/umc/cockple/demo/domain/exercise/integration/ExerciseQueryIntegrationTest.java
@@ -38,9 +38,6 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
-
-import javax.sql.DataSource;
-
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.nullValue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -59,7 +56,6 @@ class ExerciseQueryIntegrationTest extends IntegrationTestBase {
     @Autowired MemberExerciseRepository memberExerciseRepository;
     @Autowired GuestRepository guestRepository;
     @Autowired ExerciseBookmarkRepository exerciseBookmarkRepository;
-    @Autowired DataSource dataSource;
 
     private Member manager;
     private Member subManager;
@@ -1381,6 +1377,26 @@ class ExerciseQueryIntegrationTest extends IntegrationTestBase {
                         .andExpect(jsonPath("$.data.centerLongitude").value(129.13))
                         .andExpect(jsonPath("$.data.radiusKm").value(5.0))
                         .andExpect(jsonPath("$.data.buildings['2026-04-06'][0].buildingName").value("부산빌딩"));
+            }
+
+            @Test
+            @DisplayName("MySQL POINT는 longitude latitude 순서로 생성되어 부산 좌표가 서울 결과와 섞이지 않는다")
+            void mysql_point는_longitude_latitude_순서로_생성되어_부산_좌표가_서울_결과와_섞이지_않는다() throws Exception {
+                SecurityContextHelper.setAuthentication(normalMember.getId(), normalMember.getNickname());
+
+                mockMvc.perform(get("/api/buildings/map/monthly")
+                                .param("date", targetDate.toString())
+                                .param("latitude", "35.17")
+                                .param("longitude", "129.13")
+                                .param("radiusKm", "1.0"))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.data.centerLatitude").value(35.17))
+                        .andExpect(jsonPath("$.data.centerLongitude").value(129.13))
+                        .andExpect(jsonPath("$.data.buildings['2026-04-05'][0].buildingName").value("반경밖빌딩"))
+                        .andExpect(jsonPath("$.data.buildings['2026-04-06'][0].buildingName").value("부산빌딩"))
+                        .andExpect(jsonPath("$.data.buildings['2026-04-03']").doesNotExist())
+                        .andExpect(jsonPath("$.data.buildings['2026-04-04']").doesNotExist())
+                        .andExpect(jsonPath("$.data.buildings['2026-04-07']").doesNotExist());
             }
 
             @Test

--- a/src/test/java/umc/cockple/demo/domain/exercise/integration/ExerciseRepositorySpatialIntegrationTest.java
+++ b/src/test/java/umc/cockple/demo/domain/exercise/integration/ExerciseRepositorySpatialIntegrationTest.java
@@ -1,0 +1,121 @@
+package umc.cockple.demo.domain.exercise.integration;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.support.GeneratedKeyHolder;
+import org.springframework.jdbc.support.KeyHolder;
+import umc.cockple.demo.support.IntegrationTestBase;
+
+import java.sql.PreparedStatement;
+import java.sql.Statement;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("ExerciseRepository Spatial 조회")
+class ExerciseRepositorySpatialIntegrationTest extends IntegrationTestBase {
+
+    @Autowired JdbcTemplate jdbcTemplate;
+
+    @BeforeEach
+    void setUp() {
+        deleteSpatialExplainData();
+
+        Long nearAddrId = insertExerciseAddr("공간인덱스테스트1", 37.5, 127.0);
+        Long fractionalRadiusAddrId = insertExerciseAddr("공간인덱스테스트2", 37.535, 127.0);
+        Long farAddrId = insertExerciseAddr("공간인덱스테스트3", 35.17, 129.13);
+
+        insertExercise(nearAddrId, LocalDate.of(2026, 4, 3), "09:00:00");
+        insertExercise(fractionalRadiusAddrId, LocalDate.of(2026, 4, 7), "15:00:00");
+        insertExercise(farAddrId, LocalDate.of(2026, 4, 6), "14:00:00");
+    }
+
+    @AfterEach
+    void tearDown() {
+        deleteSpatialExplainData();
+    }
+
+    @Test
+    @DisplayName("월간 지도 spatial 후보 조회는 exercise_addr location 공간 인덱스를 사용할 수 있는 형태를 유지한다")
+    void 월간_지도_spatial_후보_조회는_exercise_addr_location_공간_인덱스를_사용할_수_있는_형태를_유지한다() {
+        String centerPointWkt = "POINT(127.0 37.5)";
+        String boundingBoxWkt = "POLYGON((126.95 37.45,127.05 37.45,127.05 37.55,126.95 37.55,126.95 37.45))";
+
+        List<Map<String, Object>> planRows = jdbcTemplate.queryForList("""
+                EXPLAIN
+                SELECT e.id
+                FROM exercise_addr addr
+                JOIN exercise e ON e.addr_id = addr.id
+                WHERE e.date BETWEEN ? AND ?
+                AND MBRWithin(
+                    addr.location,
+                    ST_GeomFromText(?, 4326, 'axis-order=long-lat')
+                )
+                AND ST_Distance_Sphere(
+                    addr.location,
+                    ST_GeomFromText(?, 4326, 'axis-order=long-lat')
+                ) <= (? * 1000.0)
+                ORDER BY e.date ASC, e.start_time ASC
+                """,
+                LocalDate.of(2026, 4, 1),
+                LocalDate.of(2026, 4, 30),
+                boundingBoxWkt,
+                centerPointWkt,
+                3.9);
+
+        Map<String, Object> addrPlan = planRows.stream()
+                .filter(row -> "addr".equals(Objects.toString(row.get("table"), "")))
+                .findFirst()
+                .orElseThrow();
+
+        String possibleKeys = Objects.toString(addrPlan.get("possible_keys"), "");
+        String selectedKey = Objects.toString(addrPlan.get("key"), "");
+        String accessType = Objects.toString(addrPlan.get("type"), "");
+
+        assertThat(possibleKeys).contains("idx_exercise_addr_location");
+        assertThat(selectedKey).isEqualTo("idx_exercise_addr_location");
+        assertThat(accessType).isEqualTo("range");
+    }
+
+    private Long insertExerciseAddr(String buildingName, double latitude, double longitude) {
+        KeyHolder keyHolder = new GeneratedKeyHolder();
+
+        jdbcTemplate.update(connection -> {
+            PreparedStatement ps = connection.prepareStatement("""
+                    INSERT INTO exercise_addr (
+                        addr1, addr2, street_addr, building_name, latitude, longitude
+                    ) VALUES (?, ?, ?, ?, ?, ?)
+                    """, Statement.RETURN_GENERATED_KEYS);
+            ps.setString(1, "서울특별시");
+            ps.setString(2, "강남구");
+            ps.setString(3, "서울특별시 강남구 테헤란로");
+            ps.setString(4, buildingName);
+            ps.setDouble(5, latitude);
+            ps.setDouble(6, longitude);
+            return ps;
+        }, keyHolder);
+
+        return Objects.requireNonNull(keyHolder.getKey()).longValue();
+    }
+
+    private void insertExercise(Long addrId, LocalDate date, String startTime) {
+        jdbcTemplate.update("""
+                INSERT INTO exercise (
+                    addr_id, date, start_time, max_capacity,
+                    party_guest_accept, outside_guest_accept, notice
+                ) VALUES (?, ?, ?, ?, ?, ?, ?)
+                """, addrId, date, startTime, 12, true, true, "spatial-explain-test");
+    }
+
+    private void deleteSpatialExplainData() {
+        jdbcTemplate.update("DELETE FROM exercise WHERE notice = 'spatial-explain-test'");
+        jdbcTemplate.update("DELETE FROM exercise_addr WHERE building_name LIKE '공간인덱스테스트%'");
+    }
+}

--- a/src/test/java/umc/cockple/demo/domain/exercise/integration/ExerciseRepositorySpatialIntegrationTest.java
+++ b/src/test/java/umc/cockple/demo/domain/exercise/integration/ExerciseRepositorySpatialIntegrationTest.java
@@ -43,7 +43,7 @@ class ExerciseRepositorySpatialIntegrationTest extends IntegrationTestBase {
     }
 
     @Test
-    @DisplayName("월간 지도 spatial 후보 조회는 exercise_addr location 공간 인덱스를 사용할 수 있는 형태를 유지한다")
+    @DisplayName("월간 지도 spatial 후보 조회는 location 공간 인덱스를 사용할 수 있는 형태를 유지한다")
     void 월간_지도_spatial_후보_조회는_exercise_addr_location_공간_인덱스를_사용할_수_있는_형태를_유지한다() {
         String centerPointWkt = "POINT(127.0 37.5)";
         String boundingBoxWkt = "POLYGON((126.95 37.45,127.05 37.45,127.05 37.55,126.95 37.55,126.95 37.45))";
@@ -79,9 +79,14 @@ class ExerciseRepositorySpatialIntegrationTest extends IntegrationTestBase {
         String selectedKey = Objects.toString(addrPlan.get("key"), "");
         String accessType = Objects.toString(addrPlan.get("type"), "");
 
-        assertThat(possibleKeys).contains("idx_exercise_addr_location");
-        assertThat(selectedKey).isEqualTo("idx_exercise_addr_location");
-        assertThat(accessType).isEqualTo("range");
+        /*
+         * Testcontainers의 데이터량과 통계값은 운영 DB와 다르므로 optimizer가 고른 key/type을
+         * 정확히 고정하지 않는다. 이 테스트는 쿼리가 spatial index를 사용할 수 있는 형태인지
+         * possible_keys 기준으로 확인하는 smoke 테스트다.
+         */
+        assertThat(possibleKeys)
+                .as("공간 인덱스가 후보에 있어야 한다. selectedKey=%s, accessType=%s", selectedKey, accessType)
+                .contains("idx_exercise_addr_location");
     }
 
     private Long insertExerciseAddr(String buildingName, double latitude, double longitude) {

--- a/src/test/java/umc/cockple/demo/domain/exercise/repository/ExerciseRepositoryTest.java
+++ b/src/test/java/umc/cockple/demo/domain/exercise/repository/ExerciseRepositoryTest.java
@@ -3,6 +3,7 @@ package umc.cockple.demo.domain.exercise.repository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import umc.cockple.demo.domain.exercise.domain.Exercise;
+import umc.cockple.demo.domain.exercise.repository.support.ExerciseMapSpatialSearchCondition;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -29,25 +30,35 @@ class ExerciseRepositoryTest {
                 withSettings().defaultAnswer(CALLS_REAL_METHODS));
         LocalDate startDate = LocalDate.of(2026, 4, 1);
         LocalDate endDate = LocalDate.of(2026, 4, 30);
-        String centerPointWkt = "POINT(127.0 37.5)";
-        String boundingBoxWkt = "POLYGON((126.9 37.4,127.1 37.4,127.1 37.6,126.9 37.6,126.9 37.4))";
-        Double radiusKm = 3.9;
+        double latitude = 37.5;
+        double longitude = 127.0;
+        double radiusKm = 3.9;
+        ExerciseMapSpatialSearchCondition searchCondition =
+                ExerciseMapSpatialSearchCondition.from(latitude, longitude, radiusKm);
         List<Long> exerciseIds = List.of(10L, 20L);
         List<Exercise> expectedExercises = List.of(mock(Exercise.class), mock(Exercise.class));
 
         doReturn(exerciseIds).when(exerciseRepository).findExerciseIdsByMonthAndRadius(
-                startDate, endDate, centerPointWkt, boundingBoxWkt, radiusKm);
+                startDate,
+                endDate,
+                searchCondition.centerPointWkt(),
+                searchCondition.boundingBoxWkt(),
+                searchCondition.radiusKm());
         doReturn(expectedExercises).when(exerciseRepository).findExercisesByIdsForMonthlyMap(exerciseIds);
 
         // when
         List<Exercise> exercises = exerciseRepository.findExercisesByMonthAndRadius(
-                startDate, endDate, centerPointWkt, boundingBoxWkt, radiusKm);
+                startDate, endDate, latitude, longitude, radiusKm);
 
         // then
         assertThat(exercises).isSameAs(expectedExercises);
         var inOrder = inOrder(exerciseRepository);
         inOrder.verify(exerciseRepository).findExerciseIdsByMonthAndRadius(
-                startDate, endDate, centerPointWkt, boundingBoxWkt, radiusKm);
+                startDate,
+                endDate,
+                searchCondition.centerPointWkt(),
+                searchCondition.boundingBoxWkt(),
+                searchCondition.radiusKm());
         inOrder.verify(exerciseRepository).findExercisesByIdsForMonthlyMap(exerciseIds);
     }
 
@@ -60,16 +71,22 @@ class ExerciseRepositoryTest {
                 withSettings().defaultAnswer(CALLS_REAL_METHODS));
         LocalDate startDate = LocalDate.of(2026, 4, 1);
         LocalDate endDate = LocalDate.of(2026, 4, 30);
-        String centerPointWkt = "POINT(127.0 37.5)";
-        String boundingBoxWkt = "POLYGON((126.9 37.4,127.1 37.4,127.1 37.6,126.9 37.6,126.9 37.4))";
-        Double radiusKm = 3.9;
+        double latitude = 37.5;
+        double longitude = 127.0;
+        double radiusKm = 3.9;
+        ExerciseMapSpatialSearchCondition searchCondition =
+                ExerciseMapSpatialSearchCondition.from(latitude, longitude, radiusKm);
 
         doReturn(List.of()).when(exerciseRepository).findExerciseIdsByMonthAndRadius(
-                startDate, endDate, centerPointWkt, boundingBoxWkt, radiusKm);
+                startDate,
+                endDate,
+                searchCondition.centerPointWkt(),
+                searchCondition.boundingBoxWkt(),
+                searchCondition.radiusKm());
 
         // when
         List<Exercise> exercises = exerciseRepository.findExercisesByMonthAndRadius(
-                startDate, endDate, centerPointWkt, boundingBoxWkt, radiusKm);
+                startDate, endDate, latitude, longitude, radiusKm);
 
         // then
         assertThat(exercises).isEmpty();

--- a/src/test/java/umc/cockple/demo/domain/exercise/repository/ExerciseRepositoryTest.java
+++ b/src/test/java/umc/cockple/demo/domain/exercise/repository/ExerciseRepositoryTest.java
@@ -1,0 +1,78 @@
+package umc.cockple.demo.domain.exercise.repository;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import umc.cockple.demo.domain.exercise.domain.Exercise;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.withSettings;
+
+@DisplayName("ExerciseRepository")
+class ExerciseRepositoryTest {
+
+    @Test
+    @DisplayName("월간 지도 반경 조회는 ID 후보군을 먼저 조회한 뒤 실제 엔티티를 조회한다")
+    void 월간_지도_반경_조회는_id_후보군을_먼저_조회한_뒤_실제_엔티티를_조회한다() {
+        // given
+        ExerciseRepository exerciseRepository = mock(
+                ExerciseRepository.class,
+                withSettings().defaultAnswer(CALLS_REAL_METHODS));
+        LocalDate startDate = LocalDate.of(2026, 4, 1);
+        LocalDate endDate = LocalDate.of(2026, 4, 30);
+        String centerPointWkt = "POINT(127.0 37.5)";
+        String boundingBoxWkt = "POLYGON((126.9 37.4,127.1 37.4,127.1 37.6,126.9 37.6,126.9 37.4))";
+        Double radiusKm = 3.9;
+        List<Long> exerciseIds = List.of(10L, 20L);
+        List<Exercise> expectedExercises = List.of(mock(Exercise.class), mock(Exercise.class));
+
+        doReturn(exerciseIds).when(exerciseRepository).findExerciseIdsByMonthAndRadius(
+                startDate, endDate, centerPointWkt, boundingBoxWkt, radiusKm);
+        doReturn(expectedExercises).when(exerciseRepository).findExercisesByIdsForMonthlyMap(exerciseIds);
+
+        // when
+        List<Exercise> exercises = exerciseRepository.findExercisesByMonthAndRadius(
+                startDate, endDate, centerPointWkt, boundingBoxWkt, radiusKm);
+
+        // then
+        assertThat(exercises).isSameAs(expectedExercises);
+        var inOrder = inOrder(exerciseRepository);
+        inOrder.verify(exerciseRepository).findExerciseIdsByMonthAndRadius(
+                startDate, endDate, centerPointWkt, boundingBoxWkt, radiusKm);
+        inOrder.verify(exerciseRepository).findExercisesByIdsForMonthlyMap(exerciseIds);
+    }
+
+    @Test
+    @DisplayName("월간 지도 ID 후보군이 없으면 실제 엔티티 조회를 생략한다")
+    void 월간_지도_id_후보군이_없으면_실제_엔티티_조회를_생략한다() {
+        // given
+        ExerciseRepository exerciseRepository = mock(
+                ExerciseRepository.class,
+                withSettings().defaultAnswer(CALLS_REAL_METHODS));
+        LocalDate startDate = LocalDate.of(2026, 4, 1);
+        LocalDate endDate = LocalDate.of(2026, 4, 30);
+        String centerPointWkt = "POINT(127.0 37.5)";
+        String boundingBoxWkt = "POLYGON((126.9 37.4,127.1 37.4,127.1 37.6,126.9 37.6,126.9 37.4))";
+        Double radiusKm = 3.9;
+
+        doReturn(List.of()).when(exerciseRepository).findExerciseIdsByMonthAndRadius(
+                startDate, endDate, centerPointWkt, boundingBoxWkt, radiusKm);
+
+        // when
+        List<Exercise> exercises = exerciseRepository.findExercisesByMonthAndRadius(
+                startDate, endDate, centerPointWkt, boundingBoxWkt, radiusKm);
+
+        // then
+        assertThat(exercises).isEmpty();
+        verify(exerciseRepository, never()).findExercisesByIdsForMonthlyMap(anyList());
+    }
+}

--- a/src/test/java/umc/cockple/demo/domain/exercise/repository/support/ExerciseMapSpatialSearchConditionTest.java
+++ b/src/test/java/umc/cockple/demo/domain/exercise/repository/support/ExerciseMapSpatialSearchConditionTest.java
@@ -15,7 +15,7 @@ class ExerciseMapSpatialSearchConditionTest {
         ExerciseMapSpatialSearchCondition condition = ExerciseMapSpatialSearchCondition.from(37.5, 127.0, 3.9);
 
         // then
-        assertThat(condition.centerPointWkt()).isEqualTo("POINT(127.0 37.5)");
+        assertThat(condition.centerPointWkt()).isEqualTo("POINT(127 37.5)");
         assertThat(condition.boundingBoxWkt()).isEqualTo(
                 "POLYGON((126.9557310782598 37.46487910306632,"
                         + "127.0442689217402 37.46487910306632,"
@@ -23,6 +23,18 @@ class ExerciseMapSpatialSearchConditionTest {
                         + "126.9557310782598 37.53512089693368,"
                         + "126.9557310782598 37.46487910306632))");
         assertThat(condition.radiusKm()).isEqualTo(3.9);
+    }
+
+    @Test
+    @DisplayName("WKT 좌표를 지수 표기법 없이 plain decimal로 생성한다")
+    void wkt_좌표를_지수_표기법_없이_plain_decimal로_생성한다() {
+        // when
+        ExerciseMapSpatialSearchCondition condition = ExerciseMapSpatialSearchCondition.from(0.0001, 0.0001, 0.001);
+
+        // then
+        assertThat(condition.centerPointWkt()).isEqualTo("POINT(0.0001 0.0001)");
+        assertThat(condition.boundingBoxWkt()).doesNotContain("E");
+        assertThat(condition.boundingBoxWkt()).doesNotContain("e");
     }
 
 }

--- a/src/test/java/umc/cockple/demo/domain/exercise/repository/support/ExerciseMapSpatialSearchConditionTest.java
+++ b/src/test/java/umc/cockple/demo/domain/exercise/repository/support/ExerciseMapSpatialSearchConditionTest.java
@@ -1,0 +1,28 @@
+package umc.cockple.demo.domain.exercise.repository.support;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("ExerciseMapSpatialSearchCondition")
+class ExerciseMapSpatialSearchConditionTest {
+
+    @Test
+    @DisplayName("MySQL long-lat 축 순서에 맞춰 중심점과 bounding box WKT를 생성한다")
+    void mysql_long_lat_축_순서에_맞춰_중심점과_bounding_box_wkt를_생성한다() {
+        // when
+        ExerciseMapSpatialSearchCondition condition = ExerciseMapSpatialSearchCondition.from(37.5, 127.0, 3.9);
+
+        // then
+        assertThat(condition.centerPointWkt()).isEqualTo("POINT(127.0 37.5)");
+        assertThat(condition.boundingBoxWkt()).isEqualTo(
+                "POLYGON((126.9557310782598 37.46487910306632,"
+                        + "127.0442689217402 37.46487910306632,"
+                        + "127.0442689217402 37.53512089693368,"
+                        + "126.9557310782598 37.53512089693368,"
+                        + "126.9557310782598 37.46487910306632))");
+        assertThat(condition.radiusKm()).isEqualTo(3.9);
+    }
+
+}

--- a/src/test/java/umc/cockple/demo/domain/exercise/service/ExerciseQueryServiceTest.java
+++ b/src/test/java/umc/cockple/demo/domain/exercise/service/ExerciseQueryServiceTest.java
@@ -1905,7 +1905,11 @@ class ExerciseQueryServiceTest {
                 given(memberRepository.findMemberWithAddresses(mapMember.getId()))
                         .willReturn(Optional.of(mapMember));
                 given(exerciseRepository.findExercisesByMonthAndRadius(
-                        eq(monthStart), eq(monthEnd), eq("POINT(127.039 37.501)"), any(), eq(radiusKm)))
+                        eq(monthStart),
+                        eq(monthEnd),
+                        eq(37.501),
+                        eq(127.039),
+                        eq(radiusKm)))
                         .willReturn(List.of());
 
                 // when
@@ -1932,7 +1936,11 @@ class ExerciseQueryServiceTest {
                 given(memberRepository.findMemberWithAddresses(mapMember.getId()))
                         .willReturn(Optional.of(mapMember));
                 given(exerciseRepository.findExercisesByMonthAndRadius(
-                        eq(monthStart), eq(monthEnd), eq("POINT(127.11 37.55)"), any(), eq(radiusKm)))
+                        eq(monthStart),
+                        eq(monthEnd),
+                        eq(37.55),
+                        eq(127.11),
+                        eq(radiusKm)))
                         .willReturn(List.of());
 
                 // when
@@ -1964,7 +1972,8 @@ class ExerciseQueryServiceTest {
 
                 given(memberRepository.findMemberWithAddresses(mapMember.getId()))
                         .willReturn(Optional.of(mapMember));
-                given(exerciseRepository.findExercisesByMonthAndRadius(any(), any(), any(), any(), any()))
+                given(exerciseRepository.findExercisesByMonthAndRadius(
+                        any(), any(), any(), any(), any()))
                         .willReturn(List.of(dayOneMorning, dayOneEveningSameBuilding, dayOneOtherBuilding, dayTwoBuilding));
 
                 // when

--- a/src/test/java/umc/cockple/demo/domain/exercise/service/ExerciseQueryServiceTest.java
+++ b/src/test/java/umc/cockple/demo/domain/exercise/service/ExerciseQueryServiceTest.java
@@ -1905,7 +1905,7 @@ class ExerciseQueryServiceTest {
                 given(memberRepository.findMemberWithAddresses(mapMember.getId()))
                         .willReturn(Optional.of(mapMember));
                 given(exerciseRepository.findExercisesByMonthAndRadius(
-                        eq(monthStart), eq(monthEnd), eq(mainAddr.getLatitude()), eq(mainAddr.getLongitude()), eq(3)))
+                        eq(monthStart), eq(monthEnd), eq("POINT(127.039 37.501)"), any(), eq(radiusKm)))
                         .willReturn(List.of());
 
                 // when
@@ -1922,8 +1922,8 @@ class ExerciseQueryServiceTest {
             }
 
             @Test
-            @DisplayName("명시 좌표가 있으면 대표주소 대신 해당 좌표와 절삭 반경으로 조회한다")
-            void 명시_좌표가_있으면_대표주소_대신_해당_좌표와_절삭_반경으로_조회한다() {
+            @DisplayName("명시 좌표가 있으면 대표주소 대신 해당 좌표와 소수 반경으로 조회한다")
+            void 명시_좌표가_있으면_대표주소_대신_해당_좌표와_소수_반경으로_조회한다() {
                 // given
                 LocalDate targetDate = LocalDate.of(2026, 4, 15);
                 LocalDate monthStart = LocalDate.of(2026, 4, 1);
@@ -1932,7 +1932,7 @@ class ExerciseQueryServiceTest {
                 given(memberRepository.findMemberWithAddresses(mapMember.getId()))
                         .willReturn(Optional.of(mapMember));
                 given(exerciseRepository.findExercisesByMonthAndRadius(
-                        eq(monthStart), eq(monthEnd), eq(37.55), eq(127.11), eq(3)))
+                        eq(monthStart), eq(monthEnd), eq("POINT(127.11 37.55)"), any(), eq(radiusKm)))
                         .willReturn(List.of());
 
                 // when

--- a/src/test/java/umc/cockple/demo/domain/exercise/service/ExerciseQueryServiceTest.java
+++ b/src/test/java/umc/cockple/demo/domain/exercise/service/ExerciseQueryServiceTest.java
@@ -1910,7 +1910,7 @@ class ExerciseQueryServiceTest {
 
                 // when
                 ExerciseMapBuildingsDTO.Response response = exerciseQueryService.getExerciseMapCalendarSummary(
-                        null, null, null, radiusKm, mapMember.getId());
+                        createMapQuery(null, null, null, radiusKm), mapMember.getId());
 
                 // then
                 assertThat(response.year()).isEqualTo(currentMonth.getYear());
@@ -1937,7 +1937,7 @@ class ExerciseQueryServiceTest {
 
                 // when
                 ExerciseMapBuildingsDTO.Response response = exerciseQueryService.getExerciseMapCalendarSummary(
-                        targetDate, 37.55, 127.11, radiusKm, mapMember.getId());
+                        createMapQuery(targetDate, 37.55, 127.11, radiusKm), mapMember.getId());
 
                 // then
                 assertThat(response.year()).isEqualTo(2026);
@@ -1969,7 +1969,7 @@ class ExerciseQueryServiceTest {
 
                 // when
                 ExerciseMapBuildingsDTO.Response response = exerciseQueryService.getExerciseMapCalendarSummary(
-                        targetDate, null, null, radiusKm, mapMember.getId());
+                        createMapQuery(targetDate, null, null, radiusKm), mapMember.getId());
 
                 // then
                 assertThat(response.year()).isEqualTo(2026);
@@ -2012,7 +2012,7 @@ class ExerciseQueryServiceTest {
 
                 // when & then
                 assertThatThrownBy(() -> exerciseQueryService.getExerciseMapCalendarSummary(
-                        LocalDate.of(2026, 4, 1), null, null, radiusKm, 999L))
+                        createMapQuery(LocalDate.of(2026, 4, 1), null, null, radiusKm), 999L))
                         .isInstanceOf(ExerciseException.class)
                         .hasFieldOrPropertyWithValue("code", ExerciseErrorCode.MEMBER_NOT_FOUND);
             }
@@ -2026,7 +2026,7 @@ class ExerciseQueryServiceTest {
 
                 // when & then
                 assertThatThrownBy(() -> exerciseQueryService.getExerciseMapCalendarSummary(
-                        LocalDate.of(2026, 4, 1), null, null, radiusKm, memberWithoutMainAddr.getId()))
+                        createMapQuery(LocalDate.of(2026, 4, 1), null, null, radiusKm), memberWithoutMainAddr.getId()))
                         .isInstanceOf(ExerciseException.class)
                         .hasFieldOrPropertyWithValue("code", ExerciseErrorCode.MAIN_ADDRESS_NULL);
             }
@@ -2040,24 +2040,16 @@ class ExerciseQueryServiceTest {
 
                 // when & then
                 assertThatThrownBy(() -> exerciseQueryService.getExerciseMapCalendarSummary(
-                        LocalDate.of(2026, 4, 1), 37.5, 127.0, radiusKm, memberWithoutMainAddr.getId()))
+                        createMapQuery(LocalDate.of(2026, 4, 1), 37.5, 127.0, radiusKm), memberWithoutMainAddr.getId()))
                         .isInstanceOf(ExerciseException.class)
                         .hasFieldOrPropertyWithValue("code", ExerciseErrorCode.MAIN_ADDRESS_NULL);
             }
 
-            @Test
-            @DisplayName("위도와 경도 중 하나만 주면 예외를 던진다")
-            void 위도와_경도_중_하나만_주면_예외를_던진다() {
-                // given
-                given(memberRepository.findMemberWithAddresses(mapMember.getId()))
-                        .willReturn(Optional.of(mapMember));
+        }
 
-                // when & then
-                assertThatThrownBy(() -> exerciseQueryService.getExerciseMapCalendarSummary(
-                        LocalDate.of(2026, 4, 1), 37.5, null, radiusKm, mapMember.getId()))
-                        .isInstanceOf(ExerciseException.class)
-                        .hasFieldOrPropertyWithValue("code", ExerciseErrorCode.INCOMPLETE_LOCATION_INFO);
-            }
+        private ExerciseMapBuildingsDTO.Query createMapQuery(
+                LocalDate date, Double latitude, Double longitude, Double radiusKm) {
+            return ExerciseMapBuildingsDTO.Query.of(date, latitude, longitude, radiusKm);
         }
 
         private Exercise createMapExercise(long id, LocalDate date, String buildingName,

--- a/src/test/java/umc/cockple/demo/domain/exercise/utils/ExerciseMapBoundingBoxTest.java
+++ b/src/test/java/umc/cockple/demo/domain/exercise/utils/ExerciseMapBoundingBoxTest.java
@@ -1,0 +1,35 @@
+package umc.cockple.demo.domain.exercise.utils;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+
+@DisplayName("ExerciseMapBoundingBox")
+class ExerciseMapBoundingBoxTest {
+
+    @Test
+    @DisplayName("중심 좌표와 반경으로 bounding box 후보 영역을 계산한다")
+    void 중심_좌표와_반경으로_bounding_box_후보_영역을_계산한다() {
+        // when
+        ExerciseMapBoundingBox boundingBox = ExerciseMapBoundingBox.from(37.5, 127.0, 3.9);
+
+        // then
+        assertThat(boundingBox.minLatitude()).isCloseTo(37.46487910306632, within(1.0e-12));
+        assertThat(boundingBox.maxLatitude()).isCloseTo(37.53512089693368, within(1.0e-12));
+        assertThat(boundingBox.minLongitude()).isCloseTo(126.9557310782598, within(1.0e-12));
+        assertThat(boundingBox.maxLongitude()).isCloseTo(127.0442689217402, within(1.0e-12));
+        assertThat(boundingBox.isWithinCoordinateRange()).isTrue();
+    }
+
+    @Test
+    @DisplayName("bounding box가 SRID 4326 좌표 범위를 벗어나는지 확인한다")
+    void bounding_box가_srid_4326_좌표_범위를_벗어나는지_확인한다() {
+        // when
+        ExerciseMapBoundingBox boundingBox = ExerciseMapBoundingBox.from(37.5, 127.0, 10_000.0);
+
+        // then
+        assertThat(boundingBox.isWithinCoordinateRange()).isFalse();
+    }
+}


### PR DESCRIPTION
## ❤️ 기능 설명

월간 운동 지도 조회를 MySQL Spatial 기반 검색으로 최적화했습니다.

- `exercise_addr.location` generated `POINT` 컬럼과 공간 인덱스 추가
- 월간 지도 조회를 bbox 후보 필터 + `ST_Distance_Sphere` 실제 반경 필터로 변경
- native spatial query는 ID 후보군만 조회하고, 실제 `Exercise` 엔티티는 JPQL fetch 조회하는 2단계 구조로 분리
- `radiusKm`를 `Double`로 유지해 소수 반경 검색 지원
- 좌표/radius/bounding box 검증을 `Query` 객체로 분리
- bounding box 계산과 MySQL WKT 변환 책임 분리
- EXPLAIN 테스트는 운영 DB 통계값과 다른 Testcontainers 특성을 고려해 `possible_keys` 기반 smoke 테스트로 완화

테스트 결과 스크린샷 대신 아래 명령 실행 결과로 대체합니다.

```bash
bash ./gradlew test \
  --tests umc.cockple.demo.domain.exercise.utils.ExerciseMapBoundingBoxTest \
  --tests umc.cockple.demo.domain.exercise.repository.support.ExerciseMapSpatialSearchConditionTest \
  --tests umc.cockple.demo.domain.exercise.dto.ExerciseMapBuildingsDTOTest \
  --tests umc.cockple.demo.domain.exercise.service.ExerciseQueryServiceTest \
  --tests umc.cockple.demo.domain.exercise.repository.ExerciseRepositoryTest
# BUILD SUCCESSFUL in 28s

bash ./gradlew test --tests umc.cockple.demo.domain.exercise.integration.ExerciseRepositorySpatialIntegrationTest
# BUILD SUCCESSFUL in 2m 46s

git diff --check
# 통과
```

<br>

## 연결된 issue

close #598

<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] Flyway migration으로 `exercise_addr.location` generated column과 spatial index가 추가됩니다.
- [ ] EXPLAIN 테스트는 optimizer의 실제 선택 key/type 고정이 아니라, spatial index를 사용할 수 있는 쿼리 형태인지 확인하는 smoke 테스트입니다.
- [ ] 월간 지도 조회는 native query ID 후보군 조회 후 JPQL fetch 조회를 다시 수행하는 2단계 구조입니다.

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가? (명령 실행 결과로 대체)
- [x] 이슈넘버를 적었는가?
