### PR TITLE
[chore/#664] Tomcat 스레드 지표 노출을 위한 MBean 레지스트리 활성화

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,6 +2,10 @@ server:
   port: 8080
   address: 0.0.0.0
   forward-headers-strategy: native
+  tomcat:
+    mbeanregistry:
+      # Micrometer가 tomcat_threads_* 지표를 읽으려면 Tomcat MBean 등록이 필요(기본 off).
+      enabled: true
 
 spring:
   application:


### PR DESCRIPTION
## ❤️ 기능 설명

부하 시 Tomcat 스레드가 몇 개나 사용되는지 관측할 수 없어 커넥션 경합(HikariCP max=10)의 주체를 특정하지 못하는 문제가 있어 Micrometer의 TomcatMetrics 바인딩을 활성화해 tomcat_threads_{busy,current,config_max}를 기존 OTLP 파이프라인으로 함께 export 한다.

<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #664 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [ ] 이슈넘버를 적었는가?
