### PR TITLE
[chore/#620] 채팅 알림 응답에 webpush 추가

### DIFF
--- a/src/main/java/umc/cockple/demo/domain/notification/fcm/FcmService.java
+++ b/src/main/java/umc/cockple/demo/domain/notification/fcm/FcmService.java
@@ -4,6 +4,8 @@ import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.FirebaseMessagingException;
 import com.google.firebase.messaging.Message;
 import com.google.firebase.messaging.Notification;
+import com.google.firebase.messaging.WebpushConfig;
+import com.google.firebase.messaging.WebpushFcmOptions;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -70,6 +72,9 @@ public class FcmService {
                         .build())
                 .putData("chatRoomId", chatRoomId.toString())
                 .putData("chatRoomType", chatRoomType.name())
+                .setWebpushConfig(WebpushConfig.builder()
+                        .setFcmOptions(WebpushFcmOptions.withLink(buildChatLink(chatRoomType, chatRoomId)))
+                        .build())
                 .build();
 
         try {
@@ -79,5 +84,16 @@ public class FcmService {
         } catch (FirebaseMessagingException e) {
             log.error("채팅 FCM 전송 실패 - memberId: {}, error: {}", member.getId(), e.getMessage());
         }
+    }
+
+    /**
+     * 채팅 알림 클릭 시 이동할 경로(상대경로)를 생성한다.
+     * webpush.fcm_options.link 로 전달되어 FCM이 클릭 시 네이티브로 이동시킨다.
+     */
+    private String buildChatLink(ChatRoomType chatRoomType, Long chatRoomId) {
+        return switch (chatRoomType) {
+            case PARTY -> "/chat/group/" + chatRoomId;
+            case DIRECT -> "/chat/personal/" + chatRoomId;
+        };
     }
 }


### PR DESCRIPTION
## ❤️ 기능 설명
### 변경 배경
채팅 푸시 알림이 화면에는 정상적으로 표시되지만, 알림을 클릭했을 때 해당 채팅방으로 이동하지 않는 문제
웹 푸시에서 알림 클릭 시 자동 이동은 webpush.fcm_options.link가 설정되어 있을 때 FCM이 네이티브로 처리하기 때문에 해당 필드 추가

### 변경 지점
**FcmService.sendChatNotification**
- FCM 메시지 빌더에 WebpushConfig + WebpushFcmOptions.withLink(...)를 추가해 webpush.fcm_options.link를 설정
- chatRoomType을 프론트엔드 URL 체계로 변환하는 buildChatLink 헬퍼 메서드 추가
  - PARTY → /chat/group/{chatRoomId}
  - DIRECT → /chat/personal/{chatRoomId}
- 기존 data(chatRoomId, chatRoomType)는 서비스워커 폴백 및 메타데이터 용도로 유지


### 결과
전송되는 채팅 알림 페이로드에 webpush.fcm_options.link가 포함

  {
    "notification": { "title": "채팅방 이름", "body": "메시지 내용" },
    "data": { "chatRoomId": "123", "chatRoomType": "PARTY" },
   "webpush": { "fcm_options": { "link": "/chat/group/123" } }
  }
알림 표시(title/body) 동작은 기존과 동일
알림 클릭 시 FCM이 link를 기반으로 해당 채팅방으로 이동

<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #620 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [ ] 이슈넘버를 적었는가?
