### PR TITLE
[debug/#607] 운영 DB 백업 GCS 업로드 실패 수정

### DIFF
--- a/scripts/install_backup_systemd.sh
+++ b/scripts/install_backup_systemd.sh
@@ -25,26 +25,13 @@ require_file() {
   fi
 }
 
-ensure_gcloud_installed() {
-  if command -v gcloud >/dev/null 2>&1; then
+ensure_curl_installed() {
+  if command -v curl >/dev/null 2>&1; then
     return
   fi
 
   "${SUDO[@]}" apt-get update -y
-  "${SUDO[@]}" apt-get install -y apt-transport-https ca-certificates gnupg curl
-
-  if [[ ! -f /usr/share/keyrings/cloud.google.gpg ]]; then
-    curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg \
-      | "${SUDO[@]}" gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg
-  fi
-
-  if [[ ! -f /etc/apt/sources.list.d/google-cloud-sdk.list ]]; then
-    echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" \
-      | "${SUDO[@]}" tee /etc/apt/sources.list.d/google-cloud-sdk.list >/dev/null
-  fi
-
-  "${SUDO[@]}" apt-get update -y
-  "${SUDO[@]}" apt-get install -y google-cloud-cli
+  "${SUDO[@]}" apt-get install -y ca-certificates curl
 }
 
 install_systemd_units() {
@@ -105,7 +92,7 @@ require_file "${SOURCE_DIR}/cockple-db-backup.timer"
 
 stage_backup_runtime
 write_backup_env
-ensure_gcloud_installed
+ensure_curl_installed
 cleanup_legacy_cron
 
 require_file "${BACKUP_ENV_FILE}"

--- a/scripts/run_db_backup.sh
+++ b/scripts/run_db_backup.sh
@@ -29,10 +29,96 @@ if ! flock -n 9; then
   exit 0
 fi
 
-if ! command -v gcloud >/dev/null 2>&1; then
-  echo "gcloud CLI is not installed." >&2
+if ! command -v curl >/dev/null 2>&1; then
+  echo "curl is not installed." >&2
   exit 1
 fi
+
+if [[ ! "${GCS_BACKUP_BUCKET}" =~ ^[a-z0-9][a-z0-9._-]{1,220}[a-z0-9]$ ]]; then
+  echo "Invalid GCS_BACKUP_BUCKET: ${GCS_BACKUP_BUCKET}" >&2
+  exit 1
+fi
+
+if [[ ! "${GCS_OBJECT_PREFIX}" =~ ^[A-Za-z0-9._/-]+$ || "${GCS_OBJECT_PREFIX}" == /* || "${GCS_OBJECT_PREFIX}" == */ ]]; then
+  echo "Invalid GCS_OBJECT_PREFIX: ${GCS_OBJECT_PREFIX}" >&2
+  exit 1
+fi
+
+urlencode() {
+  local raw="$1"
+  local length=${#raw}
+  local i
+  local char
+
+  for ((i = 0; i < length; i++)); do
+    char="${raw:i:1}"
+    case "${char}" in
+      [a-zA-Z0-9.~_-]) printf '%s' "${char}" ;;
+      *) printf '%%%02X' "'${char}" ;;
+    esac
+  done
+}
+
+get_gcp_access_token() {
+  local token_json
+  local token
+
+  if token_json="$(curl -fsS --connect-timeout 2 \
+    -H "Metadata-Flavor: Google" \
+    "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token" 2>/dev/null)"; then
+    token="$(printf '%s' "${token_json}" | sed -n 's/.*"access_token"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')"
+    if [[ -n "${token}" ]]; then
+      printf '%s\n' "${token}"
+      return 0
+    fi
+  fi
+
+  if command -v gcloud >/dev/null 2>&1; then
+    gcloud auth print-access-token
+    return
+  fi
+
+  echo "Could not get a GCP access token from the metadata server, and gcloud is unavailable." >&2
+  return 1
+}
+
+upload_backup_to_gcs() {
+  local local_path="$1"
+  local object_path="$2"
+  local encoded_object_path
+  local upload_url
+  local token
+  local response_file
+  local http_code
+
+  encoded_object_path="$(urlencode "${object_path}")"
+  upload_url="https://storage.googleapis.com/upload/storage/v1/b/${GCS_BACKUP_BUCKET}/o?uploadType=media&name=${encoded_object_path}&ifGenerationMatch=0"
+  token="$(get_gcp_access_token)"
+  response_file="$(mktemp)"
+
+  echo "Uploading backup to gs://${GCS_BACKUP_BUCKET}/${object_path}"
+
+  if ! http_code="$(curl -sS -o "${response_file}" -w '%{http_code}' \
+    -X POST \
+    -H "Authorization: Bearer ${token}" \
+    -H "Content-Type: application/gzip" \
+    --data-binary "@${local_path}" \
+    "${upload_url}")"; then
+    echo "GCS upload request failed before receiving an HTTP response." >&2
+    cat "${response_file}" >&2 || true
+    rm -f "${response_file}"
+    return 1
+  fi
+
+  if [[ ! "${http_code}" =~ ^2 ]]; then
+    echo "GCS upload failed with HTTP ${http_code}." >&2
+    cat "${response_file}" >&2 || true
+    rm -f "${response_file}"
+    return 1
+  fi
+
+  rm -f "${response_file}"
+}
 
 TIMESTAMP_UTC="$(date -u +'%Y-%m-%dT%H-%M-%SZ')"
 YEAR_UTC="$(date -u +'%Y')"
@@ -53,7 +139,7 @@ echo "=== DB backup started: ${TIMESTAMP_UTC} ==="
 
 gzip -t "${LOCAL_BACKUP_PATH}"
 
-gcloud storage cp "${LOCAL_BACKUP_PATH}" "gs://${GCS_BACKUP_BUCKET}/${GCS_OBJECT_PATH}"
+upload_backup_to_gcs "${LOCAL_BACKUP_PATH}" "${GCS_OBJECT_PATH}"
 
 rm -f "${LOCAL_BACKUP_PATH}"
 


### PR DESCRIPTION
## ❤️ 기능 설명

운영 DB 백업 smoke test가 dump 파일 생성 후 GCS 업로드 단계에서 실패하던 문제를 수정합니다.

현재 로그상 `mysqldump`와 gzip 파일 생성은 성공했고, 이후 업로드 단계에서 service가 exit 1로 종료됩니다.
기존 업로드는 `gcloud storage cp`를 사용했는데, 이 경로는 VM 서비스 계정의 object create 권한만으로는 목적지 확인/read 동작이나 Cloud SDK 사용자 설정에 걸릴 수 있습니다.

변경 사항:
- `gcloud storage cp` 대신 GCE metadata server access token + GCS JSON media upload API로 직접 업로드
- `ifGenerationMatch=0`을 사용해 기존 백업 객체 overwrite 방지
- 실패 시 HTTP status/body를 journal에 남겨 다음 원인 확인 가능
- 백업 런타임 설치 시 `google-cloud-cli` 설치 의존 제거, `curl`만 보장
- 기존 objectCreator 중심 백업 IAM 정책을 유지할 수 있도록 스크립트 레벨에서 업로드 경로 수정

Terraform 변경 및 `terraform apply`는 없습니다.
Swagger/API 변경은 없는 운영 배포 스크립트 수정입니다.

<br>

## 연결된 issue

관련 issue: #607

<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] Terraform/IAM 변경 없이 스크립트만 수정합니다.
- [ ] 운영 VM의 metadata server token으로 GCS 업로드를 수행합니다.
- [ ] 운영 배포 시 DB 백업 smoke test가 실제 GCS 업로드까지 성공하는지 확인해주세요.

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가? (명령 실행 결과로 대체)
- [x] 이슈넘버를 적었는가?

테스트 결과:

```bash
bash -n scripts/install_backup_systemd.sh scripts/run_db_backup.sh scripts/backup_db.sh scripts/deploy.sh
git diff --check
bash -c 'source /tmp/urlencode-fn.sh; test "$(urlencode "prod/2026/06/cockple-test.sql.gz")" = "prod%2F2026%2F06%2Fcockple-test.sql.gz"'
terraform -chdir=terraform validate
```

검증 결과: 통과
