### PR TITLE
[refactor/#638] 운동 참여 인원 수 조회 로직 공통화

### DIFF
--- a/src/main/java/umc/cockple/demo/domain/bookmark/service/BookmarkQueryService.java
+++ b/src/main/java/umc/cockple/demo/domain/bookmark/service/BookmarkQueryService.java
@@ -12,7 +12,7 @@ import umc.cockple.demo.domain.bookmark.dto.GetAllPartyBookmarkResponseDTO;
 import umc.cockple.demo.domain.bookmark.repository.ExerciseBookmarkRepository;
 import umc.cockple.demo.domain.bookmark.repository.PartyBookmarkRepository;
 import umc.cockple.demo.domain.exercise.domain.Exercise;
-import umc.cockple.demo.domain.exercise.repository.GuestRepository;
+import umc.cockple.demo.domain.exercise.service.query.lookup.ExerciseParticipantCountLookupService;
 import umc.cockple.demo.domain.file.service.FileService;
 import umc.cockple.demo.domain.member.domain.Member;
 import umc.cockple.demo.domain.member.exception.MemberErrorCode;
@@ -29,7 +29,6 @@ import umc.cockple.demo.domain.party.enums.PartyOrderType;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -46,7 +45,7 @@ public class BookmarkQueryService {
     private final PartyBookmarkRepository partyBookmarkRepository;
     private final MemberPartyRepository memberPartyRepository;
     private final MemberExerciseRepository memberExerciseRepository;
-    private final GuestRepository guestRepository;
+    private final ExerciseParticipantCountLookupService exerciseParticipantCountLookupService;
     private final MemberRepository memberRepository;
     private final BookmarkConverter bookmarkConverter;
     private final FileService fileService;
@@ -70,8 +69,9 @@ public class BookmarkQueryService {
         Set<Long> myParties = new HashSet<>(memberPartyRepository.findAllPartyIdsByMemberAndPartyIds(memberId, partyIds));
         Set<Long> myExercises = new HashSet<>(memberExerciseRepository.findAllExerciseIdsByMemberAndExerciseIds(memberId, exerciseIds));
 
-        // 현재 인원수 count 쿼리로 집계 (N+1 제거)
-        Map<Long, Integer> nowCntByExerciseId = countNowMembers(exerciseIds);
+        // exercise 도메인의 공통 참여 인원수 조회 로직 사용 (N+1 제거)
+        Map<Long, Integer> nowCntByExerciseId = exerciseParticipantCountLookupService
+                .getParticipantCountsByExerciseIds(exerciseIds);
 
         // bookmark -> dto 변환
         return bookmarks.stream()
@@ -84,21 +84,6 @@ public class BookmarkQueryService {
                 })
                 .toList();
     }
-
-    /**
-     * 운동별 현재 인원수(참여 회원 + 게스트)를 count 쿼리 2번으로 집계
-     */
-    private Map<Long, Integer> countNowMembers(List<Long> exerciseIds) {
-        Map<Long, Integer> result = new HashMap<>();
-        if (exerciseIds.isEmpty()) return result;
-
-        memberExerciseRepository.countByExerciseIds(exerciseIds)
-                .forEach(row -> result.merge((Long) row[0], ((Long) row[1]).intValue(), Integer::sum));
-        guestRepository.countByExerciseIds(exerciseIds)
-                .forEach(row -> result.merge((Long) row[0], ((Long) row[1]).intValue(), Integer::sum));
-        return result;
-    }
-
 
     public List<GetAllPartyBookmarkResponseDTO> getAllPartyBookmarks(Long memberId, PartyOrderType orderType) {
         // 회원 조회하기

--- a/src/main/java/umc/cockple/demo/domain/bookmark/service/query/lookup/ExerciseBookmarkLookupService.java
+++ b/src/main/java/umc/cockple/demo/domain/bookmark/service/query/lookup/ExerciseBookmarkLookupService.java
@@ -1,4 +1,4 @@
-package umc.cockple.demo.domain.exercise.service.support.reader;
+package umc.cockple.demo.domain.bookmark.service.query.lookup;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -15,7 +15,7 @@ import java.util.stream.Collectors;
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
-public class ExerciseBookmarkReader {
+public class ExerciseBookmarkLookupService {
 
     private final ExerciseBookmarkRepository exerciseBookmarkRepository;
 

--- a/src/main/java/umc/cockple/demo/domain/exercise/repository/GuestRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/repository/GuestRepository.java
@@ -24,13 +24,4 @@ public interface GuestRepository extends JpaRepository<Guest, Long> {
             """)
     List<Guest> findByExerciseIdAndInviterId(@Param("exerciseId") Long exerciseId,
                                              @Param("inviterId") Long inviterId);
-
-
-    @Query("""
-            SELECT g.exercise.id, COUNT(g)
-            FROM Guest g
-            WHERE g.exercise.id IN :exerciseIds
-            GROUP BY g.exercise.id
-            """)
-    List<Object[]> countByExerciseIds(@Param("exerciseIds") List<Long> exerciseIds);
 }

--- a/src/main/java/umc/cockple/demo/domain/exercise/service/query/ExerciseMapQueryService.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/service/query/ExerciseMapQueryService.java
@@ -8,7 +8,7 @@ import umc.cockple.demo.domain.exercise.converter.ExerciseConverter;
 import umc.cockple.demo.domain.exercise.domain.Exercise;
 import umc.cockple.demo.domain.exercise.dto.ExerciseBuildingDetailDTO;
 import umc.cockple.demo.domain.exercise.dto.ExerciseMapBuildingsDTO;
-import umc.cockple.demo.domain.exercise.service.support.reader.ExerciseBookmarkReader;
+import umc.cockple.demo.domain.bookmark.service.query.lookup.ExerciseBookmarkLookupService;
 import umc.cockple.demo.domain.exercise.service.support.reader.ExerciseReader;
 import umc.cockple.demo.domain.member.domain.Member;
 import umc.cockple.demo.domain.member.domain.MemberAddr;
@@ -28,7 +28,7 @@ import java.util.stream.Collectors;
 public class ExerciseMapQueryService {
 
     private final ExerciseReader exerciseReader;
-    private final ExerciseBookmarkReader exerciseBookmarkReader;
+    private final ExerciseBookmarkLookupService exerciseBookmarkLookupService;
     private final MemberLookupService memberLookupService;
     private final ExerciseConverter exerciseConverter;
 
@@ -45,7 +45,7 @@ public class ExerciseMapQueryService {
         }
 
         List<Long> exerciseIds = getExerciseIds(exercises);
-        Map<Long, Boolean> bookmarkStatus = exerciseBookmarkReader.getBookmarkStatus(memberId, exerciseIds);
+        Map<Long, Boolean> bookmarkStatus = exerciseBookmarkLookupService.getBookmarkStatus(memberId, exerciseIds);
 
         log.info("건물 운동 상세 조회 종료 - 건물: {}, 주소: {}, 날짜: {}, 결과: {}", buildingName, streetAddr, date, exerciseIds.size());
 

--- a/src/main/java/umc/cockple/demo/domain/exercise/service/query/ExerciseMyQueryService.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/service/query/ExerciseMyQueryService.java
@@ -20,7 +20,7 @@ import umc.cockple.demo.domain.exercise.enums.MyPartyExerciseOrderType;
 import umc.cockple.demo.domain.exercise.exception.ExerciseErrorCode;
 import umc.cockple.demo.domain.exercise.exception.ExerciseException;
 import umc.cockple.demo.domain.exercise.service.query.lookup.ExerciseParticipantCountLookupService;
-import umc.cockple.demo.domain.exercise.service.support.reader.ExerciseBookmarkReader;
+import umc.cockple.demo.domain.bookmark.service.query.lookup.ExerciseBookmarkLookupService;
 import umc.cockple.demo.domain.exercise.service.support.reader.ExerciseParticipantReader;
 import umc.cockple.demo.domain.exercise.service.support.reader.ExerciseReader;
 
@@ -38,7 +38,7 @@ public class ExerciseMyQueryService {
     private final ExerciseReader exerciseReader;
     private final ExerciseParticipantReader exerciseParticipantReader;
     private final ExerciseParticipantCountLookupService exerciseParticipantCountLookupService;
-    private final ExerciseBookmarkReader exerciseBookmarkReader;
+    private final ExerciseBookmarkLookupService exerciseBookmarkLookupService;
     private final ExerciseConverter exerciseConverter;
 
     public MyExerciseCalendarDTO.Response getMyExerciseCalendar(Long memberId, LocalDate startDate, LocalDate endDate) {
@@ -106,7 +106,7 @@ public class ExerciseMyQueryService {
         }
 
         List<Long> exerciseIds = getExerciseIds(exercises);
-        Map<Long, Boolean> bookmarkStatus = exerciseBookmarkReader.getBookmarkStatus(memberId, exerciseIds);
+        Map<Long, Boolean> bookmarkStatus = exerciseBookmarkLookupService.getBookmarkStatus(memberId, exerciseIds);
 
         Map<Long, Integer> participantCounts = exerciseParticipantCountLookupService.getParticipantCountsByExerciseIdsAndDateRange(
                 exerciseIds, dateRange.start(), dateRange.end());
@@ -137,7 +137,7 @@ public class ExerciseMyQueryService {
         List<Long> exerciseIds = exercises.stream().map(Exercise::getId).toList();
 
         Map<Long, Integer> participantCountMap = exerciseParticipantCountLookupService.getParticipantCountsByExerciseIds(exerciseIds);
-        Map<Long, Boolean> bookmarkStatus = exerciseBookmarkReader.getBookmarkStatus(memberId, exerciseIds);
+        Map<Long, Boolean> bookmarkStatus = exerciseBookmarkLookupService.getBookmarkStatus(memberId, exerciseIds);
         Map<Long, Boolean> isCompletedMap = getExerciseCompletionStatus(exercises);
 
         log.info("내 참여 운동 조회 완료 - memberId: {}, 조회된 운동 수: {}", memberId, exercises.size());

--- a/src/main/java/umc/cockple/demo/domain/exercise/service/query/ExerciseMyQueryService.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/service/query/ExerciseMyQueryService.java
@@ -19,6 +19,7 @@ import umc.cockple.demo.domain.exercise.enums.MyExerciseOrderType;
 import umc.cockple.demo.domain.exercise.enums.MyPartyExerciseOrderType;
 import umc.cockple.demo.domain.exercise.exception.ExerciseErrorCode;
 import umc.cockple.demo.domain.exercise.exception.ExerciseException;
+import umc.cockple.demo.domain.exercise.service.query.lookup.ExerciseParticipantCountLookupService;
 import umc.cockple.demo.domain.exercise.service.support.reader.ExerciseBookmarkReader;
 import umc.cockple.demo.domain.exercise.service.support.reader.ExerciseParticipantReader;
 import umc.cockple.demo.domain.exercise.service.support.reader.ExerciseReader;
@@ -36,6 +37,7 @@ public class ExerciseMyQueryService {
 
     private final ExerciseReader exerciseReader;
     private final ExerciseParticipantReader exerciseParticipantReader;
+    private final ExerciseParticipantCountLookupService exerciseParticipantCountLookupService;
     private final ExerciseBookmarkReader exerciseBookmarkReader;
     private final ExerciseConverter exerciseConverter;
 
@@ -106,7 +108,8 @@ public class ExerciseMyQueryService {
         List<Long> exerciseIds = getExerciseIds(exercises);
         Map<Long, Boolean> bookmarkStatus = exerciseBookmarkReader.getBookmarkStatus(memberId, exerciseIds);
 
-        Map<Long, Integer> participantCounts = exerciseParticipantReader.getParticipantCountsMap(exerciseIds, dateRange.start(), dateRange.end());
+        Map<Long, Integer> participantCounts = exerciseParticipantCountLookupService.getParticipantCountsByExerciseIdsAndDateRange(
+                exerciseIds, dateRange.start(), dateRange.end());
 
         log.info("내 운동 캘린더 조회 완료 - memberId: {}, 조회된 운동 수: {}", memberId, exercises.size());
 
@@ -133,7 +136,7 @@ public class ExerciseMyQueryService {
         List<Exercise> exercises = exerciseSlice.getContent();
         List<Long> exerciseIds = exercises.stream().map(Exercise::getId).toList();
 
-        Map<Long, Integer> participantCountMap = exerciseParticipantReader.getParticipantCountsMap(exerciseIds);
+        Map<Long, Integer> participantCountMap = exerciseParticipantCountLookupService.getParticipantCountsByExerciseIds(exerciseIds);
         Map<Long, Boolean> bookmarkStatus = exerciseBookmarkReader.getBookmarkStatus(memberId, exerciseIds);
         Map<Long, Boolean> isCompletedMap = getExerciseCompletionStatus(exercises);
 

--- a/src/main/java/umc/cockple/demo/domain/exercise/service/query/ExerciseRecommendationQueryService.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/service/query/ExerciseRecommendationQueryService.java
@@ -8,9 +8,9 @@ import umc.cockple.demo.domain.exercise.converter.ExerciseConverter;
 import umc.cockple.demo.domain.exercise.domain.Exercise;
 import umc.cockple.demo.domain.exercise.dto.ExerciseRecommendationCalendarDTO;
 import umc.cockple.demo.domain.exercise.dto.ExerciseRecommendationDTO;
+import umc.cockple.demo.domain.exercise.service.query.lookup.ExerciseParticipantCountLookupService;
 import umc.cockple.demo.domain.exercise.service.support.reader.ExerciseBookmarkReader;
 import umc.cockple.demo.domain.exercise.service.support.ExerciseDistanceCalculator;
-import umc.cockple.demo.domain.exercise.service.support.reader.ExerciseParticipantReader;
 import umc.cockple.demo.domain.exercise.service.support.reader.ExerciseReader;
 import umc.cockple.demo.domain.member.domain.Member;
 import umc.cockple.demo.domain.member.domain.MemberAddr;
@@ -29,7 +29,7 @@ public class ExerciseRecommendationQueryService {
 
     private final ExerciseReader exerciseReader;
     private final ExerciseBookmarkReader exerciseBookmarkReader;
-    private final ExerciseParticipantReader exerciseParticipantReader;
+    private final ExerciseParticipantCountLookupService exerciseParticipantCountLookupService;
     private final ExerciseDistanceCalculator exerciseDistanceCalculator;
     private final MemberLookupService memberLookupService;
     private final ExerciseConverter exerciseConverter;
@@ -78,7 +78,7 @@ public class ExerciseRecommendationQueryService {
 
         List<Long> exerciseIds = getExerciseIds(exercises);
         Map<Long, Boolean> bookmarkStatus = exerciseBookmarkReader.getBookmarkStatus(memberId, exerciseIds);
-        Map<Long, Integer> participantCountMap = exerciseParticipantReader.getParticipantCountsMap(exerciseIds);
+        Map<Long, Integer> participantCountMap = exerciseParticipantCountLookupService.getParticipantCountsByExerciseIds(exerciseIds);
         MemberAddr mainAddr = memberLookupService.findMainAddressOrThrow(member);
 
         log.info("사용자 추천 운동 캘린더 조회 완료 - memberId: {}, 결과 수: {}", memberId, exercises.size());

--- a/src/main/java/umc/cockple/demo/domain/exercise/service/query/ExerciseRecommendationQueryService.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/service/query/ExerciseRecommendationQueryService.java
@@ -9,7 +9,7 @@ import umc.cockple.demo.domain.exercise.domain.Exercise;
 import umc.cockple.demo.domain.exercise.dto.ExerciseRecommendationCalendarDTO;
 import umc.cockple.demo.domain.exercise.dto.ExerciseRecommendationDTO;
 import umc.cockple.demo.domain.exercise.service.query.lookup.ExerciseParticipantCountLookupService;
-import umc.cockple.demo.domain.exercise.service.support.reader.ExerciseBookmarkReader;
+import umc.cockple.demo.domain.bookmark.service.query.lookup.ExerciseBookmarkLookupService;
 import umc.cockple.demo.domain.exercise.service.support.ExerciseDistanceCalculator;
 import umc.cockple.demo.domain.exercise.service.support.reader.ExerciseReader;
 import umc.cockple.demo.domain.member.domain.Member;
@@ -28,7 +28,7 @@ import java.util.Map;
 public class ExerciseRecommendationQueryService {
 
     private final ExerciseReader exerciseReader;
-    private final ExerciseBookmarkReader exerciseBookmarkReader;
+    private final ExerciseBookmarkLookupService exerciseBookmarkLookupService;
     private final ExerciseParticipantCountLookupService exerciseParticipantCountLookupService;
     private final ExerciseDistanceCalculator exerciseDistanceCalculator;
     private final MemberLookupService memberLookupService;
@@ -48,7 +48,7 @@ public class ExerciseRecommendationQueryService {
         List<Exercise> finalExercises = extractExercises(finalExercisesWithDistance);
 
         List<Long> exerciseIds = getExerciseIds(finalExercises);
-        Map<Long, Boolean> bookmarkStatus = exerciseBookmarkReader.getBookmarkStatus(memberId, exerciseIds);
+        Map<Long, Boolean> bookmarkStatus = exerciseBookmarkLookupService.getBookmarkStatus(memberId, exerciseIds);
 
         log.info("운동 추천 조회 종료 - memberId: {}, 결과 : {}", memberId, exerciseIds.size());
 
@@ -77,7 +77,7 @@ public class ExerciseRecommendationQueryService {
         }
 
         List<Long> exerciseIds = getExerciseIds(exercises);
-        Map<Long, Boolean> bookmarkStatus = exerciseBookmarkReader.getBookmarkStatus(memberId, exerciseIds);
+        Map<Long, Boolean> bookmarkStatus = exerciseBookmarkLookupService.getBookmarkStatus(memberId, exerciseIds);
         Map<Long, Integer> participantCountMap = exerciseParticipantCountLookupService.getParticipantCountsByExerciseIds(exerciseIds);
         MemberAddr mainAddr = memberLookupService.findMainAddressOrThrow(member);
 

--- a/src/main/java/umc/cockple/demo/domain/exercise/service/query/PartyExerciseQueryService.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/service/query/PartyExerciseQueryService.java
@@ -10,7 +10,7 @@ import umc.cockple.demo.domain.exercise.dto.PartyExerciseCalendarDTO;
 import umc.cockple.demo.domain.exercise.exception.ExerciseErrorCode;
 import umc.cockple.demo.domain.exercise.exception.ExerciseException;
 import umc.cockple.demo.domain.exercise.service.query.lookup.ExerciseParticipantCountLookupService;
-import umc.cockple.demo.domain.exercise.service.support.reader.ExerciseBookmarkReader;
+import umc.cockple.demo.domain.bookmark.service.query.lookup.ExerciseBookmarkLookupService;
 import umc.cockple.demo.domain.exercise.service.support.reader.ExerciseParticipantReader;
 import umc.cockple.demo.domain.exercise.service.support.reader.ExerciseReader;
 import umc.cockple.demo.domain.member.domain.Member;
@@ -34,7 +34,7 @@ public class PartyExerciseQueryService {
     private final ExerciseReader exerciseReader;
     private final ExerciseParticipantReader exerciseParticipantReader;
     private final ExerciseParticipantCountLookupService exerciseParticipantCountLookupService;
-    private final ExerciseBookmarkReader exerciseBookmarkReader;
+    private final ExerciseBookmarkLookupService exerciseBookmarkLookupService;
     private final MemberLookupService memberLookupService;
     private final PartyLookupService partyLookupService;
     private final ExerciseConverter exerciseConverter;
@@ -66,7 +66,7 @@ public class PartyExerciseQueryService {
                 partyId, dateRange.start(), dateRange.end());
 
         List<Long> exerciseIds = getExerciseIds(exercises);
-        Map<Long, Boolean> bookmarkStatus = exerciseBookmarkReader.getBookmarkStatus(memberId, exerciseIds);
+        Map<Long, Boolean> bookmarkStatus = exerciseBookmarkLookupService.getBookmarkStatus(memberId, exerciseIds);
         Map<Long, Boolean> participatingStatus = exerciseParticipantReader.getParticipatingStatus(memberId, exerciseIds);
 
         log.info("모임 운동 캘린더 조회 완료 - partyId: {}, 조회된 운동 수: {}", partyId, exercises.size());

--- a/src/main/java/umc/cockple/demo/domain/exercise/service/query/PartyExerciseQueryService.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/service/query/PartyExerciseQueryService.java
@@ -9,6 +9,7 @@ import umc.cockple.demo.domain.exercise.domain.Exercise;
 import umc.cockple.demo.domain.exercise.dto.PartyExerciseCalendarDTO;
 import umc.cockple.demo.domain.exercise.exception.ExerciseErrorCode;
 import umc.cockple.demo.domain.exercise.exception.ExerciseException;
+import umc.cockple.demo.domain.exercise.service.query.lookup.ExerciseParticipantCountLookupService;
 import umc.cockple.demo.domain.exercise.service.support.reader.ExerciseBookmarkReader;
 import umc.cockple.demo.domain.exercise.service.support.reader.ExerciseParticipantReader;
 import umc.cockple.demo.domain.exercise.service.support.reader.ExerciseReader;
@@ -32,6 +33,7 @@ public class PartyExerciseQueryService {
 
     private final ExerciseReader exerciseReader;
     private final ExerciseParticipantReader exerciseParticipantReader;
+    private final ExerciseParticipantCountLookupService exerciseParticipantCountLookupService;
     private final ExerciseBookmarkReader exerciseBookmarkReader;
     private final MemberLookupService memberLookupService;
     private final PartyLookupService partyLookupService;
@@ -60,7 +62,7 @@ public class PartyExerciseQueryService {
                     dateRange.start(), dateRange.end(), isMember, party);
         }
 
-        Map<Long, Integer> participantCounts = exerciseParticipantReader.getParticipantCountsMap(
+        Map<Long, Integer> participantCounts = exerciseParticipantCountLookupService.getParticipantCountsByPartyIdAndDateRange(
                 partyId, dateRange.start(), dateRange.end());
 
         List<Long> exerciseIds = getExerciseIds(exercises);

--- a/src/main/java/umc/cockple/demo/domain/exercise/service/query/lookup/ExerciseParticipantCountLookupService.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/service/query/lookup/ExerciseParticipantCountLookupService.java
@@ -1,0 +1,58 @@
+package umc.cockple.demo.domain.exercise.service.query.lookup;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import umc.cockple.demo.domain.exercise.repository.ExerciseRepository;
+
+import java.time.LocalDate;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class ExerciseParticipantCountLookupService {
+
+    private final ExerciseRepository exerciseRepository;
+
+    public Map<Long, Integer> getParticipantCountsByPartyIdAndDateRange(
+            Long partyId,
+            LocalDate start,
+            LocalDate end) {
+        List<Object[]> countResults = exerciseRepository.findExerciseParticipantCounts(partyId, start, end);
+        return toCountMap(countResults);
+    }
+
+    public Map<Long, Integer> getParticipantCountsByExerciseIdsAndDateRange(
+            List<Long> exerciseIds,
+            LocalDate start,
+            LocalDate end) {
+        if (exerciseIds.isEmpty()) {
+            return Collections.emptyMap();
+        }
+
+        List<Object[]> countResults = exerciseRepository.findExerciseParticipantCountsByExerciseIds(
+                exerciseIds, start, end);
+        return toCountMap(countResults);
+    }
+
+    public Map<Long, Integer> getParticipantCountsByExerciseIds(List<Long> exerciseIds) {
+        if (exerciseIds.isEmpty()) {
+            return Collections.emptyMap();
+        }
+
+        List<Object[]> countResults = exerciseRepository.findExerciseParticipantCountsByExerciseIds(exerciseIds);
+        return toCountMap(countResults);
+    }
+
+    private Map<Long, Integer> toCountMap(List<Object[]> countResults) {
+        return countResults.stream()
+                .collect(Collectors.toMap(
+                        row -> ((Number) row[0]).longValue(),
+                        row -> ((Number) row[1]).intValue()
+                ));
+    }
+}

--- a/src/main/java/umc/cockple/demo/domain/exercise/service/support/reader/ExerciseParticipantReader.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/service/support/reader/ExerciseParticipantReader.java
@@ -3,7 +3,6 @@ package umc.cockple.demo.domain.exercise.service.support.reader;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import umc.cockple.demo.domain.exercise.repository.ExerciseRepository;
 import umc.cockple.demo.domain.member.domain.Member;
 import umc.cockple.demo.domain.member.domain.MemberExercise;
 import umc.cockple.demo.domain.member.domain.MemberParty;
@@ -12,7 +11,6 @@ import umc.cockple.demo.domain.member.repository.MemberPartyRepository;
 import umc.cockple.demo.domain.party.domain.Party;
 import umc.cockple.demo.global.enums.Role;
 
-import java.time.LocalDate;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -25,7 +23,6 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class ExerciseParticipantReader {
 
-    private final ExerciseRepository exerciseRepository;
     private final MemberExerciseRepository memberExerciseRepository;
     private final MemberPartyRepository memberPartyRepository;
 
@@ -55,30 +52,6 @@ public class ExerciseParticipantReader {
                 ));
     }
 
-    public Map<Long, Integer> getParticipantCountsMap(Long partyId, LocalDate start, LocalDate end) {
-        List<Object[]> countResults = exerciseRepository.findExerciseParticipantCounts(partyId, start, end);
-        return toCountMap(countResults);
-    }
-
-    public Map<Long, Integer> getParticipantCountsMap(List<Long> exerciseIds, LocalDate start, LocalDate end) {
-        if (exerciseIds.isEmpty()) {
-            return Collections.emptyMap();
-        }
-
-        List<Object[]> countResults = exerciseRepository.findExerciseParticipantCountsByExerciseIds(
-                exerciseIds, start, end);
-        return toCountMap(countResults);
-    }
-
-    public Map<Long, Integer> getParticipantCountsMap(List<Long> exerciseIds) {
-        if (exerciseIds.isEmpty()) {
-            return Collections.emptyMap();
-        }
-
-        List<Object[]> countResults = exerciseRepository.findExerciseParticipantCountsByExerciseIds(exerciseIds);
-        return toCountMap(countResults);
-    }
-
     public Map<Long, Boolean> getParticipatingStatus(Long memberId, List<Long> exerciseIds) {
         if (exerciseIds.isEmpty()) {
             return Collections.emptyMap();
@@ -92,14 +65,6 @@ public class ExerciseParticipantReader {
                 .collect(Collectors.toMap(
                         exerciseId -> exerciseId,
                         participatingExerciseIdSet::contains
-                ));
-    }
-
-    private Map<Long, Integer> toCountMap(List<Object[]> countResults) {
-        return countResults.stream()
-                .collect(Collectors.toMap(
-                        row -> ((Number) row[0]).longValue(),
-                        row -> ((Number) row[1]).intValue()
                 ));
     }
 }

--- a/src/main/java/umc/cockple/demo/domain/member/repository/MemberExerciseRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/member/repository/MemberExerciseRepository.java
@@ -62,13 +62,4 @@ public interface MemberExerciseRepository extends JpaRepository<MemberExercise, 
             @Param("memberIds") List<Long> memberIds,
             @Param("partyId") Long partyId);
 
-
-    @Query("""
-            SELECT me.exercise.id, COUNT(me)
-            FROM MemberExercise me
-            WHERE me.exercise.id IN :exerciseIds
-            GROUP BY me.exercise.id
-            """)
-    List<Object[]> countByExerciseIds(@Param("exerciseIds") List<Long> exerciseIds);
-
 }

--- a/src/test/java/umc/cockple/demo/domain/bookmark/integration/BookmarkQueryCountTest.java
+++ b/src/test/java/umc/cockple/demo/domain/bookmark/integration/BookmarkQueryCountTest.java
@@ -41,9 +41,9 @@ class BookmarkQueryCountTest extends IntegrationTestBase {
     /**
      * 찜한 운동 목록 조회의 기대 쿼리 수
      * 1) 회원 조회  2) 찜+운동+party+exerciseAddr+partyImg+chatRoom+levels fetch join
-     * 3) 가입 모임 IN  4) 참여 운동 IN  5) 참여자 수 count  6) 게스트 수 count
+     * 3) 가입 모임 IN  4) 참여 운동 IN  5) 참여 인원 수 공통 count
      */
-    private static final int EXERCISE_BOOKMARK_QUERY_COUNT = 6;
+    private static final int EXERCISE_BOOKMARK_QUERY_COUNT = 5;
 
     /**
      * 찜한 모임 목록 조회의 기대 쿼리 수

--- a/src/test/java/umc/cockple/demo/domain/bookmark/service/BookmarkQueryServiceTest.java
+++ b/src/test/java/umc/cockple/demo/domain/bookmark/service/BookmarkQueryServiceTest.java
@@ -18,7 +18,7 @@ import umc.cockple.demo.domain.bookmark.enums.BookmarkedExerciseOrderType;
 import umc.cockple.demo.domain.bookmark.repository.ExerciseBookmarkRepository;
 import umc.cockple.demo.domain.bookmark.repository.PartyBookmarkRepository;
 import umc.cockple.demo.domain.exercise.domain.Exercise;
-import umc.cockple.demo.domain.exercise.repository.GuestRepository;
+import umc.cockple.demo.domain.exercise.service.query.lookup.ExerciseParticipantCountLookupService;
 import umc.cockple.demo.domain.file.service.FileService;
 import umc.cockple.demo.domain.member.domain.Member;
 import umc.cockple.demo.domain.member.exception.MemberErrorCode;
@@ -40,6 +40,7 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -64,7 +65,7 @@ class BookmarkQueryServiceTest {
     @Mock private PartyBookmarkRepository partyBookmarkRepository;
     @Mock private MemberPartyRepository memberPartyRepository;
     @Mock private MemberExerciseRepository memberExerciseRepository;
-    @Mock private GuestRepository guestRepository;
+    @Mock private ExerciseParticipantCountLookupService exerciseParticipantCountLookupService;
     @Mock private MemberRepository memberRepository;
     @Mock private BookmarkConverter bookmarkConverter;
 
@@ -146,6 +147,8 @@ class BookmarkQueryServiceTest {
                         .willReturn(List.of(party.getId()));
                 given(memberExerciseRepository.findAllExerciseIdsByMemberAndExerciseIds(anyLong(), anyList()))
                         .willReturn(List.of(oldExercise.getId(), newExercise.getId()));
+                given(exerciseParticipantCountLookupService.getParticipantCountsByExerciseIds(anyList()))
+                        .willReturn(Map.of(newExercise.getId(), 2, oldExercise.getId(), 1));
                 given(bookmarkConverter.exerciseBookmarkToDTO(eq(bookmarkNew), any(Boolean.class), any(Boolean.class), anyInt()))
                         .willReturn(dtoNew);
                 given(bookmarkConverter.exerciseBookmarkToDTO(eq(bookmarkOld), any(Boolean.class), any(Boolean.class), anyInt()))
@@ -187,6 +190,8 @@ class BookmarkQueryServiceTest {
                         .willReturn(List.of(party.getId()));
                 given(memberExerciseRepository.findAllExerciseIdsByMemberAndExerciseIds(anyLong(), anyList()))
                         .willReturn(List.of(oldExercise.getId(), newExercise.getId()));
+                given(exerciseParticipantCountLookupService.getParticipantCountsByExerciseIds(anyList()))
+                        .willReturn(Map.of(oldExercise.getId(), 1, newExercise.getId(), 2));
                 given(bookmarkConverter.exerciseBookmarkToDTO(eq(bookmarkOld), any(Boolean.class), any(Boolean.class), anyInt()))
                         .willReturn(dtoOld);
                 given(bookmarkConverter.exerciseBookmarkToDTO(eq(bookmarkNew), any(Boolean.class), any(Boolean.class), anyInt()))
@@ -222,7 +227,9 @@ class BookmarkQueryServiceTest {
                         .willReturn(List.of(party.getId())); // 모임 멤버
                 given(memberExerciseRepository.findAllExerciseIdsByMemberAndExerciseIds(eq(member.getId()), anyList()))
                         .willReturn(new ArrayList<>()); // 운동 미참여
-                given(bookmarkConverter.exerciseBookmarkToDTO(eq(bookmark), eq(true), eq(false), anyInt())).willReturn(dto);
+                given(exerciseParticipantCountLookupService.getParticipantCountsByExerciseIds(anyList()))
+                        .willReturn(Map.of(exercise.getId(), 3));
+                given(bookmarkConverter.exerciseBookmarkToDTO(eq(bookmark), eq(true), eq(false), eq(3))).willReturn(dto);
 
                 // when
                 List<GetAllExerciseBookmarksResponseDTO> result =

--- a/src/test/java/umc/cockple/demo/domain/bookmark/service/ExerciseBookmarkLookupServiceTest.java
+++ b/src/test/java/umc/cockple/demo/domain/bookmark/service/ExerciseBookmarkLookupServiceTest.java
@@ -1,0 +1,67 @@
+package umc.cockple.demo.domain.bookmark.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import umc.cockple.demo.domain.bookmark.repository.ExerciseBookmarkRepository;
+import umc.cockple.demo.domain.bookmark.service.query.lookup.ExerciseBookmarkLookupService;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ExerciseBookmarkLookupService")
+class ExerciseBookmarkLookupServiceTest {
+
+    @InjectMocks
+    private ExerciseBookmarkLookupService exerciseBookmarkLookupService;
+
+    @Mock
+    private ExerciseBookmarkRepository exerciseBookmarkRepository;
+
+    @Nested
+    @DisplayName("getBookmarkStatus - 운동 ID 목록 기준 북마크 여부 조회")
+    class GetBookmarkStatus {
+
+        @Test
+        @DisplayName("운동 ID 목록이 비어있으면 빈 Map을 반환하고 Repository를 호출하지 않는다")
+        void emptyExerciseIds_returnsEmptyMapWithoutRepositoryCall() {
+            // when
+            Map<Long, Boolean> result = exerciseBookmarkLookupService.getBookmarkStatus(1L, List.of());
+
+            // then
+            assertThat(result).isEmpty();
+            verifyNoInteractions(exerciseBookmarkRepository);
+        }
+
+        @Test
+        @DisplayName("요청한 운동 ID 전체에 대해 북마크 여부 Map을 반환한다")
+        void repositoryBookmarkIds_returnsBookmarkStatusMap() {
+            // given
+            Long memberId = 1L;
+            List<Long> exerciseIds = List.of(10L, 20L, 30L);
+            given(exerciseBookmarkRepository.findAllExerciseIdsByMemberIdAndExerciseIds(memberId, exerciseIds))
+                    .willReturn(List.of(10L, 30L));
+
+            // when
+            Map<Long, Boolean> result = exerciseBookmarkLookupService.getBookmarkStatus(memberId, exerciseIds);
+
+            // then
+            assertThat(result).containsExactlyInAnyOrderEntriesOf(Map.of(
+                    10L, true,
+                    20L, false,
+                    30L, true
+            ));
+            verify(exerciseBookmarkRepository).findAllExerciseIdsByMemberIdAndExerciseIds(memberId, exerciseIds);
+        }
+    }
+}

--- a/src/test/java/umc/cockple/demo/domain/exercise/service/ExerciseGuestQueryServiceTest.java
+++ b/src/test/java/umc/cockple/demo/domain/exercise/service/ExerciseGuestQueryServiceTest.java
@@ -34,7 +34,6 @@ import umc.cockple.demo.domain.exercise.exception.ExerciseErrorCode;
 import umc.cockple.demo.domain.exercise.exception.ExerciseException;
 import umc.cockple.demo.domain.exercise.repository.ExerciseRepository;
 import umc.cockple.demo.domain.exercise.repository.GuestRepository;
-import umc.cockple.demo.domain.exercise.service.support.reader.ExerciseBookmarkReader;
 import umc.cockple.demo.domain.exercise.service.support.ExerciseParticipantInfoAssembler;
 import umc.cockple.demo.domain.exercise.service.support.reader.ExerciseParticipantReader;
 import umc.cockple.demo.domain.exercise.service.support.reader.ExerciseReader;

--- a/src/test/java/umc/cockple/demo/domain/exercise/service/ExerciseGuestQueryServiceTest.java
+++ b/src/test/java/umc/cockple/demo/domain/exercise/service/ExerciseGuestQueryServiceTest.java
@@ -106,7 +106,7 @@ class ExerciseGuestQueryServiceTest {
     void setUp() {
         ExerciseConverter exerciseConverter = new ExerciseConverter(fileService);
         ExerciseParticipantReader exerciseParticipantReader = new ExerciseParticipantReader(
-                exerciseRepository, memberExerciseRepository, memberPartyRepository);
+                memberExerciseRepository, memberPartyRepository);
         GuestReader guestReader = new GuestReader(guestRepository);
         MemberLookupService memberLookupService = new MemberLookupService(memberRepository);
 

--- a/src/test/java/umc/cockple/demo/domain/exercise/service/ExerciseLifecycleQueryServiceTest.java
+++ b/src/test/java/umc/cockple/demo/domain/exercise/service/ExerciseLifecycleQueryServiceTest.java
@@ -34,7 +34,6 @@ import umc.cockple.demo.domain.exercise.exception.ExerciseErrorCode;
 import umc.cockple.demo.domain.exercise.exception.ExerciseException;
 import umc.cockple.demo.domain.exercise.repository.ExerciseRepository;
 import umc.cockple.demo.domain.exercise.repository.GuestRepository;
-import umc.cockple.demo.domain.exercise.service.support.reader.ExerciseBookmarkReader;
 import umc.cockple.demo.domain.exercise.service.support.ExerciseParticipantInfoAssembler;
 import umc.cockple.demo.domain.exercise.service.support.reader.ExerciseParticipantReader;
 import umc.cockple.demo.domain.exercise.service.support.reader.ExerciseReader;

--- a/src/test/java/umc/cockple/demo/domain/exercise/service/ExerciseLifecycleQueryServiceTest.java
+++ b/src/test/java/umc/cockple/demo/domain/exercise/service/ExerciseLifecycleQueryServiceTest.java
@@ -126,7 +126,7 @@ class ExerciseLifecycleQueryServiceTest {
 
     private ExerciseLifecycleQueryService createExerciseLifecycleQueryService(ExerciseConverter exerciseConverter) {
         ExerciseParticipantReader exerciseParticipantReader = new ExerciseParticipantReader(
-                exerciseRepository, memberExerciseRepository, memberPartyRepository);
+                memberExerciseRepository, memberPartyRepository);
         MemberLookupService memberLookupService = new MemberLookupService(memberRepository);
 
         return new ExerciseLifecycleQueryService(

--- a/src/test/java/umc/cockple/demo/domain/exercise/service/ExerciseMapQueryServiceTest.java
+++ b/src/test/java/umc/cockple/demo/domain/exercise/service/ExerciseMapQueryServiceTest.java
@@ -17,7 +17,7 @@ import umc.cockple.demo.domain.exercise.exception.ExerciseErrorCode;
 import umc.cockple.demo.domain.exercise.exception.ExerciseException;
 import umc.cockple.demo.domain.exercise.repository.ExerciseRepository;
 import umc.cockple.demo.domain.exercise.service.query.ExerciseMapQueryService;
-import umc.cockple.demo.domain.exercise.service.support.reader.ExerciseBookmarkReader;
+import umc.cockple.demo.domain.bookmark.service.query.lookup.ExerciseBookmarkLookupService;
 import umc.cockple.demo.domain.exercise.service.support.reader.ExerciseReader;
 import umc.cockple.demo.domain.file.service.FileService;
 import umc.cockple.demo.domain.member.domain.Member;
@@ -66,7 +66,7 @@ class ExerciseMapQueryServiceTest {
         ExerciseConverter exerciseConverter = new ExerciseConverter(fileService);
         exerciseMapQueryService = new ExerciseMapQueryService(
                 new ExerciseReader(exerciseRepository),
-                new ExerciseBookmarkReader(exerciseBookmarkRepository),
+                new ExerciseBookmarkLookupService(exerciseBookmarkRepository),
                 new MemberLookupService(memberRepository),
                 exerciseConverter
         );

--- a/src/test/java/umc/cockple/demo/domain/exercise/service/ExerciseMyQueryServiceTest.java
+++ b/src/test/java/umc/cockple/demo/domain/exercise/service/ExerciseMyQueryServiceTest.java
@@ -34,6 +34,7 @@ import umc.cockple.demo.domain.exercise.exception.ExerciseErrorCode;
 import umc.cockple.demo.domain.exercise.exception.ExerciseException;
 import umc.cockple.demo.domain.exercise.repository.ExerciseRepository;
 import umc.cockple.demo.domain.exercise.repository.GuestRepository;
+import umc.cockple.demo.domain.exercise.service.query.lookup.ExerciseParticipantCountLookupService;
 import umc.cockple.demo.domain.exercise.service.support.reader.ExerciseBookmarkReader;
 import umc.cockple.demo.domain.exercise.service.support.reader.ExerciseParticipantReader;
 import umc.cockple.demo.domain.exercise.service.support.reader.ExerciseReader;
@@ -99,7 +100,8 @@ class ExerciseMyQueryServiceTest {
         ExerciseConverter exerciseConverter = new ExerciseConverter(fileService);
         exerciseMyQueryService = new ExerciseMyQueryService(
                 new ExerciseReader(exerciseRepository),
-                new ExerciseParticipantReader(exerciseRepository, memberExerciseRepository, memberPartyRepository),
+                new ExerciseParticipantReader(memberExerciseRepository, memberPartyRepository),
+                new ExerciseParticipantCountLookupService(exerciseRepository),
                 new ExerciseBookmarkReader(exerciseBookmarkRepository),
                 exerciseConverter
         );

--- a/src/test/java/umc/cockple/demo/domain/exercise/service/ExerciseMyQueryServiceTest.java
+++ b/src/test/java/umc/cockple/demo/domain/exercise/service/ExerciseMyQueryServiceTest.java
@@ -35,7 +35,7 @@ import umc.cockple.demo.domain.exercise.exception.ExerciseException;
 import umc.cockple.demo.domain.exercise.repository.ExerciseRepository;
 import umc.cockple.demo.domain.exercise.repository.GuestRepository;
 import umc.cockple.demo.domain.exercise.service.query.lookup.ExerciseParticipantCountLookupService;
-import umc.cockple.demo.domain.exercise.service.support.reader.ExerciseBookmarkReader;
+import umc.cockple.demo.domain.bookmark.service.query.lookup.ExerciseBookmarkLookupService;
 import umc.cockple.demo.domain.exercise.service.support.reader.ExerciseParticipantReader;
 import umc.cockple.demo.domain.exercise.service.support.reader.ExerciseReader;
 import umc.cockple.demo.domain.exercise.service.support.reader.GuestReader;
@@ -102,7 +102,7 @@ class ExerciseMyQueryServiceTest {
                 new ExerciseReader(exerciseRepository),
                 new ExerciseParticipantReader(memberExerciseRepository, memberPartyRepository),
                 new ExerciseParticipantCountLookupService(exerciseRepository),
-                new ExerciseBookmarkReader(exerciseBookmarkRepository),
+                new ExerciseBookmarkLookupService(exerciseBookmarkRepository),
                 exerciseConverter
         );
 

--- a/src/test/java/umc/cockple/demo/domain/exercise/service/ExerciseParticipantCountLookupServiceTest.java
+++ b/src/test/java/umc/cockple/demo/domain/exercise/service/ExerciseParticipantCountLookupServiceTest.java
@@ -1,0 +1,147 @@
+package umc.cockple.demo.domain.exercise.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import umc.cockple.demo.domain.exercise.repository.ExerciseRepository;
+import umc.cockple.demo.domain.exercise.service.query.lookup.ExerciseParticipantCountLookupService;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ExerciseParticipantCountLookupService")
+class ExerciseParticipantCountLookupServiceTest {
+
+    @InjectMocks
+    private ExerciseParticipantCountLookupService exerciseParticipantCountLookupService;
+
+    @Mock
+    private ExerciseRepository exerciseRepository;
+
+    @Nested
+    @DisplayName("getParticipantCountsByExerciseIds - 운동 ID 목록 기준 참여 인원 수 조회")
+    class GetParticipantCountsByExerciseIds {
+
+        @Test
+        @DisplayName("운동 ID 목록이 비어있으면 빈 Map을 반환하고 Repository를 호출하지 않는다")
+        void emptyExerciseIds_returnsEmptyMapWithoutRepositoryCall() {
+            // when
+            Map<Long, Integer> result = exerciseParticipantCountLookupService
+                    .getParticipantCountsByExerciseIds(List.of());
+
+            // then
+            assertThat(result).isEmpty();
+            verifyNoInteractions(exerciseRepository);
+        }
+
+        @Test
+        @DisplayName("Repository count 결과를 운동 ID별 참여 인원 수 Map으로 변환한다")
+        void repositoryCountRows_returnsParticipantCountMap() {
+            // given
+            List<Long> exerciseIds = List.of(1L, 2L);
+            given(exerciseRepository.findExerciseParticipantCountsByExerciseIds(exerciseIds))
+                    .willReturn(List.of(
+                            new Object[]{1L, 3L},
+                            new Object[]{2L, 5L}
+                    ));
+
+            // when
+            Map<Long, Integer> result = exerciseParticipantCountLookupService
+                    .getParticipantCountsByExerciseIds(exerciseIds);
+
+            // then
+            assertThat(result).containsExactlyInAnyOrderEntriesOf(Map.of(
+                    1L, 3,
+                    2L, 5
+            ));
+            verify(exerciseRepository).findExerciseParticipantCountsByExerciseIds(exerciseIds);
+        }
+    }
+
+    @Nested
+    @DisplayName("getParticipantCountsByExerciseIdsAndDateRange - 운동 ID 목록과 날짜 범위 기준 참여 인원 수 조회")
+    class GetParticipantCountsByExerciseIdsAndDateRange {
+
+        @Test
+        @DisplayName("운동 ID 목록이 비어있으면 빈 Map을 반환하고 Repository를 호출하지 않는다")
+        void emptyExerciseIds_returnsEmptyMapWithoutRepositoryCall() {
+            // when
+            Map<Long, Integer> result = exerciseParticipantCountLookupService
+                    .getParticipantCountsByExerciseIdsAndDateRange(
+                            List.of(),
+                            LocalDate.of(2026, 6, 1),
+                            LocalDate.of(2026, 6, 30)
+                    );
+
+            // then
+            assertThat(result).isEmpty();
+            verifyNoInteractions(exerciseRepository);
+        }
+
+        @Test
+        @DisplayName("Repository count 결과를 운동 ID별 참여 인원 수 Map으로 변환한다")
+        void repositoryCountRows_returnsParticipantCountMap() {
+            // given
+            List<Long> exerciseIds = List.of(1L, 2L);
+            LocalDate start = LocalDate.of(2026, 6, 1);
+            LocalDate end = LocalDate.of(2026, 6, 30);
+            given(exerciseRepository.findExerciseParticipantCountsByExerciseIds(exerciseIds, start, end))
+                    .willReturn(List.of(
+                            new Object[]{1L, 4L},
+                            new Object[]{2L, 6L}
+                    ));
+
+            // when
+            Map<Long, Integer> result = exerciseParticipantCountLookupService
+                    .getParticipantCountsByExerciseIdsAndDateRange(exerciseIds, start, end);
+
+            // then
+            assertThat(result).containsExactlyInAnyOrderEntriesOf(Map.of(
+                    1L, 4,
+                    2L, 6
+            ));
+            verify(exerciseRepository).findExerciseParticipantCountsByExerciseIds(exerciseIds, start, end);
+        }
+    }
+
+    @Nested
+    @DisplayName("getParticipantCountsByPartyIdAndDateRange - 모임과 날짜 범위 기준 참여 인원 수 조회")
+    class GetParticipantCountsByPartyIdAndDateRange {
+
+        @Test
+        @DisplayName("Repository count 결과를 운동 ID별 참여 인원 수 Map으로 변환한다")
+        void repositoryCountRows_returnsParticipantCountMap() {
+            // given
+            Long partyId = 10L;
+            LocalDate start = LocalDate.of(2026, 6, 1);
+            LocalDate end = LocalDate.of(2026, 6, 30);
+            given(exerciseRepository.findExerciseParticipantCounts(partyId, start, end))
+                    .willReturn(List.of(
+                            new Object[]{1L, 7L},
+                            new Object[]{2L, 8L}
+                    ));
+
+            // when
+            Map<Long, Integer> result = exerciseParticipantCountLookupService
+                    .getParticipantCountsByPartyIdAndDateRange(partyId, start, end);
+
+            // then
+            assertThat(result).containsExactlyInAnyOrderEntriesOf(Map.of(
+                    1L, 7,
+                    2L, 8
+            ));
+            verify(exerciseRepository).findExerciseParticipantCounts(partyId, start, end);
+        }
+    }
+}

--- a/src/test/java/umc/cockple/demo/domain/exercise/service/ExerciseRecommendationQueryServiceTest.java
+++ b/src/test/java/umc/cockple/demo/domain/exercise/service/ExerciseRecommendationQueryServiceTest.java
@@ -20,7 +20,6 @@ import umc.cockple.demo.domain.exercise.exception.ExerciseException;
 import umc.cockple.demo.domain.exercise.repository.ExerciseRepository;
 import umc.cockple.demo.domain.exercise.service.support.reader.ExerciseBookmarkReader;
 import umc.cockple.demo.domain.exercise.service.support.ExerciseDistanceCalculator;
-import umc.cockple.demo.domain.exercise.service.support.reader.ExerciseParticipantReader;
 import umc.cockple.demo.domain.exercise.service.support.reader.ExerciseReader;
 import umc.cockple.demo.domain.member.service.support.MemberLookupService;
 import umc.cockple.demo.domain.file.service.FileService;
@@ -34,6 +33,7 @@ import umc.cockple.demo.domain.member.repository.MemberRepository;
 import umc.cockple.demo.domain.party.domain.Party;
 import umc.cockple.demo.global.enums.Gender;
 import umc.cockple.demo.domain.exercise.service.query.ExerciseRecommendationQueryService;
+import umc.cockple.demo.domain.exercise.service.query.lookup.ExerciseParticipantCountLookupService;
 import umc.cockple.demo.domain.party.enums.ActivityTime;
 import umc.cockple.demo.domain.party.enums.ParticipationType;
 import umc.cockple.demo.global.enums.Level;
@@ -107,7 +107,7 @@ class ExerciseRecommendationQueryServiceTest {
         return new ExerciseRecommendationQueryService(
                 new ExerciseReader(exerciseRepository),
                 new ExerciseBookmarkReader(exerciseBookmarkRepository),
-                new ExerciseParticipantReader(exerciseRepository, memberExerciseRepository, memberPartyRepository),
+                new ExerciseParticipantCountLookupService(exerciseRepository),
                 new ExerciseDistanceCalculator(),
                 new MemberLookupService(memberRepository),
                 exerciseConverter

--- a/src/test/java/umc/cockple/demo/domain/exercise/service/ExerciseRecommendationQueryServiceTest.java
+++ b/src/test/java/umc/cockple/demo/domain/exercise/service/ExerciseRecommendationQueryServiceTest.java
@@ -18,7 +18,7 @@ import umc.cockple.demo.domain.exercise.enums.MyPartyExerciseOrderType;
 import umc.cockple.demo.domain.exercise.exception.ExerciseErrorCode;
 import umc.cockple.demo.domain.exercise.exception.ExerciseException;
 import umc.cockple.demo.domain.exercise.repository.ExerciseRepository;
-import umc.cockple.demo.domain.exercise.service.support.reader.ExerciseBookmarkReader;
+import umc.cockple.demo.domain.bookmark.service.query.lookup.ExerciseBookmarkLookupService;
 import umc.cockple.demo.domain.exercise.service.support.ExerciseDistanceCalculator;
 import umc.cockple.demo.domain.exercise.service.support.reader.ExerciseReader;
 import umc.cockple.demo.domain.member.service.support.MemberLookupService;
@@ -106,7 +106,7 @@ class ExerciseRecommendationQueryServiceTest {
     private ExerciseRecommendationQueryService createExerciseRecommendationQueryService(ExerciseConverter exerciseConverter) {
         return new ExerciseRecommendationQueryService(
                 new ExerciseReader(exerciseRepository),
-                new ExerciseBookmarkReader(exerciseBookmarkRepository),
+                new ExerciseBookmarkLookupService(exerciseBookmarkRepository),
                 new ExerciseParticipantCountLookupService(exerciseRepository),
                 new ExerciseDistanceCalculator(),
                 new MemberLookupService(memberRepository),

--- a/src/test/java/umc/cockple/demo/domain/exercise/service/PartyExerciseQueryServiceTest.java
+++ b/src/test/java/umc/cockple/demo/domain/exercise/service/PartyExerciseQueryServiceTest.java
@@ -34,6 +34,7 @@ import umc.cockple.demo.domain.exercise.exception.ExerciseErrorCode;
 import umc.cockple.demo.domain.exercise.exception.ExerciseException;
 import umc.cockple.demo.domain.exercise.repository.ExerciseRepository;
 import umc.cockple.demo.domain.exercise.repository.GuestRepository;
+import umc.cockple.demo.domain.exercise.service.query.lookup.ExerciseParticipantCountLookupService;
 import umc.cockple.demo.domain.exercise.service.support.reader.ExerciseBookmarkReader;
 import umc.cockple.demo.domain.exercise.service.support.reader.ExerciseParticipantReader;
 import umc.cockple.demo.domain.exercise.service.support.reader.ExerciseReader;
@@ -106,7 +107,8 @@ class PartyExerciseQueryServiceTest {
         ExerciseConverter exerciseConverter = new ExerciseConverter(fileService);
         partyExerciseQueryService = new PartyExerciseQueryService(
                 new ExerciseReader(exerciseRepository),
-                new ExerciseParticipantReader(exerciseRepository, memberExerciseRepository, memberPartyRepository),
+                new ExerciseParticipantReader(memberExerciseRepository, memberPartyRepository),
+                new ExerciseParticipantCountLookupService(exerciseRepository),
                 new ExerciseBookmarkReader(exerciseBookmarkRepository),
                 new MemberLookupService(memberRepository),
                 new PartyLookupService(partyRepository),

--- a/src/test/java/umc/cockple/demo/domain/exercise/service/PartyExerciseQueryServiceTest.java
+++ b/src/test/java/umc/cockple/demo/domain/exercise/service/PartyExerciseQueryServiceTest.java
@@ -35,7 +35,7 @@ import umc.cockple.demo.domain.exercise.exception.ExerciseException;
 import umc.cockple.demo.domain.exercise.repository.ExerciseRepository;
 import umc.cockple.demo.domain.exercise.repository.GuestRepository;
 import umc.cockple.demo.domain.exercise.service.query.lookup.ExerciseParticipantCountLookupService;
-import umc.cockple.demo.domain.exercise.service.support.reader.ExerciseBookmarkReader;
+import umc.cockple.demo.domain.bookmark.service.query.lookup.ExerciseBookmarkLookupService;
 import umc.cockple.demo.domain.exercise.service.support.reader.ExerciseParticipantReader;
 import umc.cockple.demo.domain.exercise.service.support.reader.ExerciseReader;
 import umc.cockple.demo.domain.exercise.service.support.reader.GuestReader;
@@ -109,7 +109,7 @@ class PartyExerciseQueryServiceTest {
                 new ExerciseReader(exerciseRepository),
                 new ExerciseParticipantReader(memberExerciseRepository, memberPartyRepository),
                 new ExerciseParticipantCountLookupService(exerciseRepository),
-                new ExerciseBookmarkReader(exerciseBookmarkRepository),
+                new ExerciseBookmarkLookupService(exerciseBookmarkRepository),
                 new MemberLookupService(memberRepository),
                 new PartyLookupService(partyRepository),
                 exerciseConverter


### PR DESCRIPTION
## ❤️ 기능 설명

운동 참여 인원 수(`참여 회원 + 게스트`) 조회 로직을 exercise 도메인의 `ExerciseParticipantCountLookupService`로 단일화했습니다.

- 북마크 도메인의 직접 count/merge 로직 제거
- exercise 조회 서비스들도 동일한 count lookup 사용
- 기존 `MemberExerciseRepository.countByExerciseIds`, `GuestRepository.countByExerciseIds` 중복 쿼리 제거
- `ExerciseBookmarkReader`를 bookmark 도메인의 `ExerciseBookmarkLookupService`로 이동하여 도메인 책임 정리
- 북마크 N+1 회귀 테스트의 기대 쿼리 수를 공통 count 쿼리 기준으로 갱신

### 성능/실행 계획 확인

#### 운영 DB EXPLAIN
- 현재 correlated subquery 방식은 `member_exercise`, `guest` 모두 `exercise_id` 인덱스를 `ref`로 사용했습니다.
- `DEPENDENT SUBQUERY` 구조지만 풀스캔은 아니며, 현재 운영 데이터 샘플에서는 인덱스 기반 lookup으로 확인됐습니다.
- `UNION ALL + GROUP BY` 후보도 확인했으나 derived table과 `Using temporary`가 발생해 즉시 교체할 근거는 부족했습니다.

#### 로컬 Docker MySQL 더미 벤치
- 데이터: `exercise 50,000`, `member_exercise 500,000`, `guest 250,000`
- 각 운동당 참여 회원 10명, 게스트 5명
- MySQL 8.0, warm-up 후 5회 평균

| target exercise IDs | 현재 correlated subquery | 기존 2-query group by | UNION ALL |
|---:|---:|---:|---:|
| 1,000 | 16.647 ms | 17.631 ms | 23.367 ms |
| 10,000 | 196.781 ms | 195.127 ms | 251.573 ms |
| 30,000 | 1148.744 ms | 1107.962 ms | 1242.529 ms |

결론: 대량 ID에서 기존 2-query가 약간 빠르지만 차이가 크지 않고, 현재 방식은 공통화/단일 쿼리/코드 단순성 이점이 있어 유지했습니다. `UNION ALL`은 이번 벤치 기준 가장 불리했습니다.

<br>

## 연결된 issue

close #638
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] `query/lookup`이 외부 도메인에서의 조회, `support/reader`가 내부 도메인에서의 조회라고 할 때, 로직 공통화를 위해서는 둘 중에 하나에 배치해야 했습니다. 따라서 외부 도메인에서의 조회를 명시적으로 나타낼 수 있도록 `query/lookup` 아래에 배치하였습니다.
- [ ] `ExerciseBookmarkLookupService`는 bookmark 도메인 소유이므로 `query/lookup`으로 이동시켰습니다.
- [ ] count SQL은 성능 벤치 결과상 운동의 수가 많아질경우에도 조금의 속도 차이가 있어 로직의 명확화를 위해 correlated subquery 방식을 유지했습니다. 의견 있으시면 말씀해주세요~

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가? (EXPLAIN/벤치 결과를 본문에 텍스트로 첨부)
- [x] 이슈넘버를 적었는가?
