### PR TITLE
[refactor/#683] 알림 생성 경로 쿼리 개선 및 보관 정책 정비

### DIFF
--- a/src/main/java/umc/cockple/demo/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/notification/repository/NotificationRepository.java
@@ -1,12 +1,15 @@
 package umc.cockple.demo.domain.notification.repository;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import umc.cockple.demo.domain.member.domain.Member;
 import umc.cockple.demo.domain.notification.domain.Notification;
 import umc.cockple.demo.domain.notification.enums.NotificationType;
 
+import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Optional;
 
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
 
@@ -16,5 +19,14 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
 
     long countByMember(Member member);
 
-    Optional<Notification> findFirstByMemberAndTypeNotOrderByCreatedAtAsc(Member member, NotificationType type);
+    @Query("""
+            SELECT n.id FROM Notification n
+            WHERE n.member = :member
+              AND (n.type <> :invite OR n.createdAt < :threshold)
+            ORDER BY n.createdAt ASC
+            """)
+    List<Long> findDeletableIdsOldestFirst(@Param("member") Member member,
+                                           @Param("invite") NotificationType invite,
+                                           @Param("threshold") LocalDateTime threshold,
+                                           Pageable pageable);
 }

--- a/src/main/java/umc/cockple/demo/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/notification/repository/NotificationRepository.java
@@ -1,9 +1,6 @@
 package umc.cockple.demo.domain.notification.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import umc.cockple.demo.domain.member.domain.Member;
 import umc.cockple.demo.domain.notification.domain.Notification;
 import umc.cockple.demo.domain.notification.enums.NotificationType;
@@ -17,9 +14,7 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
 
     boolean existsByMember_IdAndIsReadFalse(Long memberId);
 
-    Optional<Notification> findFirstByMemberAndTypeNotOrderByCreatedAtAsc(Member member, NotificationType type);
+    long countByMember(Member member);
 
-    @Modifying
-    @Query("DELETE FROM Notification n WHERE n.id = :id")
-    void deleteByIdQuery(@Param("id") Long id);
+    Optional<Notification> findFirstByMemberAndTypeNotOrderByCreatedAtAsc(Member member, NotificationType type);
 }

--- a/src/main/java/umc/cockple/demo/domain/notification/service/NotificationCommandService.java
+++ b/src/main/java/umc/cockple/demo/domain/notification/service/NotificationCommandService.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import umc.cockple.demo.domain.member.domain.Member;
@@ -22,9 +23,11 @@ import umc.cockple.demo.domain.party.exception.PartyException;
 import umc.cockple.demo.domain.party.repository.PartyRepository;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.TextStyle;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import static umc.cockple.demo.domain.notification.dto.MarkAsReadDTO.*;
