### PR TITLE
[refactor/#631] 메달 개수 쿼리 최적화

### DIFF
--- a/src/main/java/umc/cockple/demo/domain/contest/converter/ContestConverter.java
+++ b/src/main/java/umc/cockple/demo/domain/contest/converter/ContestConverter.java
@@ -6,6 +6,7 @@ import umc.cockple.demo.domain.contest.domain.Contest;
 import umc.cockple.demo.domain.contest.domain.ContestImg;
 import umc.cockple.demo.domain.contest.domain.ContestVideo;
 import umc.cockple.demo.domain.contest.dto.*;
+import umc.cockple.demo.domain.contest.repository.MedalCountProjection;
 
 import java.util.Comparator;
 import java.util.List;
@@ -108,7 +109,10 @@ public class ContestConverter {
     }
 
     // 대회 메달 개수 조회
-    public ContestMedalSummaryDTO.Response toMedalSummaryResponseDTO(int gold, int silver, int bronze) {
+    public ContestMedalSummaryDTO.Response toMedalSummaryResponseDTO(MedalCountProjection counts) {
+        int gold = (int) counts.getGold();
+        int silver = (int) counts.getSilver();
+        int bronze = (int) counts.getBronze();
         return ContestMedalSummaryDTO.Response.builder()
                 .myMedalTotal(gold + silver + bronze)
                 .goldCount(gold)

--- a/src/main/java/umc/cockple/demo/domain/contest/converter/ContestConverter.java
+++ b/src/main/java/umc/cockple/demo/domain/contest/converter/ContestConverter.java
@@ -6,7 +6,6 @@ import umc.cockple.demo.domain.contest.domain.Contest;
 import umc.cockple.demo.domain.contest.domain.ContestImg;
 import umc.cockple.demo.domain.contest.domain.ContestVideo;
 import umc.cockple.demo.domain.contest.dto.*;
-import umc.cockple.demo.domain.contest.repository.MedalCountProjection;
 
 import java.util.Comparator;
 import java.util.List;
@@ -109,10 +108,7 @@ public class ContestConverter {
     }
 
     // 대회 메달 개수 조회
-    public ContestMedalSummaryDTO.Response toMedalSummaryResponseDTO(MedalCountProjection counts) {
-        int gold = (int) counts.getGold();
-        int silver = (int) counts.getSilver();
-        int bronze = (int) counts.getBronze();
+    public ContestMedalSummaryDTO.Response toMedalSummaryResponseDTO(int gold, int silver, int bronze) {
         return ContestMedalSummaryDTO.Response.builder()
                 .myMedalTotal(gold + silver + bronze)
                 .goldCount(gold)

--- a/src/main/java/umc/cockple/demo/domain/contest/repository/ContestRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/contest/repository/ContestRepository.java
@@ -4,7 +4,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import umc.cockple.demo.domain.contest.domain.Contest;
-
 import java.util.List;
 import java.util.Optional;
 
@@ -13,16 +12,19 @@ public interface ContestRepository extends JpaRepository<Contest, Long> {
 
     List<Contest> findAllByMember_Id(Long memberId);
 
-    @Query("SELECT COUNT(c) FROM Contest c WHERE c.member.id = :memberId")
-    int countAllMedalsByMemberId(@Param("memberId") Long memberId);
-
-    @Query("SELECT COUNT(c) FROM Contest c WHERE c.member.id = :memberId AND c.medalType = 'GOLD'")
-    int countGoldMedalsByMemberId(@Param("memberId") Long memberId);
-
-    @Query("SELECT COUNT(c) FROM Contest c WHERE c.member.id = :memberId AND c.medalType = 'SILVER'")
-    int countSilverMedalsByMemberId(@Param("memberId") Long memberId);
-
-    @Query("SELECT COUNT(c) FROM Contest c WHERE c.member.id = :memberId AND c.medalType = 'BRONZE'")
-    int countBronzeMedalsByMemberId(@Param("memberId") Long memberId);
+    /**
+     * 회원의 메달을 종류별로 한 번의 조건부 집계 쿼리로 센다. (기존 GOLD/SILVER/BRONZE 3회 조회 → 1회)
+     * CASE에 ELSE가 없어 미매칭 행은 null이 되고 COUNT가 이를 무시하므로 종류별 개수만 집계된다.
+     * medal_type은 EnumType.STRING으로 저장되어 문자열 비교한다.
+     */
+    @Query(value = """
+            SELECT
+                COUNT(CASE WHEN c.medal_type = 'GOLD'   THEN 1 END) AS gold,
+                COUNT(CASE WHEN c.medal_type = 'SILVER' THEN 1 END) AS silver,
+                COUNT(CASE WHEN c.medal_type = 'BRONZE' THEN 1 END) AS bronze
+            FROM contest c
+            WHERE c.member_id = :memberId
+            """, nativeQuery = true)
+    MedalCountProjection countMedalsByMemberId(@Param("memberId") Long memberId);
 
 }

--- a/src/main/java/umc/cockple/demo/domain/contest/repository/ContestRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/contest/repository/ContestRepository.java
@@ -13,9 +13,7 @@ public interface ContestRepository extends JpaRepository<Contest, Long> {
     List<Contest> findAllByMember_Id(Long memberId);
 
     /**
-     * 회원의 메달을 종류별로 한 번의 조건부 집계 쿼리로 센다. (기존 GOLD/SILVER/BRONZE 3회 조회 → 1회)
-     * CASE에 ELSE가 없어 미매칭 행은 null이 되고 COUNT가 이를 무시하므로 종류별 개수만 집계된다.
-     * medal_type은 EnumType.STRING으로 저장되어 문자열 비교한다.
+     * 회원의 메달을 종류별로 한 번의 조건부 집계 쿼리 카운트
      */
     @Query(value = """
             SELECT

--- a/src/main/java/umc/cockple/demo/domain/contest/repository/MedalCountProjection.java
+++ b/src/main/java/umc/cockple/demo/domain/contest/repository/MedalCountProjection.java
@@ -1,0 +1,9 @@
+package umc.cockple.demo.domain.contest.repository;
+
+public interface MedalCountProjection {
+    long getGold();
+
+    long getSilver();
+
+    long getBronze();
+}

--- a/src/main/java/umc/cockple/demo/domain/contest/service/ContestQueryServiceImpl.java
+++ b/src/main/java/umc/cockple/demo/domain/contest/service/ContestQueryServiceImpl.java
@@ -87,10 +87,13 @@ public class ContestQueryServiceImpl implements ContestQueryService {
         log.info("[메달 개수 조회 시작] - memberId: {}", memberId);
 
         MedalCountProjection counts = contestRepository.countMedalsByMemberId(memberId);
+        int gold = (int) counts.getGold();
+        int silver = (int) counts.getSilver();
+        int bronze = (int) counts.getBronze();
 
         log.info("[메달 조회 완료] - memberId: {}", memberId);
 
-        return contestConverter.toMedalSummaryResponseDTO(counts);
+        return contestConverter.toMedalSummaryResponseDTO(gold, silver, bronze);
     }
 
     // 이미지 ID 리스트 반환

--- a/src/main/java/umc/cockple/demo/domain/contest/service/ContestQueryServiceImpl.java
+++ b/src/main/java/umc/cockple/demo/domain/contest/service/ContestQueryServiceImpl.java
@@ -12,6 +12,7 @@ import umc.cockple.demo.domain.contest.dto.*;
 import umc.cockple.demo.domain.contest.exception.ContestErrorCode;
 import umc.cockple.demo.domain.contest.exception.ContestException;
 import umc.cockple.demo.domain.contest.repository.ContestRepository;
+import umc.cockple.demo.domain.contest.repository.MedalCountProjection;
 import umc.cockple.demo.domain.contest.enums.MedalType;
 import umc.cockple.demo.domain.file.service.FileService;
 
@@ -85,13 +86,11 @@ public class ContestQueryServiceImpl implements ContestQueryService {
 
         log.info("[메달 개수 조회 시작] - memberId: {}", memberId);
 
-        int gold = contestRepository.countGoldMedalsByMemberId(memberId);
-        int silver = contestRepository.countSilverMedalsByMemberId(memberId);
-        int bronze = contestRepository.countBronzeMedalsByMemberId(memberId);
+        MedalCountProjection counts = contestRepository.countMedalsByMemberId(memberId);
 
         log.info("[메달 조회 완료] - memberId: {}", memberId);
 
-        return contestConverter.toMedalSummaryResponseDTO(gold, silver, bronze);
+        return contestConverter.toMedalSummaryResponseDTO(counts);
     }
 
     // 이미지 ID 리스트 반환

--- a/src/test/java/umc/cockple/demo/domain/contest/integration/ContestMedalSummaryQueryCountTest.java
+++ b/src/test/java/umc/cockple/demo/domain/contest/integration/ContestMedalSummaryQueryCountTest.java
@@ -1,0 +1,98 @@
+package umc.cockple.demo.domain.contest.integration;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import umc.cockple.demo.domain.contest.dto.ContestMedalSummaryDTO;
+import umc.cockple.demo.domain.contest.enums.MedalType;
+import umc.cockple.demo.domain.contest.repository.ContestRepository;
+import umc.cockple.demo.domain.contest.service.ContestQueryService;
+import umc.cockple.demo.domain.member.domain.Member;
+import umc.cockple.demo.domain.member.repository.MemberRepository;
+import umc.cockple.demo.global.enums.Gender;
+import umc.cockple.demo.global.enums.Level;
+import umc.cockple.demo.support.IntegrationTestBase;
+import umc.cockple.demo.support.fixture.ContestFixture;
+import umc.cockple.demo.support.fixture.MemberFixture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static umc.cockple.demo.support.QueryCountAssert.assertQueryCount;
+
+// 메달 개수 조회 쿼리 최적화(GOLD/SILVER/BRONZE 3회 → 조건부 집계 1회) 회귀 방지 테스트
+@DisplayName("메달 개수 조회 쿼리 카운트 테스트")
+class ContestMedalSummaryQueryCountTest extends IntegrationTestBase {
+
+    /**
+     * 메달 개수 조회의 기대 쿼리 수
+     * 종류별로 나누지 않고 조건부 집계로 한 번에 세므로, 메달 개수와 무관하게 1이어야 한다.
+     */
+    private static final int MEDAL_SUMMARY_QUERY_COUNT = 1;
+
+    @Autowired ContestQueryService contestQueryService;
+    @Autowired MemberRepository memberRepository;
+    @Autowired ContestRepository contestRepository;
+
+    @PersistenceContext EntityManager em;
+
+    @AfterEach
+    void tearDown() {
+        contestRepository.deleteAll();
+        memberRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("메달 개수와 무관하게 항상 1개의 쿼리만 실행한다")
+    void getMyMedalSummary_runsSingleQuery() {
+        Member member = createMember(8001L);
+        // GOLD 2, SILVER 1, BRONZE 1, NONE 1
+        seed(member, MedalType.GOLD, MedalType.GOLD, MedalType.SILVER, MedalType.BRONZE, MedalType.NONE);
+
+        assertQueryCount(em, MEDAL_SUMMARY_QUERY_COUNT, () ->
+                contestQueryService.getMyMedalSummary(member.getId()));
+    }
+
+    @Test
+    @DisplayName("조건부 집계 결과가 종류별 개수·합계와 일치한다")
+    void getMyMedalSummary_returnsCorrectCounts() {
+        Member member = createMember(8002L);
+        seed(member, MedalType.GOLD, MedalType.GOLD, MedalType.SILVER, MedalType.BRONZE, MedalType.NONE);
+
+        ContestMedalSummaryDTO.Response response = contestQueryService.getMyMedalSummary(member.getId());
+
+        assertThat(response.goldCount()).isEqualTo(2);
+        assertThat(response.silverCount()).isEqualTo(1);
+        assertThat(response.bronzeCount()).isEqualTo(1);
+        assertThat(response.myMedalTotal()).isEqualTo(4); // NONE은 합계에 미포함
+    }
+
+    @Test
+    @DisplayName("메달이 없으면 모두 0을 반환한다")
+    void getMyMedalSummary_noMedals() {
+        Member member = createMember(8003L);
+
+        ContestMedalSummaryDTO.Response response = contestQueryService.getMyMedalSummary(member.getId());
+
+        assertThat(response.goldCount()).isZero();
+        assertThat(response.silverCount()).isZero();
+        assertThat(response.bronzeCount()).isZero();
+        assertThat(response.myMedalTotal()).isZero();
+    }
+
+    // === 시딩 ===
+
+    private Member createMember(long socialId) {
+        return memberRepository.save(
+                MemberFixture.createMember("회원" + socialId, Gender.MALE, Level.A, socialId));
+    }
+
+    private void seed(Member member, MedalType... medalTypes) {
+        int idx = 0;
+        for (MedalType medalType : medalTypes) {
+            contestRepository.save(
+                    ContestFixture.createContest(member, "대회" + member.getId() + "_" + idx++, medalType));
+        }
+    }
+}

--- a/src/test/java/umc/cockple/demo/domain/contest/service/ContestQueryServiceTest.java
+++ b/src/test/java/umc/cockple/demo/domain/contest/service/ContestQueryServiceTest.java
@@ -391,8 +391,11 @@ class ContestQueryServiceTest {
                         .build();
 
                 MedalCountProjection counts = mock(MedalCountProjection.class);
+                given(counts.getGold()).willReturn(2L);
+                given(counts.getSilver()).willReturn(1L);
+                given(counts.getBronze()).willReturn(1L);
                 given(contestRepository.countMedalsByMemberId(member.getId())).willReturn(counts);
-                given(contestConverter.toMedalSummaryResponseDTO(counts)).willReturn(expectedResponse);
+                given(contestConverter.toMedalSummaryResponseDTO(2, 1, 1)).willReturn(expectedResponse);
 
                 // when
                 ContestMedalSummaryDTO.Response response =
@@ -417,8 +420,11 @@ class ContestQueryServiceTest {
                         .build();
 
                 MedalCountProjection counts = mock(MedalCountProjection.class);
+                given(counts.getGold()).willReturn(0L);
+                given(counts.getSilver()).willReturn(0L);
+                given(counts.getBronze()).willReturn(0L);
                 given(contestRepository.countMedalsByMemberId(member.getId())).willReturn(counts);
-                given(contestConverter.toMedalSummaryResponseDTO(counts)).willReturn(expectedResponse);
+                given(contestConverter.toMedalSummaryResponseDTO(0, 0, 0)).willReturn(expectedResponse);
 
                 // when
                 ContestMedalSummaryDTO.Response response =

--- a/src/test/java/umc/cockple/demo/domain/contest/service/ContestQueryServiceTest.java
+++ b/src/test/java/umc/cockple/demo/domain/contest/service/ContestQueryServiceTest.java
@@ -19,6 +19,7 @@ import umc.cockple.demo.domain.contest.enums.MedalType;
 import umc.cockple.demo.domain.contest.exception.ContestErrorCode;
 import umc.cockple.demo.domain.contest.exception.ContestException;
 import umc.cockple.demo.domain.contest.repository.ContestRepository;
+import umc.cockple.demo.domain.contest.repository.MedalCountProjection;
 import umc.cockple.demo.domain.file.service.FileService;
 import umc.cockple.demo.domain.member.domain.Member;
 import umc.cockple.demo.domain.party.enums.ParticipationType;
@@ -36,6 +37,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mock;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("ContestQueryService")
@@ -388,10 +390,9 @@ class ContestQueryServiceTest {
                         .bronzeCount(1)
                         .build();
 
-                given(contestRepository.countGoldMedalsByMemberId(member.getId())).willReturn(2);
-                given(contestRepository.countSilverMedalsByMemberId(member.getId())).willReturn(1);
-                given(contestRepository.countBronzeMedalsByMemberId(member.getId())).willReturn(1);
-                given(contestConverter.toMedalSummaryResponseDTO(2, 1, 1)).willReturn(expectedResponse);
+                MedalCountProjection counts = mock(MedalCountProjection.class);
+                given(contestRepository.countMedalsByMemberId(member.getId())).willReturn(counts);
+                given(contestConverter.toMedalSummaryResponseDTO(counts)).willReturn(expectedResponse);
 
                 // when
                 ContestMedalSummaryDTO.Response response =
@@ -415,10 +416,9 @@ class ContestQueryServiceTest {
                         .bronzeCount(0)
                         .build();
 
-                given(contestRepository.countGoldMedalsByMemberId(member.getId())).willReturn(0);
-                given(contestRepository.countSilverMedalsByMemberId(member.getId())).willReturn(0);
-                given(contestRepository.countBronzeMedalsByMemberId(member.getId())).willReturn(0);
-                given(contestConverter.toMedalSummaryResponseDTO(0, 0, 0)).willReturn(expectedResponse);
+                MedalCountProjection counts = mock(MedalCountProjection.class);
+                given(contestRepository.countMedalsByMemberId(member.getId())).willReturn(counts);
+                given(contestConverter.toMedalSummaryResponseDTO(counts)).willReturn(expectedResponse);
 
                 // when
                 ContestMedalSummaryDTO.Response response =


### PR DESCRIPTION
## ❤️ 기능 설명
대회(contest) 메달 집계 쿼리를 최적화했습니다.

**기존**
- 메달 요약 조회 시 GOLD/SILVER/BRONZE를 각각 COUNT 쿼리 3번 실행 (같은 회원 데이터를 3번 스캔)

**변경**
- 조건부 집계(COUNT(CASE WHEN ...))로 쿼리 1번에 종류별 개수를 한 번에 집계 → MedalCountProjection으로 매핑
- 사용하지 않던 countAllMedalsByMemberId 제거

쿼리 카운트 테스트를 추가해 메달 개수와 무관하게 항상 쿼리 1개만 실행됨을 회귀 방지로 박제했습니다.

커버링 인덱스는 검토했으나, member_id가 이미 FK 인덱스로 존재하고 현재 데이터 규모에선 이득 대비 중복 인덱스 비용이 커서 이번엔 제외했습니다.

<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #631 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [ ] 이슈넘버를 적었는가?
