### PR TITLE
[chore/#685] cockple.store 잔여 참조 제거 및 기본값 cockple.site 전환

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,8 +57,8 @@ services:
       JAVA_TOOL_OPTIONS: "-Xms768m -Xmx768m"
       SPRING_PROFILES_ACTIVE: prod
       LOG_PATH: /logs
-      CORS_ALLOWED_ORIGINS: ${CORS_ALLOWED_ORIGINS_PROD:-http://localhost:5173,https://cockple.store,https://www.cockple.store,https://staging.cockple.store,https://cockple-fe.vercel.app,https://cockple-fe.vercel.app/}
-      COOKIE_DOMAIN: ${COOKIE_DOMAIN:-.cockple.store}
+      CORS_ALLOWED_ORIGINS: ${CORS_ALLOWED_ORIGINS_PROD:-http://localhost:5173,https://cockple.site,https://www.cockple.site,https://staging.cockple.site,https://cockple-fe.vercel.app,https://cockple-fe.vercel.app/}
+      COOKIE_DOMAIN: ${COOKIE_DOMAIN:-}
       DB_PASSWORD: ${DB_PASSWORD}
       GCS_BUCKET: ${GCS_BUCKET}
       KAKAO_CLIENT_ID: ${KAKAO_CLIENT_ID}
@@ -85,8 +85,8 @@ services:
       JAVA_TOOL_OPTIONS: "-Xms128m -Xmx512m"
       SPRING_PROFILES_ACTIVE: staging
       LOG_PATH: /logs
-      CORS_ALLOWED_ORIGINS: ${CORS_ALLOWED_ORIGINS_STAGING:-http://localhost:5173,https://cockple.store,https://www.cockple.store,https://staging.cockple.store,https://cockple-fe.vercel.app,https://cockple-fe.vercel.app/}
-      COOKIE_DOMAIN: ${COOKIE_DOMAIN:-.cockple.store}
+      CORS_ALLOWED_ORIGINS: ${CORS_ALLOWED_ORIGINS_STAGING:-http://localhost:5173,https://cockple.site,https://www.cockple.site,https://staging.cockple.site,https://cockple-fe.vercel.app,https://cockple-fe.vercel.app/}
+      COOKIE_DOMAIN: ${COOKIE_DOMAIN:-}
       FCM_FAKE_LATENCY_MS: ${FCM_FAKE_LATENCY_MS:-0}
       # 관측성(Observability) — OTLP 메트릭 push (staging 전용). 미설정 시 off.
       OTLP_METRICS_ENABLED: ${OTLP_METRICS_ENABLED:-false}
@@ -125,8 +125,8 @@ services:
     ports:
       - "80:80"
     environment:
-      PROD_SERVER_NAME: ${NGINX_PROD_SERVER_NAME:-api.cockple.store}
-      STAGING_SERVER_NAME: ${NGINX_STAGING_SERVER_NAME:-staging.cockple.store}
+      PROD_SERVER_NAME: ${NGINX_PROD_SERVER_NAME:-api.cockple.site}
+      STAGING_SERVER_NAME: ${NGINX_STAGING_SERVER_NAME:-staging.cockple.site}
       NGINX_ENVSUBST_FILTER: SERVER_NAME
     volumes:
       - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -78,8 +78,9 @@ gcs:
 cockple:
   web:
     # WS도 이 목록 공유. cockple-fe.vercel.app/(끝슬래시)는 WS 기존값 유지용(무해).
-    allowed-origins: ${CORS_ALLOWED_ORIGINS:http://localhost:5173,https://cockple.store,https://www.cockple.store,https://staging.cockple.store,https://cockple-fe.vercel.app,https://cockple-fe.vercel.app/}
-    cookie-domain: ${COOKIE_DOMAIN:.cockple.store}
+    allowed-origins: ${CORS_ALLOWED_ORIGINS:http://localhost:5173,https://cockple.site,https://www.cockple.site,https://staging.cockple.site,https://cockple-fe.vercel.app,https://cockple-fe.vercel.app/}
+    # 비우면 host-only 쿠키. 실제 운영/스테이징 값은 GitHub Variables의 COOKIE_DOMAIN이 주입한다.
+    cookie-domain: ${COOKIE_DOMAIN:}
 
 kakao:
   client-id: ${KAKAO_CLIENT_ID}

--- a/src/test/java/umc/cockple/demo/global/config/WebPropertiesTest.java
+++ b/src/test/java/umc/cockple/demo/global/config/WebPropertiesTest.java
@@ -28,24 +28,24 @@ class WebPropertiesTest {
         // application.yml의 CORS_ALLOWED_ORIGINS 기본값과 동일한 문자열
         // (WS 편입으로 CORS/WS가 공유. cockple-fe.vercel.app/ 는 WS 기존값 유지용)
         String defaultOrigins =
-                "http://localhost:5173,https://cockple.store,https://www.cockple.store,"
-                        + "https://staging.cockple.store,https://cockple-fe.vercel.app,https://cockple-fe.vercel.app/";
+                "http://localhost:5173,https://cockple.site,https://www.cockple.site,"
+                        + "https://staging.cockple.site,https://cockple-fe.vercel.app,https://cockple-fe.vercel.app/";
 
         WebProperties props = bind(Map.of(
                 "cockple.web.allowed-origins", defaultOrigins,
-                "cockple.web.cookie-domain", ".cockple.store"
+                "cockple.web.cookie-domain", ".cockple.site"
         ));
 
         // 기존 CORS + WS 하드코딩 origin을 모두 포함해야 한다(순수 no-op)
         assertThat(props.getAllowedOrigins()).containsExactly(
                 "http://localhost:5173",
-                "https://cockple.store",
-                "https://www.cockple.store",
-                "https://staging.cockple.store",
+                "https://cockple.site",
+                "https://www.cockple.site",
+                "https://staging.cockple.site",
                 "https://cockple-fe.vercel.app",
                 "https://cockple-fe.vercel.app/"
         );
-        assertThat(props.getCookieDomain()).isEqualTo(".cockple.store");
+        assertThat(props.getCookieDomain()).isEqualTo(".cockple.site");
     }
 
     @Test

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -23,7 +23,7 @@ variable "cloudflare_zone_id" {
 variable "root_domain" {
   description = "서비스 루트 도메인. 도메인 변경 시 이 값(+ cloudflare_zone_id)만 교체."
   type        = string
-  default     = "cockple.store"
+  default     = "cockple.site"
 }
 
 variable "ssh_public_key" {


### PR DESCRIPTION
## ❤️ 기능 설명
도메인 전환 안전성을 위해 두 도메인 모두 열어두었으나, 이제 도메인이 만료되어 옛 도메인 잔여 참조를 제거합니다. 
github variables 또한 변경이 완료되었습니다.

<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #685 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!


<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
