### PR TITLE
[debug/#611] 프로필 동시성 처리 문제 해결

### DIFF
--- a/src/main/java/umc/cockple/demo/domain/file/enums/ObjectStorageDeleteSourceType.java
+++ b/src/main/java/umc/cockple/demo/domain/file/enums/ObjectStorageDeleteSourceType.java
@@ -1,5 +1,6 @@
 package umc.cockple.demo.domain.file.enums;
 
 public enum ObjectStorageDeleteSourceType {
-    PARTY_CHAT_ROOM
+    PARTY_CHAT_ROOM,
+    MEMBER_PROFILE_IMG
 }

--- a/src/main/java/umc/cockple/demo/domain/file/service/ObjectStorageDeleteOutboxService.java
+++ b/src/main/java/umc/cockple/demo/domain/file/service/ObjectStorageDeleteOutboxService.java
@@ -42,4 +42,20 @@ public class ObjectStorageDeleteOutboxService {
         objectStorageDeleteOutboxRepository.saveAll(outboxes);
         log.info("Object storage 삭제 outbox 등록 - chatRoomId: {}, 파일 수: {}", chatRoomId, outboxes.size());
     }
+
+    @Transactional
+    public void enqueueProfileImage(Long memberId, String objectKey) {
+        if (!StringUtils.hasText(objectKey)) {
+            return;
+        }
+
+        objectStorageDeleteOutboxRepository.save(
+                ObjectStorageDeleteOutbox.pending(
+                        objectKey,
+                        ObjectStorageDeleteSourceType.MEMBER_PROFILE_IMG,
+                        memberId
+                )
+        );
+        log.info("Object storage 삭제 outbox 등록 - memberId: {}, objectKey: {}", memberId, objectKey);
+    }
 }

--- a/src/main/java/umc/cockple/demo/domain/member/controller/MemberController.java
+++ b/src/main/java/umc/cockple/demo/domain/member/controller/MemberController.java
@@ -98,7 +98,7 @@ public class MemberController {
 
         Long memberId = SecurityUtil.getCurrentMemberId();
 
-        memberCommandService.memberDetailInfo(memberId, requestDTO);
+        memberProfileUpdateExecutor.registerMemberDetailInfo(memberId, requestDTO);
 
         return BaseResponse.success(CommonSuccessCode.OK);
     }

--- a/src/main/java/umc/cockple/demo/domain/member/controller/MemberController.java
+++ b/src/main/java/umc/cockple/demo/domain/member/controller/MemberController.java
@@ -14,6 +14,7 @@ import umc.cockple.demo.domain.member.dto.*;
 import umc.cockple.demo.domain.member.exception.MemberErrorCode;
 import umc.cockple.demo.domain.member.exception.MemberException;
 import umc.cockple.demo.domain.member.service.MemberCommandService;
+import umc.cockple.demo.domain.member.service.MemberProfileUpdateExecutor;
 import umc.cockple.demo.domain.member.service.MemberQueryService;
 import umc.cockple.demo.global.jwt.domain.TokenRefreshResponse;
 import umc.cockple.demo.global.oauth2.service.KakaoOauthService;
@@ -37,6 +38,7 @@ import static umc.cockple.demo.domain.member.dto.kakao.KakaoLoginDTO.*;
 public class MemberController {
 
     private final MemberCommandService memberCommandService;
+    private final MemberProfileUpdateExecutor memberProfileUpdateExecutor;
     private final MemberQueryService memberQueryService;
     private final KakaoOauthService kakaoOauthService;
 
@@ -181,7 +183,7 @@ public class MemberController {
 
         Long memberId = SecurityUtil.getCurrentMemberId();
 
-        memberCommandService.updateProfile(requestDTO, memberId);
+        memberProfileUpdateExecutor.updateProfile(requestDTO, memberId);
         return BaseResponse.success(CommonSuccessCode.OK);
     }
 

--- a/src/main/java/umc/cockple/demo/domain/member/domain/Member.java
+++ b/src/main/java/umc/cockple/demo/domain/member/domain/Member.java
@@ -21,6 +21,7 @@ import java.time.LocalDateTime;
 import java.time.Period;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import static umc.cockple.demo.domain.member.dto.CreateMemberAddrDTO.*;
 
@@ -120,13 +121,23 @@ public class Member extends BaseEntity {
         }
     }
 
