### PR TITLE
[chore/#628] 쿼리 카운트 테스트 인프라 구축

### DIFF
--- a/src/test/java/umc/cockple/demo/support/QueryCountAssert.java
+++ b/src/test/java/umc/cockple/demo/support/QueryCountAssert.java
@@ -12,6 +12,10 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Hibernate의 prepared statement 카운터를 이용해 "이 호출은 SQL이 정확히 N번 나가야 한다"를 박제한다.
  * N+1이 발생하면 카운트가 늘어나 테스트가 실패하므로, N+1 회귀를 CI에서 자동으로 잡아낸다.
  *
+ * 1차 캐시를 비워 {@code action} 안의 조회가 실제 DB를 때리게 한다. (캐시 hit으로 인한 과소 집계 방지 → 운영의 콜드 캐시 상황에 맞춤)
+ *
+ * 측정 전 clear()로 영속성 컨텍스트가 비워지므로, 이 메서드 호출 이후 픽스처 엔티티는 detach 상태가 된다. 호출 뒤 지연 로딩 접근 시
+ * LazyInitializationException이 날 수 있으니, 필요한 값은 호출 전에 읽거나 재조회한다.
  */
 public final class QueryCountAssert {
 
@@ -23,8 +27,19 @@ public final class QueryCountAssert {
                 .unwrap(SessionFactory.class)
                 .getStatistics();
 
+        // 측정 전: 1차 캐시를 비워 action의 조회가 실제 DB를 때리도록 한다.
+        if (em.isJoinedToTransaction()) {
+            em.clear();
+        }
+
         statistics.clear();
         action.run();
+
+        // 측정 후: action이 유발한 쓰기 지연 SQL을 카운트 읽기 전에 강제로 내보낸다.
+        if (em.isJoinedToTransaction()) {
+            em.flush();
+        }
+
         long actual = statistics.getPrepareStatementCount();
 
         assertThat(actual)

--- a/src/test/java/umc/cockple/demo/support/QueryCountAssert.java
+++ b/src/test/java/umc/cockple/demo/support/QueryCountAssert.java
@@ -1,0 +1,42 @@
+package umc.cockple.demo.support;
+
+import jakarta.persistence.EntityManager;
+import org.hibernate.SessionFactory;
+import org.hibernate.stat.Statistics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 특정 동작이 실행하는 SQL 쿼리 수를 단언하는 테스트 헬퍼.
+ *
+ * <p>Hibernate {@link Statistics}의 prepared statement 카운터를 이용해
+ * "이 호출은 SQL이 정확히 N번 나가야 한다"를 박제한다. N+1이 발생하면
+ * 카운트가 늘어나 테스트가 실패하므로, N+1 회귀를 CI에서 자동으로 잡아낸다.
+ *
+ * <p>전제: 테스트 프로파일에 {@code hibernate.generate_statistics=true}가 켜져 있어야 한다
+ * (운영 프로파일에는 켜지 않는다).
+ *
+ * <p>측정 대상은 보통 자기 트랜잭션을 새로 여는 서비스 메서드 호출이다.
+ * 같은 트랜잭션 안에서 시드한 엔티티가 1차 캐시에 남아 카운트가 왜곡될 수 있는
+ * 경우에는 {@link #assertQueryCount(EntityManager, long, Runnable)} 호출 전에
+ * {@code em.flush(); em.clear();}로 영속성 컨텍스트를 비운다.
+ */
+public final class QueryCountAssert {
+
+    private QueryCountAssert() {
+    }
+
+    public static void assertQueryCount(EntityManager em, long expected, Runnable action) {
+        Statistics statistics = em.getEntityManagerFactory()
+                .unwrap(SessionFactory.class)
+                .getStatistics();
+
+        statistics.clear();
+        action.run();
+        long actual = statistics.getPrepareStatementCount();
+
+        assertThat(actual)
+                .as("실행된 SQL 쿼리 수가 기대치와 다릅니다 (N+1 가능성)")
+                .isEqualTo(expected);
+    }
+}

--- a/src/test/java/umc/cockple/demo/support/QueryCountAssert.java
+++ b/src/test/java/umc/cockple/demo/support/QueryCountAssert.java
@@ -9,17 +9,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * 특정 동작이 실행하는 SQL 쿼리 수를 단언하는 테스트 헬퍼.
  *
- * <p>Hibernate {@link Statistics}의 prepared statement 카운터를 이용해
- * "이 호출은 SQL이 정확히 N번 나가야 한다"를 박제한다. N+1이 발생하면
- * 카운트가 늘어나 테스트가 실패하므로, N+1 회귀를 CI에서 자동으로 잡아낸다.
+ * Hibernate의 prepared statement 카운터를 이용해 "이 호출은 SQL이 정확히 N번 나가야 한다"를 박제한다.
+ * N+1이 발생하면 카운트가 늘어나 테스트가 실패하므로, N+1 회귀를 CI에서 자동으로 잡아낸다.
  *
- * <p>전제: 테스트 프로파일에 {@code hibernate.generate_statistics=true}가 켜져 있어야 한다
- * (운영 프로파일에는 켜지 않는다).
- *
- * <p>측정 대상은 보통 자기 트랜잭션을 새로 여는 서비스 메서드 호출이다.
- * 같은 트랜잭션 안에서 시드한 엔티티가 1차 캐시에 남아 카운트가 왜곡될 수 있는
- * 경우에는 {@link #assertQueryCount(EntityManager, long, Runnable)} 호출 전에
- * {@code em.flush(); em.clear();}로 영속성 컨텍스트를 비운다.
  */
 public final class QueryCountAssert {
 

--- a/src/test/java/umc/cockple/demo/support/QueryCountAssertSmokeTest.java
+++ b/src/test/java/umc/cockple/demo/support/QueryCountAssertSmokeTest.java
@@ -15,7 +15,7 @@ import umc.cockple.demo.support.fixture.MemberFixture;
 import static umc.cockple.demo.support.QueryCountAssert.assertQueryCount;
 
 /**
- * {@link QueryCountAssert} 헬퍼가 SQL 쿼리 수를 올바르게 세는지 검증하는 스모크 테스트.
+ * 헬퍼가 SQL 쿼리 수를 올바르게 세는지 검증하는 스모크 테스트.
  * (인프라 자체의 동작 보증용 — 도메인별 N+1 테스트는 각 도메인 PR에서 추가)
  */
 @DisplayName("QueryCountAssert 인프라 스모크 테스트")

--- a/src/test/java/umc/cockple/demo/support/QueryCountAssertSmokeTest.java
+++ b/src/test/java/umc/cockple/demo/support/QueryCountAssertSmokeTest.java
@@ -1,0 +1,48 @@
+package umc.cockple.demo.support;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import umc.cockple.demo.domain.member.domain.Member;
+import umc.cockple.demo.domain.member.repository.MemberRepository;
+import umc.cockple.demo.global.enums.Gender;
+import umc.cockple.demo.global.enums.Level;
+import umc.cockple.demo.support.fixture.MemberFixture;
+
+import static umc.cockple.demo.support.QueryCountAssert.assertQueryCount;
+
+/**
+ * {@link QueryCountAssert} 헬퍼가 SQL 쿼리 수를 올바르게 세는지 검증하는 스모크 테스트.
+ * (인프라 자체의 동작 보증용 — 도메인별 N+1 테스트는 각 도메인 PR에서 추가)
+ */
+@DisplayName("QueryCountAssert 인프라 스모크 테스트")
+class QueryCountAssertSmokeTest extends IntegrationTestBase {
+
+    @Autowired
+    MemberRepository memberRepository;
+
+    @PersistenceContext
+    EntityManager em;
+
+    private Long savedMemberId;
+
+    @AfterEach
+    void tearDown() {
+        memberRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("회원 단건 조회(findById)는 정확히 1개의 SQL을 실행한다")
+    void findById_executesExactlyOneQuery() {
+        // given - 별도 트랜잭션에서 커밋 (이후 조회 시 1차 캐시에 남지 않음)
+        Member saved = memberRepository.save(
+                MemberFixture.createMember("스모크 유저", Gender.MALE, Level.A, 9001L));
+        savedMemberId = saved.getId();
+
+        // when & then - findById 한 번 = SELECT 한 번
+        assertQueryCount(em, 1, () -> memberRepository.findById(savedMemberId));
+    }
+}

--- a/src/test/resources/application-integrationtest.yml
+++ b/src/test/resources/application-integrationtest.yml
@@ -20,6 +20,7 @@ spring:
         dialect: org.hibernate.dialect.MySQL8Dialect
         show_sql: true
         format_sql: true
+        generate_statistics: true   # 쿼리 카운트 테스트(N+1 회귀 방지)용. 테스트 프로파일에만 적용
 
   cache:
     type: redis

--- a/src/test/resources/application-integrationtest.yml
+++ b/src/test/resources/application-integrationtest.yml
@@ -21,6 +21,7 @@ spring:
         show_sql: true
         format_sql: true
         generate_statistics: true   # 쿼리 카운트 테스트(N+1 회귀 방지)용. 테스트 프로파일에만 적용
+        default_batch_fetch_size: 1000   # 운영(application.yml)과 동일하게 정합 — 테스트가 운영의 배치 페치 동작을 반영
 
   cache:
     type: redis


### PR DESCRIPTION
## ❤️ 기능 설명
테스트코드에서 쿼리 수를 강제하여 N+1의 재발을 CI에서 잡을 수 있도록 테스트 인프라를 구축합니다. 

statics가 무거워서 테스트에서만 동작하도록 설정하였습니다. 

<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #628 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!


<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [ ] 이슈넘버를 적었는가?
