### PR TITLE
[test/#667] chat service 패키지 정리 전 회귀 테스트 기준선 고정

### DIFF
--- a/src/test/java/umc/cockple/demo/domain/chat/presentation/websocket/ChatWebSocketCommandHandlerTest.java
+++ b/src/test/java/umc/cockple/demo/domain/chat/presentation/websocket/ChatWebSocketCommandHandlerTest.java
@@ -2,6 +2,7 @@ package umc.cockple.demo.domain.chat.presentation.websocket;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -44,432 +45,457 @@ class ChatWebSocketCommandHandlerTest {
         );
     }
 
-    @Test
-    @DisplayName("SEND 요청을 검증한 뒤 메시지 전송 이벤트를 발행한다")
-    void handleSend_publishesChatMessageSendEvent() {
-        // given
-        Long memberId = 10L;
-        Long chatRoomId = 20L;
-        WebSocketMessageDTO.Request request = new WebSocketMessageDTO.Request(
-                WebSocketMessageType.SEND,
-                chatRoomId,
-                null,
-                "hello",
-                List.of(),
-                null
-        );
+    @Nested
+    @DisplayName("SEND 요청")
+    class HandleSend {
 
-        // when
-        commandHandler.handle(session, request, memberId);
+        @Test
+        @DisplayName("검증한 뒤 메시지 전송 이벤트를 발행한다")
+        void publishesChatMessageSendEvent() {
+            // given
+            Long memberId = 10L;
+            Long chatRoomId = 20L;
+            WebSocketMessageDTO.Request request = new WebSocketMessageDTO.Request(
+                    WebSocketMessageType.SEND,
+                    chatRoomId,
+                    null,
+                    "hello",
+                    List.of(),
+                    null
+            );
 
-        // then
-        then(chatValidator).should().validateSendRequest(chatRoomId, "hello", List.of(), memberId);
+            // when
+            commandHandler.handle(session, request, memberId);
 
-        ArgumentCaptor<ChatMessageSendEvent> eventCaptor = ArgumentCaptor.forClass(ChatMessageSendEvent.class);
-        then(eventPublisher).should().publishEvent(eventCaptor.capture());
-        ChatMessageSendEvent event = eventCaptor.getValue();
-        assertThat(event.chatRoomId()).isEqualTo(chatRoomId);
-        assertThat(event.senderId()).isEqualTo(memberId);
-        assertThat(event.content()).isEqualTo("hello");
-        assertThat(event.files()).isEmpty();
+            // then
+            then(chatValidator).should().validateSendRequest(chatRoomId, "hello", List.of(), memberId);
 
-        then(webSocketResponseSender).shouldHaveNoInteractions();
+            ArgumentCaptor<ChatMessageSendEvent> eventCaptor = ArgumentCaptor.forClass(ChatMessageSendEvent.class);
+            then(eventPublisher).should().publishEvent(eventCaptor.capture());
+            ChatMessageSendEvent event = eventCaptor.getValue();
+            assertThat(event.chatRoomId()).isEqualTo(chatRoomId);
+            assertThat(event.senderId()).isEqualTo(memberId);
+            assertThat(event.content()).isEqualTo("hello");
+            assertThat(event.files()).isEmpty();
+
+            then(webSocketResponseSender).shouldHaveNoInteractions();
+        }
+
+        @Test
+        @DisplayName("검증 실패 시 오류 응답을 보내고 이벤트를 발행하지 않는다")
+        void sendsErrorResponse_whenValidationFails() {
+            // given
+            Long memberId = 10L;
+            Long chatRoomId = 20L;
+            ChatErrorCode errorCode = ChatErrorCode.CHAT_ROOM_ACCESS_DENIED;
+            WebSocketMessageDTO.Request request = new WebSocketMessageDTO.Request(
+                    WebSocketMessageType.SEND,
+                    chatRoomId,
+                    null,
+                    "hello",
+                    List.of(),
+                    null
+            );
+            willThrow(new ChatException(errorCode))
+                    .given(chatValidator)
+                    .validateSendRequest(chatRoomId, "hello", List.of(), memberId);
+
+            // when
+            commandHandler.handle(session, request, memberId);
+
+            // then
+            thenChatErrorResponseSent(errorCode);
+            then(eventPublisher).shouldHaveNoInteractions();
+        }
+
+        @Test
+        @DisplayName("예상치 못한 예외 발생 시 SEND_MESSAGE_ERROR 응답을 보낸다")
+        void sendsFallbackError_whenUnexpectedExceptionOccurs() {
+            // given
+            Long memberId = 10L;
+            Long chatRoomId = 20L;
+            WebSocketMessageDTO.Request request = new WebSocketMessageDTO.Request(
+                    WebSocketMessageType.SEND,
+                    chatRoomId,
+                    null,
+                    "hello",
+                    List.of(),
+                    null
+            );
+            willThrow(new IllegalStateException("boom"))
+                    .given(chatValidator)
+                    .validateSendRequest(chatRoomId, "hello", List.of(), memberId);
+
+            // when
+            commandHandler.handle(session, request, memberId);
+
+            // then
+            then(webSocketResponseSender).should()
+                    .sendErrorMessage(session, "SEND_MESSAGE_ERROR", "메시지 전송 처리 중 오류가 발생했습니다.");
+            then(eventPublisher).shouldHaveNoInteractions();
+        }
     }
 
-    @Test
-    @DisplayName("SUBSCRIBE 요청을 검증한 뒤 채팅방 구독 이벤트를 발행하고 ACK를 보낸다")
-    void handleSubscribe_publishesChatRoomSubscriptionEventAndSendsAck() {
-        // given
-        Long memberId = 10L;
-        Long chatRoomId = 20L;
-        WebSocketMessageDTO.Request request = new WebSocketMessageDTO.Request(
-                WebSocketMessageType.SUBSCRIBE,
-                chatRoomId,
-                null,
-                null,
-                null,
-                null
-        );
+    @Nested
+    @DisplayName("SUBSCRIBE 요청")
+    class HandleSubscribe {
 
-        // when
-        commandHandler.handle(session, request, memberId);
+        @Test
+        @DisplayName("검증한 뒤 채팅방 구독 이벤트를 발행하고 ACK를 보낸다")
+        void publishesChatRoomSubscriptionEventAndSendsAck() {
+            // given
+            Long memberId = 10L;
+            Long chatRoomId = 20L;
+            WebSocketMessageDTO.Request request = new WebSocketMessageDTO.Request(
+                    WebSocketMessageType.SUBSCRIBE,
+                    chatRoomId,
+                    null,
+                    null,
+                    null,
+                    null
+            );
 
-        // then
-        then(chatValidator).should().validateSubscriptionRequest(chatRoomId, memberId);
+            // when
+            commandHandler.handle(session, request, memberId);
 
-        ArgumentCaptor<ChatRoomSubscriptionEvent> eventCaptor = ArgumentCaptor.forClass(ChatRoomSubscriptionEvent.class);
-        then(eventPublisher).should().publishEvent(eventCaptor.capture());
-        ChatRoomSubscriptionEvent event = eventCaptor.getValue();
-        assertThat(event.chatRoomId()).isEqualTo(chatRoomId);
-        assertThat(event.memberId()).isEqualTo(memberId);
-        assertThat(event.action()).isEqualTo("SUBSCRIBE");
+            // then
+            then(chatValidator).should().validateSubscriptionRequest(chatRoomId, memberId);
 
-        then(webSocketResponseSender).should().sendSubscriptionMessage(session, chatRoomId, "SUBSCRIBE");
+            ArgumentCaptor<ChatRoomSubscriptionEvent> eventCaptor = ArgumentCaptor.forClass(ChatRoomSubscriptionEvent.class);
+            then(eventPublisher).should().publishEvent(eventCaptor.capture());
+            ChatRoomSubscriptionEvent event = eventCaptor.getValue();
+            assertThat(event.chatRoomId()).isEqualTo(chatRoomId);
+            assertThat(event.memberId()).isEqualTo(memberId);
+            assertThat(event.action()).isEqualTo("SUBSCRIBE");
+
+            then(webSocketResponseSender).should().sendSubscriptionMessage(session, chatRoomId, "SUBSCRIBE");
+        }
+
+        @Test
+        @DisplayName("검증 실패 시 오류 응답을 보내고 이벤트를 발행하지 않는다")
+        void sendsErrorResponse_whenValidationFails() {
+            // given
+            Long memberId = 10L;
+            Long chatRoomId = 20L;
+            ChatErrorCode errorCode = ChatErrorCode.CHAT_ROOM_ACCESS_DENIED;
+            WebSocketMessageDTO.Request request = new WebSocketMessageDTO.Request(
+                    WebSocketMessageType.SUBSCRIBE,
+                    chatRoomId,
+                    null,
+                    null,
+                    null,
+                    null
+            );
+            willThrow(new ChatException(errorCode))
+                    .given(chatValidator)
+                    .validateSubscriptionRequest(chatRoomId, memberId);
+
+            // when
+            commandHandler.handle(session, request, memberId);
+
+            // then
+            thenChatErrorResponseSent(errorCode);
+            then(eventPublisher).shouldHaveNoInteractions();
+        }
+
+        @Test
+        @DisplayName("예상치 못한 예외 발생 시 SUBSCRIPTION_ERROR 응답을 보낸다")
+        void sendsFallbackError_whenUnexpectedExceptionOccurs() {
+            // given
+            Long memberId = 10L;
+            Long chatRoomId = 20L;
+            WebSocketMessageDTO.Request request = new WebSocketMessageDTO.Request(
+                    WebSocketMessageType.SUBSCRIBE,
+                    chatRoomId,
+                    null,
+                    null,
+                    null,
+                    null
+            );
+            willThrow(new IllegalStateException("boom"))
+                    .given(chatValidator)
+                    .validateSubscriptionRequest(chatRoomId, memberId);
+
+            // when
+            commandHandler.handle(session, request, memberId);
+
+            // then
+            then(webSocketResponseSender).should()
+                    .sendErrorMessage(session, "SUBSCRIPTION_ERROR", "구독 처리 중 오류가 발생했습니다.");
+            then(eventPublisher).shouldHaveNoInteractions();
+        }
     }
 
-    @Test
-    @DisplayName("UNSUBSCRIBE 요청을 검증한 뒤 채팅방 구독 해제 이벤트를 발행하고 ACK를 보낸다")
-    void handleUnsubscribe_publishesChatRoomSubscriptionEventAndSendsAck() {
-        // given
-        Long memberId = 10L;
-        Long chatRoomId = 20L;
-        WebSocketMessageDTO.Request request = new WebSocketMessageDTO.Request(
-                WebSocketMessageType.UNSUBSCRIBE,
-                chatRoomId,
-                null,
-                null,
-                null,
-                null
-        );
+    @Nested
+    @DisplayName("UNSUBSCRIBE 요청")
+    class HandleUnsubscribe {
 
-        // when
-        commandHandler.handle(session, request, memberId);
+        @Test
+        @DisplayName("검증한 뒤 채팅방 구독 해제 이벤트를 발행하고 ACK를 보낸다")
+        void publishesChatRoomSubscriptionEventAndSendsAck() {
+            // given
+            Long memberId = 10L;
+            Long chatRoomId = 20L;
+            WebSocketMessageDTO.Request request = new WebSocketMessageDTO.Request(
+                    WebSocketMessageType.UNSUBSCRIBE,
+                    chatRoomId,
+                    null,
+                    null,
+                    null,
+                    null
+            );
 
-        // then
-        then(chatValidator).should().validateUnsubscriptionRequest(chatRoomId, memberId);
+            // when
+            commandHandler.handle(session, request, memberId);
 
-        ArgumentCaptor<ChatRoomSubscriptionEvent> eventCaptor = ArgumentCaptor.forClass(ChatRoomSubscriptionEvent.class);
-        then(eventPublisher).should().publishEvent(eventCaptor.capture());
-        ChatRoomSubscriptionEvent event = eventCaptor.getValue();
-        assertThat(event.chatRoomId()).isEqualTo(chatRoomId);
-        assertThat(event.memberId()).isEqualTo(memberId);
-        assertThat(event.action()).isEqualTo("UNSUBSCRIBE");
+            // then
+            then(chatValidator).should().validateUnsubscriptionRequest(chatRoomId, memberId);
 
-        then(webSocketResponseSender).should().sendSubscriptionMessage(session, chatRoomId, "UNSUBSCRIBE");
+            ArgumentCaptor<ChatRoomSubscriptionEvent> eventCaptor = ArgumentCaptor.forClass(ChatRoomSubscriptionEvent.class);
+            then(eventPublisher).should().publishEvent(eventCaptor.capture());
+            ChatRoomSubscriptionEvent event = eventCaptor.getValue();
+            assertThat(event.chatRoomId()).isEqualTo(chatRoomId);
+            assertThat(event.memberId()).isEqualTo(memberId);
+            assertThat(event.action()).isEqualTo("UNSUBSCRIBE");
+
+            then(webSocketResponseSender).should().sendSubscriptionMessage(session, chatRoomId, "UNSUBSCRIBE");
+        }
+
+        @Test
+        @DisplayName("검증 실패 시 오류 응답을 보내고 이벤트를 발행하지 않는다")
+        void sendsErrorResponse_whenValidationFails() {
+            // given
+            Long memberId = 10L;
+            Long chatRoomId = 20L;
+            ChatErrorCode errorCode = ChatErrorCode.CHAT_ROOM_ACCESS_DENIED;
+            WebSocketMessageDTO.Request request = new WebSocketMessageDTO.Request(
+                    WebSocketMessageType.UNSUBSCRIBE,
+                    chatRoomId,
+                    null,
+                    null,
+                    null,
+                    null
+            );
+            willThrow(new ChatException(errorCode))
+                    .given(chatValidator)
+                    .validateUnsubscriptionRequest(chatRoomId, memberId);
+
+            // when
+            commandHandler.handle(session, request, memberId);
+
+            // then
+            thenChatErrorResponseSent(errorCode);
+            then(eventPublisher).shouldHaveNoInteractions();
+        }
+
+        @Test
+        @DisplayName("예상치 못한 예외 발생 시 UNSUBSCRIPTION_ERROR 응답을 보낸다")
+        void sendsFallbackError_whenUnexpectedExceptionOccurs() {
+            // given
+            Long memberId = 10L;
+            Long chatRoomId = 20L;
+            WebSocketMessageDTO.Request request = new WebSocketMessageDTO.Request(
+                    WebSocketMessageType.UNSUBSCRIBE,
+                    chatRoomId,
+                    null,
+                    null,
+                    null,
+                    null
+            );
+            willThrow(new IllegalStateException("boom"))
+                    .given(chatValidator)
+                    .validateUnsubscriptionRequest(chatRoomId, memberId);
+
+            // when
+            commandHandler.handle(session, request, memberId);
+
+            // then
+            then(webSocketResponseSender).should()
+                    .sendErrorMessage(session, "UNSUBSCRIPTION_ERROR", "구독 해제 처리 중 오류가 발생했습니다.");
+            then(eventPublisher).shouldHaveNoInteractions();
+        }
     }
 
-    @Test
-    @DisplayName("SUBSCRIBE_CHAT_LIST 요청을 검증한 뒤 목록 구독 이벤트를 발행하고 ACK를 보낸다")
-    void handleSubscribeChatList_publishesChatListSubscriptionEventAndSendsAck() {
-        // given
-        Long memberId = 10L;
-        List<Long> chatRoomIds = List.of(20L, 30L);
-        WebSocketMessageDTO.Request request = new WebSocketMessageDTO.Request(
-                WebSocketMessageType.SUBSCRIBE_CHAT_LIST,
-                null,
-                chatRoomIds,
-                null,
-                null,
-                null
-        );
+    @Nested
+    @DisplayName("SUBSCRIBE_CHAT_LIST 요청")
+    class HandleSubscribeChatList {
 
-        // when
-        commandHandler.handle(session, request, memberId);
+        @Test
+        @DisplayName("검증한 뒤 목록 구독 이벤트를 발행하고 ACK를 보낸다")
+        void publishesChatListSubscriptionEventAndSendsAck() {
+            // given
+            Long memberId = 10L;
+            List<Long> chatRoomIds = List.of(20L, 30L);
+            WebSocketMessageDTO.Request request = new WebSocketMessageDTO.Request(
+                    WebSocketMessageType.SUBSCRIBE_CHAT_LIST,
+                    null,
+                    chatRoomIds,
+                    null,
+                    null,
+                    null
+            );
 
-        // then
-        then(chatValidator).should().validateChatListSubscriptionRequest(memberId, chatRoomIds);
+            // when
+            commandHandler.handle(session, request, memberId);
 
-        ArgumentCaptor<ChatListSubscriptionEvent> eventCaptor = ArgumentCaptor.forClass(ChatListSubscriptionEvent.class);
-        then(eventPublisher).should().publishEvent(eventCaptor.capture());
-        ChatListSubscriptionEvent event = eventCaptor.getValue();
-        assertThat(event.memberId()).isEqualTo(memberId);
-        assertThat(event.chatRoomIds()).containsExactlyElementsOf(chatRoomIds);
-        assertThat(event.action()).isEqualTo("SUBSCRIBE");
+            // then
+            then(chatValidator).should().validateChatListSubscriptionRequest(memberId, chatRoomIds);
 
-        then(webSocketResponseSender).should()
-                .sendChatListSubscriptionMessage(session, chatRoomIds, "SUBSCRIBE_CHAT_LIST");
+            ArgumentCaptor<ChatListSubscriptionEvent> eventCaptor = ArgumentCaptor.forClass(ChatListSubscriptionEvent.class);
+            then(eventPublisher).should().publishEvent(eventCaptor.capture());
+            ChatListSubscriptionEvent event = eventCaptor.getValue();
+            assertThat(event.memberId()).isEqualTo(memberId);
+            assertThat(event.chatRoomIds()).containsExactlyElementsOf(chatRoomIds);
+            assertThat(event.action()).isEqualTo("SUBSCRIBE");
+
+            then(webSocketResponseSender).should()
+                    .sendChatListSubscriptionMessage(session, chatRoomIds, "SUBSCRIBE_CHAT_LIST");
+        }
+
+        @Test
+        @DisplayName("검증 실패 시 오류 응답을 보내고 이벤트를 발행하지 않는다")
+        void sendsErrorResponse_whenValidationFails() {
+            // given
+            Long memberId = 10L;
+            List<Long> chatRoomIds = List.of(20L, 30L);
+            ChatErrorCode errorCode = ChatErrorCode.CHAT_ROOM_ACCESS_DENIED;
+            WebSocketMessageDTO.Request request = new WebSocketMessageDTO.Request(
+                    WebSocketMessageType.SUBSCRIBE_CHAT_LIST,
+                    null,
+                    chatRoomIds,
+                    null,
+                    null,
+                    null
+            );
+            willThrow(new ChatException(errorCode))
+                    .given(chatValidator)
+                    .validateChatListSubscriptionRequest(memberId, chatRoomIds);
+
+            // when
+            commandHandler.handle(session, request, memberId);
+
+            // then
+            thenChatErrorResponseSent(errorCode);
+            then(eventPublisher).shouldHaveNoInteractions();
+        }
+
+        @Test
+        @DisplayName("예상치 못한 예외 발생 시 SUBSCRIPTION_ERROR 응답을 보낸다")
+        void sendsFallbackError_whenUnexpectedExceptionOccurs() {
+            // given
+            Long memberId = 10L;
+            List<Long> chatRoomIds = List.of(20L, 30L);
+            WebSocketMessageDTO.Request request = new WebSocketMessageDTO.Request(
+                    WebSocketMessageType.SUBSCRIBE_CHAT_LIST,
+                    null,
+                    chatRoomIds,
+                    null,
+                    null,
+                    null
+            );
+            willThrow(new IllegalStateException("boom"))
+                    .given(chatValidator)
+                    .validateChatListSubscriptionRequest(memberId, chatRoomIds);
+
+            // when
+            commandHandler.handle(session, request, memberId);
+
+            // then
+            then(webSocketResponseSender).should()
+                    .sendErrorMessage(session, "SUBSCRIPTION_ERROR", "채팅방 목록 구독 처리 중 오류가 발생했습니다.");
+            then(eventPublisher).shouldHaveNoInteractions();
+        }
     }
 
-    @Test
-    @DisplayName("UNSUBSCRIBE_CHAT_LIST 요청을 검증한 뒤 목록 구독 해제 이벤트를 발행하고 ACK를 보낸다")
-    void handleUnsubscribeChatList_publishesChatListSubscriptionEventAndSendsAck() {
-        // given
-        Long memberId = 10L;
-        List<Long> chatRoomIds = List.of(20L, 30L);
-        WebSocketMessageDTO.Request request = new WebSocketMessageDTO.Request(
-                WebSocketMessageType.UNSUBSCRIBE_CHAT_LIST,
-                null,
-                chatRoomIds,
-                null,
-                null,
-                null
-        );
+    @Nested
+    @DisplayName("UNSUBSCRIBE_CHAT_LIST 요청")
+    class HandleUnsubscribeChatList {
 
-        // when
-        commandHandler.handle(session, request, memberId);
+        @Test
+        @DisplayName("검증한 뒤 목록 구독 해제 이벤트를 발행하고 ACK를 보낸다")
+        void publishesChatListSubscriptionEventAndSendsAck() {
+            // given
+            Long memberId = 10L;
+            List<Long> chatRoomIds = List.of(20L, 30L);
+            WebSocketMessageDTO.Request request = new WebSocketMessageDTO.Request(
+                    WebSocketMessageType.UNSUBSCRIBE_CHAT_LIST,
+                    null,
+                    chatRoomIds,
+                    null,
+                    null,
+                    null
+            );
 
-        // then
-        then(chatValidator).should().validateChatListUnsubscriptionRequest(memberId, chatRoomIds);
+            // when
+            commandHandler.handle(session, request, memberId);
 
-        ArgumentCaptor<ChatListSubscriptionEvent> eventCaptor = ArgumentCaptor.forClass(ChatListSubscriptionEvent.class);
-        then(eventPublisher).should().publishEvent(eventCaptor.capture());
-        ChatListSubscriptionEvent event = eventCaptor.getValue();
-        assertThat(event.memberId()).isEqualTo(memberId);
-        assertThat(event.chatRoomIds()).containsExactlyElementsOf(chatRoomIds);
-        assertThat(event.action()).isEqualTo("UNSUBSCRIBE");
+            // then
+            then(chatValidator).should().validateChatListUnsubscriptionRequest(memberId, chatRoomIds);
 
-        then(webSocketResponseSender).should()
-                .sendChatListSubscriptionMessage(session, chatRoomIds, "UNSUBSCRIBE_CHAT_LIST");
-    }
+            ArgumentCaptor<ChatListSubscriptionEvent> eventCaptor = ArgumentCaptor.forClass(ChatListSubscriptionEvent.class);
+            then(eventPublisher).should().publishEvent(eventCaptor.capture());
+            ChatListSubscriptionEvent event = eventCaptor.getValue();
+            assertThat(event.memberId()).isEqualTo(memberId);
+            assertThat(event.chatRoomIds()).containsExactlyElementsOf(chatRoomIds);
+            assertThat(event.action()).isEqualTo("UNSUBSCRIBE");
 
-    @Test
-    @DisplayName("SEND 검증 실패 시 오류 응답을 보내고 이벤트를 발행하지 않는다")
-    void handleSend_sendsErrorResponse_whenValidationFails() {
-        // given
-        Long memberId = 10L;
-        Long chatRoomId = 20L;
-        ChatErrorCode errorCode = ChatErrorCode.CHAT_ROOM_ACCESS_DENIED;
-        WebSocketMessageDTO.Request request = new WebSocketMessageDTO.Request(
-                WebSocketMessageType.SEND,
-                chatRoomId,
-                null,
-                "hello",
-                List.of(),
-                null
-        );
-        willThrow(new ChatException(errorCode))
-                .given(chatValidator)
-                .validateSendRequest(chatRoomId, "hello", List.of(), memberId);
+            then(webSocketResponseSender).should()
+                    .sendChatListSubscriptionMessage(session, chatRoomIds, "UNSUBSCRIBE_CHAT_LIST");
+        }
 
-        // when
-        commandHandler.handle(session, request, memberId);
+        @Test
+        @DisplayName("검증 실패 시 오류 응답을 보내고 이벤트를 발행하지 않는다")
+        void sendsErrorResponse_whenValidationFails() {
+            // given
+            Long memberId = 10L;
+            List<Long> chatRoomIds = List.of(20L, 30L);
+            ChatErrorCode errorCode = ChatErrorCode.CHAT_ROOM_ACCESS_DENIED;
+            WebSocketMessageDTO.Request request = new WebSocketMessageDTO.Request(
+                    WebSocketMessageType.UNSUBSCRIBE_CHAT_LIST,
+                    null,
+                    chatRoomIds,
+                    null,
+                    null,
+                    null
+            );
+            willThrow(new ChatException(errorCode))
+                    .given(chatValidator)
+                    .validateChatListUnsubscriptionRequest(memberId, chatRoomIds);
 
-        // then
-        thenChatErrorResponseSent(errorCode);
-        then(eventPublisher).shouldHaveNoInteractions();
-    }
+            // when
+            commandHandler.handle(session, request, memberId);
 
-    @Test
-    @DisplayName("SUBSCRIBE 검증 실패 시 오류 응답을 보내고 이벤트를 발행하지 않는다")
-    void handleSubscribe_sendsErrorResponse_whenValidationFails() {
-        // given
-        Long memberId = 10L;
-        Long chatRoomId = 20L;
-        ChatErrorCode errorCode = ChatErrorCode.CHAT_ROOM_ACCESS_DENIED;
-        WebSocketMessageDTO.Request request = new WebSocketMessageDTO.Request(
-                WebSocketMessageType.SUBSCRIBE,
-                chatRoomId,
-                null,
-                null,
-                null,
-                null
-        );
-        willThrow(new ChatException(errorCode))
-                .given(chatValidator)
-                .validateSubscriptionRequest(chatRoomId, memberId);
+            // then
+            thenChatErrorResponseSent(errorCode);
+            then(eventPublisher).shouldHaveNoInteractions();
+        }
 
-        // when
-        commandHandler.handle(session, request, memberId);
+        @Test
+        @DisplayName("예상치 못한 예외 발생 시 UNSUBSCRIPTION_ERROR 응답을 보낸다")
+        void sendsFallbackError_whenUnexpectedExceptionOccurs() {
+            // given
+            Long memberId = 10L;
+            List<Long> chatRoomIds = List.of(20L, 30L);
+            WebSocketMessageDTO.Request request = new WebSocketMessageDTO.Request(
+                    WebSocketMessageType.UNSUBSCRIBE_CHAT_LIST,
+                    null,
+                    chatRoomIds,
+                    null,
+                    null,
+                    null
+            );
+            willThrow(new IllegalStateException("boom"))
+                    .given(chatValidator)
+                    .validateChatListUnsubscriptionRequest(memberId, chatRoomIds);
 
-        // then
-        thenChatErrorResponseSent(errorCode);
-        then(eventPublisher).shouldHaveNoInteractions();
-    }
+            // when
+            commandHandler.handle(session, request, memberId);
 
-    @Test
-    @DisplayName("UNSUBSCRIBE 검증 실패 시 오류 응답을 보내고 이벤트를 발행하지 않는다")
-    void handleUnsubscribe_sendsErrorResponse_whenValidationFails() {
-        // given
-        Long memberId = 10L;
-        Long chatRoomId = 20L;
-        ChatErrorCode errorCode = ChatErrorCode.CHAT_ROOM_ACCESS_DENIED;
-        WebSocketMessageDTO.Request request = new WebSocketMessageDTO.Request(
-                WebSocketMessageType.UNSUBSCRIBE,
-                chatRoomId,
-                null,
-                null,
-                null,
-                null
-        );
-        willThrow(new ChatException(errorCode))
-                .given(chatValidator)
-                .validateUnsubscriptionRequest(chatRoomId, memberId);
-
-        // when
-        commandHandler.handle(session, request, memberId);
-
-        // then
-        thenChatErrorResponseSent(errorCode);
-        then(eventPublisher).shouldHaveNoInteractions();
-    }
-
-    @Test
-    @DisplayName("SUBSCRIBE_CHAT_LIST 검증 실패 시 오류 응답을 보내고 이벤트를 발행하지 않는다")
-    void handleSubscribeChatList_sendsErrorResponse_whenValidationFails() {
-        // given
-        Long memberId = 10L;
-        List<Long> chatRoomIds = List.of(20L, 30L);
-        ChatErrorCode errorCode = ChatErrorCode.CHAT_ROOM_ACCESS_DENIED;
-        WebSocketMessageDTO.Request request = new WebSocketMessageDTO.Request(
-                WebSocketMessageType.SUBSCRIBE_CHAT_LIST,
-                null,
-                chatRoomIds,
-                null,
-                null,
-                null
-        );
-        willThrow(new ChatException(errorCode))
-                .given(chatValidator)
-                .validateChatListSubscriptionRequest(memberId, chatRoomIds);
-
-        // when
-        commandHandler.handle(session, request, memberId);
-
-        // then
-        thenChatErrorResponseSent(errorCode);
-        then(eventPublisher).shouldHaveNoInteractions();
-    }
-
-    @Test
-    @DisplayName("UNSUBSCRIBE_CHAT_LIST 검증 실패 시 오류 응답을 보내고 이벤트를 발행하지 않는다")
-    void handleUnsubscribeChatList_sendsErrorResponse_whenValidationFails() {
-        // given
-        Long memberId = 10L;
-        List<Long> chatRoomIds = List.of(20L, 30L);
-        ChatErrorCode errorCode = ChatErrorCode.CHAT_ROOM_ACCESS_DENIED;
-        WebSocketMessageDTO.Request request = new WebSocketMessageDTO.Request(
-                WebSocketMessageType.UNSUBSCRIBE_CHAT_LIST,
-                null,
-                chatRoomIds,
-                null,
-                null,
-                null
-        );
-        willThrow(new ChatException(errorCode))
-                .given(chatValidator)
-                .validateChatListUnsubscriptionRequest(memberId, chatRoomIds);
-
-        // when
-        commandHandler.handle(session, request, memberId);
-
-        // then
-        thenChatErrorResponseSent(errorCode);
-        then(eventPublisher).shouldHaveNoInteractions();
-    }
-
-    @Test
-    @DisplayName("SEND 처리 중 예상치 못한 예외 발생 시 SEND_MESSAGE_ERROR 응답을 보낸다")
-    void handleSend_sendsFallbackError_whenUnexpectedExceptionOccurs() {
-        // given
-        Long memberId = 10L;
-        Long chatRoomId = 20L;
-        WebSocketMessageDTO.Request request = new WebSocketMessageDTO.Request(
-                WebSocketMessageType.SEND,
-                chatRoomId,
-                null,
-                "hello",
-                List.of(),
-                null
-        );
-        willThrow(new IllegalStateException("boom"))
-                .given(chatValidator)
-                .validateSendRequest(chatRoomId, "hello", List.of(), memberId);
-
-        // when
-        commandHandler.handle(session, request, memberId);
-
-        // then
-        then(webSocketResponseSender).should()
-                .sendErrorMessage(session, "SEND_MESSAGE_ERROR", "메시지 전송 처리 중 오류가 발생했습니다.");
-        then(eventPublisher).shouldHaveNoInteractions();
-    }
-
-    @Test
-    @DisplayName("SUBSCRIBE 처리 중 예상치 못한 예외 발생 시 SUBSCRIPTION_ERROR 응답을 보낸다")
-    void handleSubscribe_sendsFallbackError_whenUnexpectedExceptionOccurs() {
-        // given
-        Long memberId = 10L;
-        Long chatRoomId = 20L;
-        WebSocketMessageDTO.Request request = new WebSocketMessageDTO.Request(
-                WebSocketMessageType.SUBSCRIBE,
-                chatRoomId,
-                null,
-                null,
-                null,
-                null
-        );
-        willThrow(new IllegalStateException("boom"))
-                .given(chatValidator)
-                .validateSubscriptionRequest(chatRoomId, memberId);
-
-        // when
-        commandHandler.handle(session, request, memberId);
-
-        // then
-        then(webSocketResponseSender).should()
-                .sendErrorMessage(session, "SUBSCRIPTION_ERROR", "구독 처리 중 오류가 발생했습니다.");
-        then(eventPublisher).shouldHaveNoInteractions();
-    }
-
-    @Test
-    @DisplayName("UNSUBSCRIBE 처리 중 예상치 못한 예외 발생 시 UNSUBSCRIPTION_ERROR 응답을 보낸다")
-    void handleUnsubscribe_sendsFallbackError_whenUnexpectedExceptionOccurs() {
-        // given
-        Long memberId = 10L;
-        Long chatRoomId = 20L;
-        WebSocketMessageDTO.Request request = new WebSocketMessageDTO.Request(
-                WebSocketMessageType.UNSUBSCRIBE,
-                chatRoomId,
-                null,
-                null,
-                null,
-                null
-        );
-        willThrow(new IllegalStateException("boom"))
-                .given(chatValidator)
-                .validateUnsubscriptionRequest(chatRoomId, memberId);
-
-        // when
-        commandHandler.handle(session, request, memberId);
-
-        // then
-        then(webSocketResponseSender).should()
-                .sendErrorMessage(session, "UNSUBSCRIPTION_ERROR", "구독 해제 처리 중 오류가 발생했습니다.");
-        then(eventPublisher).shouldHaveNoInteractions();
-    }
-
-    @Test
-    @DisplayName("SUBSCRIBE_CHAT_LIST 처리 중 예상치 못한 예외 발생 시 SUBSCRIPTION_ERROR 응답을 보낸다")
-    void handleSubscribeChatList_sendsFallbackError_whenUnexpectedExceptionOccurs() {
-        // given
-        Long memberId = 10L;
-        List<Long> chatRoomIds = List.of(20L, 30L);
-        WebSocketMessageDTO.Request request = new WebSocketMessageDTO.Request(
-                WebSocketMessageType.SUBSCRIBE_CHAT_LIST,
-                null,
-                chatRoomIds,
-                null,
-                null,
-                null
-        );
-        willThrow(new IllegalStateException("boom"))
-                .given(chatValidator)
-                .validateChatListSubscriptionRequest(memberId, chatRoomIds);
-
-        // when
-        commandHandler.handle(session, request, memberId);
-
-        // then
-        then(webSocketResponseSender).should()
-                .sendErrorMessage(session, "SUBSCRIPTION_ERROR", "채팅방 목록 구독 처리 중 오류가 발생했습니다.");
-        then(eventPublisher).shouldHaveNoInteractions();
-    }
-
-    @Test
-    @DisplayName("UNSUBSCRIBE_CHAT_LIST 처리 중 예상치 못한 예외 발생 시 UNSUBSCRIPTION_ERROR 응답을 보낸다")
-    void handleUnsubscribeChatList_sendsFallbackError_whenUnexpectedExceptionOccurs() {
-        // given
-        Long memberId = 10L;
-        List<Long> chatRoomIds = List.of(20L, 30L);
-        WebSocketMessageDTO.Request request = new WebSocketMessageDTO.Request(
-                WebSocketMessageType.UNSUBSCRIBE_CHAT_LIST,
-                null,
-                chatRoomIds,
-                null,
-                null,
-                null
-        );
-        willThrow(new IllegalStateException("boom"))
-                .given(chatValidator)
-                .validateChatListUnsubscriptionRequest(memberId, chatRoomIds);
-
-        // when
-        commandHandler.handle(session, request, memberId);
-
-        // then
-        then(webSocketResponseSender).should()
-                .sendErrorMessage(session, "UNSUBSCRIPTION_ERROR", "채팅방 목록 구독 해제 처리 중 오류가 발생했습니다.");
-        then(eventPublisher).shouldHaveNoInteractions();
+            // then
+            then(webSocketResponseSender).should()
+                    .sendErrorMessage(session, "UNSUBSCRIPTION_ERROR", "채팅방 목록 구독 해제 처리 중 오류가 발생했습니다.");
+            then(eventPublisher).shouldHaveNoInteractions();
+        }
     }
 
     @Test

--- a/src/test/java/umc/cockple/demo/domain/chat/presentation/websocket/ChatWebSocketCommandHandlerTest.java
+++ b/src/test/java/umc/cockple/demo/domain/chat/presentation/websocket/ChatWebSocketCommandHandlerTest.java
@@ -11,6 +11,8 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.web.socket.WebSocketSession;
 import umc.cockple.demo.domain.chat.dto.WebSocketMessageDTO;
 import umc.cockple.demo.domain.chat.enums.WebSocketMessageType;
+import umc.cockple.demo.domain.chat.exception.ChatErrorCode;
+import umc.cockple.demo.domain.chat.exception.ChatException;
 import umc.cockple.demo.domain.chat.events.ChatListSubscriptionEvent;
 import umc.cockple.demo.domain.chat.events.ChatMessageSendEvent;
 import umc.cockple.demo.domain.chat.events.ChatRoomSubscriptionEvent;
@@ -20,6 +22,7 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willThrow;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("ChatWebSocketCommandHandler")
@@ -200,6 +203,276 @@ class ChatWebSocketCommandHandlerTest {
     }
 
     @Test
+    @DisplayName("SEND 검증 실패 시 오류 응답을 보내고 이벤트를 발행하지 않는다")
+    void handleSend_sendsErrorResponse_whenValidationFails() {
+        // given
+        Long memberId = 10L;
+        Long chatRoomId = 20L;
+        ChatErrorCode errorCode = ChatErrorCode.CHAT_ROOM_ACCESS_DENIED;
+        WebSocketMessageDTO.Request request = new WebSocketMessageDTO.Request(
+                WebSocketMessageType.SEND,
+                chatRoomId,
+                null,
+                "hello",
+                List.of(),
+                null
+        );
+        willThrow(new ChatException(errorCode))
+                .given(chatValidator)
+                .validateSendRequest(chatRoomId, "hello", List.of(), memberId);
+
+        // when
+        commandHandler.handle(session, request, memberId);
+
+        // then
+        thenChatErrorResponseSent(errorCode);
+        then(eventPublisher).shouldHaveNoInteractions();
+    }
+
+    @Test
+    @DisplayName("SUBSCRIBE 검증 실패 시 오류 응답을 보내고 이벤트를 발행하지 않는다")
+    void handleSubscribe_sendsErrorResponse_whenValidationFails() {
+        // given
+        Long memberId = 10L;
+        Long chatRoomId = 20L;
+        ChatErrorCode errorCode = ChatErrorCode.CHAT_ROOM_ACCESS_DENIED;
+        WebSocketMessageDTO.Request request = new WebSocketMessageDTO.Request(
+                WebSocketMessageType.SUBSCRIBE,
+                chatRoomId,
+                null,
+                null,
+                null,
+                null
+        );
+        willThrow(new ChatException(errorCode))
+                .given(chatValidator)
+                .validateSubscriptionRequest(chatRoomId, memberId);
+
+        // when
+        commandHandler.handle(session, request, memberId);
+
+        // then
+        thenChatErrorResponseSent(errorCode);
+        then(eventPublisher).shouldHaveNoInteractions();
+    }
+
+    @Test
+    @DisplayName("UNSUBSCRIBE 검증 실패 시 오류 응답을 보내고 이벤트를 발행하지 않는다")
+    void handleUnsubscribe_sendsErrorResponse_whenValidationFails() {
+        // given
+        Long memberId = 10L;
+        Long chatRoomId = 20L;
+        ChatErrorCode errorCode = ChatErrorCode.CHAT_ROOM_ACCESS_DENIED;
+        WebSocketMessageDTO.Request request = new WebSocketMessageDTO.Request(
+                WebSocketMessageType.UNSUBSCRIBE,
+                chatRoomId,
+                null,
+                null,
+                null,
+                null
+        );
+        willThrow(new ChatException(errorCode))
+                .given(chatValidator)
+                .validateUnsubscriptionRequest(chatRoomId, memberId);
+
+        // when
+        commandHandler.handle(session, request, memberId);
+
+        // then
+        thenChatErrorResponseSent(errorCode);
+        then(eventPublisher).shouldHaveNoInteractions();
+    }
+
+    @Test
+    @DisplayName("SUBSCRIBE_CHAT_LIST 검증 실패 시 오류 응답을 보내고 이벤트를 발행하지 않는다")
+    void handleSubscribeChatList_sendsErrorResponse_whenValidationFails() {
+        // given
+        Long memberId = 10L;
+        List<Long> chatRoomIds = List.of(20L, 30L);
+        ChatErrorCode errorCode = ChatErrorCode.CHAT_ROOM_ACCESS_DENIED;
+        WebSocketMessageDTO.Request request = new WebSocketMessageDTO.Request(
+                WebSocketMessageType.SUBSCRIBE_CHAT_LIST,
+                null,
+                chatRoomIds,
+                null,
+                null,
+                null
+        );
+        willThrow(new ChatException(errorCode))
+                .given(chatValidator)
+                .validateChatListSubscriptionRequest(memberId, chatRoomIds);
+
+        // when
+        commandHandler.handle(session, request, memberId);
+
+        // then
+        thenChatErrorResponseSent(errorCode);
+        then(eventPublisher).shouldHaveNoInteractions();
+    }
+
+    @Test
+    @DisplayName("UNSUBSCRIBE_CHAT_LIST 검증 실패 시 오류 응답을 보내고 이벤트를 발행하지 않는다")
+    void handleUnsubscribeChatList_sendsErrorResponse_whenValidationFails() {
+        // given
+        Long memberId = 10L;
+        List<Long> chatRoomIds = List.of(20L, 30L);
+        ChatErrorCode errorCode = ChatErrorCode.CHAT_ROOM_ACCESS_DENIED;
+        WebSocketMessageDTO.Request request = new WebSocketMessageDTO.Request(
+                WebSocketMessageType.UNSUBSCRIBE_CHAT_LIST,
+                null,
+                chatRoomIds,
+                null,
+                null,
+                null
+        );
+        willThrow(new ChatException(errorCode))
+                .given(chatValidator)
+                .validateChatListUnsubscriptionRequest(memberId, chatRoomIds);
+
+        // when
+        commandHandler.handle(session, request, memberId);
+
+        // then
+        thenChatErrorResponseSent(errorCode);
+        then(eventPublisher).shouldHaveNoInteractions();
+    }
+
+    @Test
+    @DisplayName("SEND 처리 중 예상치 못한 예외 발생 시 SEND_MESSAGE_ERROR 응답을 보낸다")
+    void handleSend_sendsFallbackError_whenUnexpectedExceptionOccurs() {
+        // given
+        Long memberId = 10L;
+        Long chatRoomId = 20L;
+        WebSocketMessageDTO.Request request = new WebSocketMessageDTO.Request(
+                WebSocketMessageType.SEND,
+                chatRoomId,
+                null,
+                "hello",
+                List.of(),
+                null
+        );
+        willThrow(new IllegalStateException("boom"))
+                .given(chatValidator)
+                .validateSendRequest(chatRoomId, "hello", List.of(), memberId);
+
+        // when
+        commandHandler.handle(session, request, memberId);
+
+        // then
+        then(webSocketResponseSender).should()
+                .sendErrorMessage(session, "SEND_MESSAGE_ERROR", "메시지 전송 처리 중 오류가 발생했습니다.");
+        then(eventPublisher).shouldHaveNoInteractions();
+    }
+
+    @Test
+    @DisplayName("SUBSCRIBE 처리 중 예상치 못한 예외 발생 시 SUBSCRIPTION_ERROR 응답을 보낸다")
+    void handleSubscribe_sendsFallbackError_whenUnexpectedExceptionOccurs() {
+        // given
+        Long memberId = 10L;
+        Long chatRoomId = 20L;
+        WebSocketMessageDTO.Request request = new WebSocketMessageDTO.Request(
+                WebSocketMessageType.SUBSCRIBE,
+                chatRoomId,
+                null,
+                null,
+                null,
+                null
+        );
+        willThrow(new IllegalStateException("boom"))
+                .given(chatValidator)
+                .validateSubscriptionRequest(chatRoomId, memberId);
+
+        // when
+        commandHandler.handle(session, request, memberId);
+
+        // then
+        then(webSocketResponseSender).should()
+                .sendErrorMessage(session, "SUBSCRIPTION_ERROR", "구독 처리 중 오류가 발생했습니다.");
+        then(eventPublisher).shouldHaveNoInteractions();
+    }
+
+    @Test
+    @DisplayName("UNSUBSCRIBE 처리 중 예상치 못한 예외 발생 시 UNSUBSCRIPTION_ERROR 응답을 보낸다")
+    void handleUnsubscribe_sendsFallbackError_whenUnexpectedExceptionOccurs() {
+        // given
+        Long memberId = 10L;
+        Long chatRoomId = 20L;
+        WebSocketMessageDTO.Request request = new WebSocketMessageDTO.Request(
+                WebSocketMessageType.UNSUBSCRIBE,
+                chatRoomId,
+                null,
+                null,
+                null,
+                null
+        );
+        willThrow(new IllegalStateException("boom"))
+                .given(chatValidator)
+                .validateUnsubscriptionRequest(chatRoomId, memberId);
+
+        // when
+        commandHandler.handle(session, request, memberId);
+
+        // then
+        then(webSocketResponseSender).should()
+                .sendErrorMessage(session, "UNSUBSCRIPTION_ERROR", "구독 해제 처리 중 오류가 발생했습니다.");
+        then(eventPublisher).shouldHaveNoInteractions();
+    }
+
+    @Test
+    @DisplayName("SUBSCRIBE_CHAT_LIST 처리 중 예상치 못한 예외 발생 시 SUBSCRIPTION_ERROR 응답을 보낸다")
+    void handleSubscribeChatList_sendsFallbackError_whenUnexpectedExceptionOccurs() {
+        // given
+        Long memberId = 10L;
+        List<Long> chatRoomIds = List.of(20L, 30L);
+        WebSocketMessageDTO.Request request = new WebSocketMessageDTO.Request(
+                WebSocketMessageType.SUBSCRIBE_CHAT_LIST,
+                null,
+                chatRoomIds,
+                null,
+                null,
+                null
+        );
+        willThrow(new IllegalStateException("boom"))
+                .given(chatValidator)
+                .validateChatListSubscriptionRequest(memberId, chatRoomIds);
+
+        // when
+        commandHandler.handle(session, request, memberId);
+
+        // then
+        then(webSocketResponseSender).should()
+                .sendErrorMessage(session, "SUBSCRIPTION_ERROR", "채팅방 목록 구독 처리 중 오류가 발생했습니다.");
+        then(eventPublisher).shouldHaveNoInteractions();
+    }
+
+    @Test
+    @DisplayName("UNSUBSCRIBE_CHAT_LIST 처리 중 예상치 못한 예외 발생 시 UNSUBSCRIPTION_ERROR 응답을 보낸다")
+    void handleUnsubscribeChatList_sendsFallbackError_whenUnexpectedExceptionOccurs() {
+        // given
+        Long memberId = 10L;
+        List<Long> chatRoomIds = List.of(20L, 30L);
+        WebSocketMessageDTO.Request request = new WebSocketMessageDTO.Request(
+                WebSocketMessageType.UNSUBSCRIBE_CHAT_LIST,
+                null,
+                chatRoomIds,
+                null,
+                null,
+                null
+        );
+        willThrow(new IllegalStateException("boom"))
+                .given(chatValidator)
+                .validateChatListUnsubscriptionRequest(memberId, chatRoomIds);
+
+        // when
+        commandHandler.handle(session, request, memberId);
+
+        // then
+        then(webSocketResponseSender).should()
+                .sendErrorMessage(session, "UNSUBSCRIPTION_ERROR", "채팅방 목록 구독 해제 처리 중 오류가 발생했습니다.");
+        then(eventPublisher).shouldHaveNoInteractions();
+    }
+
+    @Test
     @DisplayName("처리 대상이 아닌 타입이면 UNKNOWN_TYPE 오류 응답을 보낸다")
     void handle_sendsUnknownTypeError_whenRequestTypeIsNotCommand() {
         // given
@@ -221,5 +494,10 @@ class ChatWebSocketCommandHandlerTest {
                 .sendErrorMessage(session, "UNKNOWN_TYPE", "알 수 없는 메시지 타입입니다:" + WebSocketMessageType.ERROR);
         then(chatValidator).shouldHaveNoInteractions();
         then(eventPublisher).shouldHaveNoInteractions();
+    }
+
+    private void thenChatErrorResponseSent(ChatErrorCode errorCode) {
+        then(webSocketResponseSender).should()
+                .sendErrorMessage(session, errorCode.getReason().getCode(), errorCode.getReason().getMessage());
     }
 }

--- a/src/test/java/umc/cockple/demo/domain/chat/presentation/websocket/ChatWebSocketCommandHandlerTest.java
+++ b/src/test/java/umc/cockple/demo/domain/chat/presentation/websocket/ChatWebSocketCommandHandlerTest.java
@@ -11,7 +11,9 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.web.socket.WebSocketSession;
 import umc.cockple.demo.domain.chat.dto.WebSocketMessageDTO;
 import umc.cockple.demo.domain.chat.enums.WebSocketMessageType;
+import umc.cockple.demo.domain.chat.events.ChatListSubscriptionEvent;
 import umc.cockple.demo.domain.chat.events.ChatMessageSendEvent;
+import umc.cockple.demo.domain.chat.events.ChatRoomSubscriptionEvent;
 import umc.cockple.demo.domain.chat.service.ChatValidator;
 
 import java.util.List;
@@ -69,6 +71,132 @@ class ChatWebSocketCommandHandlerTest {
         assertThat(event.files()).isEmpty();
 
         then(webSocketResponseSender).shouldHaveNoInteractions();
+    }
+
+    @Test
+    @DisplayName("SUBSCRIBE 요청을 검증한 뒤 채팅방 구독 이벤트를 발행하고 ACK를 보낸다")
+    void handleSubscribe_publishesChatRoomSubscriptionEventAndSendsAck() {
+        // given
+        Long memberId = 10L;
+        Long chatRoomId = 20L;
+        WebSocketMessageDTO.Request request = new WebSocketMessageDTO.Request(
+                WebSocketMessageType.SUBSCRIBE,
+                chatRoomId,
+                null,
+                null,
+                null,
+                null
+        );
+
+        // when
+        commandHandler.handle(session, request, memberId);
+
+        // then
+        then(chatValidator).should().validateSubscriptionRequest(chatRoomId, memberId);
+
+        ArgumentCaptor<ChatRoomSubscriptionEvent> eventCaptor = ArgumentCaptor.forClass(ChatRoomSubscriptionEvent.class);
+        then(eventPublisher).should().publishEvent(eventCaptor.capture());
+        ChatRoomSubscriptionEvent event = eventCaptor.getValue();
+        assertThat(event.chatRoomId()).isEqualTo(chatRoomId);
+        assertThat(event.memberId()).isEqualTo(memberId);
+        assertThat(event.action()).isEqualTo("SUBSCRIBE");
+
+        then(webSocketResponseSender).should().sendSubscriptionMessage(session, chatRoomId, "SUBSCRIBE");
+    }
+
+    @Test
+    @DisplayName("UNSUBSCRIBE 요청을 검증한 뒤 채팅방 구독 해제 이벤트를 발행하고 ACK를 보낸다")
+    void handleUnsubscribe_publishesChatRoomSubscriptionEventAndSendsAck() {
+        // given
+        Long memberId = 10L;
+        Long chatRoomId = 20L;
+        WebSocketMessageDTO.Request request = new WebSocketMessageDTO.Request(
+                WebSocketMessageType.UNSUBSCRIBE,
+                chatRoomId,
+                null,
+                null,
+                null,
+                null
+        );
+
+        // when
+        commandHandler.handle(session, request, memberId);
+
+        // then
+        then(chatValidator).should().validateUnsubscriptionRequest(chatRoomId, memberId);
+
+        ArgumentCaptor<ChatRoomSubscriptionEvent> eventCaptor = ArgumentCaptor.forClass(ChatRoomSubscriptionEvent.class);
+        then(eventPublisher).should().publishEvent(eventCaptor.capture());
+        ChatRoomSubscriptionEvent event = eventCaptor.getValue();
+        assertThat(event.chatRoomId()).isEqualTo(chatRoomId);
+        assertThat(event.memberId()).isEqualTo(memberId);
+        assertThat(event.action()).isEqualTo("UNSUBSCRIBE");
+
+        then(webSocketResponseSender).should().sendSubscriptionMessage(session, chatRoomId, "UNSUBSCRIBE");
+    }
+
+    @Test
+    @DisplayName("SUBSCRIBE_CHAT_LIST 요청을 검증한 뒤 목록 구독 이벤트를 발행하고 ACK를 보낸다")
+    void handleSubscribeChatList_publishesChatListSubscriptionEventAndSendsAck() {
+        // given
+        Long memberId = 10L;
+        List<Long> chatRoomIds = List.of(20L, 30L);
+        WebSocketMessageDTO.Request request = new WebSocketMessageDTO.Request(
+                WebSocketMessageType.SUBSCRIBE_CHAT_LIST,
+                null,
+                chatRoomIds,
+                null,
+                null,
+                null
+        );
+
+        // when
+        commandHandler.handle(session, request, memberId);
+
+        // then
+        then(chatValidator).should().validateChatListSubscriptionRequest(memberId, chatRoomIds);
+
+        ArgumentCaptor<ChatListSubscriptionEvent> eventCaptor = ArgumentCaptor.forClass(ChatListSubscriptionEvent.class);
+        then(eventPublisher).should().publishEvent(eventCaptor.capture());
+        ChatListSubscriptionEvent event = eventCaptor.getValue();
+        assertThat(event.memberId()).isEqualTo(memberId);
+        assertThat(event.chatRoomIds()).containsExactlyElementsOf(chatRoomIds);
+        assertThat(event.action()).isEqualTo("SUBSCRIBE");
+
+        then(webSocketResponseSender).should()
+                .sendChatListSubscriptionMessage(session, chatRoomIds, "SUBSCRIBE_CHAT_LIST");
+    }
+
+    @Test
+    @DisplayName("UNSUBSCRIBE_CHAT_LIST 요청을 검증한 뒤 목록 구독 해제 이벤트를 발행하고 ACK를 보낸다")
+    void handleUnsubscribeChatList_publishesChatListSubscriptionEventAndSendsAck() {
+        // given
+        Long memberId = 10L;
+        List<Long> chatRoomIds = List.of(20L, 30L);
+        WebSocketMessageDTO.Request request = new WebSocketMessageDTO.Request(
+                WebSocketMessageType.UNSUBSCRIBE_CHAT_LIST,
+                null,
+                chatRoomIds,
+                null,
+                null,
+                null
+        );
+
+        // when
+        commandHandler.handle(session, request, memberId);
+
+        // then
+        then(chatValidator).should().validateChatListUnsubscriptionRequest(memberId, chatRoomIds);
+
+        ArgumentCaptor<ChatListSubscriptionEvent> eventCaptor = ArgumentCaptor.forClass(ChatListSubscriptionEvent.class);
+        then(eventPublisher).should().publishEvent(eventCaptor.capture());
+        ChatListSubscriptionEvent event = eventCaptor.getValue();
+        assertThat(event.memberId()).isEqualTo(memberId);
+        assertThat(event.chatRoomIds()).containsExactlyElementsOf(chatRoomIds);
+        assertThat(event.action()).isEqualTo("UNSUBSCRIBE");
+
+        then(webSocketResponseSender).should()
+                .sendChatListSubscriptionMessage(session, chatRoomIds, "UNSUBSCRIBE_CHAT_LIST");
     }
 
     @Test

--- a/src/test/java/umc/cockple/demo/domain/chat/repository/redis/ChatListSubscriptionStoreTest.java
+++ b/src/test/java/umc/cockple/demo/domain/chat/repository/redis/ChatListSubscriptionStoreTest.java
@@ -1,14 +1,22 @@
 package umc.cockple.demo.domain.chat.repository.redis;
 
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.SetOperations;
 import org.springframework.data.redis.core.StringRedisTemplate;
 
+import java.time.Duration;
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.verify;
 
@@ -22,22 +30,138 @@ class ChatListSubscriptionStoreTest {
     @Mock
     private StringRedisTemplate stringRedisTemplate;
 
-    @Test
-    @DisplayName("채팅 목록 구독 키는 best-effort로 삭제한다")
-    void tryClearChatListSubscribers_deletesKey() {
-        chatListSubscriptionStore.tryClearChatListSubscribers(10L);
+    @Mock
+    private SetOperations<String, String> setOperations;
 
-        verify(stringRedisTemplate).delete("chatlist:subscribers:10");
+    @Nested
+    @DisplayName("subscribeToChatList")
+    class SubscribeToChatList {
+
+        @Test
+        @DisplayName("요청한 모든 채팅방 목록 구독 키에 멤버 ID를 저장하고 TTL을 갱신한다")
+        void addsMemberIdToAllRooms_andRefreshesTtl() {
+            given(stringRedisTemplate.opsForSet()).willReturn(setOperations);
+
+            chatListSubscriptionStore.subscribeToChatList(10L, List.of(20L, 30L));
+
+            verify(setOperations).add("chatlist:subscribers:20", "10");
+            verify(setOperations).add("chatlist:subscribers:30", "10");
+            verify(stringRedisTemplate).expire("chatlist:subscribers:20", Duration.ofHours(2));
+            verify(stringRedisTemplate).expire("chatlist:subscribers:30", Duration.ofHours(2));
+        }
+
+        @Test
+        @DisplayName("Redis 실패는 예외를 전파하지 않는다")
+        void doesNotThrow_whenRedisFails() {
+            given(stringRedisTemplate.opsForSet()).willReturn(setOperations);
+            willThrow(new RuntimeException("redis down"))
+                    .given(setOperations)
+                    .add("chatlist:subscribers:20", "10");
+
+            assertThatCode(() -> chatListSubscriptionStore.subscribeToChatList(10L, List.of(20L, 30L)))
+                    .doesNotThrowAnyException();
+        }
     }
 
-    @Test
-    @DisplayName("채팅 목록 구독 키 삭제 실패는 TTL 만료에 맡기고 예외를 전파하지 않는다")
-    void tryClearChatListSubscribers_doesNotThrowWhenRedisFails() {
-        willThrow(new RuntimeException("redis down"))
-                .given(stringRedisTemplate)
-                .delete("chatlist:subscribers:10");
+    @Nested
+    @DisplayName("unsubscribeFromChatList")
+    class UnsubscribeFromChatList {
 
-        assertThatCode(() -> chatListSubscriptionStore.tryClearChatListSubscribers(10L))
-                .doesNotThrowAnyException();
+        @Test
+        @DisplayName("요청한 모든 채팅방 목록 구독 키에서 멤버 ID를 제거한다")
+        void removesMemberIdFromAllRooms() {
+            given(stringRedisTemplate.opsForSet()).willReturn(setOperations);
+
+            chatListSubscriptionStore.unsubscribeFromChatList(10L, List.of(20L, 30L));
+
+            verify(setOperations).remove("chatlist:subscribers:20", "10");
+            verify(setOperations).remove("chatlist:subscribers:30", "10");
+        }
+
+        @Test
+        @DisplayName("Redis 실패는 예외를 전파하지 않는다")
+        void doesNotThrow_whenRedisFails() {
+            given(stringRedisTemplate.opsForSet()).willReturn(setOperations);
+            willThrow(new RuntimeException("redis down"))
+                    .given(setOperations)
+                    .remove("chatlist:subscribers:20", "10");
+
+            assertThatCode(() -> chatListSubscriptionStore.unsubscribeFromChatList(10L, List.of(20L, 30L)))
+                    .doesNotThrowAnyException();
+        }
+    }
+
+    @Nested
+    @DisplayName("getChatListSubscribers")
+    class GetChatListSubscribers {
+
+        @Test
+        @DisplayName("멤버 ID를 Long으로 변환해 반환한다")
+        void returnsParsedMemberIds() {
+            given(stringRedisTemplate.opsForSet()).willReturn(setOperations);
+            given(setOperations.members("chatlist:subscribers:20")).willReturn(Set.of("10", "30"));
+
+            Set<Long> subscribers = chatListSubscriptionStore.getChatListSubscribers(20L);
+
+            assertThat(subscribers).containsExactlyInAnyOrder(10L, 30L);
+        }
+
+        @Test
+        @DisplayName("조회 결과가 비어 있으면 빈 Set을 반환한다")
+        void returnsEmptySet_whenNoSubscribersExist() {
+            given(stringRedisTemplate.opsForSet()).willReturn(setOperations);
+            given(setOperations.members("chatlist:subscribers:20")).willReturn(Set.of());
+
+            Set<Long> subscribers = chatListSubscriptionStore.getChatListSubscribers(20L);
+
+            assertThat(subscribers).isEmpty();
+        }
+
+        @Test
+        @DisplayName("조회 결과가 null이면 빈 Set을 반환한다")
+        void returnsEmptySet_whenRedisReturnsNull() {
+            given(stringRedisTemplate.opsForSet()).willReturn(setOperations);
+            given(setOperations.members("chatlist:subscribers:20")).willReturn(null);
+
+            Set<Long> subscribers = chatListSubscriptionStore.getChatListSubscribers(20L);
+
+            assertThat(subscribers).isEmpty();
+        }
+
+        @Test
+        @DisplayName("Redis 실패는 빈 Set을 반환한다")
+        void returnsEmptySet_whenRedisFails() {
+            given(stringRedisTemplate.opsForSet()).willReturn(setOperations);
+            given(setOperations.members("chatlist:subscribers:20"))
+                    .willThrow(new RuntimeException("redis down"));
+
+            Set<Long> subscribers = chatListSubscriptionStore.getChatListSubscribers(20L);
+
+            assertThat(subscribers).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("tryClearChatListSubscribers")
+    class TryClearChatListSubscribers {
+
+        @Test
+        @DisplayName("채팅 목록 구독 키는 best-effort로 삭제한다")
+        void deletesKey() {
+            chatListSubscriptionStore.tryClearChatListSubscribers(10L);
+
+            verify(stringRedisTemplate).delete("chatlist:subscribers:10");
+        }
+
+        @Test
+        @DisplayName("채팅 목록 구독 키 삭제 실패는 TTL 만료에 맡기고 예외를 전파하지 않는다")
+        void doesNotThrow_whenRedisFails() {
+            willThrow(new RuntimeException("redis down"))
+                    .given(stringRedisTemplate)
+                    .delete("chatlist:subscribers:10");
+
+            assertThatCode(() -> chatListSubscriptionStore.tryClearChatListSubscribers(10L))
+                    .doesNotThrowAnyException();
+        }
     }
 }

--- a/src/test/java/umc/cockple/demo/domain/chat/repository/redis/ChatRoomSubscriptionStoreTest.java
+++ b/src/test/java/umc/cockple/demo/domain/chat/repository/redis/ChatRoomSubscriptionStoreTest.java
@@ -1,15 +1,23 @@
 package umc.cockple.demo.domain.chat.repository.redis;
 
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.SetOperations;
 import org.springframework.data.redis.core.StringRedisTemplate;
 
+import java.time.Duration;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -22,22 +30,143 @@ class ChatRoomSubscriptionStoreTest {
     @Mock
     private StringRedisTemplate stringRedisTemplate;
 
-    @Test
-    @DisplayName("채팅방 구독 키는 best-effort로 삭제한다")
-    void tryClearRoomSubscribers_deletesKey() {
-        chatRoomSubscriptionStore.tryClearRoomSubscribers(10L);
+    @Mock
+    private SetOperations<String, String> setOperations;
 
-        verify(stringRedisTemplate).delete("chatroom:subscribers:10");
+    @Nested
+    @DisplayName("addSubscriber")
+    class AddSubscriber {
+
+        @Test
+        @DisplayName("채팅방 구독 키에 멤버 ID를 저장하고 TTL을 갱신한다")
+        void addsMemberId_andRefreshesTtl() {
+            given(stringRedisTemplate.opsForSet()).willReturn(setOperations);
+
+            chatRoomSubscriptionStore.addSubscriber(10L, 20L);
+
+            verify(setOperations).add("chatroom:subscribers:10", "20");
+            verify(stringRedisTemplate).expire("chatroom:subscribers:10", Duration.ofHours(2));
+        }
+
+        @Test
+        @DisplayName("Redis 실패는 예외를 전파하지 않는다")
+        void doesNotThrow_whenRedisFails() {
+            given(stringRedisTemplate.opsForSet()).willReturn(setOperations);
+            willThrow(new RuntimeException("redis down"))
+                    .given(setOperations)
+                    .add("chatroom:subscribers:10", "20");
+
+            assertThatCode(() -> chatRoomSubscriptionStore.addSubscriber(10L, 20L))
+                    .doesNotThrowAnyException();
+        }
     }
 
-    @Test
-    @DisplayName("채팅방 구독 키 삭제 실패는 TTL 만료에 맡기고 예외를 전파하지 않는다")
-    void tryClearRoomSubscribers_doesNotThrowWhenRedisFails() {
-        willThrow(new RuntimeException("redis down"))
-                .given(stringRedisTemplate)
-                .delete("chatroom:subscribers:10");
+    @Nested
+    @DisplayName("removeSubscriber")
+    class RemoveSubscriber {
 
-        assertThatCode(() -> chatRoomSubscriptionStore.tryClearRoomSubscribers(10L))
-                .doesNotThrowAnyException();
+        @Test
+        @DisplayName("남은 구독자가 없으면 채팅방 구독 키를 삭제한다")
+        void deletesKey_whenNoSubscriberRemains() {
+            given(stringRedisTemplate.opsForSet()).willReturn(setOperations);
+            given(setOperations.size("chatroom:subscribers:10")).willReturn(0L);
+
+            chatRoomSubscriptionStore.removeSubscriber(10L, 20L);
+
+            verify(setOperations).remove("chatroom:subscribers:10", "20");
+            verify(stringRedisTemplate).delete("chatroom:subscribers:10");
+            verify(stringRedisTemplate, never()).expire("chatroom:subscribers:10", Duration.ofHours(2));
+        }
+
+        @Test
+        @DisplayName("남은 구독자가 있으면 채팅방 구독 키 TTL을 갱신한다")
+        void refreshesTtl_whenSubscriberRemains() {
+            given(stringRedisTemplate.opsForSet()).willReturn(setOperations);
+            given(setOperations.size("chatroom:subscribers:10")).willReturn(1L);
+
+            chatRoomSubscriptionStore.removeSubscriber(10L, 20L);
+
+            verify(setOperations).remove("chatroom:subscribers:10", "20");
+            verify(stringRedisTemplate).expire("chatroom:subscribers:10", Duration.ofHours(2));
+            verify(stringRedisTemplate, never()).delete("chatroom:subscribers:10");
+        }
+
+        @Test
+        @DisplayName("Redis 실패는 예외를 전파하지 않는다")
+        void doesNotThrow_whenRedisFails() {
+            given(stringRedisTemplate.opsForSet()).willReturn(setOperations);
+            willThrow(new RuntimeException("redis down"))
+                    .given(setOperations)
+                    .remove("chatroom:subscribers:10", "20");
+
+            assertThatCode(() -> chatRoomSubscriptionStore.removeSubscriber(10L, 20L))
+                    .doesNotThrowAnyException();
+        }
+    }
+
+    @Nested
+    @DisplayName("getSubscribers")
+    class GetSubscribers {
+
+        @Test
+        @DisplayName("키가 있으면 TTL을 갱신하고 멤버 ID를 Long으로 변환한다")
+        void refreshesTtlAndReturnsParsedMemberIds_whenKeyExists() {
+            given(stringRedisTemplate.hasKey("chatroom:subscribers:10")).willReturn(true);
+            given(stringRedisTemplate.opsForSet()).willReturn(setOperations);
+            given(setOperations.members("chatroom:subscribers:10")).willReturn(Set.of("20", "30"));
+
+            Set<Long> subscribers = chatRoomSubscriptionStore.getSubscribers(10L);
+
+            assertThat(subscribers).containsExactlyInAnyOrder(20L, 30L);
+            verify(stringRedisTemplate).expire("chatroom:subscribers:10", Duration.ofHours(2));
+        }
+
+        @Test
+        @DisplayName("조회 결과가 비어 있으면 빈 Set을 반환한다")
+        void returnsEmptySet_whenNoSubscribersExist() {
+            given(stringRedisTemplate.hasKey("chatroom:subscribers:10")).willReturn(false);
+            given(stringRedisTemplate.opsForSet()).willReturn(setOperations);
+            given(setOperations.members("chatroom:subscribers:10")).willReturn(Set.of());
+
+            Set<Long> subscribers = chatRoomSubscriptionStore.getSubscribers(10L);
+
+            assertThat(subscribers).isEmpty();
+            verify(stringRedisTemplate, never()).expire("chatroom:subscribers:10", Duration.ofHours(2));
+        }
+
+        @Test
+        @DisplayName("Redis 실패는 빈 Set을 반환한다")
+        void returnsEmptySet_whenRedisFails() {
+            given(stringRedisTemplate.hasKey("chatroom:subscribers:10"))
+                    .willThrow(new RuntimeException("redis down"));
+
+            Set<Long> subscribers = chatRoomSubscriptionStore.getSubscribers(10L);
+
+            assertThat(subscribers).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("tryClearRoomSubscribers")
+    class TryClearRoomSubscribers {
+
+        @Test
+        @DisplayName("채팅방 구독 키는 best-effort로 삭제한다")
+        void deletesKey() {
+            chatRoomSubscriptionStore.tryClearRoomSubscribers(10L);
+
+            verify(stringRedisTemplate).delete("chatroom:subscribers:10");
+        }
+
+        @Test
+        @DisplayName("채팅방 구독 키 삭제 실패는 TTL 만료에 맡기고 예외를 전파하지 않는다")
+        void doesNotThrow_whenRedisFails() {
+            willThrow(new RuntimeException("redis down"))
+                    .given(stringRedisTemplate)
+                    .delete("chatroom:subscribers:10");
+
+            assertThatCode(() -> chatRoomSubscriptionStore.tryClearRoomSubscribers(10L))
+                    .doesNotThrowAnyException();
+        }
     }
 }

--- a/src/test/java/umc/cockple/demo/domain/chat/service/ChatRoomServiceTest.java
+++ b/src/test/java/umc/cockple/demo/domain/chat/service/ChatRoomServiceTest.java
@@ -15,6 +15,8 @@ import umc.cockple.demo.domain.chat.domain.ChatRoomMember;
 import umc.cockple.demo.domain.chat.enums.ChatRoomMemberStatus;
 import umc.cockple.demo.domain.chat.enums.ChatRoomType;
 import umc.cockple.demo.domain.chat.events.ChatRoomRedisCleanupEvent;
+import umc.cockple.demo.domain.chat.exception.ChatErrorCode;
+import umc.cockple.demo.domain.chat.exception.ChatException;
 import umc.cockple.demo.domain.chat.repository.ChatFileRepository;
 import umc.cockple.demo.domain.chat.repository.ChatMessageRepository;
 import umc.cockple.demo.domain.chat.repository.ChatRoomMemberRepository;
@@ -32,6 +34,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.inOrder;
@@ -87,6 +90,48 @@ class ChatRoomServiceTest {
             assertThat(savedMember.getChatRoom()).isSameAs(savedChatRoom);
             assertThat(savedMember.getMember()).isSameAs(owner);
             assertThat(savedMember.getStatus()).isEqualTo(ChatRoomMemberStatus.JOINED);
+        }
+    }
+
+    @Nested
+    @DisplayName("joinPartyChatRoom")
+    class JoinPartyChatRoom {
+
+        @Test
+        @DisplayName("성공 - 기존 PARTY 채팅방에 멤버를 JOINED 상태로 저장한다")
+        void success_joinPartyChatRoom() {
+            Long partyId = 1L;
+            Long chatRoomId = 2L;
+            Member member = MemberFixture.createMemberWithName("김철수", "철수", Gender.MALE, Level.B, 1002L);
+            ReflectionTestUtils.setField(member, "id", 20L);
+            var party = PartyFixture.createParty("테스트 모임", 10L, PartyFixture.createPartyAddr("서울", "강남"));
+            ReflectionTestUtils.setField(party, "id", partyId);
+            ChatRoom chatRoom = ChatFixture.createPartyChatRoom(party);
+            ReflectionTestUtils.setField(chatRoom, "id", chatRoomId);
+            given(chatRoomRepository.findByPartyId(partyId)).willReturn(Optional.of(chatRoom));
+
+            chatRoomService.joinPartyChatRoom(partyId, member);
+
+            ArgumentCaptor<ChatRoomMember> chatRoomMemberCaptor = ArgumentCaptor.forClass(ChatRoomMember.class);
+            verify(chatRoomMemberRepository).save(chatRoomMemberCaptor.capture());
+            ChatRoomMember savedMember = chatRoomMemberCaptor.getValue();
+            assertThat(savedMember.getChatRoom()).isSameAs(chatRoom);
+            assertThat(savedMember.getMember()).isSameAs(member);
+            assertThat(savedMember.getStatus()).isEqualTo(ChatRoomMemberStatus.JOINED);
+        }
+
+        @Test
+        @DisplayName("실패 - PARTY 채팅방이 없으면 CHAT_ROOM_NOT_FOUND 예외를 던지고 저장하지 않는다")
+        void fail_joinPartyChatRoom_whenRoomMissing() {
+            Long partyId = 1L;
+            Member member = MemberFixture.createMemberWithName("김철수", "철수", Gender.MALE, Level.B, 1002L);
+            ReflectionTestUtils.setField(member, "id", 20L);
+            given(chatRoomRepository.findByPartyId(partyId)).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> chatRoomService.joinPartyChatRoom(partyId, member))
+                    .isInstanceOfSatisfying(ChatException.class,
+                            exception -> assertThat(exception.getCode()).isEqualTo(ChatErrorCode.CHAT_ROOM_NOT_FOUND));
+            verify(chatRoomMemberRepository, never()).save(any(ChatRoomMember.class));
         }
     }
 

--- a/src/test/java/umc/cockple/demo/domain/chat/service/ChatRoomServiceTest.java
+++ b/src/test/java/umc/cockple/demo/domain/chat/service/ChatRoomServiceTest.java
@@ -37,6 +37,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -132,6 +133,66 @@ class ChatRoomServiceTest {
                     .isInstanceOfSatisfying(ChatException.class,
                             exception -> assertThat(exception.getCode()).isEqualTo(ChatErrorCode.CHAT_ROOM_NOT_FOUND));
             verify(chatRoomMemberRepository, never()).save(any(ChatRoomMember.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("leavePartyChatRoom")
+    class LeavePartyChatRoom {
+
+        @Test
+        @DisplayName("성공 - 참여 중인 멤버가 있으면 해당 멤버십을 삭제한다")
+        void success_leavePartyChatRoom() {
+            Long partyId = 1L;
+            Long chatRoomId = 2L;
+            Long memberId = 20L;
+            var party = PartyFixture.createParty("테스트 모임", 10L, PartyFixture.createPartyAddr("서울", "강남"));
+            ReflectionTestUtils.setField(party, "id", partyId);
+            ChatRoom chatRoom = ChatFixture.createPartyChatRoom(party);
+            ReflectionTestUtils.setField(chatRoom, "id", chatRoomId);
+            Member member = MemberFixture.createMemberWithName("김철수", "철수", Gender.MALE, Level.B, 1002L);
+            ReflectionTestUtils.setField(member, "id", memberId);
+            ChatRoomMember chatRoomMember = ChatRoomMember.create(chatRoom, member);
+            given(chatRoomRepository.findByPartyId(partyId)).willReturn(Optional.of(chatRoom));
+            given(chatRoomMemberRepository.findByChatRoomIdAndMemberId(chatRoomId, memberId))
+                    .willReturn(Optional.of(chatRoomMember));
+
+            chatRoomService.leavePartyChatRoom(partyId, memberId);
+
+            verify(chatRoomMemberRepository).delete(chatRoomMember);
+        }
+
+        @Test
+        @DisplayName("성공 - 참여 중인 멤버가 없으면 삭제하지 않고 종료한다")
+        void success_leavePartyChatRoom_whenMembershipMissing() {
+            Long partyId = 1L;
+            Long chatRoomId = 2L;
+            Long memberId = 20L;
+            var party = PartyFixture.createParty("테스트 모임", 10L, PartyFixture.createPartyAddr("서울", "강남"));
+            ReflectionTestUtils.setField(party, "id", partyId);
+            ChatRoom chatRoom = ChatFixture.createPartyChatRoom(party);
+            ReflectionTestUtils.setField(chatRoom, "id", chatRoomId);
+            given(chatRoomRepository.findByPartyId(partyId)).willReturn(Optional.of(chatRoom));
+            given(chatRoomMemberRepository.findByChatRoomIdAndMemberId(chatRoomId, memberId))
+                    .willReturn(Optional.empty());
+
+            chatRoomService.leavePartyChatRoom(partyId, memberId);
+
+            verify(chatRoomMemberRepository, never()).delete(any(ChatRoomMember.class));
+        }
+
+        @Test
+        @DisplayName("실패 - PARTY 채팅방이 없으면 CHAT_ROOM_NOT_FOUND 예외를 던지고 멤버십을 조회하지 않는다")
+        void fail_leavePartyChatRoom_whenRoomMissing() {
+            Long partyId = 1L;
+            Long memberId = 20L;
+            given(chatRoomRepository.findByPartyId(partyId)).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> chatRoomService.leavePartyChatRoom(partyId, memberId))
+                    .isInstanceOfSatisfying(ChatException.class,
+                            exception -> assertThat(exception.getCode()).isEqualTo(ChatErrorCode.CHAT_ROOM_NOT_FOUND));
+            verify(chatRoomMemberRepository, never()).findByChatRoomIdAndMemberId(anyLong(), anyLong());
+            verify(chatRoomMemberRepository, never()).delete(any(ChatRoomMember.class));
         }
     }
 

--- a/src/test/java/umc/cockple/demo/domain/chat/service/ChatRoomServiceTest.java
+++ b/src/test/java/umc/cockple/demo/domain/chat/service/ChatRoomServiceTest.java
@@ -4,12 +4,16 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.test.util.ReflectionTestUtils;
 import umc.cockple.demo.domain.chat.domain.ChatRoom;
+import umc.cockple.demo.domain.chat.domain.ChatRoomMember;
+import umc.cockple.demo.domain.chat.enums.ChatRoomMemberStatus;
+import umc.cockple.demo.domain.chat.enums.ChatRoomType;
 import umc.cockple.demo.domain.chat.events.ChatRoomRedisCleanupEvent;
 import umc.cockple.demo.domain.chat.repository.ChatFileRepository;
 import umc.cockple.demo.domain.chat.repository.ChatMessageRepository;
@@ -17,12 +21,17 @@ import umc.cockple.demo.domain.chat.repository.ChatRoomMemberRepository;
 import umc.cockple.demo.domain.chat.repository.ChatRoomRepository;
 import umc.cockple.demo.domain.chat.repository.MessageReadStatusRepository;
 import umc.cockple.demo.domain.file.service.ObjectStorageDeleteOutboxService;
+import umc.cockple.demo.domain.member.domain.Member;
+import umc.cockple.demo.global.enums.Gender;
+import umc.cockple.demo.global.enums.Level;
 import umc.cockple.demo.support.fixture.ChatFixture;
+import umc.cockple.demo.support.fixture.MemberFixture;
 import umc.cockple.demo.support.fixture.PartyFixture;
 
 import java.util.List;
 import java.util.Optional;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.inOrder;
@@ -50,6 +59,36 @@ class ChatRoomServiceTest {
     private ObjectStorageDeleteOutboxService objectStorageDeleteOutboxService;
     @Mock
     private ApplicationEventPublisher applicationEventPublisher;
+
+    @Nested
+    @DisplayName("createPartyChatRoom")
+    class CreatePartyChatRoom {
+
+        @Test
+        @DisplayName("성공 - PARTY 채팅방을 생성하고 owner를 JOINED 멤버로 포함해 저장한다")
+        void success_createPartyChatRoom() {
+            Long partyId = 1L;
+            Member owner = MemberFixture.createMemberWithName("홍길동", "길동", Gender.MALE, Level.A, 1001L);
+            ReflectionTestUtils.setField(owner, "id", 10L);
+            var party = PartyFixture.createParty("테스트 모임", owner.getId(), PartyFixture.createPartyAddr("서울", "강남"));
+            ReflectionTestUtils.setField(party, "id", partyId);
+            given(chatRoomRepository.save(any(ChatRoom.class))).willAnswer(invocation -> invocation.getArgument(0));
+
+            chatRoomService.createPartyChatRoom(party, owner);
+
+            ArgumentCaptor<ChatRoom> chatRoomCaptor = ArgumentCaptor.forClass(ChatRoom.class);
+            verify(chatRoomRepository).save(chatRoomCaptor.capture());
+            ChatRoom savedChatRoom = chatRoomCaptor.getValue();
+            assertThat(savedChatRoom.getType()).isEqualTo(ChatRoomType.PARTY);
+            assertThat(savedChatRoom.getParty()).isSameAs(party);
+            assertThat(savedChatRoom.getChatRoomMembers()).hasSize(1);
+
+            ChatRoomMember savedMember = savedChatRoom.getChatRoomMembers().get(0);
+            assertThat(savedMember.getChatRoom()).isSameAs(savedChatRoom);
+            assertThat(savedMember.getMember()).isSameAs(owner);
+            assertThat(savedMember.getStatus()).isEqualTo(ChatRoomMemberStatus.JOINED);
+        }
+    }
 
     @Nested
     @DisplayName("deletePartyChatRoom")

--- a/src/test/java/umc/cockple/demo/domain/chat/service/ChatValidatorTest.java
+++ b/src/test/java/umc/cockple/demo/domain/chat/service/ChatValidatorTest.java
@@ -1,0 +1,254 @@
+package umc.cockple.demo.domain.chat.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import umc.cockple.demo.domain.chat.dto.WebSocketMessageDTO;
+import umc.cockple.demo.domain.chat.exception.ChatErrorCode;
+import umc.cockple.demo.domain.chat.exception.ChatException;
+import umc.cockple.demo.domain.chat.repository.ChatRoomMemberRepository;
+import umc.cockple.demo.domain.chat.repository.ChatRoomRepository;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ChatValidator")
+class ChatValidatorTest {
+
+    @InjectMocks
+    private ChatValidator chatValidator;
+
+    @Mock
+    private ChatRoomRepository chatRoomRepository;
+
+    @Mock
+    private ChatRoomMemberRepository chatRoomMemberRepository;
+
+    @Nested
+    @DisplayName("validateSendRequest")
+    class ValidateSendRequest {
+
+        @Test
+        @DisplayName("성공 - 채팅방과 권한이 있고 내용이 있으면 통과한다")
+        void success_whenContentExists() {
+            givenExistingRoomAndMembership(10L, 1L);
+
+            assertThatCode(() -> chatValidator.validateSendRequest(10L, "hello", List.of(), 1L))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        @DisplayName("성공 - 내용이 없어도 파일이 있으면 통과한다")
+        void success_whenFilesExist() {
+            givenExistingRoomAndMembership(10L, 1L);
+            List<WebSocketMessageDTO.Request.FileInfo> files = List.of(
+                    new WebSocketMessageDTO.Request.FileInfo("chat/a.webp", 1, "a.webp", 100L, "image/webp")
+            );
+
+            assertThatCode(() -> chatValidator.validateSendRequest(10L, null, files, 1L))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        @DisplayName("실패 - 채팅방 ID가 없으면 CHATROOM_ID_NECESSARY 예외를 던진다")
+        void fail_whenChatRoomIdIsNull() {
+            assertChatException(
+                    ChatErrorCode.CHATROOM_ID_NECESSARY,
+                    () -> chatValidator.validateSendRequest(null, "hello", List.of(), 1L)
+            );
+            verify(chatRoomRepository, never()).existsById(null);
+        }
+
+        @Test
+        @DisplayName("실패 - 채팅방이 없으면 CHAT_ROOM_NOT_FOUND 예외를 던진다")
+        void fail_whenChatRoomNotFound() {
+            given(chatRoomRepository.existsById(10L)).willReturn(false);
+
+            assertChatException(
+                    ChatErrorCode.CHAT_ROOM_NOT_FOUND,
+                    () -> chatValidator.validateSendRequest(10L, "hello", List.of(), 1L)
+            );
+            verify(chatRoomMemberRepository, never()).existsByChatRoomIdAndMemberId(10L, 1L);
+        }
+
+        @Test
+        @DisplayName("실패 - 채팅방 멤버가 아니면 CHAT_ROOM_ACCESS_DENIED 예외를 던진다")
+        void fail_whenNotChatRoomMember() {
+            given(chatRoomRepository.existsById(10L)).willReturn(true);
+            given(chatRoomMemberRepository.existsByChatRoomIdAndMemberId(10L, 1L)).willReturn(false);
+
+            assertChatException(
+                    ChatErrorCode.CHAT_ROOM_ACCESS_DENIED,
+                    () -> chatValidator.validateSendRequest(10L, "hello", List.of(), 1L)
+            );
+        }
+
+        @Test
+        @DisplayName("실패 - 내용과 파일이 모두 없으면 EMPTY_MESSAGE_NOT_ALLOWED 예외를 던진다")
+        void fail_whenMessageIsEmpty() {
+            givenExistingRoomAndMembership(10L, 1L);
+
+            assertChatException(
+                    ChatErrorCode.EMPTY_MESSAGE_NOT_ALLOWED,
+                    () -> chatValidator.validateSendRequest(10L, "   ", List.of(), 1L)
+            );
+        }
+
+        @Test
+        @DisplayName("실패 - 내용이 1000자를 초과하면 MESSAGE_TO_LONG 예외를 던진다")
+        void fail_whenContentTooLong() {
+            givenExistingRoomAndMembership(10L, 1L);
+            String tooLongContent = "a".repeat(1001);
+
+            assertChatException(
+                    ChatErrorCode.MESSAGE_TO_LONG,
+                    () -> chatValidator.validateSendRequest(10L, tooLongContent, List.of(), 1L)
+            );
+        }
+    }
+
+    @Nested
+    @DisplayName("채팅방 구독 요청 검증")
+    class ValidateRoomSubscriptionRequest {
+
+        @Test
+        @DisplayName("성공 - 구독과 구독 해제는 채팅방과 권한이 있으면 통과한다")
+        void success_whenRoomAndMembershipExist() {
+            givenExistingRoomAndMembership(10L, 1L);
+
+            assertThatCode(() -> chatValidator.validateSubscriptionRequest(10L, 1L))
+                    .doesNotThrowAnyException();
+            assertThatCode(() -> chatValidator.validateUnsubscriptionRequest(10L, 1L))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        @DisplayName("실패 - 채팅방이 없으면 CHAT_ROOM_NOT_FOUND 예외를 던진다")
+        void fail_whenChatRoomNotFound() {
+            given(chatRoomRepository.existsById(10L)).willReturn(false);
+
+            assertChatException(
+                    ChatErrorCode.CHAT_ROOM_NOT_FOUND,
+                    () -> chatValidator.validateSubscriptionRequest(10L, 1L)
+            );
+        }
+
+        @Test
+        @DisplayName("실패 - 권한이 없으면 CHAT_ROOM_ACCESS_DENIED 예외를 던진다")
+        void fail_whenNotChatRoomMember() {
+            given(chatRoomRepository.existsById(10L)).willReturn(true);
+            given(chatRoomMemberRepository.existsByChatRoomIdAndMemberId(10L, 1L)).willReturn(false);
+
+            assertChatException(
+                    ChatErrorCode.CHAT_ROOM_ACCESS_DENIED,
+                    () -> chatValidator.validateUnsubscriptionRequest(10L, 1L)
+            );
+        }
+    }
+
+    @Nested
+    @DisplayName("채팅 목록 구독 요청 검증")
+    class ValidateChatListSubscriptionRequest {
+
+        @Test
+        @DisplayName("성공 - 중복 채팅방 ID는 distinct 처리해 권한을 확인한다")
+        void success_checksDistinctRoomIds() {
+            given(chatRoomMemberRepository.existsByChatRoomIdAndMemberId(10L, 1L)).willReturn(true);
+            given(chatRoomMemberRepository.existsByChatRoomIdAndMemberId(20L, 1L)).willReturn(true);
+
+            assertThatCode(() -> chatValidator.validateChatListSubscriptionRequest(1L, List.of(10L, 10L, 20L)))
+                    .doesNotThrowAnyException();
+
+            verify(chatRoomMemberRepository, times(1)).existsByChatRoomIdAndMemberId(10L, 1L);
+            verify(chatRoomMemberRepository, times(1)).existsByChatRoomIdAndMemberId(20L, 1L);
+        }
+
+        @Test
+        @DisplayName("성공 - 구독 해제도 동일한 채팅방 목록 검증을 통과한다")
+        void success_unsubscriptionUsesSameValidation() {
+            given(chatRoomMemberRepository.existsByChatRoomIdAndMemberId(10L, 1L)).willReturn(true);
+
+            assertThatCode(() -> chatValidator.validateChatListUnsubscriptionRequest(1L, List.of(10L)))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        @DisplayName("실패 - 채팅방 목록이 null 또는 비어 있으면 CHATROOM_LIST_EMPTY 예외를 던진다")
+        void fail_whenRoomIdsAreNullOrEmpty() {
+            assertChatException(
+                    ChatErrorCode.CHATROOM_LIST_EMPTY,
+                    () -> chatValidator.validateChatListSubscriptionRequest(1L, null)
+            );
+            assertChatException(
+                    ChatErrorCode.CHATROOM_LIST_EMPTY,
+                    () -> chatValidator.validateChatListSubscriptionRequest(1L, Collections.emptyList())
+            );
+        }
+
+        @Test
+        @DisplayName("실패 - 채팅방 목록이 100개를 초과하면 TOO_MANY_CHATROOMS 예외를 던진다")
+        void fail_whenTooManyRoomIds() {
+            List<Long> tooManyRoomIds = Collections.nCopies(101, 10L);
+
+            assertChatException(
+                    ChatErrorCode.TOO_MANY_CHATROOMS,
+                    () -> chatValidator.validateChatListSubscriptionRequest(1L, tooManyRoomIds)
+            );
+        }
+
+        @Test
+        @DisplayName("실패 - null 또는 0 이하 채팅방 ID가 있으면 INVALID_CHATROOM_ID 예외를 던진다")
+        void fail_whenRoomIdIsInvalid() {
+            assertChatException(
+                    ChatErrorCode.INVALID_CHATROOM_ID,
+                    () -> chatValidator.validateChatListSubscriptionRequest(1L, List.of(0L, 10L))
+            );
+            assertChatException(
+                    ChatErrorCode.INVALID_CHATROOM_ID,
+                    () -> chatValidator.validateChatListSubscriptionRequest(1L, Arrays.asList(null, 10L))
+            );
+        }
+
+        @Test
+        @DisplayName("실패 - 하나라도 접근 권한이 없으면 CHAT_ROOM_ACCESS_DENIED 예외를 던진다")
+        void fail_whenAnyRoomAccessDenied() {
+            given(chatRoomMemberRepository.existsByChatRoomIdAndMemberId(10L, 1L)).willReturn(true);
+            given(chatRoomMemberRepository.existsByChatRoomIdAndMemberId(20L, 1L)).willReturn(false);
+
+            assertChatException(
+                    ChatErrorCode.CHAT_ROOM_ACCESS_DENIED,
+                    () -> chatValidator.validateChatListUnsubscriptionRequest(1L, List.of(10L, 20L))
+            );
+        }
+    }
+
+    private void givenExistingRoomAndMembership(Long chatRoomId, Long memberId) {
+        given(chatRoomRepository.existsById(chatRoomId)).willReturn(true);
+        given(chatRoomMemberRepository.existsByChatRoomIdAndMemberId(chatRoomId, memberId)).willReturn(true);
+    }
+
+    private void assertChatException(ChatErrorCode expectedCode, ThrowingRunnable runnable) {
+        assertThatThrownBy(runnable::run)
+                .isInstanceOfSatisfying(ChatException.class,
+                        exception -> assertThat(exception.getCode()).isEqualTo(expectedCode));
+    }
+
+    @FunctionalInterface
+    private interface ThrowingRunnable {
+        void run();
+    }
+}


### PR DESCRIPTION
## ❤️ 기능 설명

chat service 패키지 정리 전에 현재 동작을 회귀 테스트로 고정합니다.
production code 변경 없이 테스트 기준선을 보강해, 이후 service/facade/handler 구조 변경 시 주요 동작 변화가 테스트 실패로 드러나도록 했습니다.

### 변경 내용
- `ChatRoomServiceTest`: 모임 채팅방 생성/가입/탈퇴 흐름의 현재 동작 고정
- `ChatValidatorTest`: send, room subscription, chat-list subscription 검증/예외 경로 추가
- `ChatWebSocketCommandHandlerTest`: SEND/SUBSCRIBE/UNSUBSCRIBE/chat-list 구독 성공·실패·fallback error 경로 보강
- `ChatRoomSubscriptionStoreTest`: Redis room subscription add/remove/get/clear 동작 보강
- `ChatListSubscriptionStoreTest`: Redis chat-list subscription subscribe/unsubscribe/get/clear 동작 보강

### 검증
```bash
bash ./gradlew test --tests '*domain.chat*'
# BUILD SUCCESSFUL in 3m 6s
```

<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #667 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] production code 변경 없이 테스트만 보강한 PR입니다.

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