-    public void updateMemberFirst(MemberDetailInfoRequestDTO requestDto, List<MemberKeyword> keywords, ProfileImg img) {
-        this.memberName = requestDto.memberName();
-        this.gender = requestDto.gender();
-        this.birth = requestDto.birth();
-        this.level = requestDto.level();
-        this.keywords = keywords;
-        updateProfileImg(img);
+
+    public Optional<String> changeProfileImage(String imgKey) {
+        if (this.profileImg != null) {
+            if (this.profileImg.getImgKey().equals(imgKey)) {
+                return Optional.empty(); // 동일 이미지 -> 변경 없음
+            }
+            String oldKey = this.profileImg.getImgKey();
+            this.profileImg.updateProfile(imgKey); // UPDATE (version 증가 -> 낙관적 락 적용)
+            return Optional.of(oldKey);
+        }
+
+        // 기존 이미지 없음 -> 새로 생성
+        ProfileImg newProfileImg = ProfileImg.builder()
+                .imgKey(imgKey)
+                .build();
+        updateProfileImg(newProfileImg);
+        return Optional.empty();
     }
 
     public void updateMemberFirst(MemberDetailInfoRequestDTO requestDto, List<MemberKeyword> keywords) {
@@ -137,14 +148,6 @@ public class Member extends BaseEntity {
         this.keywords = keywords;
     }
 
-
-    public void updateMember(UpdateProfileRequestDTO requestDto, List<MemberKeyword> keywords, ProfileImg img) {
-        this.memberName = requestDto.memberName();
-        this.birth = requestDto.birth();
-        this.level = requestDto.level();
-        this.keywords = keywords;
-        updateProfileImg(img);
-    }
 
     public void updateMember(UpdateProfileRequestDTO requestDto, List<MemberKeyword> keywords) {
         this.memberName = requestDto.memberName();

--- a/src/main/java/umc/cockple/demo/domain/member/domain/ProfileImg.java
+++ b/src/main/java/umc/cockple/demo/domain/member/domain/ProfileImg.java
@@ -21,6 +21,11 @@ public class ProfileImg {
     @Column(nullable = false)
     private String imgKey;
 
+    // 동시 수정 시 lost update 방지를 위한 낙관적 락 버전
+    @Version
+    @Column(nullable = false)
+    private Long version;
+
 
     public void setMember(Member member) {
         this.member = member;

--- a/src/main/java/umc/cockple/demo/domain/member/domain/ProfileImg.java
+++ b/src/main/java/umc/cockple/demo/domain/member/domain/ProfileImg.java
@@ -15,7 +15,7 @@ public class ProfileImg {
     private Long id;
 
     @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id")
+    @JoinColumn(name = "member_id", unique = true)
     private Member member;
 
     @Column(nullable = false)

--- a/src/main/java/umc/cockple/demo/domain/member/exception/MemberErrorCode.java
+++ b/src/main/java/umc/cockple/demo/domain/member/exception/MemberErrorCode.java
@@ -24,6 +24,7 @@ public enum MemberErrorCode implements BaseErrorCode {
 
     MANAGER_CANNOT_LEAVE(HttpStatus.BAD_REQUEST, "MEMBER401", "모임장은 탈퇴할 수 없습니다. 모임 삭제를 먼저 해주세요."),
     SUBMANAGER_CANNOT_LEAVE(HttpStatus.BAD_REQUEST, "MEMBER402", "부모임장은 탈퇴할 수 없습니다. 모임 삭제를 먼저 해주세요."),
+    PROFILE_UPDATE_CONFLICT(HttpStatus.CONFLICT, "MEMBER403", "프로필 수정 요청이 동시에 처리되었습니다. 잠시 후 다시 시도해주세요."),
 
     // 회원 주소 관련
     ADDRESS_NOT_FOUND(HttpStatus.NOT_FOUND, "MEM_ADDR201", "해당 주소를 찾을 수 없습니다."),

--- a/src/main/java/umc/cockple/demo/domain/member/service/MemberCommandService.java
+++ b/src/main/java/umc/cockple/demo/domain/member/service/MemberCommandService.java
@@ -16,7 +16,7 @@ import umc.cockple.demo.domain.member.exception.MemberException;
 import umc.cockple.demo.domain.member.events.MemberWithdrawnEvent;
 import umc.cockple.demo.domain.member.repository.*;
 import umc.cockple.demo.domain.member.enums.MemberStatus;
-import umc.cockple.demo.domain.file.service.FileService;
+import umc.cockple.demo.domain.file.service.ObjectStorageDeleteOutboxService;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
@@ -40,7 +40,7 @@ public class MemberCommandService {
     private final ApplicationEventPublisher applicationEventPublisher;
 
     private final KakaoOauthService kakaoOauthService;
-    private final FileService fileService;
+    private final ObjectStorageDeleteOutboxService objectStorageDeleteOutboxService;
 
 
     // ==================== 회원 관련 ===================
@@ -139,9 +139,10 @@ public class MemberCommandService {
             // 기존 이미지 존재시 이미지 새로 업로드
             if (profile != null) {
 
-                // 프로필 사진이 변경되었을 경우에만 이미지 url 변경 및 S3 사진 변경
+                // 프로필 사진이 변경되었을 경우에만 이미지 url 변경 및 기존 이미지 삭제 예약
                 if (!profile.getImgKey().equals(imgKey)) {
-                    fileService.delete(profile.getImgKey());
+                    // 즉시 삭제하지 않고 outbox 에 등록 -> 트랜잭션이 롤백되면 삭제도 함께 취소된다
+                    objectStorageDeleteOutboxService.enqueueProfileImage(memberId, profile.getImgKey());
                     profile.updateProfile(imgKey);
                 }
 

--- a/src/main/java/umc/cockple/demo/domain/member/service/MemberCommandService.java
+++ b/src/main/java/umc/cockple/demo/domain/member/service/MemberCommandService.java
@@ -49,6 +49,9 @@ public class MemberCommandService {
         // 회원 찾기
         Member member = findByMemberId(memberId);
 
+        // 기존 키워드 삭제
+        memberKeywordRepository.deleteAllByMember(member);
+
         // 키워드 저장
         List<MemberKeyword> keywords = requestDTO.keywords().stream()
                 .map(keyword -> {

--- a/src/main/java/umc/cockple/demo/domain/member/service/MemberCommandService.java
+++ b/src/main/java/umc/cockple/demo/domain/member/service/MemberCommandService.java
@@ -65,18 +65,14 @@ public class MemberCommandService {
 
         memberKeywordRepository.saveAll(keywords);
 
+        // 회원 정보 수정 (프로필 사진 제외)
+        member.updateMemberFirst(requestDTO, keywords);
+
+        // 프로필 사진은 updateProfile 과 동일한 도메인 메서드로 처리
         if (StringUtils.hasText(requestDTO.imgKey())) {
-            ProfileImg profile = ProfileImg.builder()
-                    .member(member)
-                    .imgKey(requestDTO.imgKey())
-                    .build();
-
-            member.updateMemberFirst(requestDTO, keywords, profile);
-
-        } else {
-            member.updateMemberFirst(requestDTO, keywords);
+            member.changeProfileImage(requestDTO.imgKey())
+                    .ifPresent(oldKey -> objectStorageDeleteOutboxService.enqueueProfileImage(member.getId(), oldKey));
         }
-
     }
 
     public void withdrawMember(Long memberId) {
@@ -125,41 +121,13 @@ public class MemberCommandService {
 
         memberKeywordRepository.saveAll(keywords);
 
-        log.info("===== 프로필 이미지 key값 확인 : " + requestDto.imgKey());
+        // 회원 정보 수정 (프로필 사진 제외)
+        member.updateMember(requestDto, keywords);
 
-        // 이미지 -> 저장 후 url 받아오기
-        String imgKey = requestDto.imgKey();
-
-        // 받은 key가 null인지 확인
-        if (!StringUtils.hasText(imgKey)) {
-            member.updateMember(requestDto, keywords);
-        } else {
-
-            ProfileImg profile = member.getProfileImg();
-            // 기존 이미지 존재시 이미지 새로 업로드
-            if (profile != null) {
-
-                // 프로필 사진이 변경되었을 경우에만 이미지 url 변경 및 기존 이미지 삭제 예약
-                if (!profile.getImgKey().equals(imgKey)) {
-                    // 즉시 삭제하지 않고 outbox 에 등록 -> 트랜잭션이 롤백되면 삭제도 함께 취소된다
-                    objectStorageDeleteOutboxService.enqueueProfileImage(memberId, profile.getImgKey());
-                    profile.updateProfile(imgKey);
-                }
-
-                // 회원 정보 수정하기 (프로필 사진 제외)
-                member.updateMember(requestDto, keywords);
-
-            } else {
-                // 받아온 이미지로 profile객체 생성
-                ProfileImg img = ProfileImg.builder()
-                        .member(member)
-                        .imgKey(imgKey)
-                        .build();
-
-                // 회원 정보 수정하기 (프로필 사진까지)
-                member.updateMember(requestDto, keywords, img);
-
-            }
+        // 프로필 사진 신규 등록/교체는 도메인 메서드로 위임. 교체 시 정리 대상 key를 받아 outbox 에 등록
+        if (StringUtils.hasText(requestDto.imgKey())) {
+            member.changeProfileImage(requestDto.imgKey())
+                    .ifPresent(oldKey -> objectStorageDeleteOutboxService.enqueueProfileImage(memberId, oldKey));
         }
 
         chatRoomMemberRepository.findDirectChatCounterParts(member.getId())

--- a/src/main/java/umc/cockple/demo/domain/member/service/MemberProfileUpdateExecutor.java
+++ b/src/main/java/umc/cockple/demo/domain/member/service/MemberProfileUpdateExecutor.java
@@ -1,0 +1,43 @@
+package umc.cockple.demo.domain.member.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
+import org.springframework.stereotype.Component;
+import umc.cockple.demo.domain.member.dto.UpdateProfileRequestDTO;
+import umc.cockple.demo.domain.member.exception.MemberErrorCode;
+import umc.cockple.demo.domain.member.exception.MemberException;
+
+/**
+ * 프로필 수정의 동시성 충돌을 트랜잭션 "밖에서" 재시도해 멱등하게 만든다.
+ *
+ * <ul>
+ *     <li>신규 등록 동시 진입 -> 패배 트랜잭션이 unique 제약 위반({@link DataIntegrityViolationException})</li>
+ *     <li>기존 사진 교체 동시 진입 -> 패배 트랜잭션이 낙관적 락 실패({@link ObjectOptimisticLockingFailureException})</li>
+ * </ul>
+ *
+ * 두 경우 모두 재시도하면 프로필이 이미 존재/최신 버전이므로 UPDATE 경로로 수렴해 성공한다.
+ * (재시도가 트랜잭션 경계 밖에서 일어나야 매번 새 트랜잭션/영속성 컨텍스트가 열린다.)
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class MemberProfileUpdateExecutor {
+
+    private static final int MAX_ATTEMPTS = 3;
+
+    private final MemberCommandService memberCommandService;
+
+    public void updateProfile(UpdateProfileRequestDTO requestDto, Long memberId) {
+        for (int attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+            try {
+                memberCommandService.updateProfile(requestDto, memberId);
+                return;
+            } catch (DataIntegrityViolationException | ObjectOptimisticLockingFailureException e) {
+                log.warn("프로필 수정 동시성 충돌 감지 - memberId: {}, 시도: {}/{}", memberId, attempt, MAX_ATTEMPTS);
+            }
+        }
+        throw new MemberException(MemberErrorCode.PROFILE_UPDATE_CONFLICT);
+    }
+}

--- a/src/main/java/umc/cockple/demo/domain/member/service/MemberProfileUpdateExecutor.java
+++ b/src/main/java/umc/cockple/demo/domain/member/service/MemberProfileUpdateExecutor.java
@@ -2,6 +2,7 @@ package umc.cockple.demo.domain.member.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.hibernate.exception.ConstraintViolationException;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.stereotype.Component;
@@ -26,6 +27,8 @@ public class MemberProfileUpdateExecutor {
 
     private static final int MAX_ATTEMPTS = 3;
 
+    private static final String PROFILE_IMG_UNIQUE_CONSTRAINT = "uq_profile_img_member";
+
     private final MemberCommandService memberCommandService;
 
     public void registerMemberDetailInfo(Long memberId, MemberDetailInfoRequestDTO requestDto) {
@@ -41,10 +44,34 @@ public class MemberProfileUpdateExecutor {
             try {
                 operation.run();
                 return;
-            } catch (DataIntegrityViolationException | ObjectOptimisticLockingFailureException e) {
-                log.warn("프로필 동시성 충돌 감지 - memberId: {}, 시도: {}/{}", memberId, attempt, MAX_ATTEMPTS);
+            } catch (ObjectOptimisticLockingFailureException e) {
+                // 낙관적 락 실패 = 프로필 사진 동시 교체 (ProfileImg 만 @Version 보유) -> 재시도
+                log.warn("프로필 동시성 충돌(낙관적 락) - memberId: {}, 시도: {}/{}", memberId, attempt, MAX_ATTEMPTS);
+            } catch (DataIntegrityViolationException e) {
+                // 무결성 위반 중 '프로필 이미지 유니크' 만 동시성 충돌로 간주, 그 외(NOT NULL/FK 등)는 진짜 에러로 전파
+                if (!isProfileImageUniqueViolation(e)) {
+                    throw e;
+                }
+                log.warn("프로필 동시성 충돌 - memberId: {}, 시도: {}/{}", memberId, attempt, MAX_ATTEMPTS);
             }
         }
         throw new MemberException(MemberErrorCode.PROFILE_UPDATE_CONFLICT);
+    }
+
+
+    private boolean isProfileImageUniqueViolation(Throwable e) {
+        for (Throwable t = e; t != null && t != t.getCause(); t = t.getCause()) {
+            if (t instanceof ConstraintViolationException cve) {
+                String name = cve.getConstraintName();
+                if (name != null && name.toLowerCase().contains(PROFILE_IMG_UNIQUE_CONSTRAINT)) {
+                    return true;
+                }
+            }
+            String message = t.getMessage();
+            if (message != null && message.toLowerCase().contains(PROFILE_IMG_UNIQUE_CONSTRAINT)) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/src/main/java/umc/cockple/demo/domain/member/service/MemberProfileUpdateExecutor.java
+++ b/src/main/java/umc/cockple/demo/domain/member/service/MemberProfileUpdateExecutor.java
@@ -5,12 +5,13 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.stereotype.Component;
+import umc.cockple.demo.domain.member.dto.MemberDetailInfoRequestDTO;
 import umc.cockple.demo.domain.member.dto.UpdateProfileRequestDTO;
 import umc.cockple.demo.domain.member.exception.MemberErrorCode;
 import umc.cockple.demo.domain.member.exception.MemberException;
 
 /**
- * 프로필 수정의 동시성 충돌을 트랜잭션 밖에서 재시도해 멱등하게 만든다.
+ * 프로필을 쓰는 작업(온보딩 등록 / 프로필 수정)의 동시성 충돌을 트랜잭션 밖에서 재시도해 멱등하게 만든다.
  *
  * 신규 등록 동시 진입 -> 패배 트랜잭션이 unique 제약 위반
  * 기존 사진 교체 동시 진입 -> 패배 트랜잭션이 낙관적 락 실패
@@ -27,13 +28,21 @@ public class MemberProfileUpdateExecutor {
 
     private final MemberCommandService memberCommandService;
 
+    public void registerMemberDetailInfo(Long memberId, MemberDetailInfoRequestDTO requestDto) {
+        runWithConflictRetry(memberId, () -> memberCommandService.memberDetailInfo(memberId, requestDto));
+    }
+
     public void updateProfile(UpdateProfileRequestDTO requestDto, Long memberId) {
+        runWithConflictRetry(memberId, () -> memberCommandService.updateProfile(requestDto, memberId));
+    }
+
+    private void runWithConflictRetry(Long memberId, Runnable operation) {
         for (int attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
             try {
-                memberCommandService.updateProfile(requestDto, memberId);
+                operation.run();
                 return;
             } catch (DataIntegrityViolationException | ObjectOptimisticLockingFailureException e) {
-                log.warn("프로필 수정 동시성 충돌 감지 - memberId: {}, 시도: {}/{}", memberId, attempt, MAX_ATTEMPTS);
+                log.warn("프로필 동시성 충돌 감지 - memberId: {}, 시도: {}/{}", memberId, attempt, MAX_ATTEMPTS);
             }
         }
         throw new MemberException(MemberErrorCode.PROFILE_UPDATE_CONFLICT);

--- a/src/main/java/umc/cockple/demo/domain/member/service/MemberProfileUpdateExecutor.java
+++ b/src/main/java/umc/cockple/demo/domain/member/service/MemberProfileUpdateExecutor.java
@@ -10,12 +10,10 @@ import umc.cockple.demo.domain.member.exception.MemberErrorCode;
 import umc.cockple.demo.domain.member.exception.MemberException;
 
 /**
- * 프로필 수정의 동시성 충돌을 트랜잭션 "밖에서" 재시도해 멱등하게 만든다.
+ * 프로필 수정의 동시성 충돌을 트랜잭션 밖에서 재시도해 멱등하게 만든다.
  *
- * <ul>
- *     <li>신규 등록 동시 진입 -> 패배 트랜잭션이 unique 제약 위반({@link DataIntegrityViolationException})</li>
- *     <li>기존 사진 교체 동시 진입 -> 패배 트랜잭션이 낙관적 락 실패({@link ObjectOptimisticLockingFailureException})</li>
- * </ul>
+ * 신규 등록 동시 진입 -> 패배 트랜잭션이 unique 제약 위반
+ * 기존 사진 교체 동시 진입 -> 패배 트랜잭션이 낙관적 락 실패
  *
  * 두 경우 모두 재시도하면 프로필이 이미 존재/최신 버전이므로 UPDATE 경로로 수렴해 성공한다.
  * (재시도가 트랜잭션 경계 밖에서 일어나야 매번 새 트랜잭션/영속성 컨텍스트가 열린다.)

--- a/src/main/resources/db/migration/V2026.06.27.00.00__add_unique_profile_img_member.sql
+++ b/src/main/resources/db/migration/V2026.06.27.00.00__add_unique_profile_img_member.sql
@@ -1,3 +1,25 @@
+-- 삭제될 중복 row 가 가리키던 이미지 중 '고아가 되는 key'(살아남는 row 가 안 쓰는 key)를
+-- object_storage_delete_outbox 에 적재한다. 기존 스케줄러가 GCS 에서 비동기로 삭제한다.
+-- 반드시 아래 DELETE 보다 먼저 실행되어야 한다(삭제 후엔 img_key 를 알 수 없음).
+INSERT INTO object_storage_delete_outbox
+    (object_key, source_type, source_id, status, retry_count, created_at, updated_at)
+SELECT DISTINCT doomed.img_key, 'MEMBER_PROFILE_IMG', doomed.member_id, 'PENDING', 0, NOW(6), NOW(6)
+FROM profile_img doomed
+JOIN (SELECT member_id, MAX(id) AS keep_id
+      FROM profile_img
+      WHERE member_id IS NOT NULL
+      GROUP BY member_id) keep
+    ON doomed.member_id = keep.member_id
+WHERE doomed.id <> keep.keep_id
+  AND doomed.img_key NOT IN (
+      SELECT survivor.img_key
+      FROM profile_img survivor
+      WHERE survivor.id IN (SELECT MAX(id)
+                            FROM profile_img
+                            WHERE member_id IS NOT NULL
+                            GROUP BY member_id));
+
+-- member 당 1개만 남기고 중복 row 정리
 DELETE pi
 FROM profile_img pi
 JOIN (

--- a/src/main/resources/db/migration/V2026.06.27.00.00__add_unique_profile_img_member.sql
+++ b/src/main/resources/db/migration/V2026.06.27.00.00__add_unique_profile_img_member.sql
@@ -1,0 +1,14 @@
+DELETE pi
+FROM profile_img pi
+JOIN (
+    SELECT member_id, MAX(id) AS keep_id
+    FROM profile_img
+    WHERE member_id IS NOT NULL
+    GROUP BY member_id
+) keep
+    ON pi.member_id = keep.member_id
+WHERE pi.id <> keep.keep_id;
+
+-- member 당 profile_img 1개를 DB 레벨에서 보장한다.
+ALTER TABLE profile_img
+    ADD CONSTRAINT uq_profile_img_member UNIQUE (member_id);

--- a/src/main/resources/db/migration/V2026.06.27.00.10__add_profile_img_version.sql
+++ b/src/main/resources/db/migration/V2026.06.27.00.10__add_profile_img_version.sql
@@ -1,0 +1,4 @@
+-- 프로필 사진 교체(UPDATE) 동시성에서 lost update 를 막기 위한 낙관적 락 버전 컬럼.
+-- 기존 row 는 0 으로 시작한다.
+ALTER TABLE profile_img
+    ADD COLUMN version BIGINT NOT NULL DEFAULT 0;

--- a/src/test/java/umc/cockple/demo/domain/member/integration/MemberIntegrationTest.java
+++ b/src/test/java/umc/cockple/demo/domain/member/integration/MemberIntegrationTest.java
@@ -14,6 +14,7 @@ import umc.cockple.demo.domain.contest.domain.Contest;
 import umc.cockple.demo.domain.contest.enums.MedalType;
 import umc.cockple.demo.domain.contest.repository.ContestRepository;
 import umc.cockple.demo.domain.exercise.enums.ExerciseMemberShipStatus;
+import umc.cockple.demo.domain.file.repository.ObjectStorageDeleteOutboxRepository;
 import umc.cockple.demo.domain.file.service.FileService;
 import umc.cockple.demo.domain.member.domain.*;
 import umc.cockple.demo.domain.member.dto.CreateMemberAddrDTO;
@@ -66,6 +67,7 @@ class MemberIntegrationTest extends IntegrationTestBase {
     @Autowired MemberKeywordRepository memberKeywordRepository;
     @Autowired ChatRoomRepository chatRoomRepository;
     @Autowired ChatRoomMemberRepository chatRoomMemberRepository;
+    @Autowired ObjectStorageDeleteOutboxRepository objectStorageDeleteOutboxRepository;
 
     private Member member;
 
@@ -76,6 +78,7 @@ class MemberIntegrationTest extends IntegrationTestBase {
 
     @AfterEach
     void tearDown() {
+        objectStorageDeleteOutboxRepository.deleteAll(); // 프로필 이미지 교체 시 적재된 삭제 outbox 정리
         chatRoomRepository.deleteAll(); // cascade: ChatRoomMember 함께 삭제
         memberPartyRepository.deleteAll();
         partyRepository.deleteAll();

--- a/src/test/java/umc/cockple/demo/domain/member/integration/ProfileImgUniqueViolationIntegrationTest.java
+++ b/src/test/java/umc/cockple/demo/domain/member/integration/ProfileImgUniqueViolationIntegrationTest.java
@@ -1,0 +1,77 @@
+package umc.cockple.demo.domain.member.integration;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.hibernate.exception.ConstraintViolationException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+import umc.cockple.demo.domain.member.domain.Member;
+import umc.cockple.demo.domain.member.domain.ProfileImg;
+import umc.cockple.demo.domain.member.repository.MemberRepository;
+import umc.cockple.demo.global.enums.Gender;
+import umc.cockple.demo.global.enums.Level;
+import umc.cockple.demo.support.IntegrationTestBase;
+import umc.cockple.demo.support.fixture.MemberFixture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+/**
+ * MemberProfileUpdateExecutor 가 동시성 충돌을 식별하는 근거(제약명)가 실제 DB 에서 유효한지 보장하는 회귀 테스트.
+ * 제약 이름이 바뀌거나 노출 형식이 달라지면(예: 테이블 접두사 제거) executor 의 부분 매칭과 함께 여기서 깨진다.
+ */
+class ProfileImgUniqueViolationIntegrationTest extends IntegrationTestBase {
+
+    @Autowired MemberRepository memberRepository;
+    @Autowired PlatformTransactionManager transactionManager;
+    @PersistenceContext EntityManager em;
+
+    private Long memberId;
+
+    @AfterEach
+    void tearDown() {
+        if (memberId != null) {
+            memberRepository.deleteById(memberId);
+        }
+    }
+
+    @Test
+    @DisplayName("같은 member 에 profile_img 를 2개 INSERT 하면 uq_profile_img_member 제약 위반이 cause 체인에 노출된다")
+    void duplicate_profile_img_exposes_constraint_name() {
+        Member saved = memberRepository.save(
+                MemberFixture.createMember("진단", Gender.MALE, Level.A, 777777L));
+        memberId = saved.getId();
+
+        TransactionTemplate tx = new TransactionTemplate(transactionManager);
+
+        Throwable thrown = catchThrowable(() ->
+                tx.executeWithoutResult(status -> {
+                    Member m = memberRepository.findById(memberId).orElseThrow();
+                    ProfileImg p1 = ProfileImg.builder().imgKey("a").build();
+                    p1.setMember(m);
+                    em.persist(p1);
+                    ProfileImg p2 = ProfileImg.builder().imgKey("b").build();
+                    p2.setMember(m);
+                    em.persist(p2);
+                })
+        );
+
+        assertThat(thrown).isNotNull();
+        assertThat(constraintNameInChain(thrown))
+                .as("executor 가 부분 매칭하는 제약명이 cause 체인에 존재해야 한다")
+                .containsIgnoringCase("uq_profile_img_member");
+    }
+
+    private String constraintNameInChain(Throwable e) {
+        for (Throwable t = e; t != null && t != t.getCause(); t = t.getCause()) {
+            if (t instanceof ConstraintViolationException cve && cve.getConstraintName() != null) {
+                return cve.getConstraintName();
+            }
+        }
+        return "";
+    }
+}

--- a/src/test/java/umc/cockple/demo/domain/member/service/MemberCommandServiceTest.java
+++ b/src/test/java/umc/cockple/demo/domain/member/service/MemberCommandServiceTest.java
@@ -14,7 +14,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 import umc.cockple.demo.domain.chat.domain.ChatRoomMember;
 import umc.cockple.demo.domain.chat.repository.ChatRoomMemberRepository;
 import umc.cockple.demo.support.fixture.ChatFixture;
-import umc.cockple.demo.domain.file.service.FileService;
+import umc.cockple.demo.domain.file.service.ObjectStorageDeleteOutboxService;
 import umc.cockple.demo.domain.member.domain.Member;
 import umc.cockple.demo.domain.member.domain.MemberAddr;
 import umc.cockple.demo.domain.member.domain.MemberParty;
@@ -64,7 +64,7 @@ class MemberCommandServiceTest {
     @Mock private MemberAddrRepository memberAddrRepository;
     @Mock private ChatRoomMemberRepository chatRoomMemberRepository;
     @Mock private ApplicationEventPublisher applicationEventPublisher;
-    @Mock private FileService fileService;
+    @Mock private ObjectStorageDeleteOutboxService objectStorageDeleteOutboxService;
     @Mock private KakaoOauthService kakaoOauthService;
 
     private Member normalMember;
@@ -253,7 +253,8 @@ class MemberCommandServiceTest {
                 memberCommandService.updateProfile(requestWithImg, normalMember.getId());
 
                 // then
-                then(fileService).should().delete("profile/old-key.jpg");
+                then(objectStorageDeleteOutboxService).should()
+                        .enqueueProfileImage(normalMember.getId(), "profile/old-key.jpg");
             }
 
             @Test
@@ -277,7 +278,7 @@ class MemberCommandServiceTest {
                 memberCommandService.updateProfile(sameImgRequest, normalMember.getId());
 
                 // then
-                then(fileService).should(never()).delete(any());
+                then(objectStorageDeleteOutboxService).should(never()).enqueueProfileImage(any(), any());
             }
 
             @Test

--- a/src/test/java/umc/cockple/demo/domain/member/service/MemberProfileUpdateExecutorTest.java
+++ b/src/test/java/umc/cockple/demo/domain/member/service/MemberProfileUpdateExecutorTest.java
@@ -1,0 +1,136 @@
+package umc.cockple.demo.domain.member.service;
+
+import org.hibernate.exception.ConstraintViolationException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
+import umc.cockple.demo.domain.member.exception.MemberErrorCode;
+import umc.cockple.demo.domain.member.exception.MemberException;
+
+import java.sql.SQLException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("MemberProfileUpdateExecutor")
+class MemberProfileUpdateExecutorTest {
+
+    @Mock
+    private MemberCommandService memberCommandService;
+
+    @InjectMocks
+    private MemberProfileUpdateExecutor executor;
+
+    /** profile_img 유니크 제약 위반 (MySQL8 형식: 테이블 접두사 포함). */
+    private DataIntegrityViolationException profileUniqueConflict() {
+        ConstraintViolationException cve = new ConstraintViolationException(
+                "could not execute statement",
+                new SQLException("Duplicate entry '1' for key 'profile_img.uq_profile_img_member'", "23000", 1062),
+                "profile_img.uq_profile_img_member");
+        return new DataIntegrityViolationException("duplicate", cve);
+    }
+
+    /** 프로필과 무관한 다른 무결성 위반 (예: 다른 제약). */
+    private DataIntegrityViolationException otherConstraintConflict() {
+        ConstraintViolationException cve = new ConstraintViolationException(
+                "could not execute statement",
+                new SQLException("Cannot add or update a child row", "23000", 1452),
+                "fk_some_other_constraint");
+        return new DataIntegrityViolationException("other", cve);
+    }
+
+    @Nested
+    @DisplayName("updateProfile - 동시성 충돌 재시도")
+    class UpdateProfileRetry {
+
+        @Test
+        @DisplayName("프로필 유니크 충돌이 한 번 나면 재시도해서 성공한다")
+        void 유니크_충돌_후_재시도_성공() {
+            doThrow(profileUniqueConflict()).doNothing()
+                    .when(memberCommandService).updateProfile(any(), any());
+
+            executor.updateProfile(null, 1L);
+
+            verify(memberCommandService, times(2)).updateProfile(any(), any());
+        }
+
+        @Test
+        @DisplayName("낙관적 락 충돌이 한 번 나면 재시도해서 성공한다")
+        void 낙관적락_충돌_후_재시도_성공() {
+            doThrow(new ObjectOptimisticLockingFailureException("stale", new RuntimeException()))
+                    .doNothing()
+                    .when(memberCommandService).updateProfile(any(), any());
+
+            executor.updateProfile(null, 1L);
+
+            verify(memberCommandService, times(2)).updateProfile(any(), any());
+        }
+
+        @Test
+        @DisplayName("충돌이 최대 시도까지 계속되면 PROFILE_UPDATE_CONFLICT(409)를 던진다")
+        void 충돌_지속시_409() {
+            doThrow(profileUniqueConflict())
+                    .when(memberCommandService).updateProfile(any(), any());
+
+            Throwable thrown = catchThrowable(() -> executor.updateProfile(null, 1L));
+
+            assertThat(thrown).isInstanceOfSatisfying(MemberException.class,
+                    e -> assertThat(e.getCode()).isEqualTo(MemberErrorCode.PROFILE_UPDATE_CONFLICT));
+            verify(memberCommandService, times(3)).updateProfile(any(), any());
+        }
+
+        @Test
+        @DisplayName("프로필과 무관한 무결성 위반은 재시도하지 않고 원래 예외를 그대로 전파한다")
+        void 다른_제약위반은_그대로_전파() {
+            DataIntegrityViolationException other = otherConstraintConflict();
+            doThrow(other).when(memberCommandService).updateProfile(any(), any());
+
+            Throwable thrown = catchThrowable(() -> executor.updateProfile(null, 1L));
+
+            assertThat(thrown)
+                    .isInstanceOf(DataIntegrityViolationException.class)
+                    .isNotInstanceOf(MemberException.class);
+            verify(memberCommandService, times(1)).updateProfile(any(), any());
+        }
+    }
+
+    @Nested
+    @DisplayName("registerMemberDetailInfo - 온보딩도 동일한 재시도 보호를 받는다")
+    class OnboardingRetry {
+
+        @Test
+        @DisplayName("프로필 유니크 충돌이 한 번 나면 재시도해서 성공한다")
+        void 온보딩_유니크_충돌_후_재시도_성공() {
+            doThrow(profileUniqueConflict()).doNothing()
+                    .when(memberCommandService).memberDetailInfo(any(), any());
+
+            executor.registerMemberDetailInfo(1L, null);
+
+            verify(memberCommandService, times(2)).memberDetailInfo(any(), any());
+        }
+
+        @Test
+        @DisplayName("프로필과 무관한 무결성 위반은 그대로 전파한다")
+        void 온보딩_다른_제약위반은_전파() {
+            doThrow(otherConstraintConflict()).when(memberCommandService).memberDetailInfo(any(), any());
+
+            assertThatThrownBy(() -> executor.registerMemberDetailInfo(1L, null))
+                    .isInstanceOf(DataIntegrityViolationException.class)
+                    .isNotInstanceOf(MemberException.class);
+            verify(memberCommandService, times(1)).memberDetailInfo(any(), any());
+        }
+    }
+}


### PR DESCRIPTION
## ❤️ 기능 설명
프로필이 중복 처리되는 이슈가 있어 해당 이슈를 해결합니다. 

1. 중복 생성 차단 - DB unique 제약
- profile_img.member_id에 unique 제약 추가, ProfileImg의 @JoinColumn(unique = true) 반영
- 마이그레이션에서 기존 중복 row를 member당 최신(MAX id) 1개만 남기고 정리 후 제약 추가

2. 교체 동시성 - 낙관적 락
- ProfileImg에 @Version 추가 → 동시 교체 시 패배 트랜잭션이 ObjectOptimisticLockingFailureException으로 실패

3. 멱등 재시도 - 500 방지
- MemberProfileUpdateExecutor 신설: 트랜잭션 밖에서 충돌(DataIntegrityViolationException / 낙관적 락 실패)을 최대 3회 재시도
  - 재시도 시 프로필이 이미 존재 → UPDATE 경로로 수렴해 멱등하게 성공
  - 끝까지 충돌 시 PROFILE_UPDATE_CONFLICT(409) 응답 (기존엔 500)
- MemberController가 executor를 경유하도록 변경

4. GCS 삭제 정합성 - outbox 전환
- 기존 이미지 삭제를 즉시 호출 대신 ObjectStorageDeleteOutboxService.enqueueProfileImage(...)로 트랜잭션 내 예약
- 롤백 시 삭제도 함께 취소
- ObjectStorageDeleteSourceType에 MEMBER_PROFILE_IMG 추가 (기존 스케줄러/프로세서가 그대로 처리)


<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #611 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!



<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [ ] 이슈넘버를 적었는가?
