### PR TITLE
[refactor/#624] 채팅 읽음 처리 쿼리 배치화

### DIFF
--- a/src/main/java/umc/cockple/demo/domain/chat/repository/ChatRoomMemberRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/repository/ChatRoomMemberRepository.java
@@ -45,6 +45,19 @@ public interface ChatRoomMemberRepository extends JpaRepository<ChatRoomMember, 
             @Param("chatRoomIds") List<Long> chatRoomIds,
             @Param("displayName") String displayName);
 
+    @Modifying(flushAutomatically = true)
+    @Query("""
+            UPDATE ChatRoomMember crm
+            SET crm.lastReadMessageId = :messageId
+            WHERE crm.chatRoom.id = :chatRoomId
+            AND crm.member.id = :memberId
+            AND (crm.lastReadMessageId IS NULL OR crm.lastReadMessageId < :messageId)
+            """)
+    int advanceLastReadMessageId(
+            @Param("chatRoomId") Long chatRoomId,
+            @Param("memberId") Long memberId,
+            @Param("messageId") Long messageId);
+
     // 채팅방 내 참여자 수
     @Query("SELECT COUNT(c) FROM ChatRoomMember c WHERE c.chatRoom.id = :chatRoomId")
     int countByChatRoomId(@Param("chatRoomId") Long chatRoomId);

--- a/src/main/java/umc/cockple/demo/domain/chat/repository/ChatRoomMemberRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/repository/ChatRoomMemberRepository.java
@@ -58,6 +58,19 @@ public interface ChatRoomMemberRepository extends JpaRepository<ChatRoomMember, 
             @Param("memberId") Long memberId,
             @Param("messageId") Long messageId);
 
+    @Modifying(flushAutomatically = true)
+    @Query("""
+            UPDATE ChatRoomMember crm
+            SET crm.lastReadMessageId = :messageId
+            WHERE crm.chatRoom.id = :chatRoomId
+            AND crm.member.id IN :memberIds
+            AND (crm.lastReadMessageId IS NULL OR crm.lastReadMessageId < :messageId)
+            """)
+    int advanceLastReadMessageIdForMembers(
+            @Param("chatRoomId") Long chatRoomId,
+            @Param("memberIds") List<Long> memberIds,
+            @Param("messageId") Long messageId);
+
     // 채팅방 내 참여자 수
     @Query("SELECT COUNT(c) FROM ChatRoomMember c WHERE c.chatRoom.id = :chatRoomId")
     int countByChatRoomId(@Param("chatRoomId") Long chatRoomId);

--- a/src/main/java/umc/cockple/demo/domain/chat/repository/ChatRoomMemberRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/repository/ChatRoomMemberRepository.java
@@ -45,6 +45,10 @@ public interface ChatRoomMemberRepository extends JpaRepository<ChatRoomMember, 
             @Param("chatRoomIds") List<Long> chatRoomIds,
             @Param("displayName") String displayName);
 
