### PR TITLE
[debug/#616] 회원 정보 미입력상태로 재진입시 홈으로 리다이렉트되는 오류 해결

### DIFF
--- a/src/main/java/umc/cockple/demo/domain/member/controller/MemberController.java
+++ b/src/main/java/umc/cockple/demo/domain/member/controller/MemberController.java
@@ -64,7 +64,8 @@ public class MemberController {
                         null,
                         response.memberId(),
                         response.nickname(),
-                        response.isNewMember()
+                        response.isNewMember(),
+                        response.needsOnboarding()
                 ));
     }
 
@@ -149,6 +150,17 @@ public class MemberController {
     public BaseResponse<GetProfileResponseDTO> getProfile(@PathVariable Long memberId) {
 
         return BaseResponse.success(CommonSuccessCode.OK, memberQueryService.getProfile(memberId));
+    }
+
+    @GetMapping(value = "/my/onboarding-status")
+    @Operation(summary = "온보딩 필요 여부 조회 API",
+            description = "앱 부팅(저장된 토큰으로 재진입) 시 상세정보 입력이 끝났는지 확인합니다. " +
+                    "needsOnboarding=true 이면 온보딩 화면으로 이동시켜야 합니다.")
+    public BaseResponse<OnboardingStatusResponseDTO> getOnboardingStatus() {
+
+        Long memberId = SecurityUtil.getCurrentMemberId();
+
+        return BaseResponse.success(CommonSuccessCode.OK, memberQueryService.getOnboardingStatus(memberId));
     }
 
     @GetMapping(value = "/my/profile")

--- a/src/main/java/umc/cockple/demo/domain/member/domain/Member.java
+++ b/src/main/java/umc/cockple/demo/domain/member/domain/Member.java
@@ -202,6 +202,7 @@ public class Member extends BaseEntity {
 
     public void rejoin() {
         this.isActive = MemberStatus.ACTIVE;
+        this.deletedAt = null;
         initField();
     }
 

--- a/src/main/java/umc/cockple/demo/domain/member/domain/Member.java
+++ b/src/main/java/umc/cockple/demo/domain/member/domain/Member.java
@@ -178,6 +178,17 @@ public class Member extends BaseEntity {
         return this.isActive == MemberStatus.INACTIVE;
     }
 
+    /**
+     * 온보딩(상세정보 입력) 완료 여부.
+     */
+    public boolean isProfileCompleted() {
+        return this.memberName != null
+                && this.gender != null
+                && this.birth != null
+                && this.level != null
+        ;
+    }
+
     public void withdraw() {
         this.isActive = MemberStatus.INACTIVE;
         this.deletedAt = LocalDateTime.now();

--- a/src/main/java/umc/cockple/demo/domain/member/domain/Member.java
+++ b/src/main/java/umc/cockple/demo/domain/member/domain/Member.java
@@ -205,7 +205,7 @@ public class Member extends BaseEntity {
         initField();
     }
 
-    public void initField() {
+    private void initField() {
         this.memberName = null;
         this.gender = null;
         this.birth = null;

--- a/src/main/java/umc/cockple/demo/domain/member/dto/OnboardingStatusResponseDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/member/dto/OnboardingStatusResponseDTO.java
@@ -1,0 +1,9 @@
+package umc.cockple.demo.domain.member.dto;
+
+import lombok.Builder;
+
+@Builder
+public record OnboardingStatusResponseDTO(
+        boolean needsOnboarding
+) {
+}

--- a/src/main/java/umc/cockple/demo/domain/member/dto/kakao/KakaoLoginDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/member/dto/kakao/KakaoLoginDTO.java
@@ -15,6 +15,7 @@ public class KakaoLoginDTO {
             String refreshToken,
             Long memberId,
             String nickname,
-            Boolean isNewMember
+            boolean isNewMember,
+            boolean needsOnboarding
     ){}
 }

--- a/src/main/java/umc/cockple/demo/domain/member/service/MemberQueryService.java
+++ b/src/main/java/umc/cockple/demo/domain/member/service/MemberQueryService.java
@@ -16,6 +16,7 @@ import umc.cockple.demo.domain.member.dto.GetAllAddressResponseDTO;
 import umc.cockple.demo.domain.member.dto.GetMyProfileResponseDTO;
 import umc.cockple.demo.domain.member.dto.GetNowAddressResponseDTO;
 import umc.cockple.demo.domain.member.dto.GetProfileResponseDTO;
+import umc.cockple.demo.domain.member.dto.OnboardingStatusResponseDTO;
 import umc.cockple.demo.domain.member.exception.MemberErrorCode;
 import umc.cockple.demo.domain.member.exception.MemberException;
 import umc.cockple.demo.domain.member.repository.MemberRepository;
@@ -39,6 +40,13 @@ public class MemberQueryService {
     /*
      * 프로필 관련 조회 메서드
      * */
+    public OnboardingStatusResponseDTO getOnboardingStatus(Long memberId) {
+        Member member = findByMemberId(memberId);
+        return OnboardingStatusResponseDTO.builder()
+                .needsOnboarding(!member.isProfileCompleted())
+                .build();
+    }
+
     public GetMyProfileResponseDTO getMyProfile(Long memberId) {
         // 회원 조회
         Member member = findByMemberId(memberId);

--- a/src/main/java/umc/cockple/demo/global/oauth2/service/KakaoOauthService.java
+++ b/src/main/java/umc/cockple/demo/global/oauth2/service/KakaoOauthService.java
@@ -60,8 +60,11 @@ public class KakaoOauthService {
         // 5. refresh는 redis에 저장
         refreshTokenRepository.save(refreshToken, member.getId());
 
+        // 온보딩(상세정보 입력) 필요 여부 - 신규/미완성/재가입 회원 모두 true
+        boolean needsOnboarding = !member.isProfileCompleted();
+
         // jwt개발할 때 넣기
-        return new KakaoLoginResponseDTO(accessToken, refreshToken, member.getId(), member.getNickname(), newMember);
+        return new KakaoLoginResponseDTO(accessToken, refreshToken, member.getId(), member.getNickname(), newMember, needsOnboarding);
     }
 
     public void unlinkAccess(Member member) {
@@ -95,6 +98,7 @@ public class KakaoOauthService {
                 .memberId(member.getId())
                 .nickname(member.getNickname())
                 .isNewMember(false)
+                .needsOnboarding(!member.isProfileCompleted())
                 .build()
                 ;
     }
@@ -119,6 +123,7 @@ public class KakaoOauthService {
                 .memberId(member.getId())
                 .nickname(member.getNickname())
                 .isNewMember(false)
+                .needsOnboarding(!member.isProfileCompleted())
                 .build()
                 ;
     }

--- a/src/test/java/umc/cockple/demo/domain/member/domain/MemberTest.java
+++ b/src/test/java/umc/cockple/demo/domain/member/domain/MemberTest.java
@@ -1,0 +1,105 @@
+package umc.cockple.demo.domain.member.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+import umc.cockple.demo.global.enums.Gender;
+import umc.cockple.demo.global.enums.Level;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("Member 도메인")
+class MemberTest {
+
+    @Nested
+    @DisplayName("isProfileCompleted")
+    class IsProfileCompleted {
+
+        @Test
+        @DisplayName("이름_성별_생년월일_급수가_모두_있으면_true를_반환한다")
+        void 모든_필수정보가_있으면_true() {
+            // given
+            Member member = completedMember();
+
+            // when & then
+            assertThat(member.isProfileCompleted()).isTrue();
+        }
+
+        @Test
+        @DisplayName("소셜로그인_직후_상세정보_미입력_회원은_false를_반환한다")
+        void 상세정보_미입력이면_false() {
+            // given - socialId/nickname만 있는 가입 직후 상태
+            Member member = Member.builder()
+                    .nickname("kakao_nick")
+                    .socialId(1001L)
+                    .build();
+
+            // when & then
+            assertThat(member.isProfileCompleted()).isFalse();
+        }
+
+        @Test
+        @DisplayName("memberName만_빠져도_false를_반환한다")
+        void memberName이_null이면_false() {
+            Member member = completedMember();
+            ReflectionTestUtils.setField(member, "memberName", null);
+
+            assertThat(member.isProfileCompleted()).isFalse();
+        }
+
+        @Test
+        @DisplayName("gender만_빠져도_false를_반환한다")
+        void gender가_null이면_false() {
+            Member member = completedMember();
+            ReflectionTestUtils.setField(member, "gender", null);
+
+            assertThat(member.isProfileCompleted()).isFalse();
+        }
+
+        @Test
+        @DisplayName("birth만_빠져도_false를_반환한다")
+        void birth가_null이면_false() {
+            Member member = completedMember();
+            ReflectionTestUtils.setField(member, "birth", null);
+
+            assertThat(member.isProfileCompleted()).isFalse();
+        }
+
+        @Test
+        @DisplayName("level만_빠져도_false를_반환한다")
+        void level이_null이면_false() {
+            Member member = completedMember();
+            ReflectionTestUtils.setField(member, "level", null);
+
+            assertThat(member.isProfileCompleted()).isFalse();
+        }
+
+        @Test
+        @DisplayName("재가입(initField)으로_필수정보가_초기화되면_다시_false가_된다")
+        void 재가입으로_초기화되면_false() {
+            // given
+            Member member = completedMember();
+            assertThat(member.isProfileCompleted()).isTrue();
+
+            // when - rejoin 시 호출되는 필드 초기화
+            member.initField();
+
+            // then
+            assertThat(member.isProfileCompleted()).isFalse();
+        }
+
+        private Member completedMember() {
+            return Member.builder()
+                    .memberName("강와나")
+                    .gender(Gender.FEMALE)
+                    .birth(LocalDate.of(2000, 1, 1))
+                    .level(Level.A)
+                    .nickname("kakao_nick")
+                    .socialId(1001L)
+                    .build();
+        }
+    }
+}

--- a/src/test/java/umc/cockple/demo/domain/member/domain/MemberTest.java
+++ b/src/test/java/umc/cockple/demo/domain/member/domain/MemberTest.java
@@ -78,14 +78,14 @@ class MemberTest {
         }
 
         @Test
-        @DisplayName("재가입(initField)으로_필수정보가_초기화되면_다시_false가_된다")
-        void 재가입으로_초기화되면_false() {
+        @DisplayName("재가입(rejoin)하면_필수정보가_초기화되어_다시_false가_된다")
+        void 재가입하면_false() {
             // given
             Member member = completedMember();
             assertThat(member.isProfileCompleted()).isTrue();
 
-            // when - rejoin 시 호출되는 필드 초기화
-            member.initField();
+            // when - 재가입 시 상세정보가 초기화된다
+            member.rejoin();
 
             // then
             assertThat(member.isProfileCompleted()).isFalse();

--- a/src/test/java/umc/cockple/demo/domain/member/domain/MemberTest.java
+++ b/src/test/java/umc/cockple/demo/domain/member/domain/MemberTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.util.ReflectionTestUtils;
+import umc.cockple.demo.domain.member.enums.MemberStatus;
 import umc.cockple.demo.global.enums.Gender;
 import umc.cockple.demo.global.enums.Level;
 
@@ -100,6 +101,37 @@ class MemberTest {
                     .nickname("kakao_nick")
                     .socialId(1001L)
                     .build();
+        }
+    }
+
+    @Nested
+    @DisplayName("rejoin")
+    class Rejoin {
+
+        @Test
+        @DisplayName("탈퇴한_회원이_재가입하면_활성화되고_탈퇴시각과_상세정보가_초기화된다")
+        void 재가입하면_탈퇴상태가_초기화된다() {
+            // given - 가입 후 탈퇴한 회원
+            Member member = Member.builder()
+                    .memberName("강와나")
+                    .gender(Gender.FEMALE)
+                    .birth(LocalDate.of(2000, 1, 1))
+                    .level(Level.A)
+                    .nickname("kakao_nick")
+                    .socialId(1001L)
+                    .isActive(MemberStatus.ACTIVE)
+                    .build();
+            member.withdraw();
+            assertThat(member.isWithdrawn()).isTrue();
+            assertThat(member.getDeletedAt()).isNotNull();
+
+            // when
+            member.rejoin();
+
+            // then
+            assertThat(member.getIsActive()).isEqualTo(MemberStatus.ACTIVE);
+            assertThat(member.getDeletedAt()).isNull();
+            assertThat(member.isProfileCompleted()).isFalse();
         }
     }
 }

--- a/src/test/java/umc/cockple/demo/domain/member/service/MemberQueryServiceTest.java
+++ b/src/test/java/umc/cockple/demo/domain/member/service/MemberQueryServiceTest.java
@@ -20,6 +20,7 @@ import umc.cockple.demo.domain.member.dto.GetAllAddressResponseDTO;
 import umc.cockple.demo.domain.member.dto.GetMyProfileResponseDTO;
 import umc.cockple.demo.domain.member.dto.GetNowAddressResponseDTO;
 import umc.cockple.demo.domain.member.dto.GetProfileResponseDTO;
+import umc.cockple.demo.domain.member.dto.OnboardingStatusResponseDTO;
 import umc.cockple.demo.domain.member.exception.MemberErrorCode;
 import umc.cockple.demo.domain.member.exception.MemberException;
 import umc.cockple.demo.domain.member.repository.MemberRepository;
@@ -156,6 +157,51 @@ class MemberQueryServiceTest {
         }
     }
 
+
+    @Nested
+    @DisplayName("getOnboardingStatus")
+    class GetOnboardingStatus {
+
+        @Test
+        @DisplayName("상세정보가_모두_입력된_회원은_needsOnboarding이_false다")
+        void 완성된_회원은_false() {
+            // given - setUp의 member는 이름/성별/생년월일/급수가 모두 채워진 완성 회원
+            given(memberRepository.findById(member.getId())).willReturn(Optional.of(member));
+
+            // when
+            OnboardingStatusResponseDTO response = memberQueryService.getOnboardingStatus(member.getId());
+
+            // then
+            assertThat(response.needsOnboarding()).isFalse();
+        }
+
+        @Test
+        @DisplayName("상세정보_미입력_회원은_needsOnboarding이_true다")
+        void 미입력_회원은_true() {
+            // given - 소셜로그인 직후 상세정보 미입력 상태
+            Member pendingMember = MemberFixture.createOnboardingPendingMember("kakao_nick", 2002L);
+            ReflectionTestUtils.setField(pendingMember, "id", 2L);
+            given(memberRepository.findById(pendingMember.getId())).willReturn(Optional.of(pendingMember));
+
+            // when
+            OnboardingStatusResponseDTO response = memberQueryService.getOnboardingStatus(pendingMember.getId());
+
+            // then
+            assertThat(response.needsOnboarding()).isTrue();
+        }
+
+        @Test
+        @DisplayName("존재하지_않는_회원이면_예외가_발생한다")
+        void 회원이_없으면_예외() {
+            // given
+            given(memberRepository.findById(999L)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> memberQueryService.getOnboardingStatus(999L))
+                    .isInstanceOf(MemberException.class)
+                    .hasFieldOrPropertyWithValue("code", MemberErrorCode.MEMBER_NOT_FOUND);
+        }
+    }
 
     @Nested
     @DisplayName("getMyProfile")

--- a/src/test/java/umc/cockple/demo/support/fixture/MemberFixture.java
+++ b/src/test/java/umc/cockple/demo/support/fixture/MemberFixture.java
@@ -17,12 +17,16 @@ import java.time.LocalDateTime;
 
 public class MemberFixture {
 
+    // 온보딩이 완료된(=isProfileCompleted) 회원을 의미하도록 기본 birth를 채워둔다.
+    private static final LocalDate DEFAULT_BIRTH = LocalDate.of(2000, 1, 1);
+
     public static Member createMember(String nickname, Gender gender, Level level, Long socialId) {
         return Member.builder()
                 .memberName(nickname)
                 .nickname(nickname)
                 .gender(gender)
                 .level(level)
+                .birth(DEFAULT_BIRTH)
                 .isActive(MemberStatus.ACTIVE)
                 .socialId(socialId)
                 .build();
@@ -46,6 +50,7 @@ public class MemberFixture {
                 .nickname(nickname)
                 .gender(gender)
                 .level(level)
+                .birth(DEFAULT_BIRTH)
                 .isActive(MemberStatus.ACTIVE)
                 .socialId(socialId)
                 .build();
@@ -57,7 +62,20 @@ public class MemberFixture {
                 .nickname(nickname)
                 .gender(Gender.MALE)
                 .level(Level.C)
+                .birth(DEFAULT_BIRTH)
                 .isActive(MemberStatus.INACTIVE)
+                .socialId(socialId)
+                .build();
+    }
+
+    /**
+     * 소셜로그인 직후, 상세정보(이름/성별/생년월일/급수)를 아직 입력하지 않은 회원.
+     * isProfileCompleted() == false 인 온보딩 미완료 상태 검증용.
+     */
+    public static Member createOnboardingPendingMember(String nickname, Long socialId) {
+        return Member.builder()
+                .nickname(nickname)
+                .isActive(MemberStatus.ACTIVE)
                 .socialId(socialId)
                 .build();
     }


### PR DESCRIPTION
## ❤️ 기능 설명

### 문제사항

소셜 로그인으로 회원가입한 뒤 상세정보(이름·생년월일·성별·급수)를 미입력한 채 앱을 이탈한 사용자가, 재접속 시 정보가 비어 있는 상태로 홈 화면에 진입하는 문제

**원인**
온보딩 이동 판단을 isNewMember(= 회원 row가 방금 생성됐는가)로 하고 있었음. 이 값은 **"계정 생성 여부"**일 뿐 **"프로필 입력 완료 여부"**가 아니라, 두 개념이 뭉쳐 있었음
그 결과 "가입은 했지만 정보 미입력" 회원은 재진입 시 isNewMember=false → 홈으로 빠짐


### 해결방안
판정 기준을 isNewMember → 프로필 완성 여부로 전환. 별도 status 컬럼 대신 기존 필수 필드에서 파생시켜 single source of truth 유지

- Member.isProfileCompleted() 도메인 메서드 추가 — memberName/gender/birth/level 4개가 모두 채워졌는지로 판정. 재가입(rejoin → initField)으로 필드가 초기화되면 자동으로 미완료 상태로 복귀
- 로그인 직후 경로: 로그인 응답에 needsOnboarding 필드 추가
- 앱 재진입(저장된 토큰) 경로: 전용 경량 API GET /api/my/onboarding-status 추가. (getMyProfile은 메달·주소·운동수까지 완성 프로필을 전제로 무겁게 조립하므로 부팅 게이트용으로 분리)


### 결과
신규 가입 / 정보 미입력 후 이탈 / 재가입 세 경우 모두 온보딩으로 정상 유도
로그인 직후·앱 재진입 두 경로 모두 커버

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #616 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!


<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
