### PR TITLE
[refactor/#633] 회원 프로필 조회 최적화

### DIFF
--- a/src/main/java/umc/cockple/demo/domain/member/converter/MemberConverter.java
+++ b/src/main/java/umc/cockple/demo/domain/member/converter/MemberConverter.java
@@ -12,7 +12,7 @@ import java.util.List;
 
 public class MemberConverter {
 
-    public static GetProfileResponseDTO memberToGetProfileResponseDTO(Member member, int goldMedalCnt,
+    public static GetProfileResponseDTO memberToGetProfileResponseDTO(Member member, int partyCnt, int goldMedalCnt,
                                                                       int silverMedalCnt, int bronzeMedalCnt, String imgUrl) {
         return GetProfileResponseDTO.builder()
                 .memberName(member.getMemberName())
@@ -20,7 +20,7 @@ public class MemberConverter {
                 .gender(member.getGender())
                 .level(member.getLevel())
                 .profileImgUrl(imgUrl)
-                .myPartyCnt(member.getMemberParties().size())
+                .myPartyCnt(partyCnt)
                 .myGoldMedalCnt(goldMedalCnt)
                 .mySilverMedalCnt(silverMedalCnt)
                 .myBronzeMedalCnt(bronzeMedalCnt)

--- a/src/main/java/umc/cockple/demo/domain/member/repository/MemberExerciseRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/member/repository/MemberExerciseRepository.java
@@ -17,6 +17,9 @@ public interface MemberExerciseRepository extends JpaRepository<MemberExercise, 
 
     boolean existsByExerciseAndMember(Exercise exercise, Member member);
 
+    // 프로필의 참여 운동 수. 컬렉션 전량 로딩 없이 COUNT만 수행한다.
+    long countByMember_Id(Long memberId);
+
     Optional<MemberExercise> findByExerciseAndMember(Exercise exercise, Member member);
 
     @Query("""

--- a/src/main/java/umc/cockple/demo/domain/member/repository/MemberPartyRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/member/repository/MemberPartyRepository.java
@@ -57,4 +57,7 @@ public interface MemberPartyRepository extends JpaRepository<MemberParty, Long> 
     List<MemberParty> findAllByPartyIdWithMember(@Param("partyId") Long partyId);
 
     Optional<MemberParty> findByPartyIdAndRole(Long partyId, Role role);
+
+    // 프로필의 가입 모임 수. 컬렉션 전량 로딩 없이 COUNT만 수행한다.
+    long countByMember_Id(Long memberId);
 }

--- a/src/main/java/umc/cockple/demo/domain/member/service/MemberQueryService.java
+++ b/src/main/java/umc/cockple/demo/domain/member/service/MemberQueryService.java
@@ -5,8 +5,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import umc.cockple.demo.domain.chat.dto.MemberConnectionInfo;
-import umc.cockple.demo.domain.contest.domain.Contest;
-import umc.cockple.demo.domain.contest.enums.MedalType;
+import umc.cockple.demo.domain.contest.dto.ContestMedalSummaryDTO;
+import umc.cockple.demo.domain.contest.service.ContestQueryService;
 import umc.cockple.demo.domain.file.service.FileService;
 import umc.cockple.demo.domain.member.converter.MemberConverter;
 import umc.cockple.demo.domain.member.domain.Member;
@@ -19,13 +19,14 @@ import umc.cockple.demo.domain.member.dto.GetProfileResponseDTO;
 import umc.cockple.demo.domain.member.dto.OnboardingStatusResponseDTO;
 import umc.cockple.demo.domain.member.exception.MemberErrorCode;
 import umc.cockple.demo.domain.member.exception.MemberException;
+import umc.cockple.demo.domain.member.repository.MemberExerciseRepository;
+import umc.cockple.demo.domain.member.repository.MemberPartyRepository;
 import umc.cockple.demo.domain.member.repository.MemberRepository;
 import umc.cockple.demo.global.enums.Keyword;
 
 import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
 
+import static umc.cockple.demo.domain.contest.dto.ContestMedalSummaryDTO.*;
 import static umc.cockple.demo.domain.member.converter.MemberConverter.*;
 
 @Service
@@ -35,6 +36,9 @@ import static umc.cockple.demo.domain.member.converter.MemberConverter.*;
 public class MemberQueryService {
 
     private final MemberRepository memberRepository;
+    private final MemberPartyRepository memberPartyRepository;
+    private final MemberExerciseRepository memberExerciseRepository;
+    private final ContestQueryService contestQueryService;
     private final FileService fileService;
 
     /*
@@ -57,8 +61,8 @@ public class MemberQueryService {
         // 대표 주소 추출
         MemberAddr memberAddr = findMainAddress(member);
 
-        // 운동 개수 추출
-        int exerciseCnt = member.getMemberExercises().size();
+        // 운동 개수 추출 (컬렉션 로딩 없이 COUNT)
+        int exerciseCnt = (int) memberExerciseRepository.countByMember_Id(memberId);
 
         // 엔티티 -> 값 타입으로 변환
         List<Keyword> keywords = member.getKeywords().stream()
@@ -80,15 +84,14 @@ public class MemberQueryService {
             imgUrl = fileService.getUrlFromKey(member.getProfileImg().getImgKey());
         }
 
-        // 각 메달 개수 카운트
-        Map<MedalType, Long> counts = member.getContests().stream()
-                .collect(Collectors.groupingBy(Contest::getMedalType, Collectors.counting()));
+        // 메달 개수 - contest 도메인 API로 집계 (컬렉션 로딩 없이 집계 쿼리)
+        Response medals = contestQueryService.getMyMedalSummary(memberId);
 
-        int goldMedal = counts.getOrDefault(MedalType.GOLD, 0L).intValue();
-        int silverMedal = counts.getOrDefault(MedalType.SILVER, 0L).intValue();
-        int bronzeMedal = counts.getOrDefault(MedalType.BRONZE, 0L).intValue();
+        // 가입 모임 수 - 컬렉션 로딩 없이 COUNT
+        int partyCnt = (int) memberPartyRepository.countByMember_Id(memberId);
 
-        return memberToGetProfileResponseDTO(member, goldMedal, silverMedal, bronzeMedal, imgUrl);
+        return memberToGetProfileResponseDTO(member, partyCnt,
+                medals.goldCount(), medals.silverCount(), medals.bronzeCount(), imgUrl);
     }
 
     /*

--- a/src/test/java/umc/cockple/demo/domain/member/integration/MemberProfileQueryCountTest.java
+++ b/src/test/java/umc/cockple/demo/domain/member/integration/MemberProfileQueryCountTest.java
@@ -1,0 +1,124 @@
+package umc.cockple.demo.domain.member.integration;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import umc.cockple.demo.domain.contest.enums.MedalType;
+import umc.cockple.demo.domain.contest.repository.ContestRepository;
+import umc.cockple.demo.domain.exercise.repository.ExerciseRepository;
+import umc.cockple.demo.domain.member.domain.Member;
+import umc.cockple.demo.domain.member.repository.MemberAddrRepository;
+import umc.cockple.demo.domain.member.repository.MemberExerciseRepository;
+import umc.cockple.demo.domain.member.repository.MemberPartyRepository;
+import umc.cockple.demo.domain.member.repository.MemberRepository;
+import umc.cockple.demo.domain.member.service.MemberQueryService;
+import umc.cockple.demo.domain.party.domain.Party;
+import umc.cockple.demo.domain.party.domain.PartyAddr;
+import umc.cockple.demo.domain.party.repository.PartyAddrRepository;
+import umc.cockple.demo.domain.party.repository.PartyRepository;
+import umc.cockple.demo.global.enums.Gender;
+import umc.cockple.demo.global.enums.Level;
+import umc.cockple.demo.global.enums.Role;
+import umc.cockple.demo.support.IntegrationTestBase;
+import umc.cockple.demo.support.fixture.ContestFixture;
+import umc.cockple.demo.support.fixture.ExerciseFixture;
+import umc.cockple.demo.support.fixture.MemberAddrFixture;
+import umc.cockple.demo.support.fixture.MemberFixture;
+import umc.cockple.demo.support.fixture.PartyFixture;
+
+import java.time.LocalDate;
+
+import static umc.cockple.demo.support.QueryCountAssert.assertQueryCount;
+
+// 프로필 조회 최적화(대회/모임/운동 컬렉션 전량 로딩 → 집계·COUNT 쿼리) 회귀 방지 테스트
+@DisplayName("프로필 조회 쿼리 카운트 테스트")
+class MemberProfileQueryCountTest extends IntegrationTestBase {
+
+    /**
+     * getProfile 기대 쿼리 수 (대회/모임 개수와 무관하게 고정)
+     * 1) 회원  2) 메달 집계  3) 가입 모임 수 COUNT
+     * (프로필 이미지가 없는 회원이라 이미지 조회 쿼리는 발생하지 않는다)
+     */
+    private static final int GET_PROFILE_QUERY_COUNT = 3;
+
+    /**
+     * getMyProfile 기대 쿼리 수 (대회/모임/운동 개수와 무관하게 고정)
+     * getProfile(3) + 대표주소 + 참여 운동 수 COUNT + 키워드
+     */
+    private static final int GET_MY_PROFILE_QUERY_COUNT = 6;
+
+    @Autowired MemberQueryService memberQueryService;
+    @Autowired MemberRepository memberRepository;
+    @Autowired MemberAddrRepository memberAddrRepository;
+    @Autowired ContestRepository contestRepository;
+    @Autowired PartyRepository partyRepository;
+    @Autowired PartyAddrRepository partyAddrRepository;
+    @Autowired ExerciseRepository exerciseRepository;
+    @Autowired MemberPartyRepository memberPartyRepository;
+    @Autowired MemberExerciseRepository memberExerciseRepository;
+
+    @PersistenceContext EntityManager em;
+
+    @AfterEach
+    void tearDown() {
+        memberExerciseRepository.deleteAll();
+        contestRepository.deleteAll();
+        memberPartyRepository.deleteAll();
+        exerciseRepository.deleteAll();
+        partyRepository.deleteAll();
+        partyAddrRepository.deleteAll();
+        memberAddrRepository.deleteAll();
+        memberRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("getProfile - 대회/모임 개수와 무관하게 고정된 쿼리 수만 실행한다")
+    void getProfile_hasNoNPlusOne() {
+        Member small = seedMember(3001L, 2);
+        Member large = seedMember(3002L, 10);
+
+        assertQueryCount(em, GET_PROFILE_QUERY_COUNT, () ->
+                memberQueryService.getProfile(small.getId()));
+        assertQueryCount(em, GET_PROFILE_QUERY_COUNT, () ->
+                memberQueryService.getProfile(large.getId()));
+    }
+
+    @Test
+    @DisplayName("getMyProfile - 대회/모임/운동 개수와 무관하게 고정된 쿼리 수만 실행한다")
+    void getMyProfile_hasNoNPlusOne() {
+        Member small = seedMember(3003L, 2);
+        Member large = seedMember(3004L, 10);
+
+        assertQueryCount(em, GET_MY_PROFILE_QUERY_COUNT, () ->
+                memberQueryService.getMyProfile(small.getId()));
+        assertQueryCount(em, GET_MY_PROFILE_QUERY_COUNT, () ->
+                memberQueryService.getMyProfile(large.getId()));
+    }
+
+    // === 시딩 ===
+
+    // 회원 + 대표주소 1개 + 대회 n개 + (모임 n개 가입) + (운동 n개 참여)
+    private Member seedMember(long socialId, int n) {
+        Member member = memberRepository.save(
+                MemberFixture.createMember("회원" + socialId, Gender.MALE, Level.A, socialId));
+
+        memberAddrRepository.save(
+                MemberAddrFixture.createAddr(member, "역삼동", "서울특별시 강남구 테헤란로 1", true));
+
+        for (int i = 0; i < n; i++) {
+            contestRepository.save(ContestFixture.createContest(member, "대회" + socialId + "_" + i, MedalType.GOLD));
+
+            PartyAddr addr = partyAddrRepository.save(PartyFixture.createPartyAddr("경기도", "모임" + socialId + "_" + i));
+            Party party = partyRepository.save(PartyFixture.createParty("모임" + socialId + "_" + i, member.getId(), addr));
+            memberPartyRepository.save(MemberFixture.createMemberParty(party, member, Role.PARTY_MEMBER));
+
+            var exercise = exerciseRepository.save(
+                    ExerciseFixture.createExerciseWithAddr(party, LocalDate.now().plusDays(i + 1)));
+            memberExerciseRepository.save(MemberFixture.createMemberExercise(member, exercise));
+        }
+        return member;
+    }
+}

--- a/src/test/java/umc/cockple/demo/domain/member/service/MemberQueryServiceTest.java
+++ b/src/test/java/umc/cockple/demo/domain/member/service/MemberQueryServiceTest.java
@@ -9,8 +9,8 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
-import umc.cockple.demo.domain.contest.domain.Contest;
-import umc.cockple.demo.domain.contest.enums.MedalType;
+import umc.cockple.demo.domain.contest.dto.ContestMedalSummaryDTO;
+import umc.cockple.demo.domain.contest.service.ContestQueryService;
 import umc.cockple.demo.domain.file.service.FileService;
 import umc.cockple.demo.domain.member.domain.Member;
 import umc.cockple.demo.domain.member.domain.MemberAddr;
@@ -23,6 +23,8 @@ import umc.cockple.demo.domain.member.dto.GetProfileResponseDTO;
 import umc.cockple.demo.domain.member.dto.OnboardingStatusResponseDTO;
 import umc.cockple.demo.domain.member.exception.MemberErrorCode;
 import umc.cockple.demo.domain.member.exception.MemberException;
+import umc.cockple.demo.domain.member.repository.MemberExerciseRepository;
+import umc.cockple.demo.domain.member.repository.MemberPartyRepository;
 import umc.cockple.demo.domain.member.repository.MemberRepository;
 import umc.cockple.demo.global.enums.Gender;
 import umc.cockple.demo.global.enums.Keyword;
@@ -47,9 +49,21 @@ class MemberQueryServiceTest {
     private MemberQueryService memberQueryService;
 
     @Mock private MemberRepository memberRepository;
+    @Mock private MemberPartyRepository memberPartyRepository;
+    @Mock private MemberExerciseRepository memberExerciseRepository;
+    @Mock private ContestQueryService contestQueryService;
     @Mock private FileService fileService;
 
     private Member member;
+
+    private static ContestMedalSummaryDTO.Response medals(int gold, int silver, int bronze) {
+        return ContestMedalSummaryDTO.Response.builder()
+                .myMedalTotal(gold + silver + bronze)
+                .goldCount(gold)
+                .silverCount(silver)
+                .bronzeCount(bronze)
+                .build();
+    }
 
     @BeforeEach
     void setUp() {
@@ -75,6 +89,7 @@ class MemberQueryServiceTest {
                 ReflectionTestUtils.setField(member, "profileImg", profileImg);
 
                 given(memberRepository.findById(member.getId())).willReturn(Optional.of(member));
+                given(contestQueryService.getMyMedalSummary(member.getId())).willReturn(medals(0, 0, 0));
                 given(fileService.getUrlFromKey("profile/test-key.jpg"))
                         .willReturn("https://cdn.example.com/profile/test-key.jpg");
 
@@ -91,6 +106,7 @@ class MemberQueryServiceTest {
             void profileImg가_없으면_imgUrl이_null로_반환된다() {
                 // given
                 given(memberRepository.findById(member.getId())).willReturn(Optional.of(member));
+                given(contestQueryService.getMyMedalSummary(member.getId())).willReturn(medals(0, 0, 0));
 
                 // when
                 GetProfileResponseDTO response = memberQueryService.getProfile(member.getId());
@@ -101,17 +117,11 @@ class MemberQueryServiceTest {
             }
 
             @Test
-            @DisplayName("금_은_동_메달_개수가_올바르게_집계된다")
+            @DisplayName("금_은_동_메달_개수가_contest_집계_결과로_반환된다")
             void 금_은_동_메달_개수가_올바르게_집계된다() {
                 // given
-                Contest gold1 = Contest.builder().medalType(MedalType.GOLD).build();
-                Contest gold2 = Contest.builder().medalType(MedalType.GOLD).build();
-                Contest silver = Contest.builder().medalType(MedalType.SILVER).build();
-                Contest bronze = Contest.builder().medalType(MedalType.BRONZE).build();
-
-                member.getContests().addAll(List.of(gold1, gold2, silver, bronze));
-
                 given(memberRepository.findById(member.getId())).willReturn(Optional.of(member));
+                given(contestQueryService.getMyMedalSummary(member.getId())).willReturn(medals(2, 1, 1));
 
                 // when
                 GetProfileResponseDTO response = memberQueryService.getProfile(member.getId());
@@ -123,13 +133,12 @@ class MemberQueryServiceTest {
             }
 
             @Test
-            @DisplayName("참여한_모임_수가_올바르게_반환된다")
+            @DisplayName("참여한_모임_수가_COUNT_쿼리_결과로_반환된다")
             void 참여한_모임_수가_올바르게_반환된다() {
                 // given
-                member.getMemberParties().add(MemberFixture.createMemberParty(null, member, umc.cockple.demo.global.enums.Role.PARTY_MEMBER));
-                member.getMemberParties().add(MemberFixture.createMemberParty(null, member, umc.cockple.demo.global.enums.Role.PARTY_MEMBER));
-
                 given(memberRepository.findById(member.getId())).willReturn(Optional.of(member));
+                given(contestQueryService.getMyMedalSummary(member.getId())).willReturn(medals(0, 0, 0));
+                given(memberPartyRepository.countByMember_Id(member.getId())).willReturn(2L);
 
                 // when
                 GetProfileResponseDTO response = memberQueryService.getProfile(member.getId());
@@ -218,9 +227,6 @@ class MemberQueryServiceTest {
                 MemberAddr mainAddr = MemberAddrFixture.createAddr(member, "역삼동", "서울특별시 강남구 테헤란로 1", true);
                 member.getAddresses().add(mainAddr);
 
-                MemberExercise exercise = MemberFixture.createMemberExercise(member, null);
-                member.getMemberExercises().add(exercise);
-
                 umc.cockple.demo.domain.member.domain.MemberKeyword keyword =
                         umc.cockple.demo.domain.member.domain.MemberKeyword.builder()
                                 .member(member)
@@ -229,6 +235,8 @@ class MemberQueryServiceTest {
                 member.getKeywords().add(keyword);
 
                 given(memberRepository.findById(member.getId())).willReturn(Optional.of(member));
+                given(contestQueryService.getMyMedalSummary(member.getId())).willReturn(medals(0, 0, 0));
+                given(memberExerciseRepository.countByMember_Id(member.getId())).willReturn(1L);
 
                 // when
                 GetMyProfileResponseDTO response = memberQueryService.getMyProfile(member.getId());


### PR DESCRIPTION
## ❤️ 기능 설명
회원 프로필 조회(getProfile, getMyProfile)를 최적화했습니다.

**기존**
메달·모임수·운동수를 구하려고 연관 컬렉션을 전량 로딩(하이드레이션)한 뒤 자바에서 세는 구조
데이터가 많을수록 불필요한 행/컬럼까지 통째로 엔티티로 만들어 비효율적이라 판단

**변경 후**
집계·COUNT 쿼리로 대체

<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #633 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [ ] 이슈넘버를 적었는가?
