### PR TITLE
[fix/#590] 운동 수정 API에 게스트 정책 옵션 추가

### DIFF
--- a/src/main/java/umc/cockple/demo/domain/exercise/converter/ExerciseConverter.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/converter/ExerciseConverter.java
@@ -66,6 +66,8 @@ public class ExerciseConverter {
                 .startTime(request.toParsedStartTime())
                 .endTime(request.toParsedEndTime())
                 .maxCapacity(request.maxCapacity())
+                .partyGuestAccept(request.allowMemberGuestsInvitation())
+                .outsideGuestAccept(request.allowExternalGuests())
                 .notice(request.notice())
                 .build();
     }

--- a/src/main/java/umc/cockple/demo/domain/exercise/dto/ExerciseUpdateDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/dto/ExerciseUpdateDTO.java
@@ -39,6 +39,10 @@ public class ExerciseUpdateDTO {
             @Max(value = 45, message = "모집 인원은 최대 45명 이하입니다.")
             Integer maxCapacity,
 
+            Boolean allowMemberGuestsInvitation,
+
+            Boolean allowExternalGuests,
+
             @Size(max = 45, message = "공지사항은 45자를 초과할 수 없습니다")
             String notice
     ) {

--- a/src/test/java/umc/cockple/demo/domain/exercise/integration/ExerciseCommandIntegrationTest.java
+++ b/src/test/java/umc/cockple/demo/domain/exercise/integration/ExerciseCommandIntegrationTest.java
@@ -37,6 +37,7 @@ import umc.cockple.demo.support.fixture.GuestFixture;
 import java.time.LocalDate;
 import java.time.LocalTime;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
@@ -345,6 +346,8 @@ class ExerciseCommandIntegrationTest extends IntegrationTestBase {
                     "11:00",
                     "13:00",
                     12,
+                    false,
+                    true,
                     "공지사항"
             );
         }
@@ -363,6 +366,10 @@ class ExerciseCommandIntegrationTest extends IntegrationTestBase {
                                 .content(objectMapper.writeValueAsString(validRequest)))
                         .andExpect(status().isOk())
                         .andExpect(jsonPath("$.data.exerciseId").value(exercise.getId()));
+
+                Exercise updatedExercise = exerciseRepository.findById(exercise.getId()).orElseThrow();
+                assertThat(updatedExercise.getPartyGuestAccept()).isFalse();
+                assertThat(updatedExercise.getOutsideGuestAccept()).isTrue();
             }
 
             @Test
@@ -444,7 +451,7 @@ class ExerciseCommandIntegrationTest extends IntegrationTestBase {
 
                 ExerciseUpdateDTO.Request invalidTimeRequest = new ExerciseUpdateDTO.Request(
                         "2099-12-31", null, null, null, null,
-                        "13:00", "11:00", null, null
+                        "13:00", "11:00", null, null, null, null
                 );
 
                 mockMvc.perform(patch("/api/exercises/{exerciseId}", exercise.getId())
@@ -462,7 +469,7 @@ class ExerciseCommandIntegrationTest extends IntegrationTestBase {
 
                 ExerciseUpdateDTO.Request pastDateRequest = new ExerciseUpdateDTO.Request(
                         "2000-01-01", null, null, null, null,
-                        "10:00", "12:00", null, null
+                        "10:00", "12:00", null, null, null, null
                 );
 
                 mockMvc.perform(patch("/api/exercises/{exerciseId}", exercise.getId())

--- a/src/test/java/umc/cockple/demo/domain/exercise/service/ExerciseCommandServiceTest.java
+++ b/src/test/java/umc/cockple/demo/domain/exercise/service/ExerciseCommandServiceTest.java
@@ -245,6 +245,8 @@ class ExerciseCommandServiceTest {
                     "11:00",
                     "13:00",
                     12,
+                    false,
+                    true,
                     "공지사항"
             );
         }

--- a/src/test/java/umc/cockple/demo/domain/exercise/service/ExerciseLifecycleServiceTest.java
+++ b/src/test/java/umc/cockple/demo/domain/exercise/service/ExerciseLifecycleServiceTest.java
@@ -346,6 +346,8 @@ class ExerciseLifecycleServiceTest {
                     "11:00",
                     "13:00",
                     12,
+                    false,
+                    true,
                     "공지사항"
             );
         }
@@ -374,6 +376,8 @@ class ExerciseLifecycleServiceTest {
 
                 // then
                 assertThat(response.exerciseId()).isEqualTo(100L);
+                assertThat(exercise.getPartyGuestAccept()).isFalse();
+                assertThat(exercise.getOutsideGuestAccept()).isTrue();
                 then(exerciseRepository).should().save(exercise);
             }
 
@@ -405,6 +409,35 @@ class ExerciseLifecycleServiceTest {
 
                 // then
                 assertThat(response.exerciseId()).isEqualTo(100L);
+            }
+
+            @Test
+            @DisplayName("게스트 허용 옵션이 null이면 기존 설정을 유지한다")
+            void nullGuestPolicyFields_keepExistingValues() {
+                // given
+                ExerciseUpdateDTO.Request partialRequest = new ExerciseUpdateDTO.Request(
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        "공지사항만 수정"
+                );
+                given(exerciseRepository.save(any(Exercise.class))).willReturn(exercise);
+
+                // when
+                ExerciseUpdateDTO.Response response = exerciseLifecycleService.updateExercise(exercise, manager, partialRequest);
+
+                // then
+                assertThat(response.exerciseId()).isEqualTo(100L);
+                assertThat(exercise.getPartyGuestAccept()).isTrue();
+                assertThat(exercise.getOutsideGuestAccept()).isFalse();
+                assertThat(exercise.getNotice()).isEqualTo("공지사항만 수정");
             }
         }
 
@@ -457,7 +490,7 @@ class ExerciseLifecycleServiceTest {
             void invalidTime_throwsException() {
                 ExerciseUpdateDTO.Request invalidTimeRequest = new ExerciseUpdateDTO.Request(
                         "2099-12-31", null, null, null, null,
-                        "13:00", "11:00", null, null
+                        "13:00", "11:00", null, null, null, null
                 );
 
                 assertThatThrownBy(() ->
@@ -472,7 +505,7 @@ class ExerciseLifecycleServiceTest {
             void pastDate_throwsException() {
                 ExerciseUpdateDTO.Request pastDateRequest = new ExerciseUpdateDTO.Request(
                         "2000-01-01", null, null, null, null,
-                        "10:00", "12:00", null, null
+                        "10:00", "12:00", null, null, null, null
                 );
 
                 assertThatThrownBy(() ->


### PR DESCRIPTION
## ❤️ 기능 설명

운동 수정 API에서 생성 API와 동일하게 게스트 정책 옵션을 수정할 수 있도록 반영했습니다.

- `allowMemberGuestsInvitation`, `allowExternalGuests` 요청 필드 추가
- 수정 요청 값이 `null`이면 기존 게스트 정책 유지

Swagger 테스트 성공 결과 스크린샷은 미첨부했습니다.
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #590 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 게스트 정책 옵션을 `false`로 바꿔도 기존 게스트/외부 참여자는 유지하고 이후 새 요청만 제한하는 정책으로 반영했습니다.
- [ ] 간단한 수정이므로 리뷰 없이 머지 진행하겠습니다!

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
