### PR TITLE
[fix/#594] 회원탈퇴 시 채팅 사용자 정보를 알 수 없는 사용자로 처리

### DIFF
--- a/src/main/java/umc/cockple/demo/domain/chat/converter/ChatConverter.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/converter/ChatConverter.java
@@ -220,9 +220,9 @@ public class ChatConverter {
     }
 
     public ChatRoomDetailDTO.MemberInfo toChatRoomDetailMemberInfo(Member member, String memberProfileImgUrl) {
-        boolean isWithdrawn = member.isWithdrawn();
+        boolean isWithdrawn = member == null || member.isWithdrawn();
         return ChatRoomDetailDTO.MemberInfo.builder()
-                .memberId(member.getId())
+                .memberId(isWithdrawn ? null : member.getId())
                 .memberName(isWithdrawn ? UNKNOWN_USER_NAME : member.getMemberName())
                 .profileImgUrl(isWithdrawn ? null : memberProfileImgUrl)
                 .build();

--- a/src/main/java/umc/cockple/demo/domain/chat/converter/ChatConverter.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/converter/ChatConverter.java
@@ -180,17 +180,18 @@ public class ChatConverter {
             boolean isSenderWithdrawn) {
         boolean isSystemMessage = message.getType() == MessageType.SYSTEM;
         Member sender = message.getSender();
+        boolean shouldAnonymizeSender = !isSystemMessage && (isSenderWithdrawn || sender == null);
         String senderName = isSystemMessage
                 ? SYSTEM_USER_NAME
-                : isSenderWithdrawn ? UNKNOWN_USER_NAME : sender.getMemberName();
-        String displayProfileImageUrl = isSystemMessage || isSenderWithdrawn ? null : senderProfileImageUrl;
+                : shouldAnonymizeSender ? UNKNOWN_USER_NAME : sender.getMemberName();
+        String displayProfileImageUrl = isSystemMessage || shouldAnonymizeSender ? null : senderProfileImageUrl;
 
         return ChatCommonDTO.MessageInfo.builder()
                 .messageId(message.getId())
-                .senderId(isSystemMessage ? null : sender.getId())
+                .senderId(isSystemMessage || shouldAnonymizeSender ? null : sender.getId())
                 .senderName(senderName)
                 .senderProfileImageUrl(displayProfileImageUrl)
-                .isSenderWithdrawn(isSystemMessage ? false : isSenderWithdrawn)
+                .isSenderWithdrawn(shouldAnonymizeSender)
                 .content(message.getContent())
                 .messageType(message.getType())
                 .images(processedFiles)

--- a/src/main/java/umc/cockple/demo/domain/chat/converter/ChatConverter.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/converter/ChatConverter.java
@@ -16,6 +16,9 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class ChatConverter {
 
+    public static final String UNKNOWN_USER_NAME = "알 수 없는 사용자";
+    private static final String SYSTEM_USER_NAME = "시스템";
+
     // ===모임 채팅방 목록===
     public PartyChatRoomDTO.Response toPartyChatRoomListResponse(List<PartyChatRoomDTO.ChatRoomInfo> chatRoomInfos, boolean hasNext) {
         return PartyChatRoomDTO.Response.builder()
@@ -80,8 +83,8 @@ public class ChatConverter {
                                                                String imgUrl) {
         return DirectChatRoomDTO.ChatRoomInfo.builder()
                 .chatRoomId(chatRoom.getId())
-                .displayName(chatRoomMember.getDisplayName())
-                .profileImgUrl(imgUrl)
+                .displayName(isWithdrawn ? UNKNOWN_USER_NAME : chatRoomMember.getDisplayName())
+                .profileImgUrl(isWithdrawn ? null : imgUrl)
                 .isWithdrawn(isWithdrawn)
                 .unreadCount(unreadCount)
                 .lastMessage(lastMessageInfo)
@@ -145,7 +148,7 @@ public class ChatConverter {
                 .content(content)
                 .messageType(savedMessage.getType())
                 .senderId(null)
-                .senderName("시스템")
+                .senderName(SYSTEM_USER_NAME)
                 .senderProfileImageUrl(null)
                 .timestamp(savedMessage.getCreatedAt())
                 .build();
@@ -177,12 +180,16 @@ public class ChatConverter {
             boolean isSenderWithdrawn) {
         boolean isSystemMessage = message.getType() == MessageType.SYSTEM;
         Member sender = message.getSender();
+        String senderName = isSystemMessage
+                ? SYSTEM_USER_NAME
+                : isSenderWithdrawn ? UNKNOWN_USER_NAME : sender.getMemberName();
+        String displayProfileImageUrl = isSystemMessage || isSenderWithdrawn ? null : senderProfileImageUrl;
 
         return ChatCommonDTO.MessageInfo.builder()
                 .messageId(message.getId())
                 .senderId(isSystemMessage ? null : sender.getId())
-                .senderName(isSystemMessage ? "시스템" : sender.getMemberName())
-                .senderProfileImageUrl(isSystemMessage ? null : senderProfileImageUrl)
+                .senderName(senderName)
+                .senderProfileImageUrl(displayProfileImageUrl)
                 .isSenderWithdrawn(isSystemMessage ? false : isSenderWithdrawn)
                 .content(message.getContent())
                 .messageType(message.getType())
@@ -212,10 +219,11 @@ public class ChatConverter {
     }
 
     public ChatRoomDetailDTO.MemberInfo toChatRoomDetailMemberInfo(Member member, String memberProfileImgUrl) {
+        boolean isWithdrawn = member.isWithdrawn();
         return ChatRoomDetailDTO.MemberInfo.builder()
                 .memberId(member.getId())
-                .memberName(member.getMemberName())
-                .profileImgUrl(memberProfileImgUrl)
+                .memberName(isWithdrawn ? UNKNOWN_USER_NAME : member.getMemberName())
+                .profileImgUrl(isWithdrawn ? null : memberProfileImgUrl)
                 .build();
     }
 

--- a/src/main/java/umc/cockple/demo/domain/chat/events/MemberWithdrawnChatAnonymizeListener.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/events/MemberWithdrawnChatAnonymizeListener.java
@@ -1,0 +1,23 @@
+package umc.cockple.demo.domain.chat.events;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+import umc.cockple.demo.domain.chat.service.ChatMemberAnonymizationService;
+import umc.cockple.demo.domain.member.events.MemberWithdrawnEvent;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class MemberWithdrawnChatAnonymizeListener {
+
+    private final ChatMemberAnonymizationService chatMemberAnonymizationService;
+
+    @EventListener
+    public void handleMemberWithdrawn(MemberWithdrawnEvent event) {
+        int anonymizedCount = chatMemberAnonymizationService.anonymizeDirectDisplayNames(event.memberId());
+        log.info("탈퇴 회원 direct 채팅 표시명 익명화 완료 - memberId: {}, count: {}",
+                event.memberId(), anonymizedCount);
+    }
+}

--- a/src/main/java/umc/cockple/demo/domain/chat/repository/ChatFileRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/repository/ChatFileRepository.java
@@ -16,7 +16,7 @@ public interface ChatFileRepository extends JpaRepository<ChatMessageFile, Long>
             """)
     List<String> findObjectKeysByChatRoomId(@Param("chatRoomId") Long chatRoomId);
 
-    @Modifying
+    @Modifying(flushAutomatically = true)
     @Query("""
             DELETE FROM ChatMessageFile cmf
             WHERE cmf.chatMessage.chatRoom.id = :chatRoomId

--- a/src/main/java/umc/cockple/demo/domain/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/repository/ChatMessageRepository.java
@@ -18,6 +18,14 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> 
             """)
     int deleteByChatRoomId(@Param("chatRoomId") Long chatRoomId);
 
+    @Modifying
+    @Query("""
+            UPDATE ChatMessage cm
+            SET cm.sender = null
+            WHERE cm.sender.id = :memberId
+            """)
+    int clearSenderByMemberId(@Param("memberId") Long memberId);
+
     ChatMessage findTop1ByChatRoom_IdOrderByCreatedAtDesc(Long chatRoomId);
 
     @Query("""

--- a/src/main/java/umc/cockple/demo/domain/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/repository/ChatMessageRepository.java
@@ -11,14 +11,14 @@ import java.util.List;
 
 public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
 
-    @Modifying
+    @Modifying(flushAutomatically = true)
     @Query("""
             DELETE FROM ChatMessage cm
             WHERE cm.chatRoom.id = :chatRoomId
             """)
     int deleteByChatRoomId(@Param("chatRoomId") Long chatRoomId);
 
-    @Modifying
+    @Modifying(flushAutomatically = true)
     @Query("""
             UPDATE ChatMessage cm
             SET cm.sender = null

--- a/src/main/java/umc/cockple/demo/domain/chat/repository/ChatRoomMemberRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/repository/ChatRoomMemberRepository.java
@@ -19,6 +19,14 @@ public interface ChatRoomMemberRepository extends JpaRepository<ChatRoomMember, 
             """)
     int deleteByChatRoomId(@Param("chatRoomId") Long chatRoomId);
 
+    @Modifying
+    @Query("""
+            UPDATE ChatRoomMember crm
+            SET crm.member = null
+            WHERE crm.member.id = :memberId
+            """)
+    int clearMemberByMemberId(@Param("memberId") Long memberId);
+
     // 채팅방 내 참여자 수
     @Query("SELECT COUNT(c) FROM ChatRoomMember c WHERE c.chatRoom.id = :chatRoomId")
     int countByChatRoomId(@Param("chatRoomId") Long chatRoomId);
@@ -37,10 +45,10 @@ public interface ChatRoomMemberRepository extends JpaRepository<ChatRoomMember, 
 
     @Query("""
             SELECT crm FROM ChatRoomMember crm
-            JOIN FETCH crm.member m
+            LEFT JOIN FETCH crm.member m
             LEFT JOIN FETCH m.profileImg
             WHERE crm.chatRoom.id = :chatRoomId
-            AND crm.member.id != :myId
+            AND (m.id IS NULL OR m.id != :myId)
             """)
     Optional<ChatRoomMember> findCounterPartWithMember(
             @Param("chatRoomId") Long chatRoomId,
@@ -49,7 +57,7 @@ public interface ChatRoomMemberRepository extends JpaRepository<ChatRoomMember, 
 
     @Query("""
             SELECT crm FROM ChatRoomMember crm
-            JOIN FETCH crm.member m
+            LEFT JOIN FETCH crm.member m
             LEFT JOIN FETCH m.profileImg
             WHERE crm.chatRoom.id = :chatRoomId
             ORDER BY m.memberName ASC
@@ -67,7 +75,11 @@ public interface ChatRoomMemberRepository extends JpaRepository<ChatRoomMember, 
             """)
     Optional<ChatRoomMember> findPendingMemberInDirect(Long chatRoomId, Long senderId);
 
-    @Query("SELECT crm.member.id FROM ChatRoomMember crm WHERE crm.chatRoom.id = :chatRoomId")
+    @Query("""
+            SELECT crm.member.id FROM ChatRoomMember crm
+            WHERE crm.chatRoom.id = :chatRoomId
+            AND crm.member.id IS NOT NULL
+            """)
     List<Long> findMemberIdsByChatRoomId(Long chatRoomId);
 
     @Query("""

--- a/src/main/java/umc/cockple/demo/domain/chat/repository/ChatRoomMemberRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/repository/ChatRoomMemberRepository.java
@@ -27,6 +27,24 @@ public interface ChatRoomMemberRepository extends JpaRepository<ChatRoomMember, 
             """)
     int clearMemberByMemberId(@Param("memberId") Long memberId);
 
+    @Query("""
+            SELECT DISTINCT crm.chatRoom.id
+            FROM ChatRoomMember crm
+            WHERE crm.member.id = :memberId
+            AND crm.chatRoom.type = 'DIRECT'
+            """)
+    List<Long> findDirectChatRoomIdsByMemberId(@Param("memberId") Long memberId);
+
+    @Modifying
+    @Query("""
+            UPDATE ChatRoomMember crm
+            SET crm.displayName = :displayName
+            WHERE crm.chatRoom.id IN :chatRoomIds
+            """)
+    int updateDisplayNameByChatRoomIds(
+            @Param("chatRoomIds") List<Long> chatRoomIds,
+            @Param("displayName") String displayName);
+
     // 채팅방 내 참여자 수
     @Query("SELECT COUNT(c) FROM ChatRoomMember c WHERE c.chatRoom.id = :chatRoomId")
     int countByChatRoomId(@Param("chatRoomId") Long chatRoomId);

--- a/src/main/java/umc/cockple/demo/domain/chat/repository/ChatRoomMemberRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/repository/ChatRoomMemberRepository.java
@@ -12,14 +12,14 @@ import java.util.Optional;
 
 public interface ChatRoomMemberRepository extends JpaRepository<ChatRoomMember, Long> {
 
-    @Modifying
+    @Modifying(flushAutomatically = true)
     @Query("""
             DELETE FROM ChatRoomMember crm
             WHERE crm.chatRoom.id = :chatRoomId
             """)
     int deleteByChatRoomId(@Param("chatRoomId") Long chatRoomId);
 
-    @Modifying
+    @Modifying(flushAutomatically = true)
     @Query("""
             UPDATE ChatRoomMember crm
             SET crm.member = null
@@ -35,7 +35,7 @@ public interface ChatRoomMemberRepository extends JpaRepository<ChatRoomMember, 
             """)
     List<Long> findDirectChatRoomIdsByMemberId(@Param("memberId") Long memberId);
 
-    @Modifying
+    @Modifying(flushAutomatically = true)
     @Query("""
             UPDATE ChatRoomMember crm
             SET crm.displayName = :displayName

--- a/src/main/java/umc/cockple/demo/domain/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/repository/ChatRoomRepository.java
@@ -12,7 +12,7 @@ import java.util.Optional;
 
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
 
-    @Modifying
+    @Modifying(flushAutomatically = true)
     @Query("""
             DELETE FROM ChatRoom cr
             WHERE cr.id = :chatRoomId

--- a/src/main/java/umc/cockple/demo/domain/chat/repository/MessageReadStatusRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/repository/MessageReadStatusRepository.java
@@ -10,21 +10,21 @@ import java.util.List;
 
 public interface MessageReadStatusRepository extends JpaRepository<MessageReadStatus, Long> {
 
-    @Modifying
+    @Modifying(flushAutomatically = true)
     @Query("""
             DELETE FROM MessageReadStatus mrs
             WHERE mrs.chatRoomId = :chatRoomId
             """)
     int deleteByChatRoomId(@Param("chatRoomId") Long chatRoomId);
 
-    @Modifying
+    @Modifying(flushAutomatically = true)
     @Query("""
             DELETE FROM MessageReadStatus mrs
             WHERE mrs.memberId = :memberId
             """)
     int deleteByMemberId(@Param("memberId") Long memberId);
 
-    @Modifying
+    @Modifying(flushAutomatically = true)
     @Query("""
             UPDATE MessageReadStatus mrs
             SET mrs.isRead = true

--- a/src/main/java/umc/cockple/demo/domain/chat/repository/MessageReadStatusRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/repository/MessageReadStatusRepository.java
@@ -19,6 +19,13 @@ public interface MessageReadStatusRepository extends JpaRepository<MessageReadSt
 
     @Modifying
     @Query("""
+            DELETE FROM MessageReadStatus mrs
+            WHERE mrs.memberId = :memberId
+            """)
+    int deleteByMemberId(@Param("memberId") Long memberId);
+
+    @Modifying
+    @Query("""
             UPDATE MessageReadStatus mrs
             SET mrs.isRead = true
             WHERE mrs.chatMessageId = :messageId

--- a/src/main/java/umc/cockple/demo/domain/chat/service/ChatMemberAnonymizationService.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/ChatMemberAnonymizationService.java
@@ -1,0 +1,29 @@
+package umc.cockple.demo.domain.chat.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import umc.cockple.demo.domain.chat.converter.ChatConverter;
+import umc.cockple.demo.domain.chat.repository.ChatRoomMemberRepository;
+
+import java.util.List;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ChatMemberAnonymizationService {
+
+    private final ChatRoomMemberRepository chatRoomMemberRepository;
+
+    public int anonymizeDirectDisplayNames(Long memberId) {
+        List<Long> directChatRoomIds = chatRoomMemberRepository.findDirectChatRoomIdsByMemberId(memberId);
+        if (directChatRoomIds.isEmpty()) {
+            return 0;
+        }
+
+        return chatRoomMemberRepository.updateDisplayNameByChatRoomIds(
+                directChatRoomIds,
+                ChatConverter.UNKNOWN_USER_NAME
+        );
+    }
+}

--- a/src/main/java/umc/cockple/demo/domain/chat/service/ChatMemberHardDeleteCleanupService.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/ChatMemberHardDeleteCleanupService.java
@@ -16,6 +16,19 @@ public class ChatMemberHardDeleteCleanupService {
     private final ChatMessageRepository chatMessageRepository;
     private final ChatRoomMemberRepository chatRoomMemberRepository;
 
+    /**
+     * Member hard delete 전용 chat cleanup contract.
+     * <p>
+     * 회원 탈퇴(soft delete) 시에는 호출하지 않는다. 향후 회원 hard delete scheduler/orchestrator는
+     * {@code memberRepository.delete(...)} 실행 전에 이 메서드를 같은 삭제 흐름에서 호출해야 한다.
+     * 이 메서드는 삭제 대상 회원의 채팅 발신자/채팅방 참여자 참조를 null로 끊어 기존 채팅 기록을
+     * 보존하고, 회원 개인 상태 데이터인 읽음 상태를 제거한다.
+     * </p>
+     * <p>
+     * {@code message_read_status}는 읽음 상태 계산을 위한 ID 기반 테이블이므로 Member JPA 연관관계나
+     * DB FK를 두지 않는다. 삭제 대상 회원의 읽음 상태는 이 메서드가 명시적으로 정리한다.
+     * </p>
+     */
     public Result prepareMemberHardDelete(Long memberId) {
         int deletedReadStatuses = messageReadStatusRepository.deleteByMemberId(memberId);
         int clearedMessages = chatMessageRepository.clearSenderByMemberId(memberId);

--- a/src/main/java/umc/cockple/demo/domain/chat/service/ChatMemberHardDeleteCleanupService.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/ChatMemberHardDeleteCleanupService.java
@@ -1,0 +1,33 @@
+package umc.cockple.demo.domain.chat.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import umc.cockple.demo.domain.chat.repository.ChatMessageRepository;
+import umc.cockple.demo.domain.chat.repository.ChatRoomMemberRepository;
+import umc.cockple.demo.domain.chat.repository.MessageReadStatusRepository;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ChatMemberHardDeleteCleanupService {
+
+    private final MessageReadStatusRepository messageReadStatusRepository;
+    private final ChatMessageRepository chatMessageRepository;
+    private final ChatRoomMemberRepository chatRoomMemberRepository;
+
+    public Result prepareMemberHardDelete(Long memberId) {
+        int deletedReadStatuses = messageReadStatusRepository.deleteByMemberId(memberId);
+        int clearedMessages = chatMessageRepository.clearSenderByMemberId(memberId);
+        int clearedChatRoomMembers = chatRoomMemberRepository.clearMemberByMemberId(memberId);
+
+        return new Result(clearedMessages, clearedChatRoomMembers, deletedReadStatuses);
+    }
+
+    public record Result(
+            int clearedMessages,
+            int clearedChatRoomMembers,
+            int deletedReadStatuses
+    ) {
+    }
+}

--- a/src/main/java/umc/cockple/demo/domain/chat/service/ChatProcessor.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/ChatProcessor.java
@@ -13,7 +13,6 @@ import umc.cockple.demo.domain.chat.exception.ChatException;
 import umc.cockple.demo.domain.file.service.FileService;
 import umc.cockple.demo.domain.member.domain.Member;
 import umc.cockple.demo.domain.member.domain.ProfileImg;
-import umc.cockple.demo.domain.member.enums.MemberStatus;
 
 import java.util.Comparator;
 import java.util.List;
@@ -39,12 +38,12 @@ public class ChatProcessor {
             throw new ChatException(ChatErrorCode.INVALID_MESSAGE_SENDER);
         }
 
-        String senderProfileImageUrl = sender != null
+        boolean isSenderWithdrawn = sender != null && sender.isWithdrawn();
+        String senderProfileImageUrl = sender != null && !isSenderWithdrawn
                 ? generateProfileImageUrl(sender.getProfileImg())
                 : null;
         List<ChatCommonDTO.FileInfo> processedFiles = processMessageFiles(message);
         boolean isMyMessage = sender != null && isMyMessage(sender.getId(), memberId);
-        boolean isSenderWithdrawn = sender != null && sender.getIsActive() == MemberStatus.INACTIVE;
         return chatConverter.toCommonMessageInfo(message, senderProfileImageUrl, processedFiles, isMyMessage, isSenderWithdrawn);
     }
 

--- a/src/main/java/umc/cockple/demo/domain/chat/service/ChatProcessor.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/ChatProcessor.java
@@ -1,15 +1,12 @@
 package umc.cockple.demo.domain.chat.service;
 
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import umc.cockple.demo.domain.chat.converter.ChatConverter;
 import umc.cockple.demo.domain.chat.domain.ChatMessage;
 import umc.cockple.demo.domain.chat.domain.ChatMessageFile;
 import umc.cockple.demo.domain.chat.dto.ChatCommonDTO;
 import umc.cockple.demo.domain.chat.enums.MessageType;
-import umc.cockple.demo.domain.chat.exception.ChatErrorCode;
-import umc.cockple.demo.domain.chat.exception.ChatException;
 import umc.cockple.demo.domain.file.service.FileService;
 import umc.cockple.demo.domain.member.domain.Member;
 import umc.cockple.demo.domain.member.domain.ProfileImg;
@@ -19,7 +16,6 @@ import java.util.List;
 
 @Component
 @RequiredArgsConstructor
-@Slf4j
 public class ChatProcessor {
 
     private final FileService fileService;
@@ -33,17 +29,13 @@ public class ChatProcessor {
 
     private ChatCommonDTO.MessageInfo processAndConvertMessage(ChatMessage message, Long memberId) {
         Member sender = message.getSender();
-        if (sender == null && message.getType() != MessageType.SYSTEM) {
-            log.error("일반 채팅 메시지에 sender가 없습니다. messageId={}, type={}", message.getId(), message.getType());
-            throw new ChatException(ChatErrorCode.INVALID_MESSAGE_SENDER);
-        }
-
-        boolean isSenderWithdrawn = sender != null && sender.isWithdrawn();
+        boolean isSystemMessage = message.getType() == MessageType.SYSTEM;
+        boolean isSenderWithdrawn = !isSystemMessage && (sender == null || sender.isWithdrawn());
         String senderProfileImageUrl = sender != null && !isSenderWithdrawn
                 ? generateProfileImageUrl(sender.getProfileImg())
                 : null;
         List<ChatCommonDTO.FileInfo> processedFiles = processMessageFiles(message);
-        boolean isMyMessage = sender != null && isMyMessage(sender.getId(), memberId);
+        boolean isMyMessage = sender != null && !isSenderWithdrawn && isMyMessage(sender.getId(), memberId);
         return chatConverter.toCommonMessageInfo(message, senderProfileImageUrl, processedFiles, isMyMessage, isSenderWithdrawn);
     }
 

--- a/src/main/java/umc/cockple/demo/domain/chat/service/ChatQueryServiceImpl.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/ChatQueryServiceImpl.java
@@ -228,7 +228,7 @@ public class ChatQueryServiceImpl implements ChatQueryService {
 
                     // 상대방 찾기 (나 제외)
                     ChatRoomMember displayMember = chatRoom.getChatRoomMembers().stream()
-                            .filter(crm -> !crm.getMember().getId().equals(memberId))
+                            .filter(crm -> crm.getMember() == null || !crm.getMember().getId().equals(memberId))
                             .findFirst()
                             .orElseThrow(() -> new ChatException(ChatErrorCode.CHAT_ROOM_ACCESS_DENIED));
 
@@ -243,7 +243,7 @@ public class ChatQueryServiceImpl implements ChatQueryService {
                     LastMessageCacheDTO lastMessage = chatRoomListCacheService.getLastMessage(chatRoomId);
 
                     Member counterPartMember = displayMember.getMember();
-                    boolean isWithdrawn = counterPartMember.isWithdrawn();
+                    boolean isWithdrawn = isWithdrawn(counterPartMember);
                     String displayProfileImgUrl = isWithdrawn ? null : getImageUrl(counterPartMember.getProfileImg());
 
                     return chatConverter.toDirectChatRoomInfo(
@@ -268,7 +268,7 @@ public class ChatQueryServiceImpl implements ChatQueryService {
         if (chatRoom.getType() == ChatRoomType.DIRECT) {
             ChatRoomMember counterPart = findCounterPartWithMemberOrThrow(chatRoom, myMembership);
             Member member = counterPart.getMember();
-            isCounterPartWithdrawn = member.isWithdrawn();
+            isCounterPartWithdrawn = isWithdrawn(member);
 
             displayName = isCounterPartWithdrawn ? ChatConverter.UNKNOWN_USER_NAME : member.getMemberName();
             profileImageUrl = isCounterPartWithdrawn ? null : getImageUrl(member.getProfileImg());
@@ -297,11 +297,14 @@ public class ChatQueryServiceImpl implements ChatQueryService {
 
     private ChatRoomDetailDTO.MemberInfo buildMemberInfo(ChatRoomMember chatRoomMember) {
         Member member = chatRoomMember.getMember();
-        String memberProfileImgUrl = member.isWithdrawn() ? null : getImageUrl(member.getProfileImg());
+        String memberProfileImgUrl = isWithdrawn(member) ? null : getImageUrl(member.getProfileImg());
 
         return chatConverter.toChatRoomDetailMemberInfo(member, memberProfileImgUrl);
     }
 
+    private boolean isWithdrawn(Member member) {
+        return member == null || member.isWithdrawn();
+    }
 
     private String getImageUrl(PartyImg partyImg) {
         if (partyImg != null && partyImg.getImgKey() != null && !partyImg.getImgKey().isBlank()) {

--- a/src/main/java/umc/cockple/demo/domain/chat/service/ChatQueryServiceImpl.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/ChatQueryServiceImpl.java
@@ -23,7 +23,6 @@ import umc.cockple.demo.domain.chat.service.websocket.ChatRoomListCacheService;
 import umc.cockple.demo.domain.file.service.FileService;
 import umc.cockple.demo.domain.member.domain.Member;
 import umc.cockple.demo.domain.member.domain.ProfileImg;
-import umc.cockple.demo.domain.member.enums.MemberStatus;
 import umc.cockple.demo.domain.member.repository.MemberPartyRepository;
 import umc.cockple.demo.domain.party.domain.Party;
 import umc.cockple.demo.domain.party.domain.PartyImg;
@@ -244,8 +243,8 @@ public class ChatQueryServiceImpl implements ChatQueryService {
                     LastMessageCacheDTO lastMessage = chatRoomListCacheService.getLastMessage(chatRoomId);
 
                     Member counterPartMember = displayMember.getMember();
-                    String displayProfileImgUrl = getImageUrl(counterPartMember.getProfileImg());
-                    boolean isWithdrawn = counterPartMember.getIsActive() == MemberStatus.INACTIVE;
+                    boolean isWithdrawn = counterPartMember.isWithdrawn();
+                    String displayProfileImgUrl = isWithdrawn ? null : getImageUrl(counterPartMember.getProfileImg());
 
                     return chatConverter.toDirectChatRoomInfo(
                             chatRoom,
@@ -269,10 +268,10 @@ public class ChatQueryServiceImpl implements ChatQueryService {
         if (chatRoom.getType() == ChatRoomType.DIRECT) {
             ChatRoomMember counterPart = findCounterPartWithMemberOrThrow(chatRoom, myMembership);
             Member member = counterPart.getMember();
+            isCounterPartWithdrawn = member.isWithdrawn();
 
-            displayName = member.getMemberName();
-            profileImageUrl = getImageUrl(member.getProfileImg());
-            isCounterPartWithdrawn = member.getIsActive() == MemberStatus.INACTIVE;
+            displayName = isCounterPartWithdrawn ? ChatConverter.UNKNOWN_USER_NAME : member.getMemberName();
+            profileImageUrl = isCounterPartWithdrawn ? null : getImageUrl(member.getProfileImg());
         } else {
             displayName = chatRoom.getParty().getPartyName();
             profileImageUrl = getImageUrl(chatRoom.getParty().getPartyImg());
@@ -298,10 +297,11 @@ public class ChatQueryServiceImpl implements ChatQueryService {
 
     private ChatRoomDetailDTO.MemberInfo buildMemberInfo(ChatRoomMember chatRoomMember) {
         Member member = chatRoomMember.getMember();
-        String memberProfileImgUrl = getImageUrl(member.getProfileImg());
+        String memberProfileImgUrl = member.isWithdrawn() ? null : getImageUrl(member.getProfileImg());
 
         return chatConverter.toChatRoomDetailMemberInfo(member, memberProfileImgUrl);
     }
+
 
     private String getImageUrl(PartyImg partyImg) {
         if (partyImg != null && partyImg.getImgKey() != null && !partyImg.getImgKey().isBlank()) {

--- a/src/main/java/umc/cockple/demo/domain/member/domain/Member.java
+++ b/src/main/java/umc/cockple/demo/domain/member/domain/Member.java
@@ -98,7 +98,7 @@ public class Member extends BaseEntity {
     @Builder.Default
     private List<ChatMessage> chatMessages = new ArrayList<>();
 
-    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "member")
     @Builder.Default
     private List<ChatRoomMember> chatRoomMembers = new ArrayList<>();
 

--- a/src/main/java/umc/cockple/demo/domain/member/events/MemberWithdrawnEvent.java
+++ b/src/main/java/umc/cockple/demo/domain/member/events/MemberWithdrawnEvent.java
@@ -1,0 +1,15 @@
+package umc.cockple.demo.domain.member.events;
+
+import java.time.LocalDateTime;
+
+public record MemberWithdrawnEvent(
+        Long memberId,
+        LocalDateTime occurredAt
+) {
+    public static MemberWithdrawnEvent withdrawn(Long memberId) {
+        return new MemberWithdrawnEvent(
+                memberId,
+                LocalDateTime.now()
+        );
+    }
+}

--- a/src/main/java/umc/cockple/demo/domain/member/service/MemberCommandService.java
+++ b/src/main/java/umc/cockple/demo/domain/member/service/MemberCommandService.java
@@ -2,6 +2,7 @@ package umc.cockple.demo.domain.member.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
@@ -12,6 +13,7 @@ import umc.cockple.demo.domain.member.dto.UpdateProfileRequestDTO;
 import umc.cockple.demo.domain.member.enums.MemberPartyStatus;
 import umc.cockple.demo.domain.member.exception.MemberErrorCode;
 import umc.cockple.demo.domain.member.exception.MemberException;
+import umc.cockple.demo.domain.member.events.MemberWithdrawnEvent;
 import umc.cockple.demo.domain.member.repository.*;
 import umc.cockple.demo.domain.member.enums.MemberStatus;
 import umc.cockple.demo.domain.file.service.FileService;
@@ -35,6 +37,7 @@ public class MemberCommandService {
     private final MemberExerciseRepository memberExerciseRepository;
     private final MemberPartyRepository memberPartyRepository;
     private final ChatRoomMemberRepository chatRoomMemberRepository;
+    private final ApplicationEventPublisher applicationEventPublisher;
 
     private final KakaoOauthService kakaoOauthService;
     private final FileService fileService;
@@ -93,6 +96,7 @@ public class MemberCommandService {
 
         // 활성화 여부 해제, 리프레시 토큰 삭제
         member.withdraw();
+        applicationEventPublisher.publishEvent(MemberWithdrawnEvent.withdrawn(member.getId()));
     }
 
 

--- a/src/main/resources/db/migration/V2026.06.04.15.30__set_chat_message_sender_null_on_member_delete.sql
+++ b/src/main/resources/db/migration/V2026.06.04.15.30__set_chat_message_sender_null_on_member_delete.sql
@@ -1,0 +1,10 @@
+ALTER TABLE chat_message
+    DROP FOREIGN KEY fk_chat_message_sender;
+
+ALTER TABLE chat_message
+    MODIFY sender_id BIGINT NULL;
+
+ALTER TABLE chat_message
+    ADD CONSTRAINT fk_chat_message_sender
+        FOREIGN KEY (sender_id) REFERENCES member (id)
+        ON DELETE SET NULL;

--- a/src/main/resources/db/migration/V2026.06.04.15.45__set_chat_room_member_null_on_member_delete.sql
+++ b/src/main/resources/db/migration/V2026.06.04.15.45__set_chat_room_member_null_on_member_delete.sql
@@ -1,0 +1,10 @@
+ALTER TABLE chat_room_member
+    DROP FOREIGN KEY fk_chat_room_member_member;
+
+ALTER TABLE chat_room_member
+    MODIFY member_id BIGINT NULL;
+
+ALTER TABLE chat_room_member
+    ADD CONSTRAINT fk_chat_room_member_member
+        FOREIGN KEY (member_id) REFERENCES member (id)
+        ON DELETE SET NULL;

--- a/src/test/java/umc/cockple/demo/domain/chat/integration/ChatIntegrationTest.java
+++ b/src/test/java/umc/cockple/demo/domain/chat/integration/ChatIntegrationTest.java
@@ -1,6 +1,7 @@
 package umc.cockple.demo.domain.chat.integration;
 
 import org.junit.jupiter.api.*;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -20,6 +21,7 @@ import umc.cockple.demo.domain.chat.service.ChatMemberHardDeleteCleanupService;
 import umc.cockple.demo.domain.chat.service.websocket.ChatRoomListCacheService;
 import umc.cockple.demo.domain.member.domain.Member;
 import umc.cockple.demo.domain.member.domain.ProfileImg;
+import umc.cockple.demo.domain.member.events.MemberWithdrawnEvent;
 import umc.cockple.demo.domain.member.exception.MemberErrorCode;
 import umc.cockple.demo.domain.member.repository.MemberPartyRepository;
 import umc.cockple.demo.domain.member.repository.MemberRepository;
@@ -60,6 +62,7 @@ class ChatIntegrationTest extends IntegrationTestBase {
     @Autowired MessageReadStatusRepository messageReadStatusRepository;
     @Autowired ChatRoomListCacheService chatRoomListCacheService;
     @Autowired ChatMemberHardDeleteCleanupService chatMemberHardDeleteCleanupService;
+    @Autowired ApplicationEventPublisher applicationEventPublisher;
 
     private Member member;
     private Member otherMember;
@@ -560,7 +563,7 @@ class ChatIntegrationTest extends IntegrationTestBase {
                 Member target = memberRepository.save(
                         MemberFixture.createWithdrawnMember("삭제대상", "삭제", 5005L));
 
-                chatRoomMemberRepository.save(ChatRoomMember.createJoined(directChatRoom, member, "삭제 대상과의 대화"));
+                chatRoomMemberRepository.save(ChatRoomMember.createJoined(directChatRoom, member, target.getMemberName()));
                 chatRoomMemberRepository.save(ChatRoomMember.createJoined(directChatRoom, target, member.getMemberName()));
                 ChatMessage targetMessage = chatMessageRepository.save(
                         ChatFixture.createTextMessage(directChatRoom, target, "삭제 대상 메시지"));
@@ -647,6 +650,31 @@ class ChatIntegrationTest extends IntegrationTestBase {
                         .andExpect(jsonPath("$.data.content[0].chatRoomId").value(directChatRoom.getId()))
                         .andExpect(jsonPath("$.data.content[0].displayName").value("영희 채팅"))
                         .andExpect(jsonPath("$.data.content[0].lastMessage.content").value("영희와의 최근 메시지"));
+            }
+
+            @Test
+            @DisplayName("200 - 회원 탈퇴 이벤트로 익명화된 direct 채팅방은 삭제 전 이름으로 검색되지 않는다")
+            void searchDirectChatRooms_excludesWithdrawnMemberNameAfterAnonymizationEvent() throws Exception {
+                Member target = memberRepository.save(
+                        MemberFixture.createMember("삭제대상", Gender.FEMALE, Level.C, 5005L));
+
+                chatRoomMemberRepository.save(ChatRoomMember.createJoined(directChatRoom, member, target.getMemberName()));
+                chatRoomMemberRepository.save(ChatRoomMember.createJoined(directChatRoom, target, member.getMemberName()));
+                chatMessageRepository.save(ChatFixture.createTextMessage(directChatRoom, target, "탈퇴 전 메시지"));
+
+                target.withdraw();
+                memberRepository.saveAndFlush(target);
+                applicationEventPublisher.publishEvent(MemberWithdrawnEvent.withdrawn(target.getId()));
+
+                SecurityContextHelper.setAuthentication(member.getId(), member.getNickname());
+
+                mockMvc.perform(get("/api/chats/direct/search")
+                                .param("name", target.getMemberName())
+                                .param("page", "0")
+                                .param("size", "10"))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.data.content", hasSize(0)))
+                        .andExpect(jsonPath("$.data.hasNext").value(false));
             }
 
             @Test

--- a/src/test/java/umc/cockple/demo/domain/chat/integration/ChatIntegrationTest.java
+++ b/src/test/java/umc/cockple/demo/domain/chat/integration/ChatIntegrationTest.java
@@ -505,7 +505,7 @@ class ChatIntegrationTest extends IntegrationTestBase {
                         .andExpect(jsonPath("$.data.content[0].lastMessage.messageType").value("TEXT"))
                         .andExpect(jsonPath("$.data.content[0].lastMessage.timestamp").exists())
                         .andExpect(jsonPath("$.data.content[1].chatRoomId").value(directChatRoom.getId()))
-                        .andExpect(jsonPath("$.data.content[1].displayName").value("예전 대화"))
+                        .andExpect(jsonPath("$.data.content[1].displayName").value("알 수 없는 사용자"))
                         .andExpect(jsonPath("$.data.content[1].profileImgUrl").value(nullValue()))
                         .andExpect(jsonPath("$.data.content[1].isWithdrawn").value(true))
                         .andExpect(jsonPath("$.data.content[1].unreadCount").value(0))
@@ -870,6 +870,8 @@ class ChatIntegrationTest extends IntegrationTestBase {
 
                 mockMvc.perform(get("/api/chats/rooms/{roomId}", directChatRoom.getId()))
                         .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.data.chatRoomInfo.displayName").value("알 수 없는 사용자"))
+                        .andExpect(jsonPath("$.data.chatRoomInfo.profileImageUrl").value(nullValue()))
                         .andExpect(jsonPath("$.data.chatRoomInfo.isCounterPartWithdrawn").value(true));
             }
 
@@ -941,6 +943,8 @@ class ChatIntegrationTest extends IntegrationTestBase {
 
                 mockMvc.perform(get("/api/chats/rooms/{roomId}", partyChatRoom.getId()))
                         .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.data.messages[0].senderName").value("알 수 없는 사용자"))
+                        .andExpect(jsonPath("$.data.messages[0].senderProfileImageUrl").value(nullValue()))
                         .andExpect(jsonPath("$.data.messages[0].isSenderWithdrawn").value(true));
             }
 
@@ -1182,6 +1186,8 @@ class ChatIntegrationTest extends IntegrationTestBase {
                 mockMvc.perform(get("/api/chats/rooms/{roomId}/messages/previous", partyChatRoom.getId())
                                 .param("cursor", cursor.toString()))
                         .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.data.messages[0].senderName").value("알 수 없는 사용자"))
+                        .andExpect(jsonPath("$.data.messages[0].senderProfileImageUrl").value(nullValue()))
                         .andExpect(jsonPath("$.data.messages[0].isSenderWithdrawn").value(true));
             }
 

--- a/src/test/java/umc/cockple/demo/domain/chat/integration/ChatIntegrationTest.java
+++ b/src/test/java/umc/cockple/demo/domain/chat/integration/ChatIntegrationTest.java
@@ -10,6 +10,7 @@ import umc.cockple.demo.domain.chat.domain.ChatMessageFile;
 import umc.cockple.demo.domain.chat.domain.ChatRoom;
 import umc.cockple.demo.domain.chat.domain.ChatRoomMember;
 import umc.cockple.demo.domain.chat.domain.MessageReadStatus;
+import umc.cockple.demo.domain.chat.enums.MessageType;
 import umc.cockple.demo.domain.chat.exception.ChatErrorCode;
 import umc.cockple.demo.domain.chat.repository.ChatMessageRepository;
 import umc.cockple.demo.domain.chat.repository.ChatRoomMemberRepository;
@@ -949,6 +950,24 @@ class ChatIntegrationTest extends IntegrationTestBase {
             }
 
             @Test
+            @DisplayName("200 - sender가 null인 일반 메시지는 알 수 없는 사용자로 조회된다")
+            void nullSenderTextMessage_isMappedToUnknownUser() throws Exception {
+                chatRoomMemberRepository.save(ChatRoomMember.create(partyChatRoom, member));
+                chatMessageRepository.save(
+                        ChatMessage.create(partyChatRoom, null, "삭제된 사용자 메시지", MessageType.TEXT));
+
+                SecurityContextHelper.setAuthentication(member.getId(), member.getNickname());
+
+                mockMvc.perform(get("/api/chats/rooms/{roomId}", partyChatRoom.getId()))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.data.messages[0].senderId").value(nullValue()))
+                        .andExpect(jsonPath("$.data.messages[0].senderName").value("알 수 없는 사용자"))
+                        .andExpect(jsonPath("$.data.messages[0].senderProfileImageUrl").value(nullValue()))
+                        .andExpect(jsonPath("$.data.messages[0].isSenderWithdrawn").value(true))
+                        .andExpect(jsonPath("$.data.messages[0].isMyMessage").value(false));
+            }
+
+            @Test
             @DisplayName("200 - 이미지 메시지 조회 시 images 필드에 파일 정보가 포함된다")
             void imageMessage_containsFileInfo() throws Exception {
                 chatRoomMemberRepository.save(ChatRoomMember.create(partyChatRoom, member));
@@ -1189,6 +1208,26 @@ class ChatIntegrationTest extends IntegrationTestBase {
                         .andExpect(jsonPath("$.data.messages[0].senderName").value("알 수 없는 사용자"))
                         .andExpect(jsonPath("$.data.messages[0].senderProfileImageUrl").value(nullValue()))
                         .andExpect(jsonPath("$.data.messages[0].isSenderWithdrawn").value(true));
+            }
+
+            @Test
+            @DisplayName("200 - sender가 null인 일반 과거 메시지는 알 수 없는 사용자로 조회된다")
+            void nullSenderPreviousMessage_isMappedToUnknownUser() throws Exception {
+                chatRoomMemberRepository.save(ChatRoomMember.create(partyChatRoom, member));
+                ChatMessage deletedSenderMessage = chatMessageRepository.save(
+                        ChatMessage.create(partyChatRoom, null, "삭제된 사용자 메시지", MessageType.TEXT));
+                Long cursor = deletedSenderMessage.getId() + 1;
+
+                SecurityContextHelper.setAuthentication(member.getId(), member.getNickname());
+
+                mockMvc.perform(get("/api/chats/rooms/{roomId}/messages/previous", partyChatRoom.getId())
+                                .param("cursor", cursor.toString()))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.data.messages[0].senderId").value(nullValue()))
+                        .andExpect(jsonPath("$.data.messages[0].senderName").value("알 수 없는 사용자"))
+                        .andExpect(jsonPath("$.data.messages[0].senderProfileImageUrl").value(nullValue()))
+                        .andExpect(jsonPath("$.data.messages[0].isSenderWithdrawn").value(true))
+                        .andExpect(jsonPath("$.data.messages[0].isMyMessage").value(false));
             }
 
             @Test

--- a/src/test/java/umc/cockple/demo/domain/chat/integration/ChatIntegrationTest.java
+++ b/src/test/java/umc/cockple/demo/domain/chat/integration/ChatIntegrationTest.java
@@ -16,6 +16,7 @@ import umc.cockple.demo.domain.chat.repository.ChatMessageRepository;
 import umc.cockple.demo.domain.chat.repository.ChatRoomMemberRepository;
 import umc.cockple.demo.domain.chat.repository.ChatRoomRepository;
 import umc.cockple.demo.domain.chat.repository.MessageReadStatusRepository;
+import umc.cockple.demo.domain.chat.service.ChatMemberHardDeleteCleanupService;
 import umc.cockple.demo.domain.chat.service.websocket.ChatRoomListCacheService;
 import umc.cockple.demo.domain.member.domain.Member;
 import umc.cockple.demo.domain.member.domain.ProfileImg;
@@ -58,6 +59,7 @@ class ChatIntegrationTest extends IntegrationTestBase {
     @Autowired ChatMessageRepository chatMessageRepository;
     @Autowired MessageReadStatusRepository messageReadStatusRepository;
     @Autowired ChatRoomListCacheService chatRoomListCacheService;
+    @Autowired ChatMemberHardDeleteCleanupService chatMemberHardDeleteCleanupService;
 
     private Member member;
     private Member otherMember;
@@ -550,6 +552,52 @@ class ChatIntegrationTest extends IntegrationTestBase {
                         .andExpect(jsonPath("$.data.content", hasSize(2)))
                         .andExpect(jsonPath("$.data.content[0].chatRoomId").value(latestJoinedRoom.getId()))
                         .andExpect(jsonPath("$.data.content[1].chatRoomId").value(directChatRoom.getId()));
+            }
+
+            @Test
+            @DisplayName("200 - hard delete 전처리 후 삭제된 상대방은 알 수 없는 사용자로 조회된다")
+            void hardDeletedCounterPart_isMappedToUnknownUser() throws Exception {
+                Member target = memberRepository.save(
+                        MemberFixture.createWithdrawnMember("삭제대상", "삭제", 5005L));
+
+                chatRoomMemberRepository.save(ChatRoomMember.createJoined(directChatRoom, member, "삭제 대상과의 대화"));
+                chatRoomMemberRepository.save(ChatRoomMember.createJoined(directChatRoom, target, member.getMemberName()));
+                ChatMessage targetMessage = chatMessageRepository.save(
+                        ChatFixture.createTextMessage(directChatRoom, target, "삭제 대상 메시지"));
+                messageReadStatusRepository.save(MessageReadStatus.createUnread(targetMessage.getId(), member.getId(), directChatRoom.getId()));
+                messageReadStatusRepository.save(MessageReadStatus.createRead(targetMessage.getId(), target.getId(), directChatRoom.getId()));
+
+                ChatMemberHardDeleteCleanupService.Result cleanupResult =
+                        chatMemberHardDeleteCleanupService.prepareMemberHardDelete(target.getId());
+                memberRepository.delete(target);
+                memberRepository.flush();
+
+                SecurityContextHelper.setAuthentication(member.getId(), member.getNickname());
+
+                mockMvc.perform(get("/api/chats/direct")
+                                .param("page", "0")
+                                .param("size", "10"))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.data.content", hasSize(1)))
+                        .andExpect(jsonPath("$.data.content[0].displayName").value("알 수 없는 사용자"))
+                        .andExpect(jsonPath("$.data.content[0].profileImgUrl").value(nullValue()))
+                        .andExpect(jsonPath("$.data.content[0].isWithdrawn").value(true))
+                        .andExpect(jsonPath("$.data.content[0].lastMessage.content").value("삭제 대상 메시지"));
+
+                mockMvc.perform(get("/api/chats/rooms/{roomId}", directChatRoom.getId()))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.data.chatRoomInfo.displayName").value("알 수 없는 사용자"))
+                        .andExpect(jsonPath("$.data.chatRoomInfo.profileImageUrl").value(nullValue()))
+                        .andExpect(jsonPath("$.data.chatRoomInfo.isCounterPartWithdrawn").value(true))
+                        .andExpect(jsonPath("$.data.messages[0].senderId").value(nullValue()))
+                        .andExpect(jsonPath("$.data.messages[0].senderName").value("알 수 없는 사용자"))
+                        .andExpect(jsonPath("$.data.messages[0].isSenderWithdrawn").value(true));
+
+                assertThat(cleanupResult.clearedMessages()).isEqualTo(1);
+                assertThat(cleanupResult.clearedChatRoomMembers()).isEqualTo(1);
+                assertThat(cleanupResult.deletedReadStatuses()).isEqualTo(1);
+                assertThat(messageReadStatusRepository.findAll())
+                        .noneMatch(status -> target.getId().equals(status.getMemberId()));
             }
         }
     }

--- a/src/test/java/umc/cockple/demo/domain/chat/service/ChatMemberAnonymizationServiceTest.java
+++ b/src/test/java/umc/cockple/demo/domain/chat/service/ChatMemberAnonymizationServiceTest.java
@@ -1,0 +1,62 @@
+package umc.cockple.demo.domain.chat.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import umc.cockple.demo.domain.chat.repository.ChatRoomMemberRepository;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static umc.cockple.demo.domain.chat.converter.ChatConverter.UNKNOWN_USER_NAME;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ChatMemberAnonymizationService")
+class ChatMemberAnonymizationServiceTest {
+
+    @Mock private ChatRoomMemberRepository chatRoomMemberRepository;
+
+    private ChatMemberAnonymizationService anonymizationService;
+
+    @BeforeEach
+    void setUp() {
+        anonymizationService = new ChatMemberAnonymizationService(chatRoomMemberRepository);
+    }
+
+    @Test
+    @DisplayName("회원이 속한 direct 채팅방 표시명 스냅샷을 알 수 없는 사용자로 익명화한다")
+    void anonymizeDirectDisplayNames_updatesDirectChatRoomDisplayNames() {
+        Long memberId = 10L;
+        List<Long> directChatRoomIds = List.of(100L, 200L);
+        given(chatRoomMemberRepository.findDirectChatRoomIdsByMemberId(memberId)).willReturn(directChatRoomIds);
+        given(chatRoomMemberRepository.updateDisplayNameByChatRoomIds(directChatRoomIds, UNKNOWN_USER_NAME))
+                .willReturn(4);
+
+        int result = anonymizationService.anonymizeDirectDisplayNames(memberId);
+
+        assertThat(result).isEqualTo(4);
+        verify(chatRoomMemberRepository).findDirectChatRoomIdsByMemberId(memberId);
+        verify(chatRoomMemberRepository).updateDisplayNameByChatRoomIds(directChatRoomIds, UNKNOWN_USER_NAME);
+    }
+
+    @Test
+    @DisplayName("회원이 속한 direct 채팅방이 없으면 표시명 업데이트를 건너뛴다")
+    void anonymizeDirectDisplayNames_skipsUpdate_whenNoDirectRooms() {
+        Long memberId = 10L;
+        given(chatRoomMemberRepository.findDirectChatRoomIdsByMemberId(memberId)).willReturn(List.of());
+
+        int result = anonymizationService.anonymizeDirectDisplayNames(memberId);
+
+        assertThat(result).isZero();
+        verify(chatRoomMemberRepository).findDirectChatRoomIdsByMemberId(memberId);
+        verify(chatRoomMemberRepository, never()).updateDisplayNameByChatRoomIds(anyList(), anyString());
+    }
+}

--- a/src/test/java/umc/cockple/demo/domain/chat/service/ChatMemberHardDeleteCleanupServiceTest.java
+++ b/src/test/java/umc/cockple/demo/domain/chat/service/ChatMemberHardDeleteCleanupServiceTest.java
@@ -1,0 +1,53 @@
+package umc.cockple.demo.domain.chat.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import umc.cockple.demo.domain.chat.repository.ChatMessageRepository;
+import umc.cockple.demo.domain.chat.repository.ChatRoomMemberRepository;
+import umc.cockple.demo.domain.chat.repository.MessageReadStatusRepository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ChatMemberHardDeleteCleanupService")
+class ChatMemberHardDeleteCleanupServiceTest {
+
+    @Mock private MessageReadStatusRepository messageReadStatusRepository;
+    @Mock private ChatMessageRepository chatMessageRepository;
+    @Mock private ChatRoomMemberRepository chatRoomMemberRepository;
+
+    private ChatMemberHardDeleteCleanupService cleanupService;
+
+    @BeforeEach
+    void setUp() {
+        cleanupService = new ChatMemberHardDeleteCleanupService(
+                messageReadStatusRepository,
+                chatMessageRepository,
+                chatRoomMemberRepository
+        );
+    }
+
+    @Test
+    @DisplayName("회원 hard delete 전에 채팅 메시지/참여자 참조와 읽음 상태를 정리한다")
+    void prepareMemberHardDelete_cleansChatReferences() {
+        Long memberId = 10L;
+        given(messageReadStatusRepository.deleteByMemberId(memberId)).willReturn(3);
+        given(chatMessageRepository.clearSenderByMemberId(memberId)).willReturn(2);
+        given(chatRoomMemberRepository.clearMemberByMemberId(memberId)).willReturn(1);
+
+        ChatMemberHardDeleteCleanupService.Result result = cleanupService.prepareMemberHardDelete(memberId);
+
+        assertThat(result.deletedReadStatuses()).isEqualTo(3);
+        assertThat(result.clearedMessages()).isEqualTo(2);
+        assertThat(result.clearedChatRoomMembers()).isEqualTo(1);
+        verify(messageReadStatusRepository).deleteByMemberId(memberId);
+        verify(chatMessageRepository).clearSenderByMemberId(memberId);
+        verify(chatRoomMemberRepository).clearMemberByMemberId(memberId);
+    }
+}

--- a/src/test/java/umc/cockple/demo/domain/chat/service/ChatProcessorTest.java
+++ b/src/test/java/umc/cockple/demo/domain/chat/service/ChatProcessorTest.java
@@ -14,8 +14,6 @@ import umc.cockple.demo.domain.chat.domain.ChatMessageFile;
 import umc.cockple.demo.domain.chat.domain.ChatRoom;
 import umc.cockple.demo.domain.chat.dto.ChatCommonDTO;
 import umc.cockple.demo.domain.chat.enums.MessageType;
-import umc.cockple.demo.domain.chat.exception.ChatErrorCode;
-import umc.cockple.demo.domain.chat.exception.ChatException;
 import umc.cockple.demo.domain.file.service.FileService;
 import umc.cockple.demo.domain.member.domain.Member;
 import umc.cockple.demo.domain.member.domain.ProfileImg;
@@ -28,7 +26,6 @@ import umc.cockple.demo.support.fixture.PartyFixture;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -229,14 +226,22 @@ class ChatProcessorTest {
         }
 
         @Test
-        @DisplayName("SYSTEM이 아닌데 sender가 null이면 예외를 던진다")
-        void throwsException_whenNonSystemMessageHasNullSender() {
-            ChatMessage malformedMessage = ChatMessage.create(chatRoom, null, "깨진 메시지", MessageType.TEXT);
-            ReflectionTestUtils.setField(malformedMessage, "id", 999L);
+        @DisplayName("SYSTEM이 아닌데 sender가 null이면 알 수 없는 사용자로 매핑한다")
+        void mapsUnknownUser_whenNonSystemMessageHasNullSender() {
+            ChatMessage message = ChatMessage.create(chatRoom, null, "삭제된 사용자 메시지", MessageType.TEXT);
+            ReflectionTestUtils.setField(message, "id", 999L);
 
-            assertThatThrownBy(() -> chatProcessor.processMessages(sender.getId(), List.of(malformedMessage)))
-                    .isInstanceOf(ChatException.class)
-                    .satisfies(e -> assertThat(((ChatException) e).getCode()).isEqualTo(ChatErrorCode.INVALID_MESSAGE_SENDER));
+            List<ChatCommonDTO.MessageInfo> result = chatProcessor.processMessages(sender.getId(), List.of(message));
+
+            assertThat(result).hasSize(1);
+            ChatCommonDTO.MessageInfo messageInfo = result.get(0);
+            assertThat(messageInfo.senderId()).isNull();
+            assertThat(messageInfo.senderName()).isEqualTo(ChatConverter.UNKNOWN_USER_NAME);
+            assertThat(messageInfo.senderProfileImageUrl()).isNull();
+            assertThat(messageInfo.isSenderWithdrawn()).isTrue();
+            assertThat(messageInfo.isMyMessage()).isFalse();
+            assertThat(messageInfo.content()).isEqualTo("삭제된 사용자 메시지");
+            assertThat(messageInfo.messageType()).isEqualTo(MessageType.TEXT);
         }
 
         @Test
@@ -255,6 +260,7 @@ class ChatProcessorTest {
 
             assertThat(result).hasSize(1);
             ChatCommonDTO.MessageInfo messageInfo = result.get(0);
+            assertThat(messageInfo.senderId()).isNull();
             assertThat(messageInfo.isSenderWithdrawn()).isTrue();
             assertThat(messageInfo.senderName()).isEqualTo(ChatConverter.UNKNOWN_USER_NAME);
             assertThat(messageInfo.senderProfileImageUrl()).isNull();

--- a/src/test/java/umc/cockple/demo/domain/chat/service/ChatProcessorTest.java
+++ b/src/test/java/umc/cockple/demo/domain/chat/service/ChatProcessorTest.java
@@ -244,6 +244,9 @@ class ChatProcessorTest {
         void isSenderWithdrawn_true_whenSenderIsInactive() {
             Member withdrawn = MemberFixture.createWithdrawnMember("탈퇴한사용자", "탈퇴", 3003L);
             ReflectionTestUtils.setField(withdrawn, "id", 30L);
+            withdrawn.updateProfileImg(ProfileImg.builder()
+                    .imgKey("member/withdrawn-profile.png")
+                    .build());
 
             ChatMessage message = ChatFixture.createTextMessage(chatRoom, withdrawn, "탈퇴자 메시지");
             ReflectionTestUtils.setField(message, "id", 1L);
@@ -251,7 +254,11 @@ class ChatProcessorTest {
             List<ChatCommonDTO.MessageInfo> result = chatProcessor.processMessages(sender.getId(), List.of(message));
 
             assertThat(result).hasSize(1);
-            assertThat(result.get(0).isSenderWithdrawn()).isTrue();
+            ChatCommonDTO.MessageInfo messageInfo = result.get(0);
+            assertThat(messageInfo.isSenderWithdrawn()).isTrue();
+            assertThat(messageInfo.senderName()).isEqualTo(ChatConverter.UNKNOWN_USER_NAME);
+            assertThat(messageInfo.senderProfileImageUrl()).isNull();
+            verify(fileService, never()).getUrlFromKey("member/withdrawn-profile.png");
         }
 
         @Test

--- a/src/test/java/umc/cockple/demo/domain/chat/service/ChatQueryServiceTest.java
+++ b/src/test/java/umc/cockple/demo/domain/chat/service/ChatQueryServiceTest.java
@@ -612,6 +612,9 @@ class ChatQueryServiceTest {
 
                 Member withdrawnCounterPart = MemberFixture.createWithdrawnMember("탈퇴한사용자", "탈퇴", 2002L);
                 ReflectionTestUtils.setField(withdrawnCounterPart, "id", 20L);
+                withdrawnCounterPart.updateProfileImg(ProfileImg.builder()
+                        .imgKey("member/withdrawn-direct.png")
+                        .build());
 
                 ChatRoom chatRoom = ChatFixture.createDirectChatRoom();
                 ReflectionTestUtils.setField(chatRoom, "id", roomId);
@@ -635,7 +638,11 @@ class ChatQueryServiceTest {
 
                 // then
                 assertThat(result.content()).hasSize(1);
-                assertThat(result.content().get(0).isWithdrawn()).isTrue();
+                DirectChatRoomDTO.ChatRoomInfo roomInfo = result.content().get(0);
+                assertThat(roomInfo.displayName()).isEqualTo(ChatConverter.UNKNOWN_USER_NAME);
+                assertThat(roomInfo.profileImgUrl()).isNull();
+                assertThat(roomInfo.isWithdrawn()).isTrue();
+                verify(fileService, never()).getUrlFromKey("member/withdrawn-direct.png");
             }
 
             @Test
@@ -765,9 +772,6 @@ class ChatQueryServiceTest {
                 given(messageReadStatusRepository.countUnreadMessagesAfter(roomId, memberId, 40L))
                         .willReturn(2);
                 given(chatRoomListCacheService.getLastMessage(roomId)).willReturn(lastMessage);
-                given(fileService.getUrlFromKey("member/search-profile.png"))
-                        .willReturn("https://cdn.example.com/member/search-profile.png");
-
                 // when
                 DirectChatRoomDTO.Response result = chatQueryService.searchDirectChatRoomsByName(memberId, name, 0, 5);
 
@@ -777,8 +781,8 @@ class ChatQueryServiceTest {
 
                 DirectChatRoomDTO.ChatRoomInfo roomInfo = result.content().get(0);
                 assertThat(roomInfo.chatRoomId()).isEqualTo(roomId);
-                assertThat(roomInfo.displayName()).isEqualTo("영희 채팅");
-                assertThat(roomInfo.profileImgUrl()).isEqualTo("https://cdn.example.com/member/search-profile.png");
+                assertThat(roomInfo.displayName()).isEqualTo(ChatConverter.UNKNOWN_USER_NAME);
+                assertThat(roomInfo.profileImgUrl()).isNull();
                 assertThat(roomInfo.isWithdrawn()).isTrue();
                 assertThat(roomInfo.unreadCount()).isEqualTo(2);
                 assertThat(roomInfo.lastMessage()).isNotNull();
@@ -788,8 +792,8 @@ class ChatQueryServiceTest {
 
                 verify(chatRoomRepository).searchDirectChatRoomsByName(memberId, name, PageRequest.of(0, 5));
                 verify(messageReadStatusRepository).countUnreadMessagesAfter(roomId, memberId, 40L);
+                verify(fileService, never()).getUrlFromKey("member/search-profile.png");
                 verify(chatRoomListCacheService).getLastMessage(roomId);
-                verify(fileService).getUrlFromKey("member/search-profile.png");
             }
 
             @Test
@@ -988,6 +992,9 @@ class ChatQueryServiceTest {
 
             Member withdrawnCounterPart = MemberFixture.createWithdrawnMember("탈퇴한사용자", "탈퇴", 2002L);
             ReflectionTestUtils.setField(withdrawnCounterPart, "id", counterPartId);
+            withdrawnCounterPart.updateProfileImg(ProfileImg.builder()
+                    .imgKey("member/withdrawn-detail.png")
+                    .build());
 
             ChatRoom chatRoom = ChatFixture.createDirectChatRoom();
             ReflectionTestUtils.setField(chatRoom, "id", roomId);
@@ -1011,7 +1018,12 @@ class ChatQueryServiceTest {
             ChatRoomDetailDTO.Response result = chatQueryService.getChatRoomDetail(roomId, memberId);
 
             // then
+            assertThat(result.chatRoomInfo().displayName()).isEqualTo(ChatConverter.UNKNOWN_USER_NAME);
+            assertThat(result.chatRoomInfo().profileImageUrl()).isNull();
             assertThat(result.chatRoomInfo().isCounterPartWithdrawn()).isTrue();
+            assertThat(result.participants().get(1).memberName()).isEqualTo(ChatConverter.UNKNOWN_USER_NAME);
+            assertThat(result.participants().get(1).profileImgUrl()).isNull();
+            verify(fileService, never()).getUrlFromKey("member/withdrawn-detail.png");
         }
 
         @Test
@@ -1152,6 +1164,9 @@ class ChatQueryServiceTest {
 
             Member withdrawn = MemberFixture.createWithdrawnMember("탈퇴한사용자", "탈퇴", 3003L);
             ReflectionTestUtils.setField(withdrawn, "id", withdrawnId);
+            withdrawn.updateProfileImg(ProfileImg.builder()
+                    .imgKey("member/withdrawn-message.png")
+                    .build());
 
             Party party = PartyFixture.createParty("모임", memberId, PartyFixture.createPartyAddr("서울", "강남구"));
             ReflectionTestUtils.setField(party, "id", 100L);
@@ -1178,7 +1193,11 @@ class ChatQueryServiceTest {
             ChatRoomDetailDTO.Response result = chatQueryService.getChatRoomDetail(roomId, memberId);
 
             // then
-            assertThat(result.messages().get(0).isSenderWithdrawn()).isTrue();
+            ChatRoomDetailDTO.MessageInfo messageInfo = result.messages().get(0);
+            assertThat(messageInfo.isSenderWithdrawn()).isTrue();
+            assertThat(messageInfo.senderName()).isEqualTo(ChatConverter.UNKNOWN_USER_NAME);
+            assertThat(messageInfo.senderProfileImageUrl()).isNull();
+            verify(fileService, never()).getUrlFromKey("member/withdrawn-message.png");
         }
 
         @Test
@@ -1518,6 +1537,9 @@ class ChatQueryServiceTest {
 
             Member withdrawn = MemberFixture.createWithdrawnMember("탈퇴한사용자", "탈퇴", 3003L);
             ReflectionTestUtils.setField(withdrawn, "id", withdrawnId);
+            withdrawn.updateProfileImg(ProfileImg.builder()
+                    .imgKey("member/withdrawn-previous.png")
+                    .build());
 
             Party party = PartyFixture.createParty("모임", memberId, PartyFixture.createPartyAddr("서울", "강남구"));
             ReflectionTestUtils.setField(party, "id", 100L);
@@ -1536,7 +1558,11 @@ class ChatQueryServiceTest {
             ChatMessageDTO.Response result = chatQueryService.getChatMessages(roomId, memberId, cursor, 10);
 
             // then
-            assertThat(result.messages().get(0).isSenderWithdrawn()).isTrue();
+            ChatMessageDTO.MessageInfo messageInfo = result.messages().get(0);
+            assertThat(messageInfo.isSenderWithdrawn()).isTrue();
+            assertThat(messageInfo.senderName()).isEqualTo(ChatConverter.UNKNOWN_USER_NAME);
+            assertThat(messageInfo.senderProfileImageUrl()).isNull();
+            verify(fileService, never()).getUrlFromKey("member/withdrawn-previous.png");
         }
 
         @Test

--- a/src/test/java/umc/cockple/demo/domain/chat/service/ChatQueryServiceTest.java
+++ b/src/test/java/umc/cockple/demo/domain/chat/service/ChatQueryServiceTest.java
@@ -1201,6 +1201,46 @@ class ChatQueryServiceTest {
         }
 
         @Test
+        @DisplayName("sender가 null인 일반 메시지는 알 수 없는 사용자로 조회된다")
+        void message_nullSender_isMappedToUnknownUser() {
+            // given
+            Long roomId = 1L;
+            Long memberId = 10L;
+
+            Member me = MemberFixture.createMemberWithName("홍길동", "길동", Gender.MALE, Level.A, 1001L);
+            ReflectionTestUtils.setField(me, "id", memberId);
+
+            Party party = PartyFixture.createParty("모임", memberId, PartyFixture.createPartyAddr("서울", "강남구"));
+            ReflectionTestUtils.setField(party, "id", 100L);
+
+            ChatRoom chatRoom = ChatFixture.createPartyChatRoom(party);
+            ReflectionTestUtils.setField(chatRoom, "id", roomId);
+
+            ChatRoomMember myMembership = ChatFixture.createJoinedMember(chatRoom, me);
+            ReflectionTestUtils.setField(myMembership, "id", 1L);
+
+            ChatMessage deletedSenderMessage = ChatMessage.create(chatRoom, null, "삭제된 사용자 메시지", MessageType.TEXT);
+            ReflectionTestUtils.setField(deletedSenderMessage, "id", 1L);
+
+            given(chatRoomRepository.findChatRoomWithPartyById(roomId)).willReturn(Optional.of(chatRoom));
+            given(chatRoomMemberRepository.findByChatRoomIdAndMemberId(roomId, memberId)).willReturn(Optional.of(myMembership));
+            given(chatMessageRepository.findRecentMessagesWithFiles(eq(roomId), any())).willReturn(List.of(deletedSenderMessage));
+            given(chatRoomMemberRepository.findChatRoomMembersWithMemberById(roomId)).willReturn(List.of(myMembership));
+            given(chatRoomMemberRepository.countByChatRoomId(roomId)).willReturn(1);
+
+            // when
+            ChatRoomDetailDTO.Response result = chatQueryService.getChatRoomDetail(roomId, memberId);
+
+            // then
+            ChatRoomDetailDTO.MessageInfo messageInfo = result.messages().get(0);
+            assertThat(messageInfo.senderId()).isNull();
+            assertThat(messageInfo.senderName()).isEqualTo(ChatConverter.UNKNOWN_USER_NAME);
+            assertThat(messageInfo.senderProfileImageUrl()).isNull();
+            assertThat(messageInfo.isSenderWithdrawn()).isTrue();
+            assertThat(messageInfo.isMyMessage()).isFalse();
+        }
+
+        @Test
         @DisplayName("시스템 메시지는 sender 없이도 조회되고 시스템 기본값으로 매핑된다")
         void systemMessage_isMappedWithSystemDefaults() {
             // given
@@ -1563,6 +1603,39 @@ class ChatQueryServiceTest {
             assertThat(messageInfo.senderName()).isEqualTo(ChatConverter.UNKNOWN_USER_NAME);
             assertThat(messageInfo.senderProfileImageUrl()).isNull();
             verify(fileService, never()).getUrlFromKey("member/withdrawn-previous.png");
+        }
+
+        @Test
+        @DisplayName("sender가 null인 일반 과거 메시지는 알 수 없는 사용자로 조회된다")
+        void nullSenderPreviousMessage_isMappedToUnknownUser() {
+            // given
+            Long roomId = 1L;
+            Long memberId = 10L;
+            Long cursor = 100L;
+
+            Party party = PartyFixture.createParty("모임", memberId, PartyFixture.createPartyAddr("서울", "강남구"));
+            ReflectionTestUtils.setField(party, "id", 100L);
+
+            ChatRoom chatRoom = ChatFixture.createPartyChatRoom(party);
+            ReflectionTestUtils.setField(chatRoom, "id", roomId);
+
+            ChatMessage deletedSenderMessage = ChatMessage.create(chatRoom, null, "삭제된 사용자 메시지", MessageType.TEXT);
+            ReflectionTestUtils.setField(deletedSenderMessage, "id", 1L);
+
+            given(chatRoomMemberRepository.existsByChatRoomIdAndMemberId(roomId, memberId)).willReturn(true);
+            given(chatMessageRepository.findByRoomIdAndIdLessThanOrderByCreatedAtDesc(eq(roomId), eq(cursor), any()))
+                    .willReturn(List.of(deletedSenderMessage));
+
+            // when
+            ChatMessageDTO.Response result = chatQueryService.getChatMessages(roomId, memberId, cursor, 10);
+
+            // then
+            ChatMessageDTO.MessageInfo messageInfo = result.messages().get(0);
+            assertThat(messageInfo.senderId()).isNull();
+            assertThat(messageInfo.senderName()).isEqualTo(ChatConverter.UNKNOWN_USER_NAME);
+            assertThat(messageInfo.senderProfileImageUrl()).isNull();
+            assertThat(messageInfo.isSenderWithdrawn()).isTrue();
+            assertThat(messageInfo.isMyMessage()).isFalse();
         }
 
         @Test

--- a/src/test/java/umc/cockple/demo/domain/chat/service/ChatQueryServiceTest.java
+++ b/src/test/java/umc/cockple/demo/domain/chat/service/ChatQueryServiceTest.java
@@ -646,6 +646,43 @@ class ChatQueryServiceTest {
             }
 
             @Test
+            @DisplayName("상대방 회원이 hard delete되어 membership member가 null이면 알 수 없는 사용자로 매핑한다")
+            void mapsUnknownUser_whenCounterPartMemberIsNull() {
+                // given
+                Long memberId = 10L;
+                Long roomId = 44L;
+
+                Member me = MemberFixture.createMemberWithName("홍길동", "길동", Gender.MALE, Level.A, 1001L);
+                ReflectionTestUtils.setField(me, "id", memberId);
+
+                ChatRoom chatRoom = ChatFixture.createDirectChatRoom();
+                ReflectionTestUtils.setField(chatRoom, "id", roomId);
+
+                ChatRoomMember myMembership = ChatFixture.createJoinedMember(chatRoom, me, "삭제된 상대와의 대화");
+                ReflectionTestUtils.setField(myMembership, "id", 47L);
+                ChatRoomMember deletedCounterPartMembership = ChatRoomMember.createJoined(chatRoom, null, "홍길동");
+                ReflectionTestUtils.setField(deletedCounterPartMembership, "id", 48L);
+                chatRoom.addChatRoomMember(myMembership);
+                chatRoom.addChatRoomMember(deletedCounterPartMembership);
+
+                Slice<ChatRoom> chatRooms = new SliceImpl<>(List.of(chatRoom), PageRequest.of(0, 10), false);
+
+                given(chatRoomRepository.findDirectChatRoomByMemberIdOrderByLastMsgIdDesc(memberId, PageRequest.of(0, 10)))
+                        .willReturn(chatRooms);
+                given(chatRoomMemberRepository.findByChatRoomIdAndMemberId(roomId, memberId)).willReturn(Optional.of(myMembership));
+                given(messageReadStatusRepository.countAllUnreadMessages(roomId, memberId)).willReturn(0);
+
+                // when
+                DirectChatRoomDTO.Response result = chatQueryService.getDirectChatRooms(memberId, 0, 10);
+
+                // then
+                DirectChatRoomDTO.ChatRoomInfo roomInfo = result.content().get(0);
+                assertThat(roomInfo.displayName()).isEqualTo(ChatConverter.UNKNOWN_USER_NAME);
+                assertThat(roomInfo.profileImgUrl()).isNull();
+                assertThat(roomInfo.isWithdrawn()).isTrue();
+            }
+
+            @Test
             @DisplayName("채팅방 목록은 repository가 반환한 최신 메시지 순서를 유지한다")
             void preservesRepositoryOrder() {
                 // given
@@ -1024,6 +1061,46 @@ class ChatQueryServiceTest {
             assertThat(result.participants().get(1).memberName()).isEqualTo(ChatConverter.UNKNOWN_USER_NAME);
             assertThat(result.participants().get(1).profileImgUrl()).isNull();
             verify(fileService, never()).getUrlFromKey("member/withdrawn-detail.png");
+        }
+
+        @Test
+        @DisplayName("개인 채팅방에서 상대방 회원이 hard delete된 경우 알 수 없는 사용자로 조회된다")
+        void directChatRoom_counterPartMemberNull() {
+            // given
+            Long roomId = 4L;
+            Long memberId = 10L;
+
+            Member me = MemberFixture.createMemberWithName("홍길동", "길동", Gender.MALE, Level.A, 1001L);
+            ReflectionTestUtils.setField(me, "id", memberId);
+
+            ChatRoom chatRoom = ChatFixture.createDirectChatRoom();
+            ReflectionTestUtils.setField(chatRoom, "id", roomId);
+
+            ChatRoomMember myMembership = ChatFixture.createJoinedMember(chatRoom, me);
+            ReflectionTestUtils.setField(myMembership, "id", 1L);
+
+            ChatRoomMember deletedCounterPartMembership = ChatRoomMember.createJoined(chatRoom, null, "홍길동");
+            ReflectionTestUtils.setField(deletedCounterPartMembership, "id", 2L);
+
+            List<ChatRoomMember> participants = List.of(myMembership, deletedCounterPartMembership);
+
+            given(chatRoomRepository.findChatRoomWithPartyById(roomId)).willReturn(Optional.of(chatRoom));
+            given(chatRoomMemberRepository.findByChatRoomIdAndMemberId(roomId, memberId)).willReturn(Optional.of(myMembership));
+            given(chatRoomMemberRepository.findCounterPartWithMember(roomId, memberId)).willReturn(Optional.of(deletedCounterPartMembership));
+            given(chatRoomMemberRepository.countByChatRoomId(roomId)).willReturn(2);
+            given(chatMessageRepository.findRecentMessagesWithFiles(eq(roomId), any())).willReturn(List.of());
+            given(chatRoomMemberRepository.findChatRoomMembersWithMemberById(roomId)).willReturn(participants);
+
+            // when
+            ChatRoomDetailDTO.Response result = chatQueryService.getChatRoomDetail(roomId, memberId);
+
+            // then
+            assertThat(result.chatRoomInfo().displayName()).isEqualTo(ChatConverter.UNKNOWN_USER_NAME);
+            assertThat(result.chatRoomInfo().profileImageUrl()).isNull();
+            assertThat(result.chatRoomInfo().isCounterPartWithdrawn()).isTrue();
+            assertThat(result.participants().get(1).memberId()).isNull();
+            assertThat(result.participants().get(1).memberName()).isEqualTo(ChatConverter.UNKNOWN_USER_NAME);
+            assertThat(result.participants().get(1).profileImgUrl()).isNull();
         }
 
         @Test

--- a/src/test/java/umc/cockple/demo/domain/member/domain/MemberMappingTest.java
+++ b/src/test/java/umc/cockple/demo/domain/member/domain/MemberMappingTest.java
@@ -1,0 +1,28 @@
+package umc.cockple.demo.domain.member.domain;
+
+import jakarta.persistence.OneToMany;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import umc.cockple.demo.domain.chat.domain.ChatRoomMember;
+
+import java.lang.reflect.Field;
+import java.util.Arrays;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("Member JPA mapping")
+class MemberMappingTest {
+
+    @Test
+    @DisplayName("chatRoomMembers는 회원 삭제 시 채팅방 참여 이력을 삭제하지 않도록 cascade와 orphanRemoval을 사용하지 않는다")
+    void chatRoomMembers_doesNotCascadeOrphanRemoval() throws NoSuchFieldException {
+        Field field = Member.class.getDeclaredField("chatRoomMembers");
+        OneToMany oneToMany = field.getAnnotation(OneToMany.class);
+
+        assertThat(oneToMany).isNotNull();
+        assertThat(oneToMany.mappedBy()).isEqualTo("member");
+        assertThat(field.getGenericType().getTypeName()).contains(ChatRoomMember.class.getSimpleName());
+        assertThat(Arrays.asList(oneToMany.cascade())).isEmpty();
+        assertThat(oneToMany.orphanRemoval()).isFalse();
+    }
+}

--- a/src/test/java/umc/cockple/demo/domain/member/service/MemberCommandServiceTest.java
+++ b/src/test/java/umc/cockple/demo/domain/member/service/MemberCommandServiceTest.java
@@ -5,9 +5,11 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.test.util.ReflectionTestUtils;
 import umc.cockple.demo.domain.chat.domain.ChatRoomMember;
 import umc.cockple.demo.domain.chat.repository.ChatRoomMemberRepository;
@@ -23,6 +25,7 @@ import umc.cockple.demo.domain.member.enums.MemberPartyStatus;
 import umc.cockple.demo.domain.member.enums.MemberStatus;
 import umc.cockple.demo.domain.member.exception.MemberErrorCode;
 import umc.cockple.demo.domain.member.exception.MemberException;
+import umc.cockple.demo.domain.member.events.MemberWithdrawnEvent;
 import umc.cockple.demo.domain.member.repository.*;
 import umc.cockple.demo.global.enums.Gender;
 import umc.cockple.demo.global.enums.Keyword;
@@ -60,6 +63,7 @@ class MemberCommandServiceTest {
     @Mock private MemberKeywordRepository memberKeywordRepository;
     @Mock private MemberAddrRepository memberAddrRepository;
     @Mock private ChatRoomMemberRepository chatRoomMemberRepository;
+    @Mock private ApplicationEventPublisher applicationEventPublisher;
     @Mock private FileService fileService;
     @Mock private KakaoOauthService kakaoOauthService;
 
@@ -661,6 +665,23 @@ class MemberCommandServiceTest {
 
                 // then
                 then(kakaoOauthService).should().unlinkAccess(normalMember);
+            }
+
+            @Test
+            @DisplayName("탈퇴_시_회원_탈퇴_이벤트를_발행한다")
+            void 탈퇴_시_회원_탈퇴_이벤트를_발행한다() {
+                // given
+                given(memberRepository.findById(normalMember.getId()))
+                        .willReturn(Optional.of(normalMember));
+
+                // when
+                memberCommandService.withdrawMember(normalMember.getId());
+
+                // then
+                ArgumentCaptor<MemberWithdrawnEvent> eventCaptor = ArgumentCaptor.forClass(MemberWithdrawnEvent.class);
+                then(applicationEventPublisher).should().publishEvent(eventCaptor.capture());
+                assertThat(eventCaptor.getValue().memberId()).isEqualTo(normalMember.getId());
+                assertThat(eventCaptor.getValue().occurredAt()).isNotNull();
             }
         }
 


### PR DESCRIPTION
## ❤️ 기능 설명

회원 탈퇴/삭제 이후 기존 채팅 기록은 보존하면서 사용자 식별 정보는 `알 수 없는 사용자`로 표시되도록 수정했습니다.

- 탈퇴 회원 또는 hard delete로 sender/member 참조가 끊긴 사용자를 채팅 응답에서 익명 처리
- 회원 탈퇴 이벤트 발행 후 chat 도메인에서 개인 채팅방 표시명 '알 수 없는 사용자'로 처리
- 삭제 전 이름으로 direct 채팅방 검색이 되지 않도록 보강
- hard delete 전처리 서비스로 채팅 메시지 sender, 채팅방 참여자 member 참조, 읽음 상태 정리
- `chat_message.sender_id`, `chat_room_member.member_id` FK를 hard delete 보존 정책에 맞게 정리
- `message_read_status`는 ID 기반 테이블로 유지하고 전처리에서 명시 삭제
- `Member.chatRoomMembers`의 cascade/orphanRemoval 제거
- 채팅 도메인 Modifying 쿼리에 `flushAutomatically = true` 적용

<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #594
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [x] 회원 hard delete scheduler 구현 시 꼭 `ChatMemberHardDeleteCleanupService`를 사용해서 채팅 관련 처리를 해주세요! @kanghana1 
- [ ] `message_read_status.member_id`는 FK/Member 연관관계를 추가하지 않고 ID 기반으로 유지합니다.
- [ ] direct 채팅방 이름 검색 누수 방지는 회원 탈퇴 이벤트에서 displayName 스냅샷을 익명화하는 방식입니다.

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?