@@ -34,6 +37,12 @@ import static umc.cockple.demo.domain.notification.dto.MarkAsReadDTO.*;
 @RequiredArgsConstructor
 @Slf4j
 public class NotificationCommandService {
+
+    // 보관 정책: 회원당 알림을 대략 RETENTION_CAP개로 유지
+    // 매 생성마다 정리하면 정상 상태에서도 삭제가 발생해 쓰기 경합이 생기므로, RETENTION_TRIGGER를 넘을 때만 CAP까지 한 번에 정리한다(슬랙/히스테리시스)
+    private static final int RETENTION_CAP = 50;
+    private static final int RETENTION_TRIGGER = 60;
+    private static final int INVITE_RETENTION_DAYS = 7;
 
     private final NotificationRepository notificationRepository;
     private final PartyRepository partyRepository;
@@ -60,10 +69,7 @@ public class NotificationCommandService {
         try {
             long start = System.currentTimeMillis();
             Member member = dto.member();
-            if (notificationRepository.countByMember(member) >= 50) {
-                notificationRepository.findFirstByMemberAndTypeNotOrderByCreatedAtAsc(member, NotificationType.INVITE)
-                        .ifPresent(notificationRepository::delete);
-            }
+            enforceRetentionPolicy(member);
 
             Party party = partyRepository.findById(dto.partyId())
                     .orElseThrow(() -> new PartyException(PartyErrorCode.PARTY_NOT_FOUND));
@@ -122,6 +128,24 @@ public class NotificationCommandService {
 
         } catch (JsonProcessingException e) {
             throw new NotificationException(NotificationErrorCode.INVALID_NOTIFICATION_DATA);
+        }
+    }
+
+    private void enforceRetentionPolicy(Member member) {
+        long count = notificationRepository.countByMember(member);
+        if (count < RETENTION_TRIGGER) {
+            return;
+        }
+
+        int excess = (int) (count - RETENTION_CAP);
+        List<Long> deletableIds = notificationRepository.findDeletableIdsOldestFirst(
+                member,
+                NotificationType.INVITE,
+                LocalDateTime.now().minusDays(INVITE_RETENTION_DAYS),
+                PageRequest.of(0, excess));
+
+        if (!deletableIds.isEmpty()) {
+            notificationRepository.deleteAllByIdInBatch(deletableIds);
         }
     }
 

--- a/src/main/java/umc/cockple/demo/domain/notification/service/NotificationCommandService.java
+++ b/src/main/java/umc/cockple/demo/domain/notification/service/NotificationCommandService.java
@@ -25,7 +25,6 @@ import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.time.format.TextStyle;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import static umc.cockple.demo.domain.notification.dto.MarkAsReadDTO.*;
@@ -61,10 +60,9 @@ public class NotificationCommandService {
         try {
             long start = System.currentTimeMillis();
             Member member = dto.member();
-            List<Notification> bookmarks = notificationRepository.findAllByMemberOrderByCreatedAtDesc(member);
-            if (bookmarks.size() >= 50) {
+            if (notificationRepository.countByMember(member) >= 50) {
                 notificationRepository.findFirstByMemberAndTypeNotOrderByCreatedAtAsc(member, NotificationType.INVITE)
-                        .ifPresent(n -> notificationRepository.deleteByIdQuery(n.getId()));
+                        .ifPresent(notificationRepository::delete);
             }
 
             Party party = partyRepository.findById(dto.partyId())

--- a/src/main/resources/db/migration/V2026.07.22.00.00__add_notification_member_created_at_index.sql
+++ b/src/main/resources/db/migration/V2026.07.22.00.00__add_notification_member_created_at_index.sql
@@ -1,0 +1,3 @@
+-- 보관 정책 정리(삭제 후보 조회)와 회원별 알림 목록 조회를 뒷받침하는 인덱스.
+CREATE INDEX idx_notification_member_created_at
+    ON notification (member_id, created_at);

--- a/src/test/java/umc/cockple/demo/domain/notification/integration/NotificationBulkCreateQueryCountTest.java
+++ b/src/test/java/umc/cockple/demo/domain/notification/integration/NotificationBulkCreateQueryCountTest.java
@@ -1,0 +1,77 @@
+package umc.cockple.demo.domain.notification.integration;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+import umc.cockple.demo.domain.member.domain.Member;
+import umc.cockple.demo.domain.member.repository.MemberRepository;
+import umc.cockple.demo.domain.notification.dto.CreateNotificationRequestDTO;
+import umc.cockple.demo.domain.notification.enums.NotificationTarget;
+import umc.cockple.demo.domain.notification.service.NotificationCommandService;
+import umc.cockple.demo.domain.party.domain.Party;
+import umc.cockple.demo.domain.party.domain.PartyAddr;
+import umc.cockple.demo.domain.party.repository.PartyAddrRepository;
+import umc.cockple.demo.domain.party.repository.PartyRepository;
+import umc.cockple.demo.global.enums.Gender;
+import umc.cockple.demo.global.enums.Level;
+import umc.cockple.demo.support.IntegrationTestBase;
+import umc.cockple.demo.support.fixture.MemberFixture;
+import umc.cockple.demo.support.fixture.PartyFixture;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static umc.cockple.demo.support.QueryCountAssert.assertQueryCount;
+
+/**
+ * 모임 전체 알림(createRoleNotification) 경로의 쿼리 비용 기준선.
+ *
+ * createRoleNotification은 한 트랜잭션 안에서 회원마다 createNotification을 호출한다.
+ * 이 테스트는 그 루프를 동일하게 재현해, 회원 수(N)에 따라 쿼리가 어떻게 늘어나는지 박제한다.
+ */
+@Transactional
+@DisplayName("모임 전체 알림 생성 경로 쿼리 기준선")
+class NotificationBulkCreateQueryCountTest extends IntegrationTestBase {
+
+    private static final int MEMBER_COUNT = 5;
+
+    /**
+     * N명에게 알림을 생성할 때의 총 쿼리 수.
+     * party 조회 1회(1차 캐시) + 회원마다 (countByMember 1 + insert 1) = 1 + 2N.
+     */
+    private static final int BULK_CREATE_QUERY_COUNT = 1 + 2 * MEMBER_COUNT;
+
+    @Autowired NotificationCommandService notificationCommandService;
+    @Autowired MemberRepository memberRepository;
+    @Autowired PartyRepository partyRepository;
+    @Autowired PartyAddrRepository partyAddrRepository;
+
+    @PersistenceContext EntityManager em;
+
+    @Test
+    @DisplayName("N명에게 알림을 생성하면 party는 1회만 조회하고 회원당 count+insert(=2N)만 추가된다")
+    void bulkCreate_partyLoadedOnce_perMemberCountAndInsert() {
+        PartyAddr addr = partyAddrRepository.save(PartyFixture.createPartyAddr("경기도", "벌크측정동"));
+        Party party = partyRepository.save(PartyFixture.createParty("벌크측정모임", 1L, addr));
+
+        List<Member> members = new ArrayList<>();
+        for (int i = 0; i < MEMBER_COUNT; i++) {
+            members.add(memberRepository.save(
+                    MemberFixture.createMember("벌크측정" + i, Gender.MALE, Level.A, 8300L + i)));
+        }
+        em.flush();
+
+        assertQueryCount(em, BULK_CREATE_QUERY_COUNT, () -> {
+            for (Member member : members) {
+                notificationCommandService.createNotification(CreateNotificationRequestDTO.builder()
+                        .member(member)
+                        .partyId(party.getId())
+                        .target(NotificationTarget.PARTY_MODIFY)
+                        .build());
+            }
+        });
+    }
+}

--- a/src/test/java/umc/cockple/demo/domain/notification/integration/NotificationCreateQueryCountTest.java
+++ b/src/test/java/umc/cockple/demo/domain/notification/integration/NotificationCreateQueryCountTest.java
@@ -34,11 +34,11 @@ class NotificationCreateQueryCountTest extends IntegrationTestBase {
     private static final int SEEDED_NOTIFICATIONS = 50;
 
     /** createNotification 1회가 실행하는 SQL 수 */
-    // findAll(알림) + findFirst(삭제 대상) + deleteByIdQuery + party findById + insert = 5
+    // countByMember + findFirst(삭제 대상) + delete + party findById + insert = 5
     private static final int CREATE_QUERY_COUNT = 5;
 
-    /** createNotification 1회가 DB에서 로딩하는 엔티티 수 */
-    private static final int CREATE_ENTITY_LOAD_COUNT = 51; // 알림 50 + party 1
+    // 알림 전량 로딩이 사라지고, 삭제 대상 1건 + party 1건만 로딩
+    private static final int CREATE_ENTITY_LOAD_COUNT = 2;
 
     @Autowired NotificationCommandService notificationCommandService;
     @Autowired MemberRepository memberRepository;
@@ -49,8 +49,8 @@ class NotificationCreateQueryCountTest extends IntegrationTestBase {
     @PersistenceContext EntityManager em;
 
     @Test
-    @DisplayName("알림 50건 보유 회원에게 알림을 생성하면 보관 개수 판정을 위해 알림을 전량 로딩한다")
-    void createNotification_loadsAllNotificationsForCapCheck() {
+    @DisplayName("알림 50건 보유 회원에게 알림을 생성해도 보관 개수 판정에 알림을 전량 로딩하지 않는다")
+    void createNotification_doesNotLoadAllNotificationsForCapCheck() {
         Member member = memberRepository.save(
                 MemberFixture.createMember("알림측정", Gender.MALE, Level.A, 8101L));
         PartyAddr addr = partyAddrRepository.save(PartyFixture.createPartyAddr("경기도", "알림측정동"));

--- a/src/test/java/umc/cockple/demo/domain/notification/integration/NotificationCreateQueryCountTest.java
+++ b/src/test/java/umc/cockple/demo/domain/notification/integration/NotificationCreateQueryCountTest.java
@@ -32,13 +32,8 @@ import static umc.cockple.demo.support.QueryCountAssert.assertQueryCount;
 class NotificationCreateQueryCountTest extends IntegrationTestBase {
 
     private static final int SEEDED_NOTIFICATIONS = 50;
-
-    /** createNotification 1회가 실행하는 SQL 수 */
-    // countByMember + findFirst(삭제 대상) + delete + party findById + insert = 5
-    private static final int CREATE_QUERY_COUNT = 5;
-
-    // 알림 전량 로딩이 사라지고, 삭제 대상 1건 + party 1건만 로딩
-    private static final int CREATE_ENTITY_LOAD_COUNT = 2;
+    private static final int CREATE_QUERY_COUNT = 3;
+    private static final int CREATE_ENTITY_LOAD_COUNT = 1;
 
     @Autowired NotificationCommandService notificationCommandService;
     @Autowired MemberRepository memberRepository;
@@ -67,7 +62,7 @@ class NotificationCreateQueryCountTest extends IntegrationTestBase {
                 .target(NotificationTarget.PARTY_MODIFY)
                 .build();
 
-        // 캡 로직이 "1건 삭제 + 1건 삽입"이라 두 번 실행해도 보유 건수는 50으로 유지
+        // 50건은 트리거(60) 미만이라 보관 정리가 발동하지 않는다 → 두 번 실행해도 삽입만 발생
         assertEntityLoadCount(em, CREATE_ENTITY_LOAD_COUNT, () ->
                 notificationCommandService.createNotification(dto));
         assertQueryCount(em, CREATE_QUERY_COUNT, () ->

--- a/src/test/java/umc/cockple/demo/domain/notification/integration/NotificationCreateQueryCountTest.java
+++ b/src/test/java/umc/cockple/demo/domain/notification/integration/NotificationCreateQueryCountTest.java
@@ -1,0 +1,87 @@
+package umc.cockple.demo.domain.notification.integration;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+import umc.cockple.demo.domain.member.domain.Member;
+import umc.cockple.demo.domain.member.repository.MemberRepository;
+import umc.cockple.demo.domain.notification.domain.Notification;
+import umc.cockple.demo.domain.notification.dto.CreateNotificationRequestDTO;
+import umc.cockple.demo.domain.notification.enums.NotificationTarget;
+import umc.cockple.demo.domain.notification.enums.NotificationType;
+import umc.cockple.demo.domain.notification.repository.NotificationRepository;
+import umc.cockple.demo.domain.notification.service.NotificationCommandService;
+import umc.cockple.demo.domain.party.domain.Party;
+import umc.cockple.demo.domain.party.domain.PartyAddr;
+import umc.cockple.demo.domain.party.repository.PartyAddrRepository;
+import umc.cockple.demo.domain.party.repository.PartyRepository;
+import umc.cockple.demo.global.enums.Gender;
+import umc.cockple.demo.global.enums.Level;
+import umc.cockple.demo.support.IntegrationTestBase;
+import umc.cockple.demo.support.fixture.MemberFixture;
+import umc.cockple.demo.support.fixture.PartyFixture;
+
+import static umc.cockple.demo.support.QueryCountAssert.assertEntityLoadCount;
+import static umc.cockple.demo.support.QueryCountAssert.assertQueryCount;
+
+@Transactional
+@DisplayName("알림 생성 경로 쿼리/엔티티 로드 기준선")
+class NotificationCreateQueryCountTest extends IntegrationTestBase {
+
+    private static final int SEEDED_NOTIFICATIONS = 50;
+
+    /** createNotification 1회가 실행하는 SQL 수 */
+    // findAll(알림) + findFirst(삭제 대상) + deleteByIdQuery + party findById + insert = 5
+    private static final int CREATE_QUERY_COUNT = 5;
+
+    /** createNotification 1회가 DB에서 로딩하는 엔티티 수 */
+    private static final int CREATE_ENTITY_LOAD_COUNT = 51; // 알림 50 + party 1
+
+    @Autowired NotificationCommandService notificationCommandService;
+    @Autowired MemberRepository memberRepository;
+    @Autowired PartyRepository partyRepository;
+    @Autowired PartyAddrRepository partyAddrRepository;
+    @Autowired NotificationRepository notificationRepository;
+
+    @PersistenceContext EntityManager em;
+
+    @Test
+    @DisplayName("알림 50건 보유 회원에게 알림을 생성하면 보관 개수 판정을 위해 알림을 전량 로딩한다")
+    void createNotification_loadsAllNotificationsForCapCheck() {
+        Member member = memberRepository.save(
+                MemberFixture.createMember("알림측정", Gender.MALE, Level.A, 8101L));
+        PartyAddr addr = partyAddrRepository.save(PartyFixture.createPartyAddr("경기도", "알림측정동"));
+        Party party = partyRepository.save(PartyFixture.createParty("알림측정모임", member.getId(), addr));
+
+        for (int i = 0; i < SEEDED_NOTIFICATIONS; i++) {
+            seedNotification(member, party.getId(), i);
+        }
+        em.flush();
+
+        CreateNotificationRequestDTO dto = CreateNotificationRequestDTO.builder()
+                .member(member)
+                .partyId(party.getId())
+                .target(NotificationTarget.PARTY_MODIFY)
+                .build();
+
+        // 캡 로직이 "1건 삭제 + 1건 삽입"이라 두 번 실행해도 보유 건수는 50으로 유지
+        assertEntityLoadCount(em, CREATE_ENTITY_LOAD_COUNT, () ->
+                notificationCommandService.createNotification(dto));
+        assertQueryCount(em, CREATE_QUERY_COUNT, () ->
+                notificationCommandService.createNotification(dto));
+    }
+
+    private void seedNotification(Member member, Long partyId, int idx) {
+        notificationRepository.save(Notification.builder()
+                .member(member)
+                .partyId(partyId)
+                .title("알림" + idx)
+                .content("내용" + idx)
+                .type(NotificationType.SIMPLE)   // 비-INVITE라야 캡 초과 시 삭제 후보
+                .isRead(false)
+                .build());
+    }
+}

--- a/src/test/java/umc/cockple/demo/domain/notification/integration/NotificationRetentionPolicyTest.java
+++ b/src/test/java/umc/cockple/demo/domain/notification/integration/NotificationRetentionPolicyTest.java
@@ -24,6 +24,8 @@ import umc.cockple.demo.support.IntegrationTestBase;
 import umc.cockple.demo.support.fixture.MemberFixture;
 import umc.cockple.demo.support.fixture.PartyFixture;
 
+import java.time.LocalDateTime;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -96,6 +98,25 @@ class NotificationRetentionPolicyTest extends IntegrationTestBase {
         assertThat(notificationRepository.countByMember(member)).isEqualTo(61L);
     }
 
+    @Test
+    @DisplayName("생성 7일이 지난 INVITE는 삭제 후보에 포함되어 정리된다")
+    void oldInviteIsDeletable() {
+        Member member = seedMember(8204L);
+        Party party = seedParty(member, "오래된초대모임");
+        for (int i = 0; i < 60; i++) {
+            seedNotification(member, party.getId(), NotificationType.INVITE);
+        }
+        em.flush();
+        backdateAllNotifications(member, 8);   // 전부 8일 전으로 → 7일 경과, 삭제 후보가 됨
+        em.clear();
+
+        notificationCommandService.createNotification(create(member, party));
+
+        // 60건(전부 7일 경과 INVITE) → 초과분 10건 삭제 → INVITE 50건 + 신규 1건 = 51건
+        assertThat(notificationRepository.countByMember(member)).isEqualTo(51L);
+        assertThat(countByType(member, NotificationType.INVITE)).isEqualTo(50L);
+    }
+
     // === 헬퍼 ===
 
     private CreateNotificationRequestDTO create(Member member, Party party) {
@@ -133,5 +154,13 @@ class NotificationRetentionPolicyTest extends IntegrationTestBase {
                 .setParameter("member", member)
                 .setParameter("type", type)
                 .getSingleResult();
+    }
+
+    // @CreatedDate는 persist 시점에 세팅되므로, 오래된 알림 상황은 bulk update로 생성일을 소급한다.
+    private void backdateAllNotifications(Member member, int days) {
+        em.createQuery("UPDATE Notification n SET n.createdAt = :ts WHERE n.member = :member")
+                .setParameter("ts", LocalDateTime.now().minusDays(days))
+                .setParameter("member", member)
+                .executeUpdate();
     }
 }

--- a/src/test/java/umc/cockple/demo/domain/notification/integration/NotificationRetentionPolicyTest.java
+++ b/src/test/java/umc/cockple/demo/domain/notification/integration/NotificationRetentionPolicyTest.java
@@ -1,0 +1,137 @@
+package umc.cockple.demo.domain.notification.integration;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+import umc.cockple.demo.domain.member.domain.Member;
+import umc.cockple.demo.domain.member.repository.MemberRepository;
+import umc.cockple.demo.domain.notification.domain.Notification;
+import umc.cockple.demo.domain.notification.dto.CreateNotificationRequestDTO;
+import umc.cockple.demo.domain.notification.enums.NotificationTarget;
+import umc.cockple.demo.domain.notification.enums.NotificationType;
+import umc.cockple.demo.domain.notification.repository.NotificationRepository;
+import umc.cockple.demo.domain.notification.service.NotificationCommandService;
+import umc.cockple.demo.domain.party.domain.Party;
+import umc.cockple.demo.domain.party.domain.PartyAddr;
+import umc.cockple.demo.domain.party.repository.PartyAddrRepository;
+import umc.cockple.demo.domain.party.repository.PartyRepository;
+import umc.cockple.demo.global.enums.Gender;
+import umc.cockple.demo.global.enums.Level;
+import umc.cockple.demo.support.IntegrationTestBase;
+import umc.cockple.demo.support.fixture.MemberFixture;
+import umc.cockple.demo.support.fixture.PartyFixture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 보관 정책(슬랙 기반) 동작 검증. 실제 삭제 후보 조회 쿼리를 DB에 대해 실행한다.
+ *
+ * 정책: 보유 알림이 트리거(60)를 넘으면 CAP(50)까지 초과분을 한 번에 정리한다.
+ * INVITE는 생성 7일 이내면 삭제 후보에서 제외한다.
+ */
+@Transactional
+@DisplayName("알림 보관 정책")
+class NotificationRetentionPolicyTest extends IntegrationTestBase {
+
+    @Autowired NotificationCommandService notificationCommandService;
+    @Autowired MemberRepository memberRepository;
+    @Autowired PartyRepository partyRepository;
+    @Autowired PartyAddrRepository partyAddrRepository;
+    @Autowired NotificationRepository notificationRepository;
+
+    @PersistenceContext EntityManager em;
+
+    @Test
+    @DisplayName("트리거를 크게 초과해 쌓여도 한 번의 생성으로 CAP 근처까지 정리된다")
+    void overflow_convergesToCapAfterSingleCreate() {
+        Member member = seedMember(8201L);
+        Party party = seedParty(member, "정리모임");
+        for (int i = 0; i < 200; i++) {
+            seedNotification(member, party.getId(), NotificationType.SIMPLE);
+        }
+        em.flush();
+
+        notificationCommandService.createNotification(create(member, party));
+
+        // 200건 → 초과분(200-50=150) 삭제 → 50건 + 신규 1건 = 51건
+        assertThat(notificationRepository.countByMember(member)).isEqualTo(51L);
+    }
+
+    @Test
+    @DisplayName("트리거를 넘어도 최근 INVITE는 삭제 후보에서 제외되어 보존된다")
+    void recentInviteSurvivesCleanup() {
+        Member member = seedMember(8202L);
+        Party party = seedParty(member, "초대보존모임");
+        for (int i = 0; i < 55; i++) {
+            seedNotification(member, party.getId(), NotificationType.SIMPLE);
+        }
+        for (int i = 0; i < 10; i++) {
+            seedNotification(member, party.getId(), NotificationType.INVITE);   // createdAt = now (최근)
+        }
+        em.flush();
+
+        notificationCommandService.createNotification(create(member, party));
+
+        // 65건 → 초과분 15건은 전부 SIMPLE에서 삭제, 최근 INVITE 10건은 보존
+        assertThat(countByType(member, NotificationType.INVITE)).isEqualTo(10L);
+        assertThat(notificationRepository.countByMember(member)).isEqualTo(51L);
+    }
+
+    @Test
+    @DisplayName("트리거를 넘어도 삭제 후보가 없으면(전부 최근 INVITE) 정리하지 않아 CAP를 넘을 수 있다")
+    void noDeletableCandidates_exceedsCap() {
+        Member member = seedMember(8203L);
+        Party party = seedParty(member, "초대과다모임");
+        for (int i = 0; i < 60; i++) {
+            seedNotification(member, party.getId(), NotificationType.INVITE);   // 전부 최근 → 보호됨
+        }
+        em.flush();
+
+        notificationCommandService.createNotification(create(member, party));
+
+        // 삭제 없이 신규만 추가 → 61건. 페이지네이션(이슈 B)이 조회를 방어한다.
+        assertThat(notificationRepository.countByMember(member)).isEqualTo(61L);
+    }
+
+    // === 헬퍼 ===
+
+    private CreateNotificationRequestDTO create(Member member, Party party) {
+        return CreateNotificationRequestDTO.builder()
+                .member(member)
+                .partyId(party.getId())
+                .target(NotificationTarget.PARTY_MODIFY)
+                .build();
+    }
+
+    private Member seedMember(long socialId) {
+        return memberRepository.save(
+                MemberFixture.createMember("보관정책" + socialId, Gender.MALE, Level.A, socialId));
+    }
+
+    private Party seedParty(Member member, String name) {
+        PartyAddr addr = partyAddrRepository.save(PartyFixture.createPartyAddr("경기도", name));
+        return partyRepository.save(PartyFixture.createParty(name, member.getId(), addr));
+    }
+
+    private void seedNotification(Member member, Long partyId, NotificationType type) {
+        notificationRepository.save(Notification.builder()
+                .member(member)
+                .partyId(partyId)
+                .title("알림")
+                .content("내용")
+                .type(type)
+                .isRead(false)
+                .build());
+    }
+
+    private long countByType(Member member, NotificationType type) {
+        return em.createQuery(
+                        "SELECT count(n) FROM Notification n WHERE n.member = :member AND n.type = :type", Long.class)
+                .setParameter("member", member)
+                .setParameter("type", type)
+                .getSingleResult();
+    }
+}

--- a/src/test/java/umc/cockple/demo/domain/notification/service/NotificationCommandServiceTest.java
+++ b/src/test/java/umc/cockple/demo/domain/notification/service/NotificationCommandServiceTest.java
@@ -30,8 +30,6 @@ import umc.cockple.demo.support.fixture.MemberFixture;
 import umc.cockple.demo.support.fixture.PartyFixture;
 
 import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -203,8 +201,7 @@ class NotificationCommandServiceTest {
                         .target(NotificationTarget.PARTY_DELETE)
                         .build();
 
-                given(notificationRepository.findAllByMemberOrderByCreatedAtDesc(member))
-                        .willReturn(List.of());
+                given(notificationRepository.countByMember(member)).willReturn(0L);
                 given(partyRepository.findById(party.getId())).willReturn(Optional.of(party));
                 given(notificationMessageGenerator.generatePartyDeletedMessage())
                         .willReturn("모임이 삭제되었어요!");
@@ -229,8 +226,7 @@ class NotificationCommandServiceTest {
                         .target(NotificationTarget.PARTY_INVITE)
                         .build();
 
-                given(notificationRepository.findAllByMemberOrderByCreatedAtDesc(member))
-                        .willReturn(List.of());
+                given(notificationRepository.countByMember(member)).willReturn(0L);
                 given(partyRepository.findById(party.getId())).willReturn(Optional.of(party));
                 given(notificationMessageGenerator.generateInviteMessage(party.getPartyName()))
                         .willReturn("'테스트 모임' 모임에 초대를 받았습니다.");
@@ -256,8 +252,7 @@ class NotificationCommandServiceTest {
                         .target(NotificationTarget.EXERCISE_DELETE)
                         .build();
 
-                given(notificationRepository.findAllByMemberOrderByCreatedAtDesc(member))
-                        .willReturn(List.of());
+                given(notificationRepository.countByMember(member)).willReturn(0L);
                 given(partyRepository.findById(party.getId())).willReturn(Optional.of(party));
                 given(notificationMessageGenerator.generateExerciseDeletedMessage("03.15(토)"))
                         .willReturn("03.15(토) 운동이 삭제되었어요!");
@@ -275,13 +270,6 @@ class NotificationCommandServiceTest {
             @DisplayName("알림이 50개 이상이면 INVITE가 아닌 가장 오래된 알림을 삭제 후 저장한다")
             void createNotification_over50_deletesOldestNonInvite() throws Exception {
                 // given
-                List<Notification> existingNotifications = new ArrayList<>();
-                for (int i = 0; i < 50; i++) {
-                    existingNotifications.add(Notification.builder()
-                            .member(member).partyId(100L).title("t").content("c")
-                            .type(NotificationType.SIMPLE).isRead(true).imageKey(null).data("{}").build());
-                }
-
                 Notification oldestNonInvite = Notification.builder()
                         .member(member).partyId(100L).title("오래된 알림").content("c")
                         .type(NotificationType.SIMPLE).isRead(true).imageKey(null).data("{}").build();
@@ -293,8 +281,7 @@ class NotificationCommandServiceTest {
                         .target(NotificationTarget.PARTY_DELETE)
                         .build();
 
-                given(notificationRepository.findAllByMemberOrderByCreatedAtDesc(member))
-                        .willReturn(existingNotifications);
+                given(notificationRepository.countByMember(member)).willReturn(50L);
                 given(notificationRepository.findFirstByMemberAndTypeNotOrderByCreatedAtAsc(
                         member, NotificationType.INVITE))
                         .willReturn(Optional.of(oldestNonInvite));
@@ -307,7 +294,7 @@ class NotificationCommandServiceTest {
                 notificationCommandService.createNotification(dto);
 
                 // then
-                then(notificationRepository).should().deleteByIdQuery(50L);
+                then(notificationRepository).should().delete(oldestNonInvite);
                 then(notificationRepository).should().save(any(Notification.class));
             }
 
@@ -315,21 +302,13 @@ class NotificationCommandServiceTest {
             @DisplayName("알림이 49개이면 오래된 알림 삭제 없이 바로 저장한다")
             void createNotification_under50_savesWithoutDelete() throws Exception {
                 // given
-                List<Notification> existingNotifications = new ArrayList<>();
-                for (int i = 0; i < 49; i++) {
-                    existingNotifications.add(Notification.builder()
-                            .member(member).partyId(100L).title("t").content("c")
-                            .type(NotificationType.SIMPLE).isRead(true).imageKey(null).data("{}").build());
-                }
-
                 CreateNotificationRequestDTO dto = CreateNotificationRequestDTO.builder()
                         .member(member)
                         .partyId(party.getId())
                         .target(NotificationTarget.PARTY_DELETE)
                         .build();
 
-                given(notificationRepository.findAllByMemberOrderByCreatedAtDesc(member))
-                        .willReturn(existingNotifications);
+                given(notificationRepository.countByMember(member)).willReturn(49L);
                 given(partyRepository.findById(party.getId())).willReturn(Optional.of(party));
                 given(notificationMessageGenerator.generatePartyDeletedMessage())
                         .willReturn("모임이 삭제되었어요!");
@@ -339,7 +318,7 @@ class NotificationCommandServiceTest {
                 notificationCommandService.createNotification(dto);
 
                 // then
-                then(notificationRepository).should(never()).deleteByIdQuery(any(Long.class));
+                then(notificationRepository).should(never()).delete(any(Notification.class));
                 then(notificationRepository).should().save(any(Notification.class));
             }
         }
@@ -358,8 +337,7 @@ class NotificationCommandServiceTest {
                         .target(NotificationTarget.PARTY_DELETE)
                         .build();
 
-                given(notificationRepository.findAllByMemberOrderByCreatedAtDesc(member))
-                        .willReturn(List.of());
+                given(notificationRepository.countByMember(member)).willReturn(0L);
                 given(partyRepository.findById(999L)).willReturn(Optional.empty());
 
                 // when & then

--- a/src/test/java/umc/cockple/demo/domain/notification/service/NotificationCommandServiceTest.java
+++ b/src/test/java/umc/cockple/demo/domain/notification/service/NotificationCommandServiceTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Pageable;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.context.ApplicationEventPublisher;
 import umc.cockple.demo.domain.member.domain.Member;
@@ -30,11 +31,14 @@ import umc.cockple.demo.support.fixture.MemberFixture;
 import umc.cockple.demo.support.fixture.PartyFixture;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.never;
@@ -267,13 +271,10 @@ class NotificationCommandServiceTest {
             }
 
             @Test
-            @DisplayName("알림이 50개 이상이면 INVITE가 아닌 가장 오래된 알림을 삭제 후 저장한다")
-            void createNotification_over50_deletesOldestNonInvite() throws Exception {
-                // given
-                Notification oldestNonInvite = Notification.builder()
-                        .member(member).partyId(100L).title("오래된 알림").content("c")
-                        .type(NotificationType.SIMPLE).isRead(true).imageKey(null).data("{}").build();
-                ReflectionTestUtils.setField(oldestNonInvite, "id", 50L);
+            @DisplayName("보유 알림이 트리거(60)를 넘으면 초과분을 CAP(50)까지 한 번에 삭제 후 저장한다")
+            void createNotification_overTrigger_deletesExcessDownToCap() throws Exception {
+                // given: 60건 보유 → 초과분 10건 삭제 후보
+                List<Long> excessIds = List.of(1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L);
 
                 CreateNotificationRequestDTO dto = CreateNotificationRequestDTO.builder()
                         .member(member)
@@ -281,10 +282,10 @@ class NotificationCommandServiceTest {
                         .target(NotificationTarget.PARTY_DELETE)
                         .build();
 
-                given(notificationRepository.countByMember(member)).willReturn(50L);
-                given(notificationRepository.findFirstByMemberAndTypeNotOrderByCreatedAtAsc(
-                        member, NotificationType.INVITE))
-                        .willReturn(Optional.of(oldestNonInvite));
+                given(notificationRepository.countByMember(member)).willReturn(60L);
+                given(notificationRepository.findDeletableIdsOldestFirst(
+                        eq(member), eq(NotificationType.INVITE), any(LocalDateTime.class), any(Pageable.class)))
+                        .willReturn(excessIds);
                 given(partyRepository.findById(party.getId())).willReturn(Optional.of(party));
                 given(notificationMessageGenerator.generatePartyDeletedMessage())
                         .willReturn("모임이 삭제되었어요!");
@@ -294,13 +295,13 @@ class NotificationCommandServiceTest {
                 notificationCommandService.createNotification(dto);
 
                 // then
-                then(notificationRepository).should().delete(oldestNonInvite);
+                then(notificationRepository).should().deleteAllByIdInBatch(excessIds);
                 then(notificationRepository).should().save(any(Notification.class));
             }
 
             @Test
-            @DisplayName("알림이 49개이면 오래된 알림 삭제 없이 바로 저장한다")
-            void createNotification_under50_savesWithoutDelete() throws Exception {
+            @DisplayName("보유 알림이 트리거(60) 미만이면 정리 없이 바로 저장한다")
+            void createNotification_underTrigger_savesWithoutCleanup() throws Exception {
                 // given
                 CreateNotificationRequestDTO dto = CreateNotificationRequestDTO.builder()
                         .member(member)
@@ -308,7 +309,7 @@ class NotificationCommandServiceTest {
                         .target(NotificationTarget.PARTY_DELETE)
                         .build();
 
-                given(notificationRepository.countByMember(member)).willReturn(49L);
+                given(notificationRepository.countByMember(member)).willReturn(59L);
                 given(partyRepository.findById(party.getId())).willReturn(Optional.of(party));
                 given(notificationMessageGenerator.generatePartyDeletedMessage())
                         .willReturn("모임이 삭제되었어요!");
@@ -318,7 +319,34 @@ class NotificationCommandServiceTest {
                 notificationCommandService.createNotification(dto);
 
                 // then
-                then(notificationRepository).should(never()).delete(any(Notification.class));
+                then(notificationRepository).should(never()).deleteAllByIdInBatch(any());
+                then(notificationRepository).should().save(any(Notification.class));
+            }
+
+            @Test
+            @DisplayName("트리거를 넘어도 삭제 후보가 없으면(전부 최근 INVITE) 삭제하지 않고 저장한다")
+            void createNotification_overTrigger_noDeletableCandidates_savesWithoutDelete() throws Exception {
+                // given
+                CreateNotificationRequestDTO dto = CreateNotificationRequestDTO.builder()
+                        .member(member)
+                        .partyId(party.getId())
+                        .target(NotificationTarget.PARTY_DELETE)
+                        .build();
+
+                given(notificationRepository.countByMember(member)).willReturn(60L);
+                given(notificationRepository.findDeletableIdsOldestFirst(
+                        eq(member), eq(NotificationType.INVITE), any(LocalDateTime.class), any(Pageable.class)))
+                        .willReturn(List.of());
+                given(partyRepository.findById(party.getId())).willReturn(Optional.of(party));
+                given(notificationMessageGenerator.generatePartyDeletedMessage())
+                        .willReturn("모임이 삭제되었어요!");
+                given(objectMapper.writeValueAsString(any())).willReturn("{}");
+
+                // when
+                notificationCommandService.createNotification(dto);
+
+                // then
+                then(notificationRepository).should(never()).deleteAllByIdInBatch(any());
                 then(notificationRepository).should().save(any(Notification.class));
             }
         }

--- a/src/test/java/umc/cockple/demo/support/QueryCountAssert.java
+++ b/src/test/java/umc/cockple/demo/support/QueryCountAssert.java
@@ -46,4 +46,27 @@ public final class QueryCountAssert {
                 .as("실행된 SQL 쿼리 수가 기대치와 다릅니다 (N+1 가능성)")
                 .isEqualTo(expected);
     }
+
+    public static void assertEntityLoadCount(EntityManager em, long expected, Runnable action) {
+        Statistics statistics = em.getEntityManagerFactory()
+                .unwrap(SessionFactory.class)
+                .getStatistics();
+
+        if (em.isJoinedToTransaction()) {
+            em.clear();
+        }
+
+        statistics.clear();
+        action.run();
+
+        if (em.isJoinedToTransaction()) {
+            em.flush();
+        }
+
+        long actual = statistics.getEntityLoadCount();
+
+        assertThat(actual)
+                .as("DB에서 로딩된 엔티티 수가 기대치와 다릅니다 (불필요한 전량 로딩 가능성)")
+                .isEqualTo(expected);
+    }
 }


### PR DESCRIPTION
## ❤️ 기능 설명
알림 경로에 병목이 있어 리팩토링을 진행했습니다.

### 1. 개수 판정을 count 쿼리로 전환
- 보관 개수 판정에 `findAll(...).size()`로 알림을 전량 로딩하던 것을 `countByMember`로 변경
- 불필요한 `@Modifying` 삭제 쿼리(`deleteByIdQuery`) 제거 → `delete` 사용
- 결과: `createNotification` 1회의 엔티티 로드 51 → 1, 쿼리 5 → 3

### 2. 보관 정책 재설계 (슬랙 기반)
- 매 생성마다 1건씩 삭제하던 로직을, 트리거(60) 초과 시에만 CAP(50)까지 초과분을 일괄 삭제하도록 변경
- 초과분 id 조회 후 `deleteAllByIdInBatch`로 멱등 처리 (동시 생성 레이스 대응)
- INVITE는 생성 7일 경과분만 삭제 후보에 포함
- `(member_id, created_at)` 인덱스 추가

### 3. 테스트
- `QueryCountAssert.assertEntityLoadCount` 추가
- 알림 생성 경로 쿼리/엔티티 로드 기준선 테스트
- 보관 정책 통합 테스트 (초과분 정리 / 최근 INVITE 보존 / 삭제 후보 없음)
- 모임 전체 알림 생성 경로 쿼리 기준선 테스트

### 결과
`createNotification` 1회 (알림 50건 보유 회원):

| 지표 | 개선 전 | 개선 후 |
|---|---|---|
| 엔티티 로드 수 | 51 (알림 전량) | **1** |
| SQL 쿼리 수 | 5 | **3** |

트랜잭션 안에서 커넥션을 쥔 채 하던 50행 로딩 + 매-요청 DELETE 제거


<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #683 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!



<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [ ] 이슈넘버를 적었는가?