+    /*
+     * lastReadMessageId는 고빈도 읽음 커서라 bulk JPQL로 갱신한다.
+     * 이 경로는 JPA auditing(updatedAt)을 갱신하지 않는 것을 의도한다.
+     */
     @Modifying(flushAutomatically = true)
     @Query("""
             UPDATE ChatRoomMember crm

--- a/src/main/java/umc/cockple/demo/domain/chat/repository/MessageReadStatusRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/repository/MessageReadStatusRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import umc.cockple.demo.domain.chat.domain.MessageReadStatus;
+import umc.cockple.demo.domain.chat.repository.projection.ChatMessageUnreadCountDTO;
 import umc.cockple.demo.domain.chat.repository.projection.ChatMemberUnreadCountDTO;
 import umc.cockple.demo.domain.chat.repository.projection.ChatRoomUnreadCountDTO;
 
@@ -37,6 +38,20 @@ public interface MessageReadStatusRepository extends JpaRepository<MessageReadSt
     int markAsReadInMembers(
             @Param("messageId") Long messageId,
             @Param("memberIds") List<Long> memberIds);
+
+    @Modifying(flushAutomatically = true)
+    @Query("""
+            UPDATE MessageReadStatus mrs
+            SET mrs.isRead = true
+            WHERE mrs.chatRoomId = :chatRoomId
+            AND mrs.memberId = :memberId
+            AND mrs.chatMessageId IN :messageIds
+            AND mrs.isRead = false
+            """)
+    int markMessagesAsReadForMember(
+            @Param("chatRoomId") Long chatRoomId,
+            @Param("memberId") Long memberId,
+            @Param("messageIds") List<Long> messageIds);
 
     @Query("""
             SELECT new umc.cockple.demo.domain.chat.repository.projection.ChatRoomUnreadCountDTO(mrs.chatRoomId, COUNT(mrs))
@@ -135,6 +150,16 @@ public interface MessageReadStatusRepository extends JpaRepository<MessageReadSt
             """)
     int countUnreadByMessageId(
             @Param("messageId") Long messageId);
+
+    @Query("""
+            SELECT new umc.cockple.demo.domain.chat.repository.projection.ChatMessageUnreadCountDTO(mrs.chatMessageId, COUNT(mrs))
+            FROM MessageReadStatus mrs
+            WHERE mrs.chatMessageId IN :messageIds
+            AND mrs.isRead = false
+            GROUP BY mrs.chatMessageId
+            """)
+    List<ChatMessageUnreadCountDTO> countUnreadByMessageIds(
+            @Param("messageIds") List<Long> messageIds);
 
     @Query("""
             SELECT mrs.chatMessageId FROM MessageReadStatus mrs

--- a/src/main/java/umc/cockple/demo/domain/chat/repository/projection/ChatMessageUnreadCountDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/repository/projection/ChatMessageUnreadCountDTO.java
@@ -1,0 +1,7 @@
+package umc.cockple.demo.domain.chat.repository.projection;
+
+public record ChatMessageUnreadCountDTO(
+        Long chatMessageId,
+        Long unreadCount
+) {
+}

--- a/src/main/java/umc/cockple/demo/domain/chat/service/support/ReadStatusBatchSupport.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/support/ReadStatusBatchSupport.java
@@ -1,0 +1,30 @@
+package umc.cockple.demo.domain.chat.service.support;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public final class ReadStatusBatchSupport {
+
+    public static final int IN_CLAUSE_CHUNK_SIZE = 500;
+
+    private ReadStatusBatchSupport() {
+    }
+
+    public static <T> List<List<T>> chunk(List<T> values) {
+        if (values.isEmpty()) {
+            return List.of();
+        }
+
+        List<List<T>> chunks = new ArrayList<>(chunkCount(values.size()));
+        for (int start = 0; start < values.size(); start += IN_CLAUSE_CHUNK_SIZE) {
+            int end = Math.min(start + IN_CLAUSE_CHUNK_SIZE, values.size());
+            chunks.add(values.subList(start, end));
+        }
+
+        return chunks;
+    }
+
+    private static int chunkCount(int size) {
+        return (size + IN_CLAUSE_CHUNK_SIZE - 1) / IN_CLAUSE_CHUNK_SIZE;
+    }
+}

--- a/src/main/java/umc/cockple/demo/domain/chat/service/support/reader/ReadStatusReader.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/support/reader/ReadStatusReader.java
@@ -4,11 +4,11 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import umc.cockple.demo.domain.chat.repository.MessageReadStatusRepository;
-import umc.cockple.demo.domain.chat.repository.projection.ChatMessageUnreadCountDTO;
+import umc.cockple.demo.domain.chat.service.support.ReadStatusBatchSupport;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 @Service
 @Transactional(readOnly = true)
@@ -26,12 +26,16 @@ public class ReadStatusReader {
             return Map.of();
         }
 
-        return messageReadStatusRepository.countUnreadByMessageIds(messageIds)
-                .stream()
-                .collect(Collectors.toMap(
-                        ChatMessageUnreadCountDTO::chatMessageId,
-                        count -> count.unreadCount().intValue()
-                ));
+        Map<Long, Integer> unreadCounts = new HashMap<>();
+        for (List<Long> chunk : ReadStatusBatchSupport.chunk(messageIds)) {
+            messageReadStatusRepository.countUnreadByMessageIds(chunk)
+                    .forEach(count -> unreadCounts.put(
+                            count.chatMessageId(),
+                            count.unreadCount().intValue()
+                    ));
+        }
+
+        return unreadCounts;
     }
 
     public int countUnreadByMessageId(Long messageId) {

--- a/src/main/java/umc/cockple/demo/domain/chat/service/support/reader/ReadStatusReader.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/support/reader/ReadStatusReader.java
@@ -1,0 +1,40 @@
+package umc.cockple.demo.domain.chat.service.support.reader;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import umc.cockple.demo.domain.chat.repository.MessageReadStatusRepository;
+import umc.cockple.demo.domain.chat.repository.projection.ChatMessageUnreadCountDTO;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class ReadStatusReader {
+
+    private final MessageReadStatusRepository messageReadStatusRepository;
+
+    public List<Long> findUnreadMessageIds(Long chatRoomId, Long memberId) {
+        return messageReadStatusRepository.findUnreadMessageIdsByMember(chatRoomId, memberId);
+    }
+
+    public Map<Long, Integer> countUnreadByMessageIds(List<Long> messageIds) {
+        if (messageIds.isEmpty()) {
+            return Map.of();
+        }
+
+        return messageReadStatusRepository.countUnreadByMessageIds(messageIds)
+                .stream()
+                .collect(Collectors.toMap(
+                        ChatMessageUnreadCountDTO::chatMessageId,
+                        count -> count.unreadCount().intValue()
+                ));
+    }
+
+    public int countUnreadByMessageId(Long messageId) {
+        return messageReadStatusRepository.countUnreadByMessageId(messageId);
+    }
+}

--- a/src/main/java/umc/cockple/demo/domain/chat/service/support/reader/ReadStatusReader.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/support/reader/ReadStatusReader.java
@@ -21,7 +21,7 @@ public class ReadStatusReader {
         return messageReadStatusRepository.findUnreadMessageIdsByMember(chatRoomId, memberId);
     }
 
-    public Map<Long, Integer> countUnreadByMessageIds(List<Long> messageIds) {
+    public Map<Long, Integer> countUnreadByMessageIdsAsSparseMap(List<Long> messageIds) {
         if (messageIds.isEmpty()) {
             return Map.of();
         }

--- a/src/main/java/umc/cockple/demo/domain/chat/service/support/updater/ChatMemberReadStateUpdater.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/support/updater/ChatMemberReadStateUpdater.java
@@ -1,0 +1,28 @@
+package umc.cockple.demo.domain.chat.service.support.updater;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import umc.cockple.demo.domain.chat.repository.ChatRoomMemberRepository;
+
+import java.util.List;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ChatMemberReadStateUpdater {
+
+    private final ChatRoomMemberRepository chatRoomMemberRepository;
+
+    public int advanceLastReadMessageId(Long chatRoomId, Long memberId, Long messageId) {
+        return chatRoomMemberRepository.advanceLastReadMessageId(chatRoomId, memberId, messageId);
+    }
+
+    public int advanceLastReadMessageIdForMembers(Long chatRoomId, List<Long> memberIds, Long messageId) {
+        if (memberIds.isEmpty()) {
+            return 0;
+        }
+
+        return chatRoomMemberRepository.advanceLastReadMessageIdForMembers(chatRoomId, memberIds, messageId);
+    }
+}

--- a/src/main/java/umc/cockple/demo/domain/chat/service/support/updater/ChatMemberReadStateUpdater.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/support/updater/ChatMemberReadStateUpdater.java
@@ -1,6 +1,7 @@
 package umc.cockple.demo.domain.chat.service.support.updater;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import umc.cockple.demo.domain.chat.repository.ChatRoomMemberRepository;
@@ -10,12 +11,23 @@ import java.util.List;
 @Service
 @Transactional
 @RequiredArgsConstructor
+@Slf4j
 public class ChatMemberReadStateUpdater {
 
     private final ChatRoomMemberRepository chatRoomMemberRepository;
 
     public int advanceLastReadMessageId(Long chatRoomId, Long memberId, Long messageId) {
-        return chatRoomMemberRepository.advanceLastReadMessageId(chatRoomId, memberId, messageId);
+        int updatedCount = chatRoomMemberRepository.advanceLastReadMessageId(chatRoomId, memberId, messageId);
+        if (updatedCount == 0) {
+            log.warn(
+                    "lastReadMessageId 미갱신 - 채팅방: {}, 멤버: {}, 메시지: {} (멤버십 없음 또는 이미 최신 상태)",
+                    chatRoomId,
+                    memberId,
+                    messageId
+            );
+        }
+
+        return updatedCount;
     }
 
     public int advanceLastReadMessageIdForMembers(Long chatRoomId, List<Long> memberIds, Long messageId) {
@@ -23,6 +35,18 @@ public class ChatMemberReadStateUpdater {
             return 0;
         }
 
-        return chatRoomMemberRepository.advanceLastReadMessageIdForMembers(chatRoomId, memberIds, messageId);
+        int updatedCount = chatRoomMemberRepository.advanceLastReadMessageIdForMembers(chatRoomId, memberIds, messageId);
+        if (updatedCount < memberIds.size()) {
+            log.warn(
+                    "lastReadMessageId 일부 미갱신 - 채팅방: {}, 요청 멤버 수: {}, 갱신 수: {}, 메시지: {} "
+                            + "(멤버십 없음 또는 이미 최신 상태 포함 가능)",
+                    chatRoomId,
+                    memberIds.size(),
+                    updatedCount,
+                    messageId
+            );
+        }
+
+        return updatedCount;
     }
 }

--- a/src/main/java/umc/cockple/demo/domain/chat/service/support/updater/ChatMemberReadStateUpdater.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/support/updater/ChatMemberReadStateUpdater.java
@@ -5,6 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import umc.cockple.demo.domain.chat.repository.ChatRoomMemberRepository;
+import umc.cockple.demo.domain.chat.service.support.ReadStatusBatchSupport;
 
 import java.util.List;
 
@@ -35,7 +36,15 @@ public class ChatMemberReadStateUpdater {
             return 0;
         }
 
-        int updatedCount = chatRoomMemberRepository.advanceLastReadMessageIdForMembers(chatRoomId, memberIds, messageId);
+        int updatedCount = 0;
+        for (List<Long> chunk : ReadStatusBatchSupport.chunk(memberIds)) {
+            updatedCount += chatRoomMemberRepository.advanceLastReadMessageIdForMembers(
+                    chatRoomId,
+                    chunk,
+                    messageId
+            );
+        }
+
         if (updatedCount < memberIds.size()) {
             log.warn(
                     "lastReadMessageId 일부 미갱신 - 채팅방: {}, 요청 멤버 수: {}, 갱신 수: {}, 메시지: {} "

--- a/src/main/java/umc/cockple/demo/domain/chat/service/support/updater/ReadStatusUpdater.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/support/updater/ReadStatusUpdater.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import umc.cockple.demo.domain.chat.repository.MessageReadStatusRepository;
+import umc.cockple.demo.domain.chat.service.support.ReadStatusBatchSupport;
 
 import java.util.List;
 
@@ -19,7 +20,12 @@ public class ReadStatusUpdater {
             return 0;
         }
 
-        return messageReadStatusRepository.markMessagesAsReadForMember(chatRoomId, memberId, messageIds);
+        int updatedCount = 0;
+        for (List<Long> chunk : ReadStatusBatchSupport.chunk(messageIds)) {
+            updatedCount += messageReadStatusRepository.markMessagesAsReadForMember(chatRoomId, memberId, chunk);
+        }
+
+        return updatedCount;
     }
 
     public int markMessageAsReadForMembers(Long messageId, List<Long> memberIds) {
@@ -27,6 +33,11 @@ public class ReadStatusUpdater {
             return 0;
         }
 
-        return messageReadStatusRepository.markAsReadInMembers(messageId, memberIds);
+        int updatedCount = 0;
+        for (List<Long> chunk : ReadStatusBatchSupport.chunk(memberIds)) {
+            updatedCount += messageReadStatusRepository.markAsReadInMembers(messageId, chunk);
+        }
+
+        return updatedCount;
     }
 }

--- a/src/main/java/umc/cockple/demo/domain/chat/service/support/updater/ReadStatusUpdater.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/support/updater/ReadStatusUpdater.java
@@ -1,0 +1,32 @@
+package umc.cockple.demo.domain.chat.service.support.updater;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import umc.cockple.demo.domain.chat.repository.MessageReadStatusRepository;
+
+import java.util.List;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ReadStatusUpdater {
+
+    private final MessageReadStatusRepository messageReadStatusRepository;
+
+    public int markMessagesAsReadForMember(Long chatRoomId, Long memberId, List<Long> messageIds) {
+        if (messageIds.isEmpty()) {
+            return 0;
+        }
+
+        return messageReadStatusRepository.markMessagesAsReadForMember(chatRoomId, memberId, messageIds);
+    }
+
+    public int markMessageAsReadForMembers(Long messageId, List<Long> memberIds) {
+        if (memberIds.isEmpty()) {
+            return 0;
+        }
+
+        return messageReadStatusRepository.markAsReadInMembers(messageId, memberIds);
+    }
+}

--- a/src/main/java/umc/cockple/demo/domain/chat/service/websocket/UnreadCountUpdate.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/websocket/UnreadCountUpdate.java
@@ -1,0 +1,7 @@
+package umc.cockple.demo.domain.chat.service.websocket;
+
+public record UnreadCountUpdate(
+        Long messageId,
+        int newUnreadCount
+) {
+}

--- a/src/main/java/umc/cockple/demo/domain/chat/service/websocket/broadcast/UnreadCountUpdateBroadcaster.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/websocket/broadcast/UnreadCountUpdateBroadcaster.java
@@ -5,10 +5,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import umc.cockple.demo.domain.chat.dto.WebSocketMessageDTO;
 import umc.cockple.demo.domain.chat.enums.WebSocketMessageType;
+import umc.cockple.demo.domain.chat.service.websocket.UnreadCountUpdate;
 import umc.cockple.demo.domain.chat.service.websocket.session.ChatMessageEncoder;
 import umc.cockple.demo.domain.chat.service.websocket.session.ChatMessageSender;
 import umc.cockple.demo.domain.chat.service.websocket.session.EncodedChatMessage;
-import umc.cockple.demo.domain.chat.service.websocket.subscription.support.SubscribeReadStatusService;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -23,14 +23,14 @@ public class UnreadCountUpdateBroadcaster {
 
     public void broadcast(
             Long chatRoomId,
-            List<SubscribeReadStatusService.MessageUnreadUpdate> updates,
+            List<UnreadCountUpdate> updates,
             List<Long> subscribers,
             Long excludedMemberId) {
         if (subscribers == null || subscribers.isEmpty()) {
             return;
         }
 
-        for (SubscribeReadStatusService.MessageUnreadUpdate update : updates) {
+        for (UnreadCountUpdate update : updates) {
             WebSocketMessageDTO.UnreadCountUpdateMessage updateMessage = WebSocketMessageDTO.UnreadCountUpdateMessage.builder()
                     .type(WebSocketMessageType.UNREAD_COUNT_UPDATE)
                     .chatRoomId(chatRoomId)

--- a/src/main/java/umc/cockple/demo/domain/chat/service/websocket/send/support/SentMessageReadStatusService.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/websocket/send/support/SentMessageReadStatusService.java
@@ -4,8 +4,9 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import umc.cockple.demo.domain.chat.repository.ChatRoomMemberRepository;
-import umc.cockple.demo.domain.chat.repository.MessageReadStatusRepository;
+import umc.cockple.demo.domain.chat.service.support.reader.ReadStatusReader;
+import umc.cockple.demo.domain.chat.service.support.updater.ChatMemberReadStateUpdater;
+import umc.cockple.demo.domain.chat.service.support.updater.ReadStatusUpdater;
 
 import java.util.List;
 
@@ -15,8 +16,9 @@ import java.util.List;
 @Slf4j
 public class SentMessageReadStatusService {
 
-    private final MessageReadStatusRepository messageReadStatusRepository;
-    private final ChatRoomMemberRepository chatRoomMemberRepository;
+    private final ReadStatusReader readStatusReader;
+    private final ReadStatusUpdater readStatusUpdater;
+    private final ChatMemberReadStateUpdater chatMemberReadStateUpdater;
 
     public int markActiveSubscribersAsRead(Long chatRoomId, Long messageId, List<Long> activeSubscribers, Long senderId) {
         log.info("초기 읽음 처리 - 메시지: {}, 활성 구독자 수: {}, 발신자: {}",
@@ -27,15 +29,15 @@ public class SentMessageReadStatusService {
                 .toList();
 
         if (!readers.isEmpty()) {
-            int updatedCount = messageReadStatusRepository.markAsReadInMembers(messageId, readers);
+            int updatedCount = readStatusUpdater.markMessageAsReadForMembers(messageId, readers);
             log.info("초기 읽음 처리 완료 - 처리된 구독자: {}명", updatedCount);
 
-            int lastReadUpdatedCount = chatRoomMemberRepository.advanceLastReadMessageIdForMembers(
+            int lastReadUpdatedCount = chatMemberReadStateUpdater.advanceLastReadMessageIdForMembers(
                     chatRoomId, readers, messageId);
             log.debug("활성 구독자 lastReadMessageId 배치 업데이트 완료 - 처리된 멤버: {}명", lastReadUpdatedCount);
         }
 
-        int finalUnreadCount = messageReadStatusRepository.countUnreadByMessageId(messageId);
+        int finalUnreadCount = readStatusReader.countUnreadByMessageId(messageId);
         log.info("초기 처리 후 최종 안읽은 수: {}", finalUnreadCount);
 
         return finalUnreadCount;

--- a/src/main/java/umc/cockple/demo/domain/chat/service/websocket/send/support/SentMessageReadStatusService.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/websocket/send/support/SentMessageReadStatusService.java
@@ -4,12 +4,10 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import umc.cockple.demo.domain.chat.domain.ChatRoomMember;
 import umc.cockple.demo.domain.chat.repository.ChatRoomMemberRepository;
 import umc.cockple.demo.domain.chat.repository.MessageReadStatusRepository;
 
 import java.util.List;
-import java.util.Optional;
 
 @Service
 @Transactional
@@ -32,32 +30,14 @@ public class SentMessageReadStatusService {
             int updatedCount = messageReadStatusRepository.markAsReadInMembers(messageId, readers);
             log.info("초기 읽음 처리 완료 - 처리된 구독자: {}명", updatedCount);
 
-            updateLastReadMessageIds(chatRoomId, messageId, readers);
+            int lastReadUpdatedCount = chatRoomMemberRepository.advanceLastReadMessageIdForMembers(
+                    chatRoomId, readers, messageId);
+            log.debug("활성 구독자 lastReadMessageId 배치 업데이트 완료 - 처리된 멤버: {}명", lastReadUpdatedCount);
         }
 
         int finalUnreadCount = messageReadStatusRepository.countUnreadByMessageId(messageId);
         log.info("초기 처리 후 최종 안읽은 수: {}", finalUnreadCount);
 
         return finalUnreadCount;
-    }
-
-    private void updateLastReadMessageIds(Long chatRoomId, Long messageId, List<Long> memberIds) {
-        for (Long memberId : memberIds) {
-            try {
-                Optional<ChatRoomMember> chatRoomMemberOpt =
-                        chatRoomMemberRepository.findByChatRoomIdAndMemberId(chatRoomId, memberId);
-
-                if (chatRoomMemberOpt.isPresent()) {
-                    ChatRoomMember chatRoomMember = chatRoomMemberOpt.get();
-
-                    if (chatRoomMember.getLastReadMessageId() == null ||
-                            messageId > chatRoomMember.getLastReadMessageId()) {
-                        chatRoomMember.updateLastReadMessageId(messageId);
-                    }
-                }
-            } catch (Exception e) {
-                log.error("lastReadMessageId 업데이트 실패 - 멤버: {}, 메시지: {}", memberId, messageId, e);
-            }
-        }
     }
 }

--- a/src/main/java/umc/cockple/demo/domain/chat/service/websocket/subscription/ChatRoomSubscriptionService.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/websocket/subscription/ChatRoomSubscriptionService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import umc.cockple.demo.domain.chat.repository.redis.ChatRoomSubscriptionStore;
+import umc.cockple.demo.domain.chat.service.websocket.UnreadCountUpdate;
 import umc.cockple.demo.domain.chat.service.websocket.broadcast.UnreadCountUpdateBroadcaster;
 import umc.cockple.demo.domain.chat.service.websocket.subscription.support.ActiveChatRoomSubscriberReader;
 import umc.cockple.demo.domain.chat.service.websocket.subscription.support.SubscribeReadStatusService;
@@ -31,7 +32,7 @@ public class ChatRoomSubscriptionService {
         chatRoomSubscriptionStore.addSubscriber(chatRoomId, memberId);
         log.info("채팅방 구독 - 채팅방: {}, 사용자: {}", chatRoomId, memberId);
 
-        List<SubscribeReadStatusService.MessageUnreadUpdate> updates =
+        List<UnreadCountUpdate> updates =
                 subscribeReadStatusService.markUnreadMessagesAsReadOnSubscribe(chatRoomId, memberId);
 
         if (!updates.isEmpty()) {

--- a/src/main/java/umc/cockple/demo/domain/chat/service/websocket/subscription/support/SubscribeReadStatusService.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/websocket/subscription/support/SubscribeReadStatusService.java
@@ -41,7 +41,7 @@ public class SubscribeReadStatusService {
     }
 
     private List<UnreadCountUpdate> createUnreadUpdates(List<Long> unreadMessageIds) {
-        Map<Long, Integer> unreadCounts = readStatusReader.countUnreadByMessageIds(unreadMessageIds);
+        Map<Long, Integer> unreadCounts = readStatusReader.countUnreadByMessageIdsAsSparseMap(unreadMessageIds);
 
         return unreadMessageIds.stream()
                 .map(messageId -> new UnreadCountUpdate(messageId, unreadCounts.getOrDefault(messageId, 0)))
@@ -49,7 +49,9 @@ public class SubscribeReadStatusService {
     }
 
     private Long latestMessageId(List<Long> messageIds) {
-        return messageIds.get(messageIds.size() - 1);
+        return messageIds.stream()
+                .max(Long::compareTo)
+                .orElseThrow();
     }
 
     private void updateLastReadMessageId(Long chatRoomId, Long memberId, Long messageId) {

--- a/src/main/java/umc/cockple/demo/domain/chat/service/websocket/subscription/support/SubscribeReadStatusService.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/websocket/subscription/support/SubscribeReadStatusService.java
@@ -9,6 +9,7 @@ import umc.cockple.demo.domain.chat.events.ChatUnreadStatusUpdateEvent;
 import umc.cockple.demo.domain.chat.repository.ChatRoomMemberRepository;
 import umc.cockple.demo.domain.chat.repository.MessageReadStatusRepository;
 import umc.cockple.demo.domain.chat.repository.projection.ChatMessageUnreadCountDTO;
+import umc.cockple.demo.domain.chat.service.websocket.UnreadCountUpdate;
 
 import java.util.List;
 import java.util.Map;
@@ -24,7 +25,7 @@ public class SubscribeReadStatusService {
     private final ChatRoomMemberRepository chatRoomMemberRepository;
     private final ApplicationEventPublisher eventPublisher;
 
-    public List<MessageUnreadUpdate> markUnreadMessagesAsReadOnSubscribe(Long chatRoomId, Long memberId) {
+    public List<UnreadCountUpdate> markUnreadMessagesAsReadOnSubscribe(Long chatRoomId, Long memberId) {
         List<Long> unreadMessageIds = messageReadStatusRepository.findUnreadMessageIdsByMember(chatRoomId, memberId);
         if (unreadMessageIds.isEmpty()) {
             return List.of();
@@ -32,18 +33,18 @@ public class SubscribeReadStatusService {
 
         messageReadStatusRepository.markMessagesAsReadForMember(chatRoomId, memberId, unreadMessageIds);
 
-        List<MessageUnreadUpdate> updates = createUnreadUpdates(unreadMessageIds);
+        List<UnreadCountUpdate> updates = createUnreadUpdates(unreadMessageIds);
         updateLastReadMessageId(chatRoomId, memberId, latestMessageId(unreadMessageIds));
         eventPublisher.publishEvent(ChatUnreadStatusUpdateEvent.of(List.of(memberId)));
 
         return updates;
     }
 
-    private List<MessageUnreadUpdate> createUnreadUpdates(List<Long> unreadMessageIds) {
+    private List<UnreadCountUpdate> createUnreadUpdates(List<Long> unreadMessageIds) {
         Map<Long, Integer> unreadCounts = countUnreadMessages(unreadMessageIds);
 
         return unreadMessageIds.stream()
-                .map(messageId -> new MessageUnreadUpdate(messageId, unreadCounts.getOrDefault(messageId, 0)))
+                .map(messageId -> new UnreadCountUpdate(messageId, unreadCounts.getOrDefault(messageId, 0)))
                 .toList();
     }
 
@@ -66,11 +67,5 @@ public class SubscribeReadStatusService {
         } catch (Exception e) {
             log.error("구독 시 lastReadMessageId 업데이트 실패 - 멤버: {}, 메시지: {}", memberId, messageId, e);
         }
-    }
-
-    public record MessageUnreadUpdate(
-            Long messageId,
-            int newUnreadCount
-    ) {
     }
 }

--- a/src/main/java/umc/cockple/demo/domain/chat/service/websocket/subscription/support/SubscribeReadStatusService.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/websocket/subscription/support/SubscribeReadStatusService.java
@@ -6,14 +6,13 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import umc.cockple.demo.domain.chat.events.ChatUnreadStatusUpdateEvent;
-import umc.cockple.demo.domain.chat.repository.ChatRoomMemberRepository;
-import umc.cockple.demo.domain.chat.repository.MessageReadStatusRepository;
-import umc.cockple.demo.domain.chat.repository.projection.ChatMessageUnreadCountDTO;
+import umc.cockple.demo.domain.chat.service.support.reader.ReadStatusReader;
+import umc.cockple.demo.domain.chat.service.support.updater.ChatMemberReadStateUpdater;
+import umc.cockple.demo.domain.chat.service.support.updater.ReadStatusUpdater;
 import umc.cockple.demo.domain.chat.service.websocket.UnreadCountUpdate;
 
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 @Service
 @Transactional
@@ -21,17 +20,18 @@ import java.util.stream.Collectors;
 @Slf4j
 public class SubscribeReadStatusService {
 
-    private final MessageReadStatusRepository messageReadStatusRepository;
-    private final ChatRoomMemberRepository chatRoomMemberRepository;
+    private final ReadStatusReader readStatusReader;
+    private final ReadStatusUpdater readStatusUpdater;
+    private final ChatMemberReadStateUpdater chatMemberReadStateUpdater;
     private final ApplicationEventPublisher eventPublisher;
 
     public List<UnreadCountUpdate> markUnreadMessagesAsReadOnSubscribe(Long chatRoomId, Long memberId) {
-        List<Long> unreadMessageIds = messageReadStatusRepository.findUnreadMessageIdsByMember(chatRoomId, memberId);
+        List<Long> unreadMessageIds = readStatusReader.findUnreadMessageIds(chatRoomId, memberId);
         if (unreadMessageIds.isEmpty()) {
             return List.of();
         }
 
-        messageReadStatusRepository.markMessagesAsReadForMember(chatRoomId, memberId, unreadMessageIds);
+        readStatusUpdater.markMessagesAsReadForMember(chatRoomId, memberId, unreadMessageIds);
 
         List<UnreadCountUpdate> updates = createUnreadUpdates(unreadMessageIds);
         updateLastReadMessageId(chatRoomId, memberId, latestMessageId(unreadMessageIds));
@@ -41,20 +41,11 @@ public class SubscribeReadStatusService {
     }
 
     private List<UnreadCountUpdate> createUnreadUpdates(List<Long> unreadMessageIds) {
-        Map<Long, Integer> unreadCounts = countUnreadMessages(unreadMessageIds);
+        Map<Long, Integer> unreadCounts = readStatusReader.countUnreadByMessageIds(unreadMessageIds);
 
         return unreadMessageIds.stream()
                 .map(messageId -> new UnreadCountUpdate(messageId, unreadCounts.getOrDefault(messageId, 0)))
                 .toList();
-    }
-
-    private Map<Long, Integer> countUnreadMessages(List<Long> messageIds) {
-        return messageReadStatusRepository.countUnreadByMessageIds(messageIds)
-                .stream()
-                .collect(Collectors.toMap(
-                        ChatMessageUnreadCountDTO::chatMessageId,
-                        count -> count.unreadCount().intValue()
-                ));
     }
 
     private Long latestMessageId(List<Long> messageIds) {
@@ -63,7 +54,7 @@ public class SubscribeReadStatusService {
 
     private void updateLastReadMessageId(Long chatRoomId, Long memberId, Long messageId) {
         try {
-            chatRoomMemberRepository.advanceLastReadMessageId(chatRoomId, memberId, messageId);
+            chatMemberReadStateUpdater.advanceLastReadMessageId(chatRoomId, memberId, messageId);
         } catch (Exception e) {
             log.error("구독 시 lastReadMessageId 업데이트 실패 - 멤버: {}, 메시지: {}", memberId, messageId, e);
         }

--- a/src/main/java/umc/cockple/demo/domain/chat/service/websocket/subscription/support/SubscribeReadStatusService.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/websocket/subscription/support/SubscribeReadStatusService.java
@@ -11,7 +11,9 @@ import umc.cockple.demo.domain.chat.repository.ChatRoomMemberRepository;
 import umc.cockple.demo.domain.chat.repository.MessageReadStatusRepository;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Service
 @Transactional
@@ -34,16 +36,18 @@ public class SubscribeReadStatusService {
         }
         log.debug("처리할 안읽은 메시지 수: {} - 채팅방: {}, 멤버: {}", unreadMessageIds.size(), chatRoomId, memberId);
 
-        List<MessageUnreadUpdate> updates = unreadMessageIds.stream()
-                .map(messageId -> {
-                    log.debug("메시지 읽음 처리 중 - 메시지: {}, 멤버: {}", messageId, memberId);
-                    int processedCount = messageReadStatusRepository.markAsReadInMembers(messageId, List.of(memberId));
-                    int newUnreadCount = messageReadStatusRepository.countUnreadByMessageId(messageId);
-                    log.debug("메시지 읽음 처리 완료 - 메시지: {}, 처리 결과: {}, 새 안읽은 수: {}",
-                            messageId, processedCount > 0 ? "성공" : "이미 읽음", newUnreadCount);
+        int processedCount = messageReadStatusRepository.markMessagesAsReadForMember(chatRoomId, memberId, unreadMessageIds);
+        log.debug("구독 시 메시지 읽음 배치 처리 완료 - 처리된 메시지 수: {}", processedCount);
 
-                    return new MessageUnreadUpdate(messageId, newUnreadCount);
-                })
+        Map<Long, Integer> unreadCounts = messageReadStatusRepository.countUnreadByMessageIds(unreadMessageIds)
+                .stream()
+                .collect(Collectors.toMap(
+                        count -> count.chatMessageId(),
+                        count -> count.unreadCount().intValue()
+                ));
+
+        List<MessageUnreadUpdate> updates = unreadMessageIds.stream()
+                .map(messageId -> new MessageUnreadUpdate(messageId, unreadCounts.getOrDefault(messageId, 0)))
                 .toList();
 
         if (!unreadMessageIds.isEmpty()) {

--- a/src/main/java/umc/cockple/demo/domain/chat/service/websocket/subscription/support/SubscribeReadStatusService.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/websocket/subscription/support/SubscribeReadStatusService.java
@@ -8,6 +8,7 @@ import org.springframework.transaction.annotation.Transactional;
 import umc.cockple.demo.domain.chat.events.ChatUnreadStatusUpdateEvent;
 import umc.cockple.demo.domain.chat.repository.ChatRoomMemberRepository;
 import umc.cockple.demo.domain.chat.repository.MessageReadStatusRepository;
+import umc.cockple.demo.domain.chat.repository.projection.ChatMessageUnreadCountDTO;
 
 import java.util.List;
 import java.util.Map;
@@ -24,51 +25,44 @@ public class SubscribeReadStatusService {
     private final ApplicationEventPublisher eventPublisher;
 
     public List<MessageUnreadUpdate> markUnreadMessagesAsReadOnSubscribe(Long chatRoomId, Long memberId) {
-        log.info("구독 시 안읽은 메시지 처리 시작 - 채팅방: {}, 멤버: {}", chatRoomId, memberId);
-
         List<Long> unreadMessageIds = messageReadStatusRepository.findUnreadMessageIdsByMember(chatRoomId, memberId);
-
         if (unreadMessageIds.isEmpty()) {
-            log.debug("처리할 안읽은 메시지가 없음 - 채팅방: {}, 멤버: {}", chatRoomId, memberId);
             return List.of();
         }
-        log.debug("처리할 안읽은 메시지 수: {} - 채팅방: {}, 멤버: {}", unreadMessageIds.size(), chatRoomId, memberId);
 
-        int processedCount = messageReadStatusRepository.markMessagesAsReadForMember(chatRoomId, memberId, unreadMessageIds);
-        log.debug("구독 시 메시지 읽음 배치 처리 완료 - 처리된 메시지 수: {}", processedCount);
+        messageReadStatusRepository.markMessagesAsReadForMember(chatRoomId, memberId, unreadMessageIds);
 
-        Map<Long, Integer> unreadCounts = messageReadStatusRepository.countUnreadByMessageIds(unreadMessageIds)
-                .stream()
-                .collect(Collectors.toMap(
-                        count -> count.chatMessageId(),
-                        count -> count.unreadCount().intValue()
-                ));
-
-        List<MessageUnreadUpdate> updates = unreadMessageIds.stream()
-                .map(messageId -> new MessageUnreadUpdate(messageId, unreadCounts.getOrDefault(messageId, 0)))
-                .toList();
-
-        if (!unreadMessageIds.isEmpty()) {
-            Long latestMessageId = unreadMessageIds.get(unreadMessageIds.size() - 1);
-            updateLastReadMessageId(chatRoomId, memberId, latestMessageId);
-            log.debug("lastReadMessageId 업데이트 완료 - 채팅방: {}, 멤버: {}, 최신 메시지: {}",
-                    chatRoomId, memberId, latestMessageId);
-        }
-
-        log.info("구독 시 안읽은 메시지 처리 완료 - 채팅방: {}, 멤버: {}, 처리된 메시지 수: {}",
-                chatRoomId, memberId, updates.size());
-
+        List<MessageUnreadUpdate> updates = createUnreadUpdates(unreadMessageIds);
+        updateLastReadMessageId(chatRoomId, memberId, latestMessageId(unreadMessageIds));
         eventPublisher.publishEvent(ChatUnreadStatusUpdateEvent.of(List.of(memberId)));
-        log.info("구독 읽음 처리 후 안읽음 상태 업데이트 이벤트 발행 - 채팅방: {}, 멤버: {}", chatRoomId, memberId);
 
         return updates;
     }
 
+    private List<MessageUnreadUpdate> createUnreadUpdates(List<Long> unreadMessageIds) {
+        Map<Long, Integer> unreadCounts = countUnreadMessages(unreadMessageIds);
+
+        return unreadMessageIds.stream()
+                .map(messageId -> new MessageUnreadUpdate(messageId, unreadCounts.getOrDefault(messageId, 0)))
+                .toList();
+    }
+
+    private Map<Long, Integer> countUnreadMessages(List<Long> messageIds) {
+        return messageReadStatusRepository.countUnreadByMessageIds(messageIds)
+                .stream()
+                .collect(Collectors.toMap(
+                        ChatMessageUnreadCountDTO::chatMessageId,
+                        count -> count.unreadCount().intValue()
+                ));
+    }
+
+    private Long latestMessageId(List<Long> messageIds) {
+        return messageIds.get(messageIds.size() - 1);
+    }
+
     private void updateLastReadMessageId(Long chatRoomId, Long memberId, Long messageId) {
         try {
-            int updatedCount = chatRoomMemberRepository.advanceLastReadMessageId(chatRoomId, memberId, messageId);
-            log.debug("구독 시 lastReadMessageId 배치 업데이트 - 채팅방: {}, 멤버: {}, 메시지: {}, 처리 수: {}",
-                    chatRoomId, memberId, messageId, updatedCount);
+            chatRoomMemberRepository.advanceLastReadMessageId(chatRoomId, memberId, messageId);
         } catch (Exception e) {
             log.error("구독 시 lastReadMessageId 업데이트 실패 - 멤버: {}, 메시지: {}", memberId, messageId, e);
         }

--- a/src/main/java/umc/cockple/demo/domain/chat/service/websocket/subscription/support/SubscribeReadStatusService.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/websocket/subscription/support/SubscribeReadStatusService.java
@@ -5,14 +5,12 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import umc.cockple.demo.domain.chat.domain.ChatRoomMember;
 import umc.cockple.demo.domain.chat.events.ChatUnreadStatusUpdateEvent;
 import umc.cockple.demo.domain.chat.repository.ChatRoomMemberRepository;
 import umc.cockple.demo.domain.chat.repository.MessageReadStatusRepository;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
@@ -68,24 +66,9 @@ public class SubscribeReadStatusService {
 
     private void updateLastReadMessageId(Long chatRoomId, Long memberId, Long messageId) {
         try {
-            Optional<ChatRoomMember> chatRoomMemberOpt =
-                    chatRoomMemberRepository.findByChatRoomIdAndMemberId(chatRoomId, memberId);
-
-            if (chatRoomMemberOpt.isPresent()) {
-                ChatRoomMember chatRoomMember = chatRoomMemberOpt.get();
-
-                if (chatRoomMember.getLastReadMessageId() == null ||
-                        messageId > chatRoomMember.getLastReadMessageId()) {
-
-                    Long previousLastRead = chatRoomMember.getLastReadMessageId();
-                    chatRoomMember.updateLastReadMessageId(messageId);
-
-                    log.debug("구독 시 lastReadMessageId 업데이트 - 멤버: {}, 이전: {}, 새로운: {}",
-                            memberId, previousLastRead, messageId);
-                }
-            } else {
-                log.warn("ChatRoomMember를 찾을 수 없음 - 채팅방: {}, 멤버: {}", chatRoomId, memberId);
-            }
+            int updatedCount = chatRoomMemberRepository.advanceLastReadMessageId(chatRoomId, memberId, messageId);
+            log.debug("구독 시 lastReadMessageId 배치 업데이트 - 채팅방: {}, 멤버: {}, 메시지: {}, 처리 수: {}",
+                    chatRoomId, memberId, messageId, updatedCount);
         } catch (Exception e) {
             log.error("구독 시 lastReadMessageId 업데이트 실패 - 멤버: {}, 메시지: {}", memberId, messageId, e);
         }

--- a/src/test/java/umc/cockple/demo/domain/chat/repository/ChatRoomMemberRepositoryTest.java
+++ b/src/test/java/umc/cockple/demo/domain/chat/repository/ChatRoomMemberRepositoryTest.java
@@ -16,6 +16,8 @@ import umc.cockple.demo.global.enums.Level;
 import umc.cockple.demo.support.fixture.ChatFixture;
 import umc.cockple.demo.support.fixture.MemberFixture;
 
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 @DisplayName("ChatRoomMemberRepository")
@@ -64,5 +66,37 @@ class ChatRoomMemberRepositoryTest {
         entityManager.clear();
         ChatRoomMember updatedMembership = chatRoomMemberRepository.findById(membership.getId()).orElseThrow();
         assertThat(updatedMembership.getLastReadMessageId()).isEqualTo(200L);
+    }
+
+    @Test
+    @DisplayName("advanceLastReadMessageIdForMembers는 여러 멤버의 lastReadMessageId를 전진시킨다")
+    void advanceLastReadMessageIdForMembers_updatesMultipleMembers() {
+        // given
+        Member firstMember = memberRepository.save(MemberFixture.createMember("첫번째", Gender.MALE, Level.A, 1001L));
+        Member secondMember = memberRepository.save(MemberFixture.createMember("두번째", Gender.FEMALE, Level.B, 2002L));
+        Member skippedMember = memberRepository.save(MemberFixture.createMember("스킵", Gender.MALE, Level.C, 3003L));
+        ChatRoom chatRoom = chatRoomRepository.save(ChatFixture.createDirectChatRoom());
+        ChatRoomMember firstMembership =
+                chatRoomMemberRepository.save(ChatRoomMember.createJoined(chatRoom, firstMember, "첫번째"));
+        ChatRoomMember secondMembership = chatRoomMemberRepository.save(
+                ChatFixture.createJoinedMemberWithLastRead(chatRoom, secondMember, 50L));
+        ChatRoomMember skippedMembership = chatRoomMemberRepository.save(
+                ChatFixture.createJoinedMemberWithLastRead(chatRoom, skippedMember, 300L));
+
+        // when
+        int updatedCount = chatRoomMemberRepository.advanceLastReadMessageIdForMembers(
+                chatRoom.getId(),
+                List.of(firstMember.getId(), secondMember.getId(), skippedMember.getId()),
+                200L);
+
+        // then
+        assertThat(updatedCount).isEqualTo(2);
+        entityManager.clear();
+        assertThat(chatRoomMemberRepository.findById(firstMembership.getId()).orElseThrow().getLastReadMessageId())
+                .isEqualTo(200L);
+        assertThat(chatRoomMemberRepository.findById(secondMembership.getId()).orElseThrow().getLastReadMessageId())
+                .isEqualTo(200L);
+        assertThat(chatRoomMemberRepository.findById(skippedMembership.getId()).orElseThrow().getLastReadMessageId())
+                .isEqualTo(300L);
     }
 }

--- a/src/test/java/umc/cockple/demo/domain/chat/repository/ChatRoomMemberRepositoryTest.java
+++ b/src/test/java/umc/cockple/demo/domain/chat/repository/ChatRoomMemberRepositoryTest.java
@@ -1,0 +1,68 @@
+package umc.cockple.demo.domain.chat.repository;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+import umc.cockple.demo.domain.chat.domain.ChatRoom;
+import umc.cockple.demo.domain.chat.domain.ChatRoomMember;
+import umc.cockple.demo.domain.member.domain.Member;
+import umc.cockple.demo.domain.member.repository.MemberRepository;
+import umc.cockple.demo.global.config.QuerydslConfig;
+import umc.cockple.demo.global.enums.Gender;
+import umc.cockple.demo.global.enums.Level;
+import umc.cockple.demo.support.fixture.ChatFixture;
+import umc.cockple.demo.support.fixture.MemberFixture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("ChatRoomMemberRepository")
+@DataJpaTest
+@Import(QuerydslConfig.class)
+class ChatRoomMemberRepositoryTest {
+
+    @Autowired private ChatRoomMemberRepository chatRoomMemberRepository;
+    @Autowired private ChatRoomRepository chatRoomRepository;
+    @Autowired private MemberRepository memberRepository;
+    @Autowired private TestEntityManager entityManager;
+
+    @Test
+    @DisplayName("advanceLastReadMessageId는 기존 값이 없으면 새 메시지 ID로 설정한다")
+    void advanceLastReadMessageId_updatesNullValue() {
+        // given
+        Member member = memberRepository.save(MemberFixture.createMember("홍길동", Gender.MALE, Level.A, 1001L));
+        ChatRoom chatRoom = chatRoomRepository.save(ChatFixture.createDirectChatRoom());
+        ChatRoomMember membership =
+                chatRoomMemberRepository.save(ChatRoomMember.createJoined(chatRoom, member, "상대방"));
+
+        // when
+        int updatedCount = chatRoomMemberRepository.advanceLastReadMessageId(chatRoom.getId(), member.getId(), 100L);
+
+        // then
+        assertThat(updatedCount).isEqualTo(1);
+        entityManager.clear();
+        ChatRoomMember updatedMembership = chatRoomMemberRepository.findById(membership.getId()).orElseThrow();
+        assertThat(updatedMembership.getLastReadMessageId()).isEqualTo(100L);
+    }
+
+    @Test
+    @DisplayName("advanceLastReadMessageId는 기존 값보다 작은 메시지 ID로 감소시키지 않는다")
+    void advanceLastReadMessageId_doesNotMoveBackward() {
+        // given
+        Member member = memberRepository.save(MemberFixture.createMember("홍길동", Gender.MALE, Level.A, 1001L));
+        ChatRoom chatRoom = chatRoomRepository.save(ChatFixture.createDirectChatRoom());
+        ChatRoomMember membership = chatRoomMemberRepository.save(
+                ChatFixture.createJoinedMemberWithLastRead(chatRoom, member, 200L));
+
+        // when
+        int updatedCount = chatRoomMemberRepository.advanceLastReadMessageId(chatRoom.getId(), member.getId(), 100L);
+
+        // then
+        assertThat(updatedCount).isEqualTo(0);
+        entityManager.clear();
+        ChatRoomMember updatedMembership = chatRoomMemberRepository.findById(membership.getId()).orElseThrow();
+        assertThat(updatedMembership.getLastReadMessageId()).isEqualTo(200L);
+    }
+}

--- a/src/test/java/umc/cockple/demo/domain/chat/repository/MessageReadStatusRepositoryTest.java
+++ b/src/test/java/umc/cockple/demo/domain/chat/repository/MessageReadStatusRepositoryTest.java
@@ -1,0 +1,115 @@
+package umc.cockple.demo.domain.chat.repository;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+import umc.cockple.demo.domain.chat.domain.MessageReadStatus;
+import umc.cockple.demo.domain.chat.repository.projection.ChatMessageUnreadCountDTO;
+import umc.cockple.demo.global.config.QuerydslConfig;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("MessageReadStatusRepository")
+@DataJpaTest
+@Import(QuerydslConfig.class)
+class MessageReadStatusRepositoryTest {
+
+    @Autowired private MessageReadStatusRepository messageReadStatusRepository;
+    @Autowired private TestEntityManager entityManager;
+
+    @Test
+    @DisplayName("markMessagesAsReadForMember는 지정 채팅방/멤버/메시지 목록의 unread 상태만 읽음 처리한다")
+    void markMessagesAsReadForMember_updatesOnlyMatchingUnreadStatuses() {
+        // given
+        Long chatRoomId = 10L;
+        Long memberId = 101L;
+        Long otherMemberId = 102L;
+        Long otherChatRoomId = 11L;
+        Long firstMessageId = 201L;
+        Long secondMessageId = 202L;
+        Long excludedMessageId = 203L;
+        Long otherRoomMessageId = 204L;
+
+        MessageReadStatus firstUnread = saveUnread(firstMessageId, memberId, chatRoomId);
+        MessageReadStatus secondUnread = saveUnread(secondMessageId, memberId, chatRoomId);
+        MessageReadStatus excludedUnread = saveUnread(excludedMessageId, memberId, chatRoomId);
+        MessageReadStatus otherMemberUnread = saveUnread(firstMessageId, otherMemberId, chatRoomId);
+        MessageReadStatus otherRoomUnread = saveUnread(otherRoomMessageId, memberId, otherChatRoomId);
+        MessageReadStatus alreadyRead = saveRead(205L, memberId, chatRoomId);
+
+        // when
+        int updatedCount = messageReadStatusRepository.markMessagesAsReadForMember(
+                chatRoomId,
+                memberId,
+                List.of(firstMessageId, secondMessageId, otherRoomMessageId)
+        );
+
+        // then
+        assertThat(updatedCount).isEqualTo(2);
+        entityManager.clear();
+
+        assertThat(readStatus(firstUnread).getIsRead()).isTrue();
+        assertThat(readStatus(secondUnread).getIsRead()).isTrue();
+        assertThat(readStatus(excludedUnread).getIsRead()).isFalse();
+        assertThat(readStatus(otherMemberUnread).getIsRead()).isFalse();
+        assertThat(readStatus(otherRoomUnread).getIsRead()).isFalse();
+        assertThat(readStatus(alreadyRead).getIsRead()).isTrue();
+    }
+
+    @Test
+    @DisplayName("countUnreadByMessageIds는 메시지별 unread 수를 그룹으로 조회하고 fully-read 메시지는 결과에서 제외한다")
+    void countUnreadByMessageIds_countsUnreadByMessageAndOmitsFullyReadMessages() {
+        // given
+        Long chatRoomId = 10L;
+        Long firstMessageId = 201L;
+        Long secondMessageId = 202L;
+        Long fullyReadMessageId = 203L;
+        Long excludedMessageId = 204L;
+
+        saveUnread(firstMessageId, 101L, chatRoomId);
+        saveUnread(firstMessageId, 102L, chatRoomId);
+        saveRead(firstMessageId, 103L, chatRoomId);
+        saveUnread(secondMessageId, 101L, chatRoomId);
+        saveRead(fullyReadMessageId, 101L, chatRoomId);
+        saveRead(fullyReadMessageId, 102L, chatRoomId);
+        saveUnread(excludedMessageId, 101L, chatRoomId);
+
+        // when
+        List<ChatMessageUnreadCountDTO> result = messageReadStatusRepository.countUnreadByMessageIds(
+                List.of(firstMessageId, secondMessageId, fullyReadMessageId)
+        );
+
+        // then
+        assertThat(result)
+                .extracting(ChatMessageUnreadCountDTO::chatMessageId)
+                .containsExactlyInAnyOrder(firstMessageId, secondMessageId);
+        assertThat(result)
+                .anySatisfy(count -> {
+                    assertThat(count.chatMessageId()).isEqualTo(firstMessageId);
+                    assertThat(count.unreadCount()).isEqualTo(2L);
+                })
+                .anySatisfy(count -> {
+                    assertThat(count.chatMessageId()).isEqualTo(secondMessageId);
+                    assertThat(count.unreadCount()).isEqualTo(1L);
+                })
+                .noneSatisfy(count -> assertThat(count.chatMessageId()).isEqualTo(fullyReadMessageId))
+                .noneSatisfy(count -> assertThat(count.chatMessageId()).isEqualTo(excludedMessageId));
+    }
+
+    private MessageReadStatus saveUnread(Long messageId, Long memberId, Long chatRoomId) {
+        return messageReadStatusRepository.save(MessageReadStatus.createUnread(messageId, memberId, chatRoomId));
+    }
+
+    private MessageReadStatus saveRead(Long messageId, Long memberId, Long chatRoomId) {
+        return messageReadStatusRepository.save(MessageReadStatus.createRead(messageId, memberId, chatRoomId));
+    }
+
+    private MessageReadStatus readStatus(MessageReadStatus status) {
+        return messageReadStatusRepository.findById(status.getId()).orElseThrow();
+    }
+}

--- a/src/test/java/umc/cockple/demo/domain/chat/service/support/reader/ReadStatusReaderTest.java
+++ b/src/test/java/umc/cockple/demo/domain/chat/service/support/reader/ReadStatusReaderTest.java
@@ -49,8 +49,8 @@ class ReadStatusReaderTest {
     }
 
     @Test
-    @DisplayName("메시지별 unread 수를 Map으로 변환한다")
-    void countUnreadByMessageIds_returnsCountMap() {
+    @DisplayName("메시지별 unread 수를 sparse Map으로 변환한다")
+    void countUnreadByMessageIdsAsSparseMap_returnsSparseCountMap() {
         // given
         Long firstMessageId = 201L;
         Long secondMessageId = 202L;
@@ -62,7 +62,7 @@ class ReadStatusReaderTest {
                 ));
 
         // when
-        Map<Long, Integer> result = readStatusReader.countUnreadByMessageIds(messageIds);
+        Map<Long, Integer> result = readStatusReader.countUnreadByMessageIdsAsSparseMap(messageIds);
 
         // then
         assertThat(result).containsEntry(firstMessageId, 2)
@@ -70,8 +70,26 @@ class ReadStatusReaderTest {
     }
 
     @Test
+    @DisplayName("메시지별 unread 수 sparse Map은 repository 결과에 없는 메시지를 0으로 채우지 않는다")
+    void countUnreadByMessageIdsAsSparseMap_doesNotFillMissingMessageCount() {
+        // given
+        Long unreadMessageId = 201L;
+        Long fullyReadMessageId = 202L;
+        List<Long> messageIds = List.of(unreadMessageId, fullyReadMessageId);
+        given(messageReadStatusRepository.countUnreadByMessageIds(messageIds))
+                .willReturn(List.of(new ChatMessageUnreadCountDTO(unreadMessageId, 1L)));
+
+        // when
+        Map<Long, Integer> result = readStatusReader.countUnreadByMessageIdsAsSparseMap(messageIds);
+
+        // then
+        assertThat(result).containsEntry(unreadMessageId, 1);
+        assertThat(result).doesNotContainKey(fullyReadMessageId);
+    }
+
+    @Test
     @DisplayName("메시지별 unread 수 조회는 큰 메시지 ID 목록을 chunk로 나눠 조회한다")
-    void countUnreadByMessageIds_chunksLargeMessageIds() {
+    void countUnreadByMessageIdsAsSparseMap_chunksLargeMessageIds() {
         // given
         List<Long> messageIds = LongStream.rangeClosed(1, ReadStatusBatchSupport.IN_CLAUSE_CHUNK_SIZE + 1L)
                 .boxed()
@@ -85,7 +103,7 @@ class ReadStatusReaderTest {
                 .willReturn(List.of(new ChatMessageUnreadCountDTO((long) messageIds.size(), 1L)));
 
         // when
-        Map<Long, Integer> result = readStatusReader.countUnreadByMessageIds(messageIds);
+        Map<Long, Integer> result = readStatusReader.countUnreadByMessageIdsAsSparseMap(messageIds);
 
         // then
         assertThat(result).containsEntry(1L, 2)
@@ -96,9 +114,9 @@ class ReadStatusReaderTest {
 
     @Test
     @DisplayName("메시지 ID 목록이 비어 있으면 unread 수를 조회하지 않는다")
-    void countUnreadByMessageIds_skipsRepositoryWhenMessageIdsEmpty() {
+    void countUnreadByMessageIdsAsSparseMap_skipsRepositoryWhenMessageIdsEmpty() {
         // when
-        Map<Long, Integer> result = readStatusReader.countUnreadByMessageIds(List.of());
+        Map<Long, Integer> result = readStatusReader.countUnreadByMessageIdsAsSparseMap(List.of());
 
         // then
         assertThat(result).isEmpty();

--- a/src/test/java/umc/cockple/demo/domain/chat/service/support/reader/ReadStatusReaderTest.java
+++ b/src/test/java/umc/cockple/demo/domain/chat/service/support/reader/ReadStatusReaderTest.java
@@ -1,0 +1,94 @@
+package umc.cockple.demo.domain.chat.service.support.reader;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import umc.cockple.demo.domain.chat.repository.MessageReadStatusRepository;
+import umc.cockple.demo.domain.chat.repository.projection.ChatMessageUnreadCountDTO;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ReadStatusReader")
+class ReadStatusReaderTest {
+
+    @Mock private MessageReadStatusRepository messageReadStatusRepository;
+
+    private ReadStatusReader readStatusReader;
+
+    @BeforeEach
+    void setUp() {
+        readStatusReader = new ReadStatusReader(messageReadStatusRepository);
+    }
+
+    @Test
+    @DisplayName("멤버의 unread 메시지 ID 목록을 조회한다")
+    void findUnreadMessageIds_returnsMessageIds() {
+        // given
+        Long chatRoomId = 10L;
+        Long memberId = 101L;
+        List<Long> messageIds = List.of(201L, 202L);
+        given(messageReadStatusRepository.findUnreadMessageIdsByMember(chatRoomId, memberId))
+                .willReturn(messageIds);
+
+        // when
+        List<Long> result = readStatusReader.findUnreadMessageIds(chatRoomId, memberId);
+
+        // then
+        assertThat(result).isEqualTo(messageIds);
+    }
+
+    @Test
+    @DisplayName("메시지별 unread 수를 Map으로 변환한다")
+    void countUnreadByMessageIds_returnsCountMap() {
+        // given
+        Long firstMessageId = 201L;
+        Long secondMessageId = 202L;
+        List<Long> messageIds = List.of(firstMessageId, secondMessageId);
+        given(messageReadStatusRepository.countUnreadByMessageIds(messageIds))
+                .willReturn(List.of(
+                        new ChatMessageUnreadCountDTO(firstMessageId, 2L),
+                        new ChatMessageUnreadCountDTO(secondMessageId, 1L)
+                ));
+
+        // when
+        Map<Long, Integer> result = readStatusReader.countUnreadByMessageIds(messageIds);
+
+        // then
+        assertThat(result).containsEntry(firstMessageId, 2)
+                .containsEntry(secondMessageId, 1);
+    }
+
+    @Test
+    @DisplayName("메시지 ID 목록이 비어 있으면 unread 수를 조회하지 않는다")
+    void countUnreadByMessageIds_skipsRepositoryWhenMessageIdsEmpty() {
+        // when
+        Map<Long, Integer> result = readStatusReader.countUnreadByMessageIds(List.of());
+
+        // then
+        assertThat(result).isEmpty();
+        then(messageReadStatusRepository).shouldHaveNoInteractions();
+    }
+
+    @Test
+    @DisplayName("단일 메시지 unread 수를 조회한다")
+    void countUnreadByMessageId_returnsCount() {
+        // given
+        Long messageId = 201L;
+        given(messageReadStatusRepository.countUnreadByMessageId(messageId)).willReturn(3);
+
+        // when
+        int result = readStatusReader.countUnreadByMessageId(messageId);
+
+        // then
+        assertThat(result).isEqualTo(3);
+    }
+}

--- a/src/test/java/umc/cockple/demo/domain/chat/service/support/reader/ReadStatusReaderTest.java
+++ b/src/test/java/umc/cockple/demo/domain/chat/service/support/reader/ReadStatusReaderTest.java
@@ -8,9 +8,11 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import umc.cockple.demo.domain.chat.repository.MessageReadStatusRepository;
 import umc.cockple.demo.domain.chat.repository.projection.ChatMessageUnreadCountDTO;
+import umc.cockple.demo.domain.chat.service.support.ReadStatusBatchSupport;
 
 import java.util.List;
 import java.util.Map;
+import java.util.stream.LongStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
@@ -65,6 +67,31 @@ class ReadStatusReaderTest {
         // then
         assertThat(result).containsEntry(firstMessageId, 2)
                 .containsEntry(secondMessageId, 1);
+    }
+
+    @Test
+    @DisplayName("메시지별 unread 수 조회는 큰 메시지 ID 목록을 chunk로 나눠 조회한다")
+    void countUnreadByMessageIds_chunksLargeMessageIds() {
+        // given
+        List<Long> messageIds = LongStream.rangeClosed(1, ReadStatusBatchSupport.IN_CLAUSE_CHUNK_SIZE + 1L)
+                .boxed()
+                .toList();
+        List<Long> firstChunk = messageIds.subList(0, ReadStatusBatchSupport.IN_CLAUSE_CHUNK_SIZE);
+        List<Long> secondChunk = messageIds.subList(ReadStatusBatchSupport.IN_CLAUSE_CHUNK_SIZE, messageIds.size());
+
+        given(messageReadStatusRepository.countUnreadByMessageIds(firstChunk))
+                .willReturn(List.of(new ChatMessageUnreadCountDTO(1L, 2L)));
+        given(messageReadStatusRepository.countUnreadByMessageIds(secondChunk))
+                .willReturn(List.of(new ChatMessageUnreadCountDTO((long) messageIds.size(), 1L)));
+
+        // when
+        Map<Long, Integer> result = readStatusReader.countUnreadByMessageIds(messageIds);
+
+        // then
+        assertThat(result).containsEntry(1L, 2)
+                .containsEntry((long) messageIds.size(), 1);
+        then(messageReadStatusRepository).should().countUnreadByMessageIds(firstChunk);
+        then(messageReadStatusRepository).should().countUnreadByMessageIds(secondChunk);
     }
 
     @Test

--- a/src/test/java/umc/cockple/demo/domain/chat/service/support/updater/ChatMemberReadStateUpdaterTest.java
+++ b/src/test/java/umc/cockple/demo/domain/chat/service/support/updater/ChatMemberReadStateUpdaterTest.java
@@ -45,6 +45,23 @@ class ChatMemberReadStateUpdaterTest {
     }
 
     @Test
+    @DisplayName("멤버의 마지막 읽은 메시지 ID가 갱신되지 않으면 0을 반환한다")
+    void advanceLastReadMessageId_returnsZeroWhenNotUpdated() {
+        // given
+        Long chatRoomId = 10L;
+        Long memberId = 101L;
+        Long messageId = 201L;
+        given(chatRoomMemberRepository.advanceLastReadMessageId(chatRoomId, memberId, messageId))
+                .willReturn(0);
+
+        // when
+        int result = chatMemberReadStateUpdater.advanceLastReadMessageId(chatRoomId, memberId, messageId);
+
+        // then
+        assertThat(result).isZero();
+    }
+
+    @Test
     @DisplayName("여러 멤버의 마지막 읽은 메시지 ID를 전진시킨다")
     void advanceLastReadMessageIdForMembers_delegatesToRepository() {
         // given
@@ -59,6 +76,23 @@ class ChatMemberReadStateUpdaterTest {
 
         // then
         assertThat(result).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("여러 멤버의 마지막 읽은 메시지 ID가 일부만 갱신되면 갱신 수를 반환한다")
+    void advanceLastReadMessageIdForMembers_returnsPartialUpdatedCount() {
+        // given
+        Long chatRoomId = 10L;
+        Long messageId = 201L;
+        List<Long> memberIds = List.of(101L, 102L);
+        given(chatRoomMemberRepository.advanceLastReadMessageIdForMembers(chatRoomId, memberIds, messageId))
+                .willReturn(1);
+
+        // when
+        int result = chatMemberReadStateUpdater.advanceLastReadMessageIdForMembers(chatRoomId, memberIds, messageId);
+
+        // then
+        assertThat(result).isEqualTo(1);
     }
 
     @Test

--- a/src/test/java/umc/cockple/demo/domain/chat/service/support/updater/ChatMemberReadStateUpdaterTest.java
+++ b/src/test/java/umc/cockple/demo/domain/chat/service/support/updater/ChatMemberReadStateUpdaterTest.java
@@ -7,8 +7,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import umc.cockple.demo.domain.chat.repository.ChatRoomMemberRepository;
+import umc.cockple.demo.domain.chat.service.support.ReadStatusBatchSupport;
 
 import java.util.List;
+import java.util.stream.LongStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
@@ -93,6 +95,34 @@ class ChatMemberReadStateUpdaterTest {
 
         // then
         assertThat(result).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("여러 멤버의 마지막 읽은 메시지 ID 갱신은 큰 멤버 ID 목록을 chunk로 나눠 처리한다")
+    void advanceLastReadMessageIdForMembers_chunksLargeMemberIds() {
+        // given
+        Long chatRoomId = 10L;
+        Long messageId = 201L;
+        List<Long> memberIds = LongStream.rangeClosed(1, ReadStatusBatchSupport.IN_CLAUSE_CHUNK_SIZE + 1L)
+                .boxed()
+                .toList();
+        List<Long> firstChunk = memberIds.subList(0, ReadStatusBatchSupport.IN_CLAUSE_CHUNK_SIZE);
+        List<Long> secondChunk = memberIds.subList(ReadStatusBatchSupport.IN_CLAUSE_CHUNK_SIZE, memberIds.size());
+
+        given(chatRoomMemberRepository.advanceLastReadMessageIdForMembers(chatRoomId, firstChunk, messageId))
+                .willReturn(ReadStatusBatchSupport.IN_CLAUSE_CHUNK_SIZE);
+        given(chatRoomMemberRepository.advanceLastReadMessageIdForMembers(chatRoomId, secondChunk, messageId))
+                .willReturn(1);
+
+        // when
+        int result = chatMemberReadStateUpdater.advanceLastReadMessageIdForMembers(chatRoomId, memberIds, messageId);
+
+        // then
+        assertThat(result).isEqualTo(memberIds.size());
+        then(chatRoomMemberRepository).should()
+                .advanceLastReadMessageIdForMembers(chatRoomId, firstChunk, messageId);
+        then(chatRoomMemberRepository).should()
+                .advanceLastReadMessageIdForMembers(chatRoomId, secondChunk, messageId);
     }
 
     @Test

--- a/src/test/java/umc/cockple/demo/domain/chat/service/support/updater/ChatMemberReadStateUpdaterTest.java
+++ b/src/test/java/umc/cockple/demo/domain/chat/service/support/updater/ChatMemberReadStateUpdaterTest.java
@@ -1,0 +1,74 @@
+package umc.cockple.demo.domain.chat.service.support.updater;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import umc.cockple.demo.domain.chat.repository.ChatRoomMemberRepository;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ChatMemberReadStateUpdater")
+class ChatMemberReadStateUpdaterTest {
+
+    @Mock private ChatRoomMemberRepository chatRoomMemberRepository;
+
+    private ChatMemberReadStateUpdater chatMemberReadStateUpdater;
+
+    @BeforeEach
+    void setUp() {
+        chatMemberReadStateUpdater = new ChatMemberReadStateUpdater(chatRoomMemberRepository);
+    }
+
+    @Test
+    @DisplayName("멤버의 마지막 읽은 메시지 ID를 전진시킨다")
+    void advanceLastReadMessageId_delegatesToRepository() {
+        // given
+        Long chatRoomId = 10L;
+        Long memberId = 101L;
+        Long messageId = 201L;
+        given(chatRoomMemberRepository.advanceLastReadMessageId(chatRoomId, memberId, messageId))
+                .willReturn(1);
+
+        // when
+        int result = chatMemberReadStateUpdater.advanceLastReadMessageId(chatRoomId, memberId, messageId);
+
+        // then
+        assertThat(result).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("여러 멤버의 마지막 읽은 메시지 ID를 전진시킨다")
+    void advanceLastReadMessageIdForMembers_delegatesToRepository() {
+        // given
+        Long chatRoomId = 10L;
+        Long messageId = 201L;
+        List<Long> memberIds = List.of(101L, 102L);
+        given(chatRoomMemberRepository.advanceLastReadMessageIdForMembers(chatRoomId, memberIds, messageId))
+                .willReturn(2);
+
+        // when
+        int result = chatMemberReadStateUpdater.advanceLastReadMessageIdForMembers(chatRoomId, memberIds, messageId);
+
+        // then
+        assertThat(result).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("마지막 읽은 메시지를 갱신할 멤버 목록이 비어 있으면 갱신하지 않는다")
+    void advanceLastReadMessageIdForMembers_skipsRepositoryWhenMemberIdsEmpty() {
+        // when
+        int result = chatMemberReadStateUpdater.advanceLastReadMessageIdForMembers(10L, List.of(), 201L);
+
+        // then
+        assertThat(result).isZero();
+        then(chatRoomMemberRepository).shouldHaveNoInteractions();
+    }
+}

--- a/src/test/java/umc/cockple/demo/domain/chat/service/support/updater/ReadStatusUpdaterTest.java
+++ b/src/test/java/umc/cockple/demo/domain/chat/service/support/updater/ReadStatusUpdaterTest.java
@@ -7,8 +7,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import umc.cockple.demo.domain.chat.repository.MessageReadStatusRepository;
+import umc.cockple.demo.domain.chat.service.support.ReadStatusBatchSupport;
 
 import java.util.List;
+import java.util.stream.LongStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
@@ -45,6 +47,34 @@ class ReadStatusUpdaterTest {
     }
 
     @Test
+    @DisplayName("멤버의 메시지 목록 읽음 처리는 큰 메시지 ID 목록을 chunk로 나눠 갱신한다")
+    void markMessagesAsReadForMember_chunksLargeMessageIds() {
+        // given
+        Long chatRoomId = 10L;
+        Long memberId = 101L;
+        List<Long> messageIds = LongStream.rangeClosed(1, ReadStatusBatchSupport.IN_CLAUSE_CHUNK_SIZE + 1L)
+                .boxed()
+                .toList();
+        List<Long> firstChunk = messageIds.subList(0, ReadStatusBatchSupport.IN_CLAUSE_CHUNK_SIZE);
+        List<Long> secondChunk = messageIds.subList(ReadStatusBatchSupport.IN_CLAUSE_CHUNK_SIZE, messageIds.size());
+
+        given(messageReadStatusRepository.markMessagesAsReadForMember(chatRoomId, memberId, firstChunk))
+                .willReturn(ReadStatusBatchSupport.IN_CLAUSE_CHUNK_SIZE);
+        given(messageReadStatusRepository.markMessagesAsReadForMember(chatRoomId, memberId, secondChunk))
+                .willReturn(1);
+
+        // when
+        int result = readStatusUpdater.markMessagesAsReadForMember(chatRoomId, memberId, messageIds);
+
+        // then
+        assertThat(result).isEqualTo(messageIds.size());
+        then(messageReadStatusRepository).should()
+                .markMessagesAsReadForMember(chatRoomId, memberId, firstChunk);
+        then(messageReadStatusRepository).should()
+                .markMessagesAsReadForMember(chatRoomId, memberId, secondChunk);
+    }
+
+    @Test
     @DisplayName("읽음 처리할 메시지 목록이 비어 있으면 갱신하지 않는다")
     void markMessagesAsReadForMember_skipsRepositoryWhenMessageIdsEmpty() {
         // when
@@ -68,6 +98,31 @@ class ReadStatusUpdaterTest {
 
         // then
         assertThat(result).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("여러 멤버 읽음 처리는 큰 멤버 ID 목록을 chunk로 나눠 갱신한다")
+    void markMessageAsReadForMembers_chunksLargeMemberIds() {
+        // given
+        Long messageId = 201L;
+        List<Long> memberIds = LongStream.rangeClosed(1, ReadStatusBatchSupport.IN_CLAUSE_CHUNK_SIZE + 1L)
+                .boxed()
+                .toList();
+        List<Long> firstChunk = memberIds.subList(0, ReadStatusBatchSupport.IN_CLAUSE_CHUNK_SIZE);
+        List<Long> secondChunk = memberIds.subList(ReadStatusBatchSupport.IN_CLAUSE_CHUNK_SIZE, memberIds.size());
+
+        given(messageReadStatusRepository.markAsReadInMembers(messageId, firstChunk))
+                .willReturn(ReadStatusBatchSupport.IN_CLAUSE_CHUNK_SIZE);
+        given(messageReadStatusRepository.markAsReadInMembers(messageId, secondChunk))
+                .willReturn(1);
+
+        // when
+        int result = readStatusUpdater.markMessageAsReadForMembers(messageId, memberIds);
+
+        // then
+        assertThat(result).isEqualTo(memberIds.size());
+        then(messageReadStatusRepository).should().markAsReadInMembers(messageId, firstChunk);
+        then(messageReadStatusRepository).should().markAsReadInMembers(messageId, secondChunk);
     }
 
     @Test

--- a/src/test/java/umc/cockple/demo/domain/chat/service/support/updater/ReadStatusUpdaterTest.java
+++ b/src/test/java/umc/cockple/demo/domain/chat/service/support/updater/ReadStatusUpdaterTest.java
@@ -1,0 +1,83 @@
+package umc.cockple.demo.domain.chat.service.support.updater;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import umc.cockple.demo.domain.chat.repository.MessageReadStatusRepository;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ReadStatusUpdater")
+class ReadStatusUpdaterTest {
+
+    @Mock private MessageReadStatusRepository messageReadStatusRepository;
+
+    private ReadStatusUpdater readStatusUpdater;
+
+    @BeforeEach
+    void setUp() {
+        readStatusUpdater = new ReadStatusUpdater(messageReadStatusRepository);
+    }
+
+    @Test
+    @DisplayName("멤버의 메시지 목록을 읽음 처리한다")
+    void markMessagesAsReadForMember_delegatesToRepository() {
+        // given
+        Long chatRoomId = 10L;
+        Long memberId = 101L;
+        List<Long> messageIds = List.of(201L, 202L);
+        given(messageReadStatusRepository.markMessagesAsReadForMember(chatRoomId, memberId, messageIds))
+                .willReturn(2);
+
+        // when
+        int result = readStatusUpdater.markMessagesAsReadForMember(chatRoomId, memberId, messageIds);
+
+        // then
+        assertThat(result).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("읽음 처리할 메시지 목록이 비어 있으면 갱신하지 않는다")
+    void markMessagesAsReadForMember_skipsRepositoryWhenMessageIdsEmpty() {
+        // when
+        int result = readStatusUpdater.markMessagesAsReadForMember(10L, 101L, List.of());
+
+        // then
+        assertThat(result).isZero();
+        then(messageReadStatusRepository).shouldHaveNoInteractions();
+    }
+
+    @Test
+    @DisplayName("메시지를 여러 멤버에 대해 읽음 처리한다")
+    void markMessageAsReadForMembers_delegatesToRepository() {
+        // given
+        Long messageId = 201L;
+        List<Long> memberIds = List.of(101L, 102L);
+        given(messageReadStatusRepository.markAsReadInMembers(messageId, memberIds)).willReturn(2);
+
+        // when
+        int result = readStatusUpdater.markMessageAsReadForMembers(messageId, memberIds);
+
+        // then
+        assertThat(result).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("읽음 처리할 멤버 목록이 비어 있으면 갱신하지 않는다")
+    void markMessageAsReadForMembers_skipsRepositoryWhenMemberIdsEmpty() {
+        // when
+        int result = readStatusUpdater.markMessageAsReadForMembers(201L, List.of());
+
+        // then
+        assertThat(result).isZero();
+        then(messageReadStatusRepository).shouldHaveNoInteractions();
+    }
+}

--- a/src/test/java/umc/cockple/demo/domain/chat/service/websocket/broadcast/UnreadCountUpdateBroadcasterTest.java
+++ b/src/test/java/umc/cockple/demo/domain/chat/service/websocket/broadcast/UnreadCountUpdateBroadcasterTest.java
@@ -9,10 +9,10 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import umc.cockple.demo.domain.chat.dto.WebSocketMessageDTO;
 import umc.cockple.demo.domain.chat.enums.WebSocketMessageType;
+import umc.cockple.demo.domain.chat.service.websocket.UnreadCountUpdate;
 import umc.cockple.demo.domain.chat.service.websocket.session.ChatMessageEncoder;
 import umc.cockple.demo.domain.chat.service.websocket.session.ChatMessageSender;
 import umc.cockple.demo.domain.chat.service.websocket.session.EncodedChatMessage;
-import umc.cockple.demo.domain.chat.service.websocket.subscription.support.SubscribeReadStatusService;
 
 import java.util.List;
 import java.util.Optional;
@@ -42,8 +42,8 @@ class UnreadCountUpdateBroadcasterTest {
         // given
         Long chatRoomId = 1L;
         Long excludedMemberId = 10L;
-        SubscribeReadStatusService.MessageUnreadUpdate update =
-                new SubscribeReadStatusService.MessageUnreadUpdate(100L, 2);
+        UnreadCountUpdate update =
+                new UnreadCountUpdate(100L, 2);
         EncodedChatMessage encodedMessage = new EncodedChatMessage("unread-count-json");
 
         given(messageEncoder.encode(any(WebSocketMessageDTO.UnreadCountUpdateMessage.class)))
@@ -71,8 +71,8 @@ class UnreadCountUpdateBroadcasterTest {
     @DisplayName("구독자가 없으면 메시지를 직렬화하지 않는다")
     void broadcast_doesNotSerializeWhenSubscribersEmpty() {
         // given
-        SubscribeReadStatusService.MessageUnreadUpdate update =
-                new SubscribeReadStatusService.MessageUnreadUpdate(100L, 2);
+        UnreadCountUpdate update =
+                new UnreadCountUpdate(100L, 2);
 
         // when
         broadcaster.broadcast(1L, List.of(update), List.of(), 10L);
@@ -86,8 +86,8 @@ class UnreadCountUpdateBroadcasterTest {
     @DisplayName("직렬화 실패 시 전송하지 않고 다음 업데이트로 넘어간다")
     void broadcast_doesNotSendWhenSerializationFails() {
         // given
-        SubscribeReadStatusService.MessageUnreadUpdate update =
-                new SubscribeReadStatusService.MessageUnreadUpdate(100L, 2);
+        UnreadCountUpdate update =
+                new UnreadCountUpdate(100L, 2);
         given(messageEncoder.encode(any(WebSocketMessageDTO.UnreadCountUpdateMessage.class)))
                 .willReturn(Optional.empty());
 

--- a/src/test/java/umc/cockple/demo/domain/chat/service/websocket/send/support/SentMessageReadStatusServiceTest.java
+++ b/src/test/java/umc/cockple/demo/domain/chat/service/websocket/send/support/SentMessageReadStatusServiceTest.java
@@ -1,0 +1,104 @@
+package umc.cockple.demo.domain.chat.service.websocket.send.support;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import umc.cockple.demo.domain.chat.repository.ChatRoomMemberRepository;
+import umc.cockple.demo.domain.chat.repository.MessageReadStatusRepository;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("SentMessageReadStatusService")
+class SentMessageReadStatusServiceTest {
+
+    @Mock private MessageReadStatusRepository messageReadStatusRepository;
+    @Mock private ChatRoomMemberRepository chatRoomMemberRepository;
+
+    private SentMessageReadStatusService sentMessageReadStatusService;
+
+    @BeforeEach
+    void setUp() {
+        sentMessageReadStatusService =
+                new SentMessageReadStatusService(messageReadStatusRepository, chatRoomMemberRepository);
+    }
+
+    @Test
+    @DisplayName("활성 구독자 중 발신자를 제외하고 읽음 처리와 lastReadMessageId 갱신을 배치 처리한다")
+    void markActiveSubscribersAsRead_excludesSenderAndUpdatesReadersInBatch() {
+        // given
+        Long chatRoomId = 10L;
+        Long messageId = 100L;
+        Long senderId = 1L;
+        List<Long> activeSubscribers = List.of(senderId, 2L, 3L);
+        List<Long> readers = List.of(2L, 3L);
+
+        given(messageReadStatusRepository.markAsReadInMembers(messageId, readers)).willReturn(2);
+        given(chatRoomMemberRepository.advanceLastReadMessageIdForMembers(chatRoomId, readers, messageId))
+                .willReturn(2);
+        given(messageReadStatusRepository.countUnreadByMessageId(messageId)).willReturn(1);
+
+        // when
+        int unreadCount = sentMessageReadStatusService.markActiveSubscribersAsRead(
+                chatRoomId, messageId, activeSubscribers, senderId);
+
+        // then
+        assertThat(unreadCount).isEqualTo(1);
+        then(messageReadStatusRepository).should().markAsReadInMembers(messageId, readers);
+        then(chatRoomMemberRepository).should().advanceLastReadMessageIdForMembers(chatRoomId, readers, messageId);
+    }
+
+    @Test
+    @DisplayName("시스템 메시지는 활성 구독자 전체를 읽음 처리와 lastReadMessageId 갱신 대상으로 삼는다")
+    void markActiveSubscribersAsRead_includesAllSubscribersForSystemMessage() {
+        // given
+        Long chatRoomId = 10L;
+        Long messageId = 100L;
+        List<Long> activeSubscribers = List.of(1L, 2L);
+
+        given(messageReadStatusRepository.markAsReadInMembers(messageId, activeSubscribers)).willReturn(2);
+        given(chatRoomMemberRepository.advanceLastReadMessageIdForMembers(chatRoomId, activeSubscribers, messageId))
+                .willReturn(2);
+        given(messageReadStatusRepository.countUnreadByMessageId(messageId)).willReturn(0);
+
+        // when
+        int unreadCount = sentMessageReadStatusService.markActiveSubscribersAsRead(
+                chatRoomId, messageId, activeSubscribers, null);
+
+        // then
+        assertThat(unreadCount).isZero();
+        then(messageReadStatusRepository).should().markAsReadInMembers(messageId, activeSubscribers);
+        then(chatRoomMemberRepository).should()
+                .advanceLastReadMessageIdForMembers(chatRoomId, activeSubscribers, messageId);
+    }
+
+    @Test
+    @DisplayName("발신자만 활성 구독 중이면 읽음 처리와 lastReadMessageId 갱신 없이 최종 안읽음 수만 조회한다")
+    void markActiveSubscribersAsRead_skipsReadUpdatesWhenOnlySenderIsActive() {
+        // given
+        Long chatRoomId = 10L;
+        Long messageId = 100L;
+        Long senderId = 1L;
+        given(messageReadStatusRepository.countUnreadByMessageId(messageId)).willReturn(2);
+
+        // when
+        int unreadCount = sentMessageReadStatusService.markActiveSubscribersAsRead(
+                chatRoomId, messageId, List.of(senderId), senderId);
+
+        // then
+        assertThat(unreadCount).isEqualTo(2);
+        then(messageReadStatusRepository).should(never()).markAsReadInMembers(anyLong(), anyList());
+        then(chatRoomMemberRepository).should(never())
+                .advanceLastReadMessageIdForMembers(anyLong(), anyList(), anyLong());
+    }
+}

--- a/src/test/java/umc/cockple/demo/domain/chat/service/websocket/send/support/SentMessageReadStatusServiceTest.java
+++ b/src/test/java/umc/cockple/demo/domain/chat/service/websocket/send/support/SentMessageReadStatusServiceTest.java
@@ -6,8 +6,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import umc.cockple.demo.domain.chat.repository.ChatRoomMemberRepository;
-import umc.cockple.demo.domain.chat.repository.MessageReadStatusRepository;
+import umc.cockple.demo.domain.chat.service.support.reader.ReadStatusReader;
+import umc.cockple.demo.domain.chat.service.support.updater.ChatMemberReadStateUpdater;
+import umc.cockple.demo.domain.chat.service.support.updater.ReadStatusUpdater;
 
 import java.util.List;
 
@@ -22,15 +23,16 @@ import static org.mockito.Mockito.never;
 @DisplayName("SentMessageReadStatusService")
 class SentMessageReadStatusServiceTest {
 
-    @Mock private MessageReadStatusRepository messageReadStatusRepository;
-    @Mock private ChatRoomMemberRepository chatRoomMemberRepository;
+    @Mock private ReadStatusReader readStatusReader;
+    @Mock private ReadStatusUpdater readStatusUpdater;
+    @Mock private ChatMemberReadStateUpdater chatMemberReadStateUpdater;
 
     private SentMessageReadStatusService sentMessageReadStatusService;
 
     @BeforeEach
     void setUp() {
         sentMessageReadStatusService =
-                new SentMessageReadStatusService(messageReadStatusRepository, chatRoomMemberRepository);
+                new SentMessageReadStatusService(readStatusReader, readStatusUpdater, chatMemberReadStateUpdater);
     }
 
     @Test
@@ -43,10 +45,10 @@ class SentMessageReadStatusServiceTest {
         List<Long> activeSubscribers = List.of(senderId, 2L, 3L);
         List<Long> readers = List.of(2L, 3L);
 
-        given(messageReadStatusRepository.markAsReadInMembers(messageId, readers)).willReturn(2);
-        given(chatRoomMemberRepository.advanceLastReadMessageIdForMembers(chatRoomId, readers, messageId))
+        given(readStatusUpdater.markMessageAsReadForMembers(messageId, readers)).willReturn(2);
+        given(chatMemberReadStateUpdater.advanceLastReadMessageIdForMembers(chatRoomId, readers, messageId))
                 .willReturn(2);
-        given(messageReadStatusRepository.countUnreadByMessageId(messageId)).willReturn(1);
+        given(readStatusReader.countUnreadByMessageId(messageId)).willReturn(1);
 
         // when
         int unreadCount = sentMessageReadStatusService.markActiveSubscribersAsRead(
@@ -54,8 +56,8 @@ class SentMessageReadStatusServiceTest {
 
         // then
         assertThat(unreadCount).isEqualTo(1);
-        then(messageReadStatusRepository).should().markAsReadInMembers(messageId, readers);
-        then(chatRoomMemberRepository).should().advanceLastReadMessageIdForMembers(chatRoomId, readers, messageId);
+        then(readStatusUpdater).should().markMessageAsReadForMembers(messageId, readers);
+        then(chatMemberReadStateUpdater).should().advanceLastReadMessageIdForMembers(chatRoomId, readers, messageId);
     }
 
     @Test
@@ -66,10 +68,10 @@ class SentMessageReadStatusServiceTest {
         Long messageId = 100L;
         List<Long> activeSubscribers = List.of(1L, 2L);
 
-        given(messageReadStatusRepository.markAsReadInMembers(messageId, activeSubscribers)).willReturn(2);
-        given(chatRoomMemberRepository.advanceLastReadMessageIdForMembers(chatRoomId, activeSubscribers, messageId))
+        given(readStatusUpdater.markMessageAsReadForMembers(messageId, activeSubscribers)).willReturn(2);
+        given(chatMemberReadStateUpdater.advanceLastReadMessageIdForMembers(chatRoomId, activeSubscribers, messageId))
                 .willReturn(2);
-        given(messageReadStatusRepository.countUnreadByMessageId(messageId)).willReturn(0);
+        given(readStatusReader.countUnreadByMessageId(messageId)).willReturn(0);
 
         // when
         int unreadCount = sentMessageReadStatusService.markActiveSubscribersAsRead(
@@ -77,8 +79,8 @@ class SentMessageReadStatusServiceTest {
 
         // then
         assertThat(unreadCount).isZero();
-        then(messageReadStatusRepository).should().markAsReadInMembers(messageId, activeSubscribers);
-        then(chatRoomMemberRepository).should()
+        then(readStatusUpdater).should().markMessageAsReadForMembers(messageId, activeSubscribers);
+        then(chatMemberReadStateUpdater).should()
                 .advanceLastReadMessageIdForMembers(chatRoomId, activeSubscribers, messageId);
     }
 
@@ -89,7 +91,7 @@ class SentMessageReadStatusServiceTest {
         Long chatRoomId = 10L;
         Long messageId = 100L;
         Long senderId = 1L;
-        given(messageReadStatusRepository.countUnreadByMessageId(messageId)).willReturn(2);
+        given(readStatusReader.countUnreadByMessageId(messageId)).willReturn(2);
 
         // when
         int unreadCount = sentMessageReadStatusService.markActiveSubscribersAsRead(
@@ -97,8 +99,8 @@ class SentMessageReadStatusServiceTest {
 
         // then
         assertThat(unreadCount).isEqualTo(2);
-        then(messageReadStatusRepository).should(never()).markAsReadInMembers(anyLong(), anyList());
-        then(chatRoomMemberRepository).should(never())
+        then(readStatusUpdater).should(never()).markMessageAsReadForMembers(anyLong(), anyList());
+        then(chatMemberReadStateUpdater).should(never())
                 .advanceLastReadMessageIdForMembers(anyLong(), anyList(), anyLong());
     }
 }

--- a/src/test/java/umc/cockple/demo/domain/chat/service/websocket/subscription/ChatRoomSubscriptionServiceTest.java
+++ b/src/test/java/umc/cockple/demo/domain/chat/service/websocket/subscription/ChatRoomSubscriptionServiceTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import umc.cockple.demo.domain.chat.repository.redis.ChatRoomSubscriptionStore;
+import umc.cockple.demo.domain.chat.service.websocket.UnreadCountUpdate;
 import umc.cockple.demo.domain.chat.service.websocket.broadcast.UnreadCountUpdateBroadcaster;
 import umc.cockple.demo.domain.chat.service.websocket.subscription.support.ActiveChatRoomSubscriberReader;
 import umc.cockple.demo.domain.chat.service.websocket.subscription.support.SubscribeReadStatusService;
@@ -44,8 +45,8 @@ class ChatRoomSubscriptionServiceTest {
         Long chatRoomId = 1L;
         Long memberId = 10L;
         List<Long> activeSubscribers = List.of(memberId, 20L);
-        List<SubscribeReadStatusService.MessageUnreadUpdate> updates =
-                List.of(new SubscribeReadStatusService.MessageUnreadUpdate(100L, 1));
+        List<UnreadCountUpdate> updates =
+                List.of(new UnreadCountUpdate(100L, 1));
 
         given(subscribeReadStatusService.markUnreadMessagesAsReadOnSubscribe(chatRoomId, memberId))
                 .willReturn(updates);

--- a/src/test/java/umc/cockple/demo/domain/chat/service/websocket/subscription/support/SubscribeReadStatusServiceTest.java
+++ b/src/test/java/umc/cockple/demo/domain/chat/service/websocket/subscription/support/SubscribeReadStatusServiceTest.java
@@ -14,6 +14,7 @@ import umc.cockple.demo.domain.chat.domain.ChatRoomMember;
 import umc.cockple.demo.domain.chat.events.ChatUnreadStatusUpdateEvent;
 import umc.cockple.demo.domain.chat.repository.ChatRoomMemberRepository;
 import umc.cockple.demo.domain.chat.repository.MessageReadStatusRepository;
+import umc.cockple.demo.domain.chat.repository.projection.ChatMessageUnreadCountDTO;
 import umc.cockple.demo.domain.member.domain.Member;
 import umc.cockple.demo.global.enums.Gender;
 import umc.cockple.demo.global.enums.Level;
@@ -24,8 +25,11 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("SubscribeReadStatusService")
@@ -63,10 +67,13 @@ class SubscribeReadStatusServiceTest {
 
         given(messageReadStatusRepository.findUnreadMessageIdsByMember(chatRoomId, memberId))
                 .willReturn(List.of(firstMessageId, secondMessageId));
-        given(messageReadStatusRepository.markAsReadInMembers(firstMessageId, List.of(memberId))).willReturn(1);
-        given(messageReadStatusRepository.markAsReadInMembers(secondMessageId, List.of(memberId))).willReturn(1);
-        given(messageReadStatusRepository.countUnreadByMessageId(firstMessageId)).willReturn(2);
-        given(messageReadStatusRepository.countUnreadByMessageId(secondMessageId)).willReturn(1);
+        given(messageReadStatusRepository.markMessagesAsReadForMember(
+                chatRoomId, memberId, List.of(firstMessageId, secondMessageId))).willReturn(2);
+        given(messageReadStatusRepository.countUnreadByMessageIds(List.of(firstMessageId, secondMessageId)))
+                .willReturn(List.of(
+                        new ChatMessageUnreadCountDTO(firstMessageId, 2L),
+                        new ChatMessageUnreadCountDTO(secondMessageId, 1L)
+                ));
         given(chatRoomMemberRepository.findByChatRoomIdAndMemberId(chatRoomId, memberId))
                 .willReturn(Optional.of(chatRoomMember));
 
@@ -82,6 +89,10 @@ class SubscribeReadStatusServiceTest {
                 .extracting(SubscribeReadStatusService.MessageUnreadUpdate::newUnreadCount)
                 .containsExactly(2, 1);
         assertThat(chatRoomMember.getLastReadMessageId()).isEqualTo(secondMessageId);
+        then(messageReadStatusRepository).should()
+                .markMessagesAsReadForMember(chatRoomId, memberId, List.of(firstMessageId, secondMessageId));
+        then(messageReadStatusRepository).should()
+                .countUnreadByMessageIds(List.of(firstMessageId, secondMessageId));
 
         ArgumentCaptor<ChatUnreadStatusUpdateEvent> eventCaptor =
                 ArgumentCaptor.forClass(ChatUnreadStatusUpdateEvent.class);
@@ -104,6 +115,46 @@ class SubscribeReadStatusServiceTest {
 
         // then
         assertThat(updates).isEmpty();
+        then(messageReadStatusRepository).should(never())
+                .markMessagesAsReadForMember(anyLong(), anyLong(), anyList());
+        then(messageReadStatusRepository).should(never()).countUnreadByMessageIds(anyList());
         then(eventPublisher).shouldHaveNoInteractions();
+    }
+
+    @Test
+    @DisplayName("구독 시 메시지별 안읽음 수 결과가 누락되면 0으로 반환한다")
+    void markUnreadMessagesAsReadOnSubscribe_fillsMissingUnreadCountWithZero() {
+        // given
+        Long chatRoomId = 10L;
+        Long memberId = 101L;
+        Long firstMessageId = 201L;
+        Long secondMessageId = 202L;
+
+        ChatRoom chatRoom = ChatFixture.createDirectChatRoom();
+        ReflectionTestUtils.setField(chatRoom, "id", chatRoomId);
+        Member member = MemberFixture.createMemberWithName("홍길동", "길동", Gender.MALE, Level.A, 1001L);
+        ReflectionTestUtils.setField(member, "id", memberId);
+        ChatRoomMember chatRoomMember = ChatFixture.createJoinedMemberWithLastRead(chatRoom, member, firstMessageId - 1);
+
+        given(messageReadStatusRepository.findUnreadMessageIdsByMember(chatRoomId, memberId))
+                .willReturn(List.of(firstMessageId, secondMessageId));
+        given(messageReadStatusRepository.markMessagesAsReadForMember(
+                chatRoomId, memberId, List.of(firstMessageId, secondMessageId))).willReturn(2);
+        given(messageReadStatusRepository.countUnreadByMessageIds(List.of(firstMessageId, secondMessageId)))
+                .willReturn(List.of(new ChatMessageUnreadCountDTO(firstMessageId, 2L)));
+        given(chatRoomMemberRepository.findByChatRoomIdAndMemberId(chatRoomId, memberId))
+                .willReturn(Optional.of(chatRoomMember));
+
+        // when
+        List<SubscribeReadStatusService.MessageUnreadUpdate> updates =
+                subscribeReadStatusService.markUnreadMessagesAsReadOnSubscribe(chatRoomId, memberId);
+
+        // then
+        assertThat(updates)
+                .extracting(SubscribeReadStatusService.MessageUnreadUpdate::messageId)
+                .containsExactly(firstMessageId, secondMessageId);
+        assertThat(updates)
+                .extracting(SubscribeReadStatusService.MessageUnreadUpdate::newUnreadCount)
+                .containsExactly(2, 0);
     }
 }

--- a/src/test/java/umc/cockple/demo/domain/chat/service/websocket/subscription/support/SubscribeReadStatusServiceTest.java
+++ b/src/test/java/umc/cockple/demo/domain/chat/service/websocket/subscription/support/SubscribeReadStatusServiceTest.java
@@ -9,12 +9,13 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.ApplicationEventPublisher;
 import umc.cockple.demo.domain.chat.events.ChatUnreadStatusUpdateEvent;
-import umc.cockple.demo.domain.chat.repository.ChatRoomMemberRepository;
-import umc.cockple.demo.domain.chat.repository.MessageReadStatusRepository;
-import umc.cockple.demo.domain.chat.repository.projection.ChatMessageUnreadCountDTO;
+import umc.cockple.demo.domain.chat.service.support.reader.ReadStatusReader;
+import umc.cockple.demo.domain.chat.service.support.updater.ChatMemberReadStateUpdater;
+import umc.cockple.demo.domain.chat.service.support.updater.ReadStatusUpdater;
 import umc.cockple.demo.domain.chat.service.websocket.UnreadCountUpdate;
 
 import java.util.List;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyList;
@@ -27,8 +28,9 @@ import static org.mockito.Mockito.never;
 @DisplayName("SubscribeReadStatusService")
 class SubscribeReadStatusServiceTest {
 
-    @Mock private MessageReadStatusRepository messageReadStatusRepository;
-    @Mock private ChatRoomMemberRepository chatRoomMemberRepository;
+    @Mock private ReadStatusReader readStatusReader;
+    @Mock private ReadStatusUpdater readStatusUpdater;
+    @Mock private ChatMemberReadStateUpdater chatMemberReadStateUpdater;
     @Mock private ApplicationEventPublisher eventPublisher;
 
     private SubscribeReadStatusService subscribeReadStatusService;
@@ -36,8 +38,9 @@ class SubscribeReadStatusServiceTest {
     @BeforeEach
     void setUp() {
         subscribeReadStatusService = new SubscribeReadStatusService(
-                messageReadStatusRepository,
-                chatRoomMemberRepository,
+                readStatusReader,
+                readStatusUpdater,
+                chatMemberReadStateUpdater,
                 eventPublisher
         );
     }
@@ -51,16 +54,13 @@ class SubscribeReadStatusServiceTest {
         Long firstMessageId = 201L;
         Long secondMessageId = 202L;
 
-        given(messageReadStatusRepository.findUnreadMessageIdsByMember(chatRoomId, memberId))
+        given(readStatusReader.findUnreadMessageIds(chatRoomId, memberId))
                 .willReturn(List.of(firstMessageId, secondMessageId));
-        given(messageReadStatusRepository.markMessagesAsReadForMember(
+        given(readStatusUpdater.markMessagesAsReadForMember(
                 chatRoomId, memberId, List.of(firstMessageId, secondMessageId))).willReturn(2);
-        given(messageReadStatusRepository.countUnreadByMessageIds(List.of(firstMessageId, secondMessageId)))
-                .willReturn(List.of(
-                        new ChatMessageUnreadCountDTO(firstMessageId, 2L),
-                        new ChatMessageUnreadCountDTO(secondMessageId, 1L)
-                ));
-        given(chatRoomMemberRepository.advanceLastReadMessageId(chatRoomId, memberId, secondMessageId))
+        given(readStatusReader.countUnreadByMessageIds(List.of(firstMessageId, secondMessageId)))
+                .willReturn(Map.of(firstMessageId, 2, secondMessageId, 1));
+        given(chatMemberReadStateUpdater.advanceLastReadMessageId(chatRoomId, memberId, secondMessageId))
                 .willReturn(1);
 
         // when
@@ -74,11 +74,11 @@ class SubscribeReadStatusServiceTest {
         assertThat(updates)
                 .extracting(UnreadCountUpdate::newUnreadCount)
                 .containsExactly(2, 1);
-        then(messageReadStatusRepository).should()
+        then(readStatusUpdater).should()
                 .markMessagesAsReadForMember(chatRoomId, memberId, List.of(firstMessageId, secondMessageId));
-        then(messageReadStatusRepository).should()
+        then(readStatusReader).should()
                 .countUnreadByMessageIds(List.of(firstMessageId, secondMessageId));
-        then(chatRoomMemberRepository).should()
+        then(chatMemberReadStateUpdater).should()
                 .advanceLastReadMessageId(chatRoomId, memberId, secondMessageId);
 
         ArgumentCaptor<ChatUnreadStatusUpdateEvent> eventCaptor =
@@ -93,7 +93,7 @@ class SubscribeReadStatusServiceTest {
         // given
         Long chatRoomId = 10L;
         Long memberId = 101L;
-        given(messageReadStatusRepository.findUnreadMessageIdsByMember(chatRoomId, memberId))
+        given(readStatusReader.findUnreadMessageIds(chatRoomId, memberId))
                 .willReturn(List.of());
 
         // when
@@ -102,10 +102,10 @@ class SubscribeReadStatusServiceTest {
 
         // then
         assertThat(updates).isEmpty();
-        then(messageReadStatusRepository).should(never())
+        then(readStatusUpdater).should(never())
                 .markMessagesAsReadForMember(anyLong(), anyLong(), anyList());
-        then(messageReadStatusRepository).should(never()).countUnreadByMessageIds(anyList());
-        then(chatRoomMemberRepository).should(never()).advanceLastReadMessageId(anyLong(), anyLong(), anyLong());
+        then(readStatusReader).should(never()).countUnreadByMessageIds(anyList());
+        then(chatMemberReadStateUpdater).should(never()).advanceLastReadMessageId(anyLong(), anyLong(), anyLong());
         then(eventPublisher).shouldHaveNoInteractions();
     }
 
@@ -118,13 +118,13 @@ class SubscribeReadStatusServiceTest {
         Long firstMessageId = 201L;
         Long secondMessageId = 202L;
 
-        given(messageReadStatusRepository.findUnreadMessageIdsByMember(chatRoomId, memberId))
+        given(readStatusReader.findUnreadMessageIds(chatRoomId, memberId))
                 .willReturn(List.of(firstMessageId, secondMessageId));
-        given(messageReadStatusRepository.markMessagesAsReadForMember(
+        given(readStatusUpdater.markMessagesAsReadForMember(
                 chatRoomId, memberId, List.of(firstMessageId, secondMessageId))).willReturn(2);
-        given(messageReadStatusRepository.countUnreadByMessageIds(List.of(firstMessageId, secondMessageId)))
-                .willReturn(List.of(new ChatMessageUnreadCountDTO(firstMessageId, 2L)));
-        given(chatRoomMemberRepository.advanceLastReadMessageId(chatRoomId, memberId, secondMessageId))
+        given(readStatusReader.countUnreadByMessageIds(List.of(firstMessageId, secondMessageId)))
+                .willReturn(Map.of(firstMessageId, 2));
+        given(chatMemberReadStateUpdater.advanceLastReadMessageId(chatRoomId, memberId, secondMessageId))
                 .willReturn(1);
 
         // when

--- a/src/test/java/umc/cockple/demo/domain/chat/service/websocket/subscription/support/SubscribeReadStatusServiceTest.java
+++ b/src/test/java/umc/cockple/demo/domain/chat/service/websocket/subscription/support/SubscribeReadStatusServiceTest.java
@@ -8,21 +8,12 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.test.util.ReflectionTestUtils;
-import umc.cockple.demo.domain.chat.domain.ChatRoom;
-import umc.cockple.demo.domain.chat.domain.ChatRoomMember;
 import umc.cockple.demo.domain.chat.events.ChatUnreadStatusUpdateEvent;
 import umc.cockple.demo.domain.chat.repository.ChatRoomMemberRepository;
 import umc.cockple.demo.domain.chat.repository.MessageReadStatusRepository;
 import umc.cockple.demo.domain.chat.repository.projection.ChatMessageUnreadCountDTO;
-import umc.cockple.demo.domain.member.domain.Member;
-import umc.cockple.demo.global.enums.Gender;
-import umc.cockple.demo.global.enums.Level;
-import umc.cockple.demo.support.fixture.ChatFixture;
-import umc.cockple.demo.support.fixture.MemberFixture;
 
 import java.util.List;
-import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyList;
@@ -59,12 +50,6 @@ class SubscribeReadStatusServiceTest {
         Long firstMessageId = 201L;
         Long secondMessageId = 202L;
 
-        ChatRoom chatRoom = ChatFixture.createDirectChatRoom();
-        ReflectionTestUtils.setField(chatRoom, "id", chatRoomId);
-        Member member = MemberFixture.createMemberWithName("홍길동", "길동", Gender.MALE, Level.A, 1001L);
-        ReflectionTestUtils.setField(member, "id", memberId);
-        ChatRoomMember chatRoomMember = ChatFixture.createJoinedMemberWithLastRead(chatRoom, member, firstMessageId - 1);
-
         given(messageReadStatusRepository.findUnreadMessageIdsByMember(chatRoomId, memberId))
                 .willReturn(List.of(firstMessageId, secondMessageId));
         given(messageReadStatusRepository.markMessagesAsReadForMember(
@@ -74,8 +59,8 @@ class SubscribeReadStatusServiceTest {
                         new ChatMessageUnreadCountDTO(firstMessageId, 2L),
                         new ChatMessageUnreadCountDTO(secondMessageId, 1L)
                 ));
-        given(chatRoomMemberRepository.findByChatRoomIdAndMemberId(chatRoomId, memberId))
-                .willReturn(Optional.of(chatRoomMember));
+        given(chatRoomMemberRepository.advanceLastReadMessageId(chatRoomId, memberId, secondMessageId))
+                .willReturn(1);
 
         // when
         List<SubscribeReadStatusService.MessageUnreadUpdate> updates =
@@ -88,11 +73,12 @@ class SubscribeReadStatusServiceTest {
         assertThat(updates)
                 .extracting(SubscribeReadStatusService.MessageUnreadUpdate::newUnreadCount)
                 .containsExactly(2, 1);
-        assertThat(chatRoomMember.getLastReadMessageId()).isEqualTo(secondMessageId);
         then(messageReadStatusRepository).should()
                 .markMessagesAsReadForMember(chatRoomId, memberId, List.of(firstMessageId, secondMessageId));
         then(messageReadStatusRepository).should()
                 .countUnreadByMessageIds(List.of(firstMessageId, secondMessageId));
+        then(chatRoomMemberRepository).should()
+                .advanceLastReadMessageId(chatRoomId, memberId, secondMessageId);
 
         ArgumentCaptor<ChatUnreadStatusUpdateEvent> eventCaptor =
                 ArgumentCaptor.forClass(ChatUnreadStatusUpdateEvent.class);
@@ -118,6 +104,7 @@ class SubscribeReadStatusServiceTest {
         then(messageReadStatusRepository).should(never())
                 .markMessagesAsReadForMember(anyLong(), anyLong(), anyList());
         then(messageReadStatusRepository).should(never()).countUnreadByMessageIds(anyList());
+        then(chatRoomMemberRepository).should(never()).advanceLastReadMessageId(anyLong(), anyLong(), anyLong());
         then(eventPublisher).shouldHaveNoInteractions();
     }
 
@@ -130,20 +117,14 @@ class SubscribeReadStatusServiceTest {
         Long firstMessageId = 201L;
         Long secondMessageId = 202L;
 
-        ChatRoom chatRoom = ChatFixture.createDirectChatRoom();
-        ReflectionTestUtils.setField(chatRoom, "id", chatRoomId);
-        Member member = MemberFixture.createMemberWithName("홍길동", "길동", Gender.MALE, Level.A, 1001L);
-        ReflectionTestUtils.setField(member, "id", memberId);
-        ChatRoomMember chatRoomMember = ChatFixture.createJoinedMemberWithLastRead(chatRoom, member, firstMessageId - 1);
-
         given(messageReadStatusRepository.findUnreadMessageIdsByMember(chatRoomId, memberId))
                 .willReturn(List.of(firstMessageId, secondMessageId));
         given(messageReadStatusRepository.markMessagesAsReadForMember(
                 chatRoomId, memberId, List.of(firstMessageId, secondMessageId))).willReturn(2);
         given(messageReadStatusRepository.countUnreadByMessageIds(List.of(firstMessageId, secondMessageId)))
                 .willReturn(List.of(new ChatMessageUnreadCountDTO(firstMessageId, 2L)));
-        given(chatRoomMemberRepository.findByChatRoomIdAndMemberId(chatRoomId, memberId))
-                .willReturn(Optional.of(chatRoomMember));
+        given(chatRoomMemberRepository.advanceLastReadMessageId(chatRoomId, memberId, secondMessageId))
+                .willReturn(1);
 
         // when
         List<SubscribeReadStatusService.MessageUnreadUpdate> updates =

--- a/src/test/java/umc/cockple/demo/domain/chat/service/websocket/subscription/support/SubscribeReadStatusServiceTest.java
+++ b/src/test/java/umc/cockple/demo/domain/chat/service/websocket/subscription/support/SubscribeReadStatusServiceTest.java
@@ -58,7 +58,7 @@ class SubscribeReadStatusServiceTest {
                 .willReturn(List.of(firstMessageId, secondMessageId));
         given(readStatusUpdater.markMessagesAsReadForMember(
                 chatRoomId, memberId, List.of(firstMessageId, secondMessageId))).willReturn(2);
-        given(readStatusReader.countUnreadByMessageIds(List.of(firstMessageId, secondMessageId)))
+        given(readStatusReader.countUnreadByMessageIdsAsSparseMap(List.of(firstMessageId, secondMessageId)))
                 .willReturn(Map.of(firstMessageId, 2, secondMessageId, 1));
         given(chatMemberReadStateUpdater.advanceLastReadMessageId(chatRoomId, memberId, secondMessageId))
                 .willReturn(1);
@@ -77,7 +77,7 @@ class SubscribeReadStatusServiceTest {
         then(readStatusUpdater).should()
                 .markMessagesAsReadForMember(chatRoomId, memberId, List.of(firstMessageId, secondMessageId));
         then(readStatusReader).should()
-                .countUnreadByMessageIds(List.of(firstMessageId, secondMessageId));
+                .countUnreadByMessageIdsAsSparseMap(List.of(firstMessageId, secondMessageId));
         then(chatMemberReadStateUpdater).should()
                 .advanceLastReadMessageId(chatRoomId, memberId, secondMessageId);
 
@@ -104,7 +104,7 @@ class SubscribeReadStatusServiceTest {
         assertThat(updates).isEmpty();
         then(readStatusUpdater).should(never())
                 .markMessagesAsReadForMember(anyLong(), anyLong(), anyList());
-        then(readStatusReader).should(never()).countUnreadByMessageIds(anyList());
+        then(readStatusReader).should(never()).countUnreadByMessageIdsAsSparseMap(anyList());
         then(chatMemberReadStateUpdater).should(never()).advanceLastReadMessageId(anyLong(), anyLong(), anyLong());
         then(eventPublisher).shouldHaveNoInteractions();
     }
@@ -122,7 +122,7 @@ class SubscribeReadStatusServiceTest {
                 .willReturn(List.of(firstMessageId, secondMessageId));
         given(readStatusUpdater.markMessagesAsReadForMember(
                 chatRoomId, memberId, List.of(firstMessageId, secondMessageId))).willReturn(2);
-        given(readStatusReader.countUnreadByMessageIds(List.of(firstMessageId, secondMessageId)))
+        given(readStatusReader.countUnreadByMessageIdsAsSparseMap(List.of(firstMessageId, secondMessageId)))
                 .willReturn(Map.of(firstMessageId, 2));
         given(chatMemberReadStateUpdater.advanceLastReadMessageId(chatRoomId, memberId, secondMessageId))
                 .willReturn(1);
@@ -138,5 +138,32 @@ class SubscribeReadStatusServiceTest {
         assertThat(updates)
                 .extracting(UnreadCountUpdate::newUnreadCount)
                 .containsExactly(2, 0);
+    }
+
+    @Test
+    @DisplayName("구독 시 unread 메시지 ID 목록이 정렬되지 않아도 가장 큰 메시지 ID로 lastReadMessageId를 갱신한다")
+    void markUnreadMessagesAsReadOnSubscribe_advancesLastReadToMaxMessageId() {
+        // given
+        Long chatRoomId = 10L;
+        Long memberId = 101L;
+        Long latestMessageId = 202L;
+        Long olderMessageId = 201L;
+        List<Long> unorderedMessageIds = List.of(latestMessageId, olderMessageId);
+
+        given(readStatusReader.findUnreadMessageIds(chatRoomId, memberId))
+                .willReturn(unorderedMessageIds);
+        given(readStatusUpdater.markMessagesAsReadForMember(chatRoomId, memberId, unorderedMessageIds))
+                .willReturn(2);
+        given(readStatusReader.countUnreadByMessageIdsAsSparseMap(unorderedMessageIds))
+                .willReturn(Map.of(latestMessageId, 1, olderMessageId, 1));
+        given(chatMemberReadStateUpdater.advanceLastReadMessageId(chatRoomId, memberId, latestMessageId))
+                .willReturn(1);
+
+        // when
+        subscribeReadStatusService.markUnreadMessagesAsReadOnSubscribe(chatRoomId, memberId);
+
+        // then
+        then(chatMemberReadStateUpdater).should()
+                .advanceLastReadMessageId(chatRoomId, memberId, latestMessageId);
     }
 }

--- a/src/test/java/umc/cockple/demo/domain/chat/service/websocket/subscription/support/SubscribeReadStatusServiceTest.java
+++ b/src/test/java/umc/cockple/demo/domain/chat/service/websocket/subscription/support/SubscribeReadStatusServiceTest.java
@@ -12,6 +12,7 @@ import umc.cockple.demo.domain.chat.events.ChatUnreadStatusUpdateEvent;
 import umc.cockple.demo.domain.chat.repository.ChatRoomMemberRepository;
 import umc.cockple.demo.domain.chat.repository.MessageReadStatusRepository;
 import umc.cockple.demo.domain.chat.repository.projection.ChatMessageUnreadCountDTO;
+import umc.cockple.demo.domain.chat.service.websocket.UnreadCountUpdate;
 
 import java.util.List;
 
@@ -63,15 +64,15 @@ class SubscribeReadStatusServiceTest {
                 .willReturn(1);
 
         // when
-        List<SubscribeReadStatusService.MessageUnreadUpdate> updates =
+        List<UnreadCountUpdate> updates =
                 subscribeReadStatusService.markUnreadMessagesAsReadOnSubscribe(chatRoomId, memberId);
 
         // then
         assertThat(updates)
-                .extracting(SubscribeReadStatusService.MessageUnreadUpdate::messageId)
+                .extracting(UnreadCountUpdate::messageId)
                 .containsExactly(firstMessageId, secondMessageId);
         assertThat(updates)
-                .extracting(SubscribeReadStatusService.MessageUnreadUpdate::newUnreadCount)
+                .extracting(UnreadCountUpdate::newUnreadCount)
                 .containsExactly(2, 1);
         then(messageReadStatusRepository).should()
                 .markMessagesAsReadForMember(chatRoomId, memberId, List.of(firstMessageId, secondMessageId));
@@ -96,7 +97,7 @@ class SubscribeReadStatusServiceTest {
                 .willReturn(List.of());
 
         // when
-        List<SubscribeReadStatusService.MessageUnreadUpdate> updates =
+        List<UnreadCountUpdate> updates =
                 subscribeReadStatusService.markUnreadMessagesAsReadOnSubscribe(chatRoomId, memberId);
 
         // then
@@ -127,15 +128,15 @@ class SubscribeReadStatusServiceTest {
                 .willReturn(1);
 
         // when
-        List<SubscribeReadStatusService.MessageUnreadUpdate> updates =
+        List<UnreadCountUpdate> updates =
                 subscribeReadStatusService.markUnreadMessagesAsReadOnSubscribe(chatRoomId, memberId);
 
         // then
         assertThat(updates)
-                .extracting(SubscribeReadStatusService.MessageUnreadUpdate::messageId)
+                .extracting(UnreadCountUpdate::messageId)
                 .containsExactly(firstMessageId, secondMessageId);
         assertThat(updates)
-                .extracting(SubscribeReadStatusService.MessageUnreadUpdate::newUnreadCount)
+                .extracting(UnreadCountUpdate::newUnreadCount)
                 .containsExactly(2, 0);
     }
 }


### PR DESCRIPTION
## ❤️ 기능 설명

채팅 읽음 처리 write-path의 반복 쿼리를 배치 처리 기반으로 개선했습니다.

- 구독 시 unread 메시지 목록을 기준으로 읽음 상태를 bulk update 처리
- 메시지별 unread count를 `GROUP BY chatMessageId` 기반 batch 조회로 변경
- 메시지 전송 시 활성 구독자들의 `lastReadMessageId`를 bulk update 처리
- 큰 `IN` 절 방지를 위해 메시지/멤버 ID 목록을 chunk 처리
- WebSocket unread count update payload 형식은 유지
- `lastReadMessageId`는 기존 값보다 큰 메시지 ID일 때만 전진하도록 보장
- `lastReadMessageId` bulk JPQL은 고빈도 read cursor 갱신이므로 `updatedAt` auditing을 갱신하지 않는 의도 주석 추가


<br>

## 연결된 issue

close #624

<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 채팅 멤버 테이블의 updatedAt 칼럼을 사용하는 곳도 없었기에 `lastReadMessageId` bulk JPQL이 `updatedAt`을 갱신하지 않도록 했습니다.
- [ ] `ReadStatusReader` / `ReadStatusUpdater` / `ChatMemberReadStateUpdater`를 각 서비스에서 리포지토리 직접 참조하는 걸 피하려고 분리했습니다.

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
