### PR TITLE
[refactor/#632] 안 읽은 알림 조회 최적화

### DIFF
--- a/src/main/java/umc/cockple/demo/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/notification/repository/NotificationRepository.java
@@ -15,6 +15,8 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
 
     List<Notification> findAllByMemberOrderByCreatedAtDesc(Member member);
 
+    boolean existsByMember_IdAndIsReadFalse(Long memberId);
+
     Optional<Notification> findFirstByMemberAndTypeNotOrderByCreatedAtAsc(Member member, NotificationType type);
 
     @Modifying

--- a/src/main/java/umc/cockple/demo/domain/notification/service/NotificationQueryService.java
+++ b/src/main/java/umc/cockple/demo/domain/notification/service/NotificationQueryService.java
@@ -49,23 +49,10 @@ public class NotificationQueryService {
 
 
     public ExistNewNotificationResponseDTO checkUnreadNotification(Long memberId) {
-        Member member = findByMemberId(memberId);
-
-        List<Notification> notifications = member.getNotifications();
-
-        long count = notifications.stream()
-                .filter(notification -> notification.getIsRead().equals(false))
-                .count();
-
-        if (count > 0) {
-            return ExistNewNotificationResponseDTO.builder()
-                    .existNewNotification(true)
-                    .build();
-        } else {
-            return ExistNewNotificationResponseDTO.builder()
-                    .existNewNotification(false)
-                    .build();
-        }
+        boolean existNewNotification = notificationRepository.existsByMember_IdAndIsReadFalse(memberId);
+        return ExistNewNotificationResponseDTO.builder()
+                .existNewNotification(existNewNotification)
+                .build();
     }
 
 

--- a/src/test/java/umc/cockple/demo/domain/notification/integration/NotificationUnreadQueryCountTest.java
+++ b/src/test/java/umc/cockple/demo/domain/notification/integration/NotificationUnreadQueryCountTest.java
@@ -1,0 +1,99 @@
+package umc.cockple.demo.domain.notification.integration;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import umc.cockple.demo.domain.member.domain.Member;
+import umc.cockple.demo.domain.member.repository.MemberRepository;
+import umc.cockple.demo.domain.notification.domain.Notification;
+import umc.cockple.demo.domain.notification.dto.ExistNewNotificationResponseDTO;
+import umc.cockple.demo.domain.notification.enums.NotificationType;
+import umc.cockple.demo.domain.notification.repository.NotificationRepository;
+import umc.cockple.demo.domain.notification.service.NotificationQueryService;
+import umc.cockple.demo.global.enums.Gender;
+import umc.cockple.demo.global.enums.Level;
+import umc.cockple.demo.support.IntegrationTestBase;
+import umc.cockple.demo.support.fixture.MemberFixture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static umc.cockple.demo.support.QueryCountAssert.assertQueryCount;
+
+// 안 읽은 알림 존재여부 조회 최적화(알림 전량 로딩 → EXISTS 1회) 회귀 방지 테스트
+@DisplayName("안 읽은 알림 존재여부 조회 쿼리 카운트 테스트")
+class NotificationUnreadQueryCountTest extends IntegrationTestBase {
+
+    /**
+     * checkUnreadNotification의 기대 쿼리 수
+     * 회원/알림 컬렉션 로딩 없이 EXISTS 한 번만 실행하므로, 알림 개수와 무관하게 1이어야 한다.
+     */
+    private static final int UNREAD_CHECK_QUERY_COUNT = 1;
+
+    @Autowired NotificationQueryService notificationQueryService;
+    @Autowired MemberRepository memberRepository;
+    @Autowired NotificationRepository notificationRepository;
+
+    @PersistenceContext EntityManager em;
+
+    @AfterEach
+    void tearDown() {
+        notificationRepository.deleteAll();
+        memberRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("알림 개수와 무관하게 항상 1개의 쿼리만 실행한다")
+    void checkUnreadNotification_runsSingleQuery() {
+        Member member = createMember(9001L);
+        // 읽은 알림 5, 안 읽은 알림 3
+        for (int i = 0; i < 5; i++) seedNotification(member, true, i);
+        for (int i = 0; i < 3; i++) seedNotification(member, false, i);
+
+        assertQueryCount(em, UNREAD_CHECK_QUERY_COUNT, () ->
+                notificationQueryService.checkUnreadNotification(member.getId()));
+    }
+
+    @Test
+    @DisplayName("안 읽은 알림이 있으면 true, 모두 읽었으면 false를 반환한다")
+    void checkUnreadNotification_returnsCorrectResult() {
+        Member hasUnread = createMember(9002L);
+        seedNotification(hasUnread, true, 0);
+        seedNotification(hasUnread, false, 1);
+
+        Member allRead = createMember(9003L);
+        seedNotification(allRead, true, 0);
+        seedNotification(allRead, true, 1);
+
+        Member noNotifications = createMember(9004L);
+
+        assertThat(check(hasUnread)).isTrue();
+        assertThat(check(allRead)).isFalse();
+        assertThat(check(noNotifications)).isFalse();
+    }
+
+    // === 헬퍼 ===
+
+    private boolean check(Member member) {
+        ExistNewNotificationResponseDTO response =
+                notificationQueryService.checkUnreadNotification(member.getId());
+        return response.existNewNotification();
+    }
+
+    private Member createMember(long socialId) {
+        return memberRepository.save(
+                MemberFixture.createMember("회원" + socialId, Gender.MALE, Level.A, socialId));
+    }
+
+    private void seedNotification(Member member, boolean isRead, int idx) {
+        notificationRepository.save(Notification.builder()
+                .member(member)
+                .partyId(100L)
+                .title("알림" + idx)
+                .content("내용" + idx)
+                .type(NotificationType.SIMPLE)
+                .isRead(isRead)
+                .build());
+    }
+}

--- a/src/test/java/umc/cockple/demo/domain/notification/service/NotificationQueryServiceTest.java
+++ b/src/test/java/umc/cockple/demo/domain/notification/service/NotificationQueryServiceTest.java
@@ -212,8 +212,7 @@ class NotificationQueryServiceTest {
             @DisplayName("읽지 않은 알림이 있으면 existNewNotification이 true이다")
             void hasUnreadNotification_returnsTrue() {
                 // given
-                ReflectionTestUtils.setField(member, "notifications", List.of(notification));
-                given(memberRepository.findById(member.getId())).willReturn(Optional.of(member));
+                given(notificationRepository.existsByMember_IdAndIsReadFalse(member.getId())).willReturn(true);
 
                 // when
                 ExistNewNotificationResponseDTO result = notificationQueryService.checkUnreadNotification(member.getId());
@@ -223,50 +222,16 @@ class NotificationQueryServiceTest {
             }
 
             @Test
-            @DisplayName("모든 알림이 읽힌 상태이면 existNewNotification이 false이다")
-            void allNotificationsRead_returnsFalse() {
+            @DisplayName("읽지 않은 알림이 없으면 existNewNotification이 false이다")
+            void noUnreadNotification_returnsFalse() {
                 // given
-                notification.read();
-                ReflectionTestUtils.setField(member, "notifications", List.of(notification));
-                given(memberRepository.findById(member.getId())).willReturn(Optional.of(member));
+                given(notificationRepository.existsByMember_IdAndIsReadFalse(member.getId())).willReturn(false);
 
                 // when
                 ExistNewNotificationResponseDTO result = notificationQueryService.checkUnreadNotification(member.getId());
 
                 // then
                 assertThat(result.existNewNotification()).isFalse();
-            }
-
-            @Test
-            @DisplayName("알림이 없으면 existNewNotification이 false이다")
-            void noNotifications_returnsFalse() {
-                // given
-                ReflectionTestUtils.setField(member, "notifications", List.of());
-                given(memberRepository.findById(member.getId())).willReturn(Optional.of(member));
-
-                // when
-                ExistNewNotificationResponseDTO result = notificationQueryService.checkUnreadNotification(member.getId());
-
-                // then
-                assertThat(result.existNewNotification()).isFalse();
-            }
-        }
-
-        @Nested
-        @DisplayName("실패 케이스")
-        class Failure {
-
-            @Test
-            @DisplayName("존재하지 않는 회원이면 MemberException(MEMBER_NOT_FOUND)을 던진다")
-            void memberNotFound_throwsMemberException() {
-                // given
-                given(memberRepository.findById(999L)).willReturn(Optional.empty());
-
-                // when & then
-                assertThatThrownBy(() -> notificationQueryService.checkUnreadNotification(999L))
-                        .isInstanceOf(MemberException.class)
-                        .satisfies(e -> assertThat(((MemberException) e).getCode())
-                                .isEqualTo(MemberErrorCode.MEMBER_NOT_FOUND));
             }
         }
     }


### PR DESCRIPTION
## ❤️ 기능 설명
안 읽은 알림 존재여부 조회(GET /notifications/count)를 최적화했습니다.

**기존**
- 회원 조회 후 해당 회원의 모든 알림을 메모리에 로딩 → 자바 스트림으로 안 읽은 것만 필터링해 count > 0 판단 (2쿼리 + 전체 엔티티 하이드레이션)
**변경**
- existsByMember_IdAndIsReadFalse EXISTS 쿼리 1번으로 판단. DB가 안 읽은 알림을 1건 찾는 즉시 반환

알림 개수와 무관하게 항상 쿼리 1개만 실행됨을 쿼리 카운트 테스트로 박제했습니다.

<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #632 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [ ] 이슈넘버를 적었는가?
