### PR TITLE
[refactor/#630] Bookmark 도메인 N+1 제거

### DIFF
--- a/src/main/java/umc/cockple/demo/domain/bookmark/converter/BookmarkConverter.java
+++ b/src/main/java/umc/cockple/demo/domain/bookmark/converter/BookmarkConverter.java
@@ -20,7 +20,8 @@ import java.util.List;
 public class BookmarkConverter {
 
     public GetAllExerciseBookmarksResponseDTO exerciseBookmarkToDTO(ExerciseBookmark bookmark,
-                                                                           boolean includeParty, boolean includeExercise) {
+                                                                           boolean includeParty, boolean includeExercise,
+                                                                           int nowMemberCnt) {
         Exercise exercise = bookmark.getExercise();
 
         return GetAllExerciseBookmarksResponseDTO.builder()
@@ -34,7 +35,7 @@ public class BookmarkConverter {
                 .startExerciseTime(exercise.getStartTime())
                 .endExerciseTime(exercise.getEndTime())
                 .maxMemberCnt(exercise.getMaxCapacity())
-                .nowMemberCnt(exercise.getNowCapacity())
+                .nowMemberCnt(nowMemberCnt)
                 .includeParty(includeParty)
                 .includeExercise(includeExercise)
                 .build();

--- a/src/main/java/umc/cockple/demo/domain/bookmark/repository/ExerciseBookmarkRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/bookmark/repository/ExerciseBookmarkRepository.java
@@ -18,14 +18,6 @@ public interface ExerciseBookmarkRepository extends JpaRepository<ExerciseBookma
 
     List<ExerciseBookmark> findAllByMember(Member member);
 
-    /**
-     * 찜한 운동 목록 조회 시 사용. 연관 엔티티를 한 번에 가져와 N+1을 제거한다.
-     * - toOne(exercise, party, exerciseAddr)은 fetch join으로 즉시 로딩
-     * - party의 역방향 @OneToOne(partyImg, chatRoom)은 LAZY여도 Hibernate가 party마다 즉시 조회하므로
-     *   (eager라 batch로도 안 묶임) 함께 fetch join해 N+1을 제거한다.
-     * - 컬렉션은 한 쿼리에 여러 bag을 fetch join할 수 없어(MultipleBagFetchException)
-     *   levels만 fetch join하고, 나머지(memberExercises, guests)는 배치로 로딩된다.
-     */
     @Query("""
             SELECT DISTINCT eb
             FROM ExerciseBookmark eb

--- a/src/main/java/umc/cockple/demo/domain/bookmark/repository/ExerciseBookmarkRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/bookmark/repository/ExerciseBookmarkRepository.java
@@ -18,6 +18,23 @@ public interface ExerciseBookmarkRepository extends JpaRepository<ExerciseBookma
 
     List<ExerciseBookmark> findAllByMember(Member member);
 
+    /**
+     * 찜한 운동 목록 조회 시 사용. 연관 엔티티를 한 번에 가져와 N+1을 제거한다.
+     * - toOne(exercise, party, exerciseAddr)은 fetch join으로 즉시 로딩
+     * - 컬렉션은 한 쿼리에 여러 bag을 fetch join할 수 없어(MultipleBagFetchException)
+     *   levels만 fetch join하고, 나머지(memberExercises, guests)는 배치로 로딩된다.
+     */
+    @Query("""
+            SELECT DISTINCT eb
+            FROM ExerciseBookmark eb
+            JOIN FETCH eb.exercise e
+            JOIN FETCH e.party p
+            LEFT JOIN FETCH e.exerciseAddr
+            LEFT JOIN FETCH p.levels
+            WHERE eb.member = :member
+            """)
+    List<ExerciseBookmark> findAllByMemberWithDetails(@Param("member") Member member);
+
 
     @Query("""
             SELECT eb.exercise.id FROM ExerciseBookmark eb

--- a/src/main/java/umc/cockple/demo/domain/bookmark/repository/ExerciseBookmarkRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/bookmark/repository/ExerciseBookmarkRepository.java
@@ -21,6 +21,8 @@ public interface ExerciseBookmarkRepository extends JpaRepository<ExerciseBookma
     /**
      * 찜한 운동 목록 조회 시 사용. 연관 엔티티를 한 번에 가져와 N+1을 제거한다.
      * - toOne(exercise, party, exerciseAddr)은 fetch join으로 즉시 로딩
+     * - party의 역방향 @OneToOne(partyImg, chatRoom)은 LAZY여도 Hibernate가 party마다 즉시 조회하므로
+     *   (eager라 batch로도 안 묶임) 함께 fetch join해 N+1을 제거한다.
      * - 컬렉션은 한 쿼리에 여러 bag을 fetch join할 수 없어(MultipleBagFetchException)
      *   levels만 fetch join하고, 나머지(memberExercises, guests)는 배치로 로딩된다.
      */
@@ -30,6 +32,8 @@ public interface ExerciseBookmarkRepository extends JpaRepository<ExerciseBookma
             JOIN FETCH eb.exercise e
             JOIN FETCH e.party p
             LEFT JOIN FETCH e.exerciseAddr
+            LEFT JOIN FETCH p.partyImg
+            LEFT JOIN FETCH p.chatRoom
             LEFT JOIN FETCH p.levels
             WHERE eb.member = :member
             """)

--- a/src/main/java/umc/cockple/demo/domain/bookmark/repository/PartyBookmarkRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/bookmark/repository/PartyBookmarkRepository.java
@@ -18,14 +18,6 @@ public interface PartyBookmarkRepository extends JpaRepository<PartyBookmark, Lo
 
     Optional<PartyBookmark> findByMemberAndParty(Member member, Party party);
 
-    /**
-     * 찜한 모임 목록 조회 시 사용. 연관 엔티티를 한 번에 가져와 N+1을 제거한다.
-     * - toOne(partyAddr, partyImg)은 fetch join으로 즉시 로딩
-     * - party의 역방향 @OneToOne(chatRoom)은 LAZY여도 Hibernate가 party마다 즉시 조회하므로
-     *   (eager라 batch로도 안 묶임) 함께 fetch join해 N+1을 제거한다.
-     * - 컬렉션은 한 쿼리에 여러 bag을 fetch join할 수 없어(MultipleBagFetchException)
-     *   exercises만 fetch join하고, levels는 배치로 로딩된다.
-     */
     @Query("""
         SELECT DISTINCT pb
         FROM PartyBookmark pb

--- a/src/main/java/umc/cockple/demo/domain/bookmark/repository/PartyBookmarkRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/bookmark/repository/PartyBookmarkRepository.java
@@ -21,6 +21,8 @@ public interface PartyBookmarkRepository extends JpaRepository<PartyBookmark, Lo
     /**
      * 찜한 모임 목록 조회 시 사용. 연관 엔티티를 한 번에 가져와 N+1을 제거한다.
      * - toOne(partyAddr, partyImg)은 fetch join으로 즉시 로딩
+     * - party의 역방향 @OneToOne(chatRoom)은 LAZY여도 Hibernate가 party마다 즉시 조회하므로
+     *   (eager라 batch로도 안 묶임) 함께 fetch join해 N+1을 제거한다.
      * - 컬렉션은 한 쿼리에 여러 bag을 fetch join할 수 없어(MultipleBagFetchException)
      *   exercises만 fetch join하고, levels는 배치로 로딩된다.
      */
@@ -30,6 +32,7 @@ public interface PartyBookmarkRepository extends JpaRepository<PartyBookmark, Lo
         JOIN FETCH pb.party p
         LEFT JOIN FETCH p.partyAddr
         LEFT JOIN FETCH p.partyImg
+        LEFT JOIN FETCH p.chatRoom
         LEFT JOIN FETCH p.exercises
         WHERE pb.member = :member
         """)

--- a/src/main/java/umc/cockple/demo/domain/bookmark/repository/PartyBookmarkRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/bookmark/repository/PartyBookmarkRepository.java
@@ -18,10 +18,18 @@ public interface PartyBookmarkRepository extends JpaRepository<PartyBookmark, Lo
 
     Optional<PartyBookmark> findByMemberAndParty(Member member, Party party);
 
+    /**
+     * 찜한 모임 목록 조회 시 사용. 연관 엔티티를 한 번에 가져와 N+1을 제거한다.
+     * - toOne(partyAddr, partyImg)은 fetch join으로 즉시 로딩
+     * - 컬렉션은 한 쿼리에 여러 bag을 fetch join할 수 없어(MultipleBagFetchException)
+     *   exercises만 fetch join하고, levels는 배치로 로딩된다.
+     */
     @Query("""
         SELECT DISTINCT pb
         FROM PartyBookmark pb
         JOIN FETCH pb.party p
+        LEFT JOIN FETCH p.partyAddr
+        LEFT JOIN FETCH p.partyImg
         LEFT JOIN FETCH p.exercises
         WHERE pb.member = :member
         """)

--- a/src/main/java/umc/cockple/demo/domain/bookmark/service/BookmarkQueryService.java
+++ b/src/main/java/umc/cockple/demo/domain/bookmark/service/BookmarkQueryService.java
@@ -30,9 +30,11 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 @Service
 @Transactional(readOnly = true)
@@ -65,8 +67,8 @@ public class BookmarkQueryService {
         List<Long> partyIds = bookmarks.stream().map(b -> b.getExercise().getParty().getId()).toList();
         List<Long> exerciseIds = bookmarks.stream().map(b -> b.getExercise().getId()).toList();
 
-        List<Long> myParties = memberPartyRepository.findAllPartyIdsByMemberAndPartyIds(memberId, partyIds);
-        List<Long> myExercises = memberExerciseRepository.findAllExerciseIdsByMemberAndExerciseIds(memberId, exerciseIds);
+        Set<Long> myParties = new HashSet<>(memberPartyRepository.findAllPartyIdsByMemberAndPartyIds(memberId, partyIds));
+        Set<Long> myExercises = new HashSet<>(memberExerciseRepository.findAllExerciseIdsByMemberAndExerciseIds(memberId, exerciseIds));
 
         // 현재 인원수 count 쿼리로 집계 (N+1 제거)
         Map<Long, Integer> nowCntByExerciseId = countNowMembers(exerciseIds);

--- a/src/main/java/umc/cockple/demo/domain/bookmark/service/BookmarkQueryService.java
+++ b/src/main/java/umc/cockple/demo/domain/bookmark/service/BookmarkQueryService.java
@@ -50,7 +50,7 @@ public class BookmarkQueryService {
         Member member = findByMemberId(memberId);
 
         // 찜한 운동 가져오기
-        List<ExerciseBookmark> bookmarks = exerciseBookmarkRepository.findAllByMember(member);
+        List<ExerciseBookmark> bookmarks = exerciseBookmarkRepository.findAllByMemberWithDetails(member);
 
         // orderType에 따른 정렬
         Comparator<ExerciseBookmark> comparator = Comparator.comparing(ExerciseBookmark::getCreatedAt);

--- a/src/main/java/umc/cockple/demo/domain/bookmark/service/BookmarkQueryService.java
+++ b/src/main/java/umc/cockple/demo/domain/bookmark/service/BookmarkQueryService.java
@@ -12,6 +12,7 @@ import umc.cockple.demo.domain.bookmark.dto.GetAllPartyBookmarkResponseDTO;
 import umc.cockple.demo.domain.bookmark.repository.ExerciseBookmarkRepository;
 import umc.cockple.demo.domain.bookmark.repository.PartyBookmarkRepository;
 import umc.cockple.demo.domain.exercise.domain.Exercise;
+import umc.cockple.demo.domain.exercise.repository.GuestRepository;
 import umc.cockple.demo.domain.file.service.FileService;
 import umc.cockple.demo.domain.member.domain.Member;
 import umc.cockple.demo.domain.member.exception.MemberErrorCode;
@@ -28,7 +29,9 @@ import umc.cockple.demo.domain.party.enums.PartyOrderType;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 @Service
@@ -41,6 +44,7 @@ public class BookmarkQueryService {
     private final PartyBookmarkRepository partyBookmarkRepository;
     private final MemberPartyRepository memberPartyRepository;
     private final MemberExerciseRepository memberExerciseRepository;
+    private final GuestRepository guestRepository;
     private final MemberRepository memberRepository;
     private final BookmarkConverter bookmarkConverter;
     private final FileService fileService;
@@ -64,14 +68,33 @@ public class BookmarkQueryService {
         List<Long> myParties = memberPartyRepository.findAllPartyIdsByMemberAndPartyIds(memberId, partyIds);
         List<Long> myExercises = memberExerciseRepository.findAllExerciseIdsByMemberAndExerciseIds(memberId, exerciseIds);
 
+        // 현재 인원수: 컬렉션 로딩(over-fetch) 대신 count 쿼리로 집계 (N+1 제거)
+        Map<Long, Integer> nowCntByExerciseId = countNowMembers(exerciseIds);
+
         // bookmark -> dto 변환
         return bookmarks.stream()
                 .map(bookmark -> {
+                    Long exerciseId = bookmark.getExercise().getId();
                     boolean includeParty = myParties.contains(bookmark.getExercise().getParty().getId());
-                    boolean includeExercise = myExercises.contains(bookmark.getExercise().getId());
-                    return bookmarkConverter.exerciseBookmarkToDTO(bookmark, includeParty, includeExercise);
+                    boolean includeExercise = myExercises.contains(exerciseId);
+                    int nowMemberCnt = nowCntByExerciseId.getOrDefault(exerciseId, 0);
+                    return bookmarkConverter.exerciseBookmarkToDTO(bookmark, includeParty, includeExercise, nowMemberCnt);
                 })
                 .toList();
+    }
+
+    /**
+     * 운동별 현재 인원수(참여 회원 + 게스트)를 count 쿼리 2번으로 집계한다.
+     */
+    private Map<Long, Integer> countNowMembers(List<Long> exerciseIds) {
+        Map<Long, Integer> result = new HashMap<>();
+        if (exerciseIds.isEmpty()) return result;
+
+        memberExerciseRepository.countByExerciseIds(exerciseIds)
+                .forEach(row -> result.merge((Long) row[0], ((Long) row[1]).intValue(), Integer::sum));
+        guestRepository.countByExerciseIds(exerciseIds)
+                .forEach(row -> result.merge((Long) row[0], ((Long) row[1]).intValue(), Integer::sum));
+        return result;
     }
 
 

--- a/src/main/java/umc/cockple/demo/domain/bookmark/service/BookmarkQueryService.java
+++ b/src/main/java/umc/cockple/demo/domain/bookmark/service/BookmarkQueryService.java
@@ -68,7 +68,7 @@ public class BookmarkQueryService {
         List<Long> myParties = memberPartyRepository.findAllPartyIdsByMemberAndPartyIds(memberId, partyIds);
         List<Long> myExercises = memberExerciseRepository.findAllExerciseIdsByMemberAndExerciseIds(memberId, exerciseIds);
 
-        // 현재 인원수: 컬렉션 로딩(over-fetch) 대신 count 쿼리로 집계 (N+1 제거)
+        // 현재 인원수 count 쿼리로 집계 (N+1 제거)
         Map<Long, Integer> nowCntByExerciseId = countNowMembers(exerciseIds);
 
         // bookmark -> dto 변환
@@ -84,7 +84,7 @@ public class BookmarkQueryService {
     }
 
     /**
-     * 운동별 현재 인원수(참여 회원 + 게스트)를 count 쿼리 2번으로 집계한다.
+     * 운동별 현재 인원수(참여 회원 + 게스트)를 count 쿼리 2번으로 집계
      */
     private Map<Long, Integer> countNowMembers(List<Long> exerciseIds) {
         Map<Long, Integer> result = new HashMap<>();

--- a/src/main/java/umc/cockple/demo/domain/exercise/repository/GuestRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/repository/GuestRepository.java
@@ -24,4 +24,16 @@ public interface GuestRepository extends JpaRepository<Guest, Long> {
             """)
     List<Guest> findByExerciseIdAndInviterId(@Param("exerciseId") Long exerciseId,
                                              @Param("inviterId") Long inviterId);
+
+    /**
+     * 운동별 게스트 수를 한 번에 집계한다. (over-fetch 대신 COUNT로 N+1 제거)
+     * 반환: [exerciseId, count]
+     */
+    @Query("""
+            SELECT g.exercise.id, COUNT(g)
+            FROM Guest g
+            WHERE g.exercise.id IN :exerciseIds
+            GROUP BY g.exercise.id
+            """)
+    List<Object[]> countByExerciseIds(@Param("exerciseIds") List<Long> exerciseIds);
 }

--- a/src/main/java/umc/cockple/demo/domain/exercise/repository/GuestRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/repository/GuestRepository.java
@@ -25,10 +25,7 @@ public interface GuestRepository extends JpaRepository<Guest, Long> {
     List<Guest> findByExerciseIdAndInviterId(@Param("exerciseId") Long exerciseId,
                                              @Param("inviterId") Long inviterId);
 
-    /**
-     * 운동별 게스트 수를 한 번에 집계한다. (over-fetch 대신 COUNT로 N+1 제거)
-     * 반환: [exerciseId, count]
-     */
+
     @Query("""
             SELECT g.exercise.id, COUNT(g)
             FROM Guest g

--- a/src/main/java/umc/cockple/demo/domain/member/repository/MemberExerciseRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/member/repository/MemberExerciseRepository.java
@@ -62,11 +62,7 @@ public interface MemberExerciseRepository extends JpaRepository<MemberExercise, 
             @Param("memberIds") List<Long> memberIds,
             @Param("partyId") Long partyId);
 
-    /**
-     * 운동별 참여 회원 수를 한 번에 집계한다.
-     * 컬렉션(memberExercises)을 로딩해 size()를 세는 over-fetch 대신 COUNT로 집계해 N+1을 제거한다.
-     * 반환: [exerciseId, count]
-     */
+
     @Query("""
             SELECT me.exercise.id, COUNT(me)
             FROM MemberExercise me

--- a/src/main/java/umc/cockple/demo/domain/member/repository/MemberExerciseRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/member/repository/MemberExerciseRepository.java
@@ -62,4 +62,17 @@ public interface MemberExerciseRepository extends JpaRepository<MemberExercise, 
             @Param("memberIds") List<Long> memberIds,
             @Param("partyId") Long partyId);
 
+    /**
+     * 운동별 참여 회원 수를 한 번에 집계한다.
+     * 컬렉션(memberExercises)을 로딩해 size()를 세는 over-fetch 대신 COUNT로 집계해 N+1을 제거한다.
+     * 반환: [exerciseId, count]
+     */
+    @Query("""
+            SELECT me.exercise.id, COUNT(me)
+            FROM MemberExercise me
+            WHERE me.exercise.id IN :exerciseIds
+            GROUP BY me.exercise.id
+            """)
+    List<Object[]> countByExerciseIds(@Param("exerciseIds") List<Long> exerciseIds);
+
 }

--- a/src/test/java/umc/cockple/demo/domain/bookmark/integration/BookmarkQueryCountTest.java
+++ b/src/test/java/umc/cockple/demo/domain/bookmark/integration/BookmarkQueryCountTest.java
@@ -34,28 +34,19 @@ import java.time.LocalDate;
 
 import static umc.cockple.demo.support.QueryCountAssert.assertQueryCount;
 
-/**
- * 찜 목록 조회의 N+1 회귀 방지 테스트.
- *
- * <p>같은 기대 쿼리 수를 서로 다른 찜 개수(N=2, N=8)에 대해 단언한다.
- * <ul>
- *   <li>두 N에서 쿼리 수가 같음 → 행 수에 비례하는 N+1이 없음(스케일 불변성)</li>
- *   <li>쿼리 수가 고정 상수 → fetch join 최적화가 유지됨. 누군가 fetch join을 제거하면
- *       (예: party의 역방향 @OneToOne partyImg/chatRoom) 쿼리 수가 늘어 테스트가 깨진다.</li>
- * </ul>
- */
+// 찜 목록 조회 N+1 회귀 방지 테스트
 @DisplayName("북마크 찜 목록 N+1 회귀 테스트")
 class BookmarkQueryCountTest extends IntegrationTestBase {
 
     /**
-     * 찜한 운동 목록 조회의 기대 쿼리 수.
+     * 찜한 운동 목록 조회의 기대 쿼리 수
      * 1) 회원 조회  2) 찜+운동+party+exerciseAddr+partyImg+chatRoom+levels fetch join
      * 3) 가입 모임 IN  4) 참여 운동 IN  5) 참여자 수 count  6) 게스트 수 count
      */
     private static final int EXERCISE_BOOKMARK_QUERY_COUNT = 6;
 
     /**
-     * 찜한 모임 목록 조회의 기대 쿼리 수.
+     * 찜한 모임 목록 조회의 기대 쿼리 수
      * 1) 회원 조회  2) 찜+party+partyAddr+partyImg+chatRoom+exercises fetch join  3) levels 배치 로딩
      */
     private static final int PARTY_BOOKMARK_QUERY_COUNT = 3;
@@ -112,7 +103,7 @@ class BookmarkQueryCountTest extends IntegrationTestBase {
                 bookmarkQueryService.getAllPartyBookmarks(large.getId(), PartyOrderType.LATEST));
     }
 
-    // === 시딩 (BookmarkIntegrationTest 패턴 미러링) ===
+    // === 시딩 ===
 
     private Member createMember(long socialId) {
         return memberRepository.save(

--- a/src/test/java/umc/cockple/demo/domain/bookmark/integration/BookmarkQueryCountTest.java
+++ b/src/test/java/umc/cockple/demo/domain/bookmark/integration/BookmarkQueryCountTest.java
@@ -1,0 +1,145 @@
+package umc.cockple.demo.domain.bookmark.integration;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import umc.cockple.demo.domain.bookmark.domain.ExerciseBookmark;
+import umc.cockple.demo.domain.bookmark.domain.PartyBookmark;
+import umc.cockple.demo.domain.bookmark.enums.BookmarkedExerciseOrderType;
+import umc.cockple.demo.domain.bookmark.repository.ExerciseBookmarkRepository;
+import umc.cockple.demo.domain.bookmark.repository.PartyBookmarkRepository;
+import umc.cockple.demo.domain.bookmark.service.BookmarkQueryService;
+import umc.cockple.demo.domain.exercise.repository.ExerciseRepository;
+import umc.cockple.demo.domain.member.domain.Member;
+import umc.cockple.demo.domain.member.repository.MemberExerciseRepository;
+import umc.cockple.demo.domain.member.repository.MemberPartyRepository;
+import umc.cockple.demo.domain.member.repository.MemberRepository;
+import umc.cockple.demo.domain.party.domain.Party;
+import umc.cockple.demo.domain.party.domain.PartyAddr;
+import umc.cockple.demo.domain.party.enums.PartyOrderType;
+import umc.cockple.demo.domain.party.repository.PartyAddrRepository;
+import umc.cockple.demo.domain.party.repository.PartyRepository;
+import umc.cockple.demo.global.enums.Gender;
+import umc.cockple.demo.global.enums.Level;
+import umc.cockple.demo.global.enums.Role;
+import umc.cockple.demo.support.IntegrationTestBase;
+import umc.cockple.demo.support.fixture.ExerciseFixture;
+import umc.cockple.demo.support.fixture.MemberFixture;
+import umc.cockple.demo.support.fixture.PartyFixture;
+
+import java.time.LocalDate;
+
+import static umc.cockple.demo.support.QueryCountAssert.assertQueryCount;
+
+/**
+ * 찜 목록 조회의 N+1 회귀 방지 테스트.
+ *
+ * <p>같은 기대 쿼리 수를 서로 다른 찜 개수(N=2, N=8)에 대해 단언한다.
+ * <ul>
+ *   <li>두 N에서 쿼리 수가 같음 → 행 수에 비례하는 N+1이 없음(스케일 불변성)</li>
+ *   <li>쿼리 수가 고정 상수 → fetch join 최적화가 유지됨. 누군가 fetch join을 제거하면
+ *       (예: party의 역방향 @OneToOne partyImg/chatRoom) 쿼리 수가 늘어 테스트가 깨진다.</li>
+ * </ul>
+ */
+@DisplayName("북마크 찜 목록 N+1 회귀 테스트")
+class BookmarkQueryCountTest extends IntegrationTestBase {
+
+    /**
+     * 찜한 운동 목록 조회의 기대 쿼리 수.
+     * 1) 회원 조회  2) 찜+운동+party+exerciseAddr+partyImg+chatRoom+levels fetch join
+     * 3) 가입 모임 IN  4) 참여 운동 IN  5) 참여자 수 count  6) 게스트 수 count
+     */
+    private static final int EXERCISE_BOOKMARK_QUERY_COUNT = 6;
+
+    /**
+     * 찜한 모임 목록 조회의 기대 쿼리 수.
+     * 1) 회원 조회  2) 찜+party+partyAddr+partyImg+chatRoom+exercises fetch join  3) levels 배치 로딩
+     */
+    private static final int PARTY_BOOKMARK_QUERY_COUNT = 3;
+
+    @Autowired BookmarkQueryService bookmarkQueryService;
+    @Autowired MemberRepository memberRepository;
+    @Autowired PartyRepository partyRepository;
+    @Autowired PartyAddrRepository partyAddrRepository;
+    @Autowired ExerciseRepository exerciseRepository;
+    @Autowired ExerciseBookmarkRepository exerciseBookmarkRepository;
+    @Autowired PartyBookmarkRepository partyBookmarkRepository;
+    @Autowired MemberPartyRepository memberPartyRepository;
+    @Autowired MemberExerciseRepository memberExerciseRepository;
+
+    @PersistenceContext EntityManager em;
+
+    @AfterEach
+    void tearDown() {
+        exerciseBookmarkRepository.deleteAll();
+        partyBookmarkRepository.deleteAll();
+        memberExerciseRepository.deleteAll();
+        exerciseRepository.deleteAll();
+        memberPartyRepository.deleteAll();
+        partyRepository.deleteAll();
+        partyAddrRepository.deleteAll();
+        memberRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("찜한 운동 목록 - 찜 개수와 무관하게 고정된 쿼리 수만 실행한다")
+    void getAllExerciseBookmarks_hasNoNPlusOne() {
+        Member small = createMember(7001L);
+        Member large = createMember(7002L);
+        for (int i = 0; i < 2; i++) seedExerciseBookmark(small, i);
+        for (int i = 0; i < 8; i++) seedExerciseBookmark(large, i);
+
+        assertQueryCount(em, EXERCISE_BOOKMARK_QUERY_COUNT, () ->
+                bookmarkQueryService.getAllExerciseBookmarks(small.getId(), BookmarkedExerciseOrderType.LATEST));
+        assertQueryCount(em, EXERCISE_BOOKMARK_QUERY_COUNT, () ->
+                bookmarkQueryService.getAllExerciseBookmarks(large.getId(), BookmarkedExerciseOrderType.LATEST));
+    }
+
+    @Test
+    @DisplayName("찜한 모임 목록 - 찜 개수와 무관하게 고정된 쿼리 수만 실행한다")
+    void getAllPartyBookmarks_hasNoNPlusOne() {
+        Member small = createMember(7003L);
+        Member large = createMember(7004L);
+        for (int i = 0; i < 2; i++) seedPartyBookmark(small, i);
+        for (int i = 0; i < 8; i++) seedPartyBookmark(large, i);
+
+        assertQueryCount(em, PARTY_BOOKMARK_QUERY_COUNT, () ->
+                bookmarkQueryService.getAllPartyBookmarks(small.getId(), PartyOrderType.LATEST));
+        assertQueryCount(em, PARTY_BOOKMARK_QUERY_COUNT, () ->
+                bookmarkQueryService.getAllPartyBookmarks(large.getId(), PartyOrderType.LATEST));
+    }
+
+    // === 시딩 (BookmarkIntegrationTest 패턴 미러링) ===
+
+    private Member createMember(long socialId) {
+        return memberRepository.save(
+                MemberFixture.createMember("회원" + socialId, Gender.MALE, Level.A, socialId));
+    }
+
+    private void seedExerciseBookmark(Member member, int idx) {
+        Party party = newParty(member, "운동모임" + member.getId() + "_" + idx);
+        memberPartyRepository.save(MemberFixture.createMemberParty(party, member, Role.PARTY_MANAGER));
+        var exercise = exerciseRepository.save(
+                ExerciseFixture.createExerciseWithAddr(party, LocalDate.now().plusDays(idx + 1)));
+        memberExerciseRepository.save(MemberFixture.createMemberExercise(member, exercise));
+        exerciseBookmarkRepository.save(ExerciseBookmark.builder()
+                .member(member).exercise(exercise).build());
+    }
+
+    private void seedPartyBookmark(Member member, int idx) {
+        Party party = newParty(member, "찜모임" + member.getId() + "_" + idx);
+        exerciseRepository.save(
+                ExerciseFixture.createExerciseWithAddr(party, LocalDate.now().plusDays(idx + 1)));
+        partyBookmarkRepository.save(PartyBookmark.builder()
+                .party(party).member(member).orderType(PartyOrderType.LATEST).build());
+    }
+
+    private Party newParty(Member member, String name) {
+        // PartyAddr는 (addr1, addr2) UNIQUE 제약이 있어 addr2를 유니크한 name으로 만든다.
+        PartyAddr addr = partyAddrRepository.save(PartyFixture.createPartyAddr("경기도", name));
+        return partyRepository.save(PartyFixture.createParty(name, member.getId(), addr));
+    }
+}

--- a/src/test/java/umc/cockple/demo/domain/bookmark/service/BookmarkQueryServiceTest.java
+++ b/src/test/java/umc/cockple/demo/domain/bookmark/service/BookmarkQueryServiceTest.java
@@ -18,6 +18,7 @@ import umc.cockple.demo.domain.bookmark.enums.BookmarkedExerciseOrderType;
 import umc.cockple.demo.domain.bookmark.repository.ExerciseBookmarkRepository;
 import umc.cockple.demo.domain.bookmark.repository.PartyBookmarkRepository;
 import umc.cockple.demo.domain.exercise.domain.Exercise;
+import umc.cockple.demo.domain.exercise.repository.GuestRepository;
 import umc.cockple.demo.domain.file.service.FileService;
 import umc.cockple.demo.domain.member.domain.Member;
 import umc.cockple.demo.domain.member.exception.MemberErrorCode;
@@ -44,6 +45,7 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
@@ -62,6 +64,7 @@ class BookmarkQueryServiceTest {
     @Mock private PartyBookmarkRepository partyBookmarkRepository;
     @Mock private MemberPartyRepository memberPartyRepository;
     @Mock private MemberExerciseRepository memberExerciseRepository;
+    @Mock private GuestRepository guestRepository;
     @Mock private MemberRepository memberRepository;
     @Mock private BookmarkConverter bookmarkConverter;
 
@@ -103,7 +106,7 @@ class BookmarkQueryServiceTest {
             void noBookmarks_returnsEmptyList() {
                 // given
                 given(memberRepository.findById(member.getId())).willReturn(Optional.of(member));
-                given(exerciseBookmarkRepository.findAllByMember(member)).willReturn(new ArrayList<>());
+                given(exerciseBookmarkRepository.findAllByMemberWithDetails(member)).willReturn(new ArrayList<>());
                 given(memberPartyRepository.findAllPartyIdsByMemberAndPartyIds(anyLong(), anyList()))
                         .willReturn(new ArrayList<>());
                 given(memberExerciseRepository.findAllExerciseIdsByMemberAndExerciseIds(anyLong(), anyList()))
@@ -138,14 +141,14 @@ class BookmarkQueryServiceTest {
                         .exerciseId(102L).partyName("테스트 모임").build();
 
                 given(memberRepository.findById(member.getId())).willReturn(Optional.of(member));
-                given(exerciseBookmarkRepository.findAllByMember(member)).willReturn(bookmarks);
+                given(exerciseBookmarkRepository.findAllByMemberWithDetails(member)).willReturn(bookmarks);
                 given(memberPartyRepository.findAllPartyIdsByMemberAndPartyIds(anyLong(), anyList()))
                         .willReturn(List.of(party.getId()));
                 given(memberExerciseRepository.findAllExerciseIdsByMemberAndExerciseIds(anyLong(), anyList()))
                         .willReturn(List.of(oldExercise.getId(), newExercise.getId()));
-                given(bookmarkConverter.exerciseBookmarkToDTO(eq(bookmarkNew), any(Boolean.class), any(Boolean.class)))
+                given(bookmarkConverter.exerciseBookmarkToDTO(eq(bookmarkNew), any(Boolean.class), any(Boolean.class), anyInt()))
                         .willReturn(dtoNew);
-                given(bookmarkConverter.exerciseBookmarkToDTO(eq(bookmarkOld), any(Boolean.class), any(Boolean.class)))
+                given(bookmarkConverter.exerciseBookmarkToDTO(eq(bookmarkOld), any(Boolean.class), any(Boolean.class), anyInt()))
                         .willReturn(dtoOld);
 
                 // when
@@ -179,14 +182,14 @@ class BookmarkQueryServiceTest {
                         .exerciseId(102L).partyName("테스트 모임").build();
 
                 given(memberRepository.findById(member.getId())).willReturn(Optional.of(member));
-                given(exerciseBookmarkRepository.findAllByMember(member)).willReturn(bookmarks);
+                given(exerciseBookmarkRepository.findAllByMemberWithDetails(member)).willReturn(bookmarks);
                 given(memberPartyRepository.findAllPartyIdsByMemberAndPartyIds(anyLong(), anyList()))
                         .willReturn(List.of(party.getId()));
                 given(memberExerciseRepository.findAllExerciseIdsByMemberAndExerciseIds(anyLong(), anyList()))
                         .willReturn(List.of(oldExercise.getId(), newExercise.getId()));
-                given(bookmarkConverter.exerciseBookmarkToDTO(eq(bookmarkOld), any(Boolean.class), any(Boolean.class)))
+                given(bookmarkConverter.exerciseBookmarkToDTO(eq(bookmarkOld), any(Boolean.class), any(Boolean.class), anyInt()))
                         .willReturn(dtoOld);
-                given(bookmarkConverter.exerciseBookmarkToDTO(eq(bookmarkNew), any(Boolean.class), any(Boolean.class)))
+                given(bookmarkConverter.exerciseBookmarkToDTO(eq(bookmarkNew), any(Boolean.class), any(Boolean.class), anyInt()))
                         .willReturn(dtoNew);
 
                 // when
@@ -214,12 +217,12 @@ class BookmarkQueryServiceTest {
                         .exerciseId(101L).includeParty(true).includeExercise(false).build();
 
                 given(memberRepository.findById(member.getId())).willReturn(Optional.of(member));
-                given(exerciseBookmarkRepository.findAllByMember(member)).willReturn(new ArrayList<>(List.of(bookmark)));
+                given(exerciseBookmarkRepository.findAllByMemberWithDetails(member)).willReturn(new ArrayList<>(List.of(bookmark)));
                 given(memberPartyRepository.findAllPartyIdsByMemberAndPartyIds(eq(member.getId()), anyList()))
                         .willReturn(List.of(party.getId())); // 모임 멤버
                 given(memberExerciseRepository.findAllExerciseIdsByMemberAndExerciseIds(eq(member.getId()), anyList()))
                         .willReturn(new ArrayList<>()); // 운동 미참여
-                given(bookmarkConverter.exerciseBookmarkToDTO(bookmark, true, false)).willReturn(dto);
+                given(bookmarkConverter.exerciseBookmarkToDTO(eq(bookmark), eq(true), eq(false), anyInt())).willReturn(dto);
 
                 // when
                 List<GetAllExerciseBookmarksResponseDTO> result =


### PR DESCRIPTION
## ❤️ 기능 설명
찜 목록 조회(찜한 운동 / 찜한 모임)의 N+1 쿼리를 제거하고, 회귀를 막는 쿼리 카운트 테스트를 추가했습니다.

### 개선방법
1. 현재 인원수 집계를 count 쿼리로 바꿔서 over-fetch 제거
  - MemberExerciseRepository.countByExerciseIds, GuestRepository.countByExerciseIds 추가 (운동별 GROUP BY count)
  - BookmarkQueryService에서 운동 id들로 한 번에 집계 후 주입, BookmarkConverter는 nowMemberCnt를 파라미터로 받음
  - 참여자 엔티티를 메모리에 올리지 않고 숫자만 조회

2. 역방향 OneToOne fetch join으로 N+1 해결
  - 찜한 운동 쿼리: partyImg, chatRoom fetch join 추가
  - 찜한 모임 쿼리: chatRoom fetch join 추가 (partyImg는 기존 포함)
  - toOne만 추가해 MultipleBagFetchException 회피 (컬렉션은 기존대로 1개만 fetch + batch)

3. 회귀 방지 테스트 추가
  - BookmarkQueryCountTest: 찜 개수(N=2, N=8)가 달라도 쿼리 수가 고정 상수임을 단언 → N+1 재발 시 즉시 실패
  - 단위 테스트(BookmarkQueryServiceTest)는 변경된 시그니처에 맞춰 갱신


<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #630 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!


<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [ ] 이슈넘버를 적었는가?
