### PR TITLE
[feat/#684] 알림 목록 조회에 커서 페이지네이션 도입

### DIFF
--- a/src/main/java/umc/cockple/demo/domain/notification/controller/NotificationController.java
+++ b/src/main/java/umc/cockple/demo/domain/notification/controller/NotificationController.java
@@ -6,8 +6,8 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
-import umc.cockple.demo.domain.notification.dto.AllNotificationsResponseDTO;
 import umc.cockple.demo.domain.notification.dto.FcmTokenRequestDTO;
+import umc.cockple.demo.domain.notification.dto.NotificationListResponseDTO;
 import umc.cockple.demo.domain.notification.fcm.FcmService;
 import umc.cockple.demo.domain.notification.service.NotificationCommandService;
 import umc.cockple.demo.domain.notification.dto.ExistNewNotificationResponseDTO;
@@ -15,8 +15,6 @@ import umc.cockple.demo.domain.notification.service.NotificationQueryService;
 import umc.cockple.demo.global.response.BaseResponse;
 import umc.cockple.demo.global.response.code.status.CommonSuccessCode;
 import umc.cockple.demo.global.security.utils.SecurityUtil;
-
-import java.util.List;
 
 import static umc.cockple.demo.domain.notification.dto.MarkAsReadDTO.*;
 
@@ -33,12 +31,16 @@ public class NotificationController {
 
     @GetMapping("/notifications")
     @Operation(summary = "내 알림 전체 조회",
-            description = "사용자에게 온 알림 전체를 조회합니다. ")
-    public BaseResponse<List<AllNotificationsResponseDTO>> getAllNotifications() {
+            description = "사용자에게 온 알림을 커서 페이지네이션으로 조회합니다. "
+                    + "첫 페이지는 cursor 생략, 다음 페이지는 직전 응답의 nextCursor를 전달합니다.")
+    public BaseResponse<NotificationListResponseDTO> getAllNotifications(
+            @RequestParam(required = false) Long cursor,
+            @RequestParam(defaultValue = "20") int size) {
 
         Long memberId = SecurityUtil.getCurrentMemberId();
 
-        return BaseResponse.success(CommonSuccessCode.OK, notificationQueryService.getAllNotifications(memberId));
+        return BaseResponse.success(CommonSuccessCode.OK,
+                notificationQueryService.getAllNotifications(memberId, cursor, size));
     }
 
 

--- a/src/main/java/umc/cockple/demo/domain/notification/controller/NotificationController.java
+++ b/src/main/java/umc/cockple/demo/domain/notification/controller/NotificationController.java
@@ -3,6 +3,9 @@ package umc.cockple.demo.domain.notification.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
@@ -34,8 +37,8 @@ public class NotificationController {
             description = "사용자에게 온 알림을 커서 페이지네이션으로 조회합니다. "
                     + "첫 페이지는 cursor 생략, 다음 페이지는 직전 응답의 nextCursor를 전달합니다.")
     public BaseResponse<NotificationListResponseDTO> getAllNotifications(
-            @RequestParam(required = false) Long cursor,
-            @RequestParam(defaultValue = "20") int size) {
+            @RequestParam(required = false) @Positive Long cursor,
+            @RequestParam(defaultValue = "20") @Min(1) @Max(100) int size) {
 
         Long memberId = SecurityUtil.getCurrentMemberId();
 

--- a/src/main/java/umc/cockple/demo/domain/notification/converter/NotificationConverter.java
+++ b/src/main/java/umc/cockple/demo/domain/notification/converter/NotificationConverter.java
@@ -2,6 +2,9 @@ package umc.cockple.demo.domain.notification.converter;
 
 import umc.cockple.demo.domain.notification.domain.Notification;
 import umc.cockple.demo.domain.notification.dto.AllNotificationsResponseDTO;
+import umc.cockple.demo.domain.notification.dto.NotificationListResponseDTO;
+
+import java.util.List;
 
 public class NotificationConverter {
 
@@ -15,6 +18,16 @@ public class NotificationConverter {
                 .isRead(notification.getIsRead())
                 .imgUrl(imgUrl)
                 .data(notification.getData())
+                .build();
+    }
+
+    public static NotificationListResponseDTO toNotificationListResponse(
+            List<AllNotificationsResponseDTO> notifications, boolean hasNext, Long nextCursor, int totalElements) {
+        return NotificationListResponseDTO.builder()
+                .notifications(notifications)
+                .hasNext(hasNext)
+                .nextCursor(nextCursor)
+                .totalElements(totalElements)
                 .build();
     }
 }

--- a/src/main/java/umc/cockple/demo/domain/notification/dto/NotificationListResponseDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/notification/dto/NotificationListResponseDTO.java
@@ -1,0 +1,14 @@
+package umc.cockple.demo.domain.notification.dto;
+
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record NotificationListResponseDTO(
+        List<AllNotificationsResponseDTO> notifications,
+        Boolean hasNext,
+        Long nextCursor,
+        int totalElements
+) {
+}

--- a/src/main/java/umc/cockple/demo/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/notification/repository/NotificationRepository.java
@@ -13,11 +13,19 @@ import java.util.List;
 
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
 
-    List<Notification> findAllByMemberOrderByCreatedAtDesc(Member member);
-
     boolean existsByMember_IdAndIsReadFalse(Long memberId);
 
     long countByMember(Member member);
+
+    @Query("""
+            SELECT n FROM Notification n
+            WHERE n.member = :member
+              AND (:cursor IS NULL OR n.id < :cursor)
+            ORDER BY n.id DESC
+            """)
+    List<Notification> findPageByMember(@Param("member") Member member,
+                                        @Param("cursor") Long cursor,
+                                        Pageable pageable);
 
     @Query("""
             SELECT n.id FROM Notification n

--- a/src/main/java/umc/cockple/demo/domain/notification/service/NotificationQueryService.java
+++ b/src/main/java/umc/cockple/demo/domain/notification/service/NotificationQueryService.java
@@ -9,10 +9,13 @@ import umc.cockple.demo.domain.member.domain.Member;
 import umc.cockple.demo.domain.member.exception.MemberErrorCode;
 import umc.cockple.demo.domain.member.exception.MemberException;
 import umc.cockple.demo.domain.member.repository.MemberRepository;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import umc.cockple.demo.domain.notification.converter.NotificationConverter;
 import umc.cockple.demo.domain.notification.domain.Notification;
 import umc.cockple.demo.domain.notification.dto.AllNotificationsResponseDTO;
 import umc.cockple.demo.domain.notification.dto.ExistNewNotificationResponseDTO;
+import umc.cockple.demo.domain.notification.dto.NotificationListResponseDTO;
 import umc.cockple.demo.domain.notification.repository.NotificationRepository;
 
 import java.util.List;
@@ -28,23 +31,30 @@ public class NotificationQueryService {
     private final FileService fileService;
 
 
-    public List<AllNotificationsResponseDTO> getAllNotifications(Long memberId) {
+    public NotificationListResponseDTO getAllNotifications(Long memberId, Long cursor, int size) {
         // 회원 조회
         Member member = findByMemberId(memberId);
 
-        // 회원의 모든 알림 조회
-        List<Notification> notifications = notificationRepository.findAllByMemberOrderByCreatedAtDesc(member);
+        Pageable pageable = PageRequest.of(0, size + 1);
+        List<Notification> rows = notificationRepository.findPageByMember(member, cursor, pageable);
 
-        if (notifications.isEmpty()) {
-            return List.of();
-        }
-        // dto 매핑 및 반환
-        return notifications.stream()
+        boolean hasNext = rows.size() > size;
+        List<Notification> page = hasNext ? rows.subList(0, size) : rows;
+
+        // dto 매핑
+        List<AllNotificationsResponseDTO> notifications = page.stream()
                 .map(notification -> {
                     String url = fileService.getUrlFromKey(notification.getImageKey());
                     return NotificationConverter.toAllNotificationResponseDTO(notification, url);
                 })
                 .toList();
+
+        Long nextCursor = hasNext && !page.isEmpty()
+                ? page.get(page.size() - 1).getId() : null;
+
+        int totalElements = (int) notificationRepository.countByMember(member);
+
+        return NotificationConverter.toNotificationListResponse(notifications, hasNext, nextCursor, totalElements);
     }
 
 

--- a/src/test/java/umc/cockple/demo/domain/notification/integration/NotificationIntegrationTest.java
+++ b/src/test/java/umc/cockple/demo/domain/notification/integration/NotificationIntegrationTest.java
@@ -17,9 +17,6 @@ import umc.cockple.demo.support.IntegrationTestBase;
 import umc.cockple.demo.support.SecurityContextHelper;
 import umc.cockple.demo.support.fixture.MemberFixture;
 
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.nullValue;
-import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -49,11 +46,6 @@ class NotificationIntegrationTest extends IntegrationTestBase {
                 .imageKey("test-image-key")
                 .data("{\"invitationId\":1}")
                 .build());
-
-        given(fileService.getUrlFromKey("test-image-key"))
-                .willReturn("https://test-storage.com/test-image-key");
-        given(fileService.getUrlFromKey(null))
-                .willReturn(null);
     }
 
     @AfterEach
@@ -61,108 +53,6 @@ class NotificationIntegrationTest extends IntegrationTestBase {
         notificationRepository.deleteAll();
         memberRepository.deleteAll();
         SecurityContextHelper.clearAuthentication();
-    }
-
-
-    @Nested
-    @DisplayName("GET /api/notifications - 내 알림 전체 조회")
-    class GetAllNotifications {
-
-        @Nested
-        @DisplayName("성공 케이스")
-        class Success {
-
-            @Test
-            @DisplayName("200 - 알림 목록의 모든 필드를 반환한다")
-            void getAllNotifications_allFields() throws Exception {
-                SecurityContextHelper.setAuthentication(member.getId(), member.getNickname());
-
-                mockMvc.perform(get("/api/notifications"))
-                        .andExpect(status().isOk())
-                        .andExpect(jsonPath("$.data", hasSize(1)))
-                        .andExpect(jsonPath("$.data[0].notificationId").value(notification.getId()))
-                        .andExpect(jsonPath("$.data[0].partyId").value(100))
-                        .andExpect(jsonPath("$.data[0].title").value("테스트 모임"))
-                        .andExpect(jsonPath("$.data[0].content").value("테스트 알림 내용"))
-                        .andExpect(jsonPath("$.data[0].type").value("INVITE"))
-                        .andExpect(jsonPath("$.data[0].isRead").value(false))
-                        .andExpect(jsonPath("$.data[0].imgUrl").value("https://test-storage.com/test-image-key"))
-                        .andExpect(jsonPath("$.data[0].data").value("{\"invitationId\":1}"));
-            }
-
-            @Test
-            @DisplayName("200 - 알림이 없으면 빈 리스트를 반환한다")
-            void getAllNotifications_empty() throws Exception {
-                Member otherMember = memberRepository.save(
-                        MemberFixture.createMember("다른멤버", Gender.FEMALE, Level.B, 2002L));
-                SecurityContextHelper.setAuthentication(otherMember.getId(), otherMember.getNickname());
-
-                mockMvc.perform(get("/api/notifications"))
-                        .andExpect(status().isOk())
-                        .andExpect(jsonPath("$.data", hasSize(0)));
-            }
-
-            @Test
-            @DisplayName("200 - 알림 목록이 createdAt 기준 내림차순으로 정렬된다")
-            void getAllNotifications_sortedByCreatedAtDesc() throws Exception {
-                // 먼저 저장된 알림 (더 오래된)
-                Notification olderNotification = notificationRepository.save(Notification.builder()
-                        .member(member)
-                        .partyId(200L)
-                        .title("오래된 알림")
-                        .content("먼저 생성된 알림")
-                        .type(NotificationType.SIMPLE)
-                        .isRead(false)
-                        .imageKey(null)
-                        .data("{}")
-                        .build());
-
-                Thread.sleep(10); // createdAt이 서로 다르도록 대기
-
-                // 나중에 저장된 알림 (더 최신)
-                Notification newerNotification = notificationRepository.save(Notification.builder()
-                        .member(member)
-                        .partyId(300L)
-                        .title("최신 알림")
-                        .content("나중에 생성된 알림")
-                        .type(NotificationType.SIMPLE)
-                        .isRead(false)
-                        .imageKey(null)
-                        .data("{}")
-                        .build());
-
-                SecurityContextHelper.setAuthentication(member.getId(), member.getNickname());
-
-                // 내림차순이면 newerNotification → olderNotification → setUp의 notification 순
-                mockMvc.perform(get("/api/notifications"))
-                        .andExpect(status().isOk())
-                        .andExpect(jsonPath("$.data", hasSize(3)))
-                        .andExpect(jsonPath("$.data[0].notificationId").value(newerNotification.getId()))
-                        .andExpect(jsonPath("$.data[1].notificationId").value(olderNotification.getId()))
-                        .andExpect(jsonPath("$.data[2].notificationId").value(notification.getId()));
-            }
-
-            @Test
-            @DisplayName("200 - imageKey가 없는 알림은 imgUrl이 null로 반환된다")
-            void getAllNotifications_nullImgUrl() throws Exception {
-                notificationRepository.save(Notification.builder()
-                        .member(member)
-                        .partyId(200L)
-                        .title("이미지 없는 알림")
-                        .content("모임이 삭제되었어요!")
-                        .type(NotificationType.SIMPLE)
-                        .isRead(false)
-                        .imageKey(null)
-                        .data("{}")
-                        .build());
-                SecurityContextHelper.setAuthentication(member.getId(), member.getNickname());
-
-                mockMvc.perform(get("/api/notifications"))
-                        .andExpect(status().isOk())
-                        .andExpect(jsonPath("$.data", hasSize(2)))
-                        .andExpect(jsonPath("$.data[0].imgUrl").value(nullValue()));
-            }
-        }
     }
 
 

--- a/src/test/java/umc/cockple/demo/domain/notification/integration/NotificationIntegrationTest.java
+++ b/src/test/java/umc/cockple/demo/domain/notification/integration/NotificationIntegrationTest.java
@@ -17,6 +17,8 @@ import umc.cockple.demo.support.IntegrationTestBase;
 import umc.cockple.demo.support.SecurityContextHelper;
 import umc.cockple.demo.support.fixture.MemberFixture;
 
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.nullValue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -53,6 +55,90 @@ class NotificationIntegrationTest extends IntegrationTestBase {
         notificationRepository.deleteAll();
         memberRepository.deleteAll();
         SecurityContextHelper.clearAuthentication();
+    }
+
+
+    @Nested
+    @DisplayName("GET /api/notifications - 내 알림 커서 페이지네이션 조회")
+    class GetAllNotifications {
+
+        @Nested
+        @DisplayName("성공 케이스")
+        class Success {
+
+            @Test
+            @DisplayName("200 - 응답 data가 객체(notifications 배열 + 페이지 메타)로 반환된다")
+            void returnsPagedObject() throws Exception {
+                SecurityContextHelper.setAuthentication(member.getId(), member.getNickname());
+
+                // setUp에서 알림 1건 저장됨
+                mockMvc.perform(get("/api/notifications"))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.data.notifications", hasSize(1)))
+                        .andExpect(jsonPath("$.data.notifications[0].notificationId").value(notification.getId()))
+                        .andExpect(jsonPath("$.data.notifications[0].title").value("테스트 모임"))
+                        .andExpect(jsonPath("$.data.hasNext").value(false))
+                        .andExpect(jsonPath("$.data.nextCursor").value(nullValue()))
+                        .andExpect(jsonPath("$.data.totalElements").value(1));
+            }
+
+            @Test
+            @DisplayName("200 - size보다 많으면 hasNext=true, nextCursor로 다음 페이지를 이어 조회한다")
+            void cursorTraversal() throws Exception {
+                // setUp의 notification(가장 오래됨) + 2건 추가 = 총 3건
+                Notification middle = saveNotification("중간 알림");
+                Notification newest = saveNotification("최신 알림");
+                SecurityContextHelper.setAuthentication(member.getId(), member.getNickname());
+
+                // 첫 페이지: size=2 → 최신순 [newest, middle], 다음 존재
+                mockMvc.perform(get("/api/notifications").param("size", "2"))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.data.notifications", hasSize(2)))
+                        .andExpect(jsonPath("$.data.notifications[0].notificationId").value(newest.getId()))
+                        .andExpect(jsonPath("$.data.notifications[1].notificationId").value(middle.getId()))
+                        .andExpect(jsonPath("$.data.hasNext").value(true))
+                        .andExpect(jsonPath("$.data.nextCursor").value(middle.getId()))
+                        .andExpect(jsonPath("$.data.totalElements").value(3));
+
+                // 다음 페이지: cursor=middle.id → [oldest(setUp notification)], 다음 없음
+                mockMvc.perform(get("/api/notifications")
+                                .param("size", "2")
+                                .param("cursor", String.valueOf(middle.getId())))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.data.notifications", hasSize(1)))
+                        .andExpect(jsonPath("$.data.notifications[0].notificationId").value(notification.getId()))
+                        .andExpect(jsonPath("$.data.hasNext").value(false))
+                        .andExpect(jsonPath("$.data.nextCursor").value(nullValue()));
+            }
+
+            @Test
+            @DisplayName("200 - 알림이 없으면 빈 배열과 hasNext=false를 반환한다")
+            void emptyPage() throws Exception {
+                Member otherMember = memberRepository.save(
+                        MemberFixture.createMember("다른멤버", Gender.FEMALE, Level.B, 2002L));
+                SecurityContextHelper.setAuthentication(otherMember.getId(), otherMember.getNickname());
+
+                mockMvc.perform(get("/api/notifications"))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.data.notifications", hasSize(0)))
+                        .andExpect(jsonPath("$.data.hasNext").value(false))
+                        .andExpect(jsonPath("$.data.nextCursor").value(nullValue()))
+                        .andExpect(jsonPath("$.data.totalElements").value(0));
+            }
+        }
+
+        private Notification saveNotification(String title) {
+            return notificationRepository.save(Notification.builder()
+                    .member(member)
+                    .partyId(200L)
+                    .title(title)
+                    .content("내용")
+                    .type(NotificationType.SIMPLE)
+                    .isRead(false)
+                    .imageKey(null)
+                    .data("{}")
+                    .build());
+        }
     }
 
 

--- a/src/test/java/umc/cockple/demo/domain/notification/integration/NotificationIntegrationTest.java
+++ b/src/test/java/umc/cockple/demo/domain/notification/integration/NotificationIntegrationTest.java
@@ -127,6 +127,38 @@ class NotificationIntegrationTest extends IntegrationTestBase {
             }
         }
 
+        @Nested
+        @DisplayName("실패 케이스 - 파라미터 검증")
+        class Failure {
+
+            @Test
+            @DisplayName("400 - size가 1 미만이면 검증에 실패한다")
+            void size_belowMin_returnsBadRequest() throws Exception {
+                SecurityContextHelper.setAuthentication(member.getId(), member.getNickname());
+
+                mockMvc.perform(get("/api/notifications").param("size", "0"))
+                        .andExpect(status().isBadRequest());
+            }
+
+            @Test
+            @DisplayName("400 - size가 100을 초과하면 검증에 실패한다")
+            void size_aboveMax_returnsBadRequest() throws Exception {
+                SecurityContextHelper.setAuthentication(member.getId(), member.getNickname());
+
+                mockMvc.perform(get("/api/notifications").param("size", "101"))
+                        .andExpect(status().isBadRequest());
+            }
+
+            @Test
+            @DisplayName("400 - cursor가 양수가 아니면 검증에 실패한다")
+            void cursor_notPositive_returnsBadRequest() throws Exception {
+                SecurityContextHelper.setAuthentication(member.getId(), member.getNickname());
+
+                mockMvc.perform(get("/api/notifications").param("cursor", "0"))
+                        .andExpect(status().isBadRequest());
+            }
+        }
+
         private Notification saveNotification(String title) {
             return notificationRepository.save(Notification.builder()
                     .member(member)

--- a/src/test/java/umc/cockple/demo/domain/notification/integration/NotificationListQueryCountTest.java
+++ b/src/test/java/umc/cockple/demo/domain/notification/integration/NotificationListQueryCountTest.java
@@ -1,0 +1,65 @@
+package umc.cockple.demo.domain.notification.integration;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+import umc.cockple.demo.domain.member.domain.Member;
+import umc.cockple.demo.domain.member.repository.MemberRepository;
+import umc.cockple.demo.domain.notification.domain.Notification;
+import umc.cockple.demo.domain.notification.enums.NotificationType;
+import umc.cockple.demo.domain.notification.repository.NotificationRepository;
+import umc.cockple.demo.domain.notification.service.NotificationQueryService;
+import umc.cockple.demo.global.enums.Gender;
+import umc.cockple.demo.global.enums.Level;
+import umc.cockple.demo.support.IntegrationTestBase;
+import umc.cockple.demo.support.fixture.MemberFixture;
+
+import static umc.cockple.demo.support.QueryCountAssert.assertQueryCount;
+
+/**
+ * 알림 목록(커서 페이지네이션) 조회의 쿼리 수 고정 — N+1 회귀 방지.
+ *
+ * 커서 조회는 알림 건수와 무관하게 항상 3쿼리여야 한다:
+ * 회원 조회 + 커서 조회(findPageByMember) + 전체 개수(countByMember).
+ * DTO 매핑은 로딩된 컬럼만 사용하므로 지연 로딩/추가 쿼리가 없다.
+ */
+@Transactional
+@DisplayName("알림 목록 조회 쿼리 카운트")
+class NotificationListQueryCountTest extends IntegrationTestBase {
+
+    private static final int LIST_QUERY_COUNT = 3;
+
+    @Autowired NotificationQueryService notificationQueryService;
+    @Autowired MemberRepository memberRepository;
+    @Autowired NotificationRepository notificationRepository;
+
+    @PersistenceContext EntityManager em;
+
+    @Test
+    @DisplayName("알림 개수와 무관하게 고정된 쿼리 수(3)만 실행한다")
+    void getAllNotifications_noNPlusOne() {
+        Member member = memberRepository.save(
+                MemberFixture.createMember("목록측정", Gender.MALE, Level.A, 8401L));
+        for (int i = 0; i < 30; i++) {
+            seedNotification(member, i);
+        }
+        em.flush();
+
+        assertQueryCount(em, LIST_QUERY_COUNT, () ->
+                notificationQueryService.getAllNotifications(member.getId(), null, 20));
+    }
+
+    private void seedNotification(Member member, int idx) {
+        notificationRepository.save(Notification.builder()
+                .member(member)
+                .partyId(100L)
+                .title("알림" + idx)
+                .content("내용" + idx)
+                .type(NotificationType.SIMPLE)
+                .isRead(false)
+                .build());
+    }
+}

--- a/src/test/java/umc/cockple/demo/domain/notification/service/NotificationQueryServiceTest.java
+++ b/src/test/java/umc/cockple/demo/domain/notification/service/NotificationQueryServiceTest.java
@@ -11,24 +11,14 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 import umc.cockple.demo.domain.file.service.FileService;
 import umc.cockple.demo.domain.member.domain.Member;
-import umc.cockple.demo.domain.member.exception.MemberErrorCode;
-import umc.cockple.demo.domain.member.exception.MemberException;
 import umc.cockple.demo.domain.member.repository.MemberRepository;
-import umc.cockple.demo.domain.notification.domain.Notification;
-import umc.cockple.demo.domain.notification.dto.AllNotificationsResponseDTO;
 import umc.cockple.demo.domain.notification.dto.ExistNewNotificationResponseDTO;
-import umc.cockple.demo.domain.notification.enums.NotificationType;
 import umc.cockple.demo.domain.notification.repository.NotificationRepository;
 import umc.cockple.demo.global.enums.Gender;
 import umc.cockple.demo.global.enums.Level;
 import umc.cockple.demo.support.fixture.MemberFixture;
 
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Optional;
-
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 
 @ExtendWith(MockitoExtension.class)
@@ -43,162 +33,12 @@ class NotificationQueryServiceTest {
     @Mock private FileService fileService;
 
     private Member member;
-    private Notification notification;
 
     @BeforeEach
     void setUp() {
         member = MemberFixture.createMember("테스터", Gender.MALE, Level.A, 1001L);
         ReflectionTestUtils.setField(member, "id", 1L);
-
-        notification = Notification.builder()
-                .member(member)
-                .partyId(100L)
-                .title("테스트 모임")
-                .content("테스트 알림 내용")
-                .type(NotificationType.INVITE)
-                .isRead(false)
-                .imageKey("test-image-key")
-                .data("{\"invitationId\":1}")
-                .build();
-        ReflectionTestUtils.setField(notification, "id", 10L);
     }
-
-
-    @Nested
-    @DisplayName("getAllNotifications - 내 알림 전체 조회")
-    class GetAllNotifications {
-
-        @Nested
-        @DisplayName("성공 케이스")
-        class Success {
-
-            @Test
-            @DisplayName("알림 목록을 DTO로 변환하여 반환한다")
-            void getAllNotifications_returnsDtoList() {
-                // given
-                given(memberRepository.findById(member.getId())).willReturn(Optional.of(member));
-                given(notificationRepository.findAllByMemberOrderByCreatedAtDesc(member))
-                        .willReturn(List.of(notification));
-                given(fileService.getUrlFromKey("test-image-key"))
-                        .willReturn("https://test-storage.com/test-image-key");
-
-                // when
-                List<AllNotificationsResponseDTO> result = notificationQueryService.getAllNotifications(member.getId());
-
-                // then
-                assertThat(result).hasSize(1);
-                assertThat(result.get(0).notificationId()).isEqualTo(10L);
-                assertThat(result.get(0).partyId()).isEqualTo(100L);
-                assertThat(result.get(0).title()).isEqualTo("테스트 모임");
-                assertThat(result.get(0).content()).isEqualTo("테스트 알림 내용");
-                assertThat(result.get(0).type()).isEqualTo(NotificationType.INVITE);
-                assertThat(result.get(0).isRead()).isFalse();
-                assertThat(result.get(0).imgUrl()).isEqualTo("https://test-storage.com/test-image-key");
-                assertThat(result.get(0).data()).isEqualTo("{\"invitationId\":1}");
-            }
-
-            @Test
-            @DisplayName("imageKey가 없는 알림은 imgUrl이 null로 반환된다")
-            void getAllNotifications_nullImageKey_returnsNullImgUrl() {
-                // given
-                Notification noImageNotification = Notification.builder()
-                        .member(member)
-                        .partyId(200L)
-                        .title("이미지 없는 알림")
-                        .content("모임이 삭제되었어요!")
-                        .type(NotificationType.SIMPLE)
-                        .isRead(false)
-                        .imageKey(null)
-                        .data("{}")
-                        .build();
-                ReflectionTestUtils.setField(noImageNotification, "id", 20L);
-
-                given(memberRepository.findById(member.getId())).willReturn(Optional.of(member));
-                given(notificationRepository.findAllByMemberOrderByCreatedAtDesc(member))
-                        .willReturn(List.of(noImageNotification));
-                given(fileService.getUrlFromKey(null)).willReturn(null);
-
-                // when
-                List<AllNotificationsResponseDTO> result = notificationQueryService.getAllNotifications(member.getId());
-
-                // then
-                assertThat(result).hasSize(1);
-                assertThat(result.get(0).imgUrl()).isNull();
-            }
-
-            @Test
-            @DisplayName("레포지토리가 반환한 createdAt 내림차순 순서를 그대로 유지하여 반환한다")
-            void getAllNotifications_preservesDescOrderFromRepository() {
-                // given
-                Notification oldest = Notification.builder()
-                        .member(member).partyId(100L).title("오래된 알림").content("c1")
-                        .type(NotificationType.SIMPLE).isRead(true).imageKey(null).data("{}").build();
-                ReflectionTestUtils.setField(oldest, "id", 1L);
-                ReflectionTestUtils.setField(oldest, "createdAt", LocalDateTime.of(2025, 1, 1, 9, 0));
-
-                Notification middle = Notification.builder()
-                        .member(member).partyId(100L).title("중간 알림").content("c2")
-                        .type(NotificationType.CHANGE).isRead(false).imageKey(null).data("{}").build();
-                ReflectionTestUtils.setField(middle, "id", 2L);
-                ReflectionTestUtils.setField(middle, "createdAt", LocalDateTime.of(2025, 6, 1, 9, 0));
-
-                Notification newest = Notification.builder()
-                        .member(member).partyId(100L).title("최신 알림").content("c3")
-                        .type(NotificationType.INVITE).isRead(false).imageKey(null).data("{}").build();
-                ReflectionTestUtils.setField(newest, "id", 3L);
-                ReflectionTestUtils.setField(newest, "createdAt", LocalDateTime.of(2025, 12, 1, 9, 0));
-
-                // 레포지토리는 createdAt DESC 순으로 반환 (newest → middle → oldest)
-                given(memberRepository.findById(member.getId())).willReturn(Optional.of(member));
-                given(notificationRepository.findAllByMemberOrderByCreatedAtDesc(member))
-                        .willReturn(List.of(newest, middle, oldest));
-                given(fileService.getUrlFromKey(null)).willReturn(null);
-
-                // when
-                List<AllNotificationsResponseDTO> result = notificationQueryService.getAllNotifications(member.getId());
-
-                // then
-                assertThat(result).hasSize(3);
-                assertThat(result.get(0).notificationId()).isEqualTo(3L); // newest
-                assertThat(result.get(1).notificationId()).isEqualTo(2L); // middle
-                assertThat(result.get(2).notificationId()).isEqualTo(1L); // oldest
-            }
-
-            @Test
-            @DisplayName("알림이 없으면 빈 리스트를 반환한다")
-            void getAllNotifications_noNotifications_returnsEmptyList() {
-                // given
-                given(memberRepository.findById(member.getId())).willReturn(Optional.of(member));
-                given(notificationRepository.findAllByMemberOrderByCreatedAtDesc(member))
-                        .willReturn(List.of());
-
-                // when
-                List<AllNotificationsResponseDTO> result = notificationQueryService.getAllNotifications(member.getId());
-
-                // then
-                assertThat(result).isEmpty();
-            }
-        }
-
-        @Nested
-        @DisplayName("실패 케이스")
-        class Failure {
-
-            @Test
-            @DisplayName("존재하지 않는 회원이면 MemberException(MEMBER_NOT_FOUND)을 던진다")
-            void memberNotFound_throwsMemberException() {
-                // given
-                given(memberRepository.findById(999L)).willReturn(Optional.empty());
-
-                // when & then
-                assertThatThrownBy(() -> notificationQueryService.getAllNotifications(999L))
-                        .isInstanceOf(MemberException.class)
-                        .satisfies(e -> assertThat(((MemberException) e).getCode())
-                                .isEqualTo(MemberErrorCode.MEMBER_NOT_FOUND));
-            }
-        }
-    }
-
 
     @Nested
     @DisplayName("checkUnreadNotification - 읽지 않은 알림 존재여부 조회")

--- a/src/test/java/umc/cockple/demo/domain/notification/service/NotificationQueryServiceTest.java
+++ b/src/test/java/umc/cockple/demo/domain/notification/service/NotificationQueryServiceTest.java
@@ -5,21 +5,36 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Pageable;
 import org.springframework.test.util.ReflectionTestUtils;
 import umc.cockple.demo.domain.file.service.FileService;
 import umc.cockple.demo.domain.member.domain.Member;
+import umc.cockple.demo.domain.member.exception.MemberErrorCode;
+import umc.cockple.demo.domain.member.exception.MemberException;
 import umc.cockple.demo.domain.member.repository.MemberRepository;
+import umc.cockple.demo.domain.notification.domain.Notification;
 import umc.cockple.demo.domain.notification.dto.ExistNewNotificationResponseDTO;
+import umc.cockple.demo.domain.notification.dto.NotificationListResponseDTO;
+import umc.cockple.demo.domain.notification.enums.NotificationType;
 import umc.cockple.demo.domain.notification.repository.NotificationRepository;
 import umc.cockple.demo.global.enums.Gender;
 import umc.cockple.demo.global.enums.Level;
 import umc.cockple.demo.support.fixture.MemberFixture;
 
+import java.util.List;
+import java.util.Optional;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("NotificationQueryService")
@@ -38,6 +53,92 @@ class NotificationQueryServiceTest {
     void setUp() {
         member = MemberFixture.createMember("테스터", Gender.MALE, Level.A, 1001L);
         ReflectionTestUtils.setField(member, "id", 1L);
+    }
+
+    @Nested
+    @DisplayName("getAllNotifications - 커서 페이지네이션 조회")
+    class GetAllNotifications {
+
+        @Test
+        @DisplayName("size보다 많이 조회되면 hasNext=true, size개만 반환하고 nextCursor는 마지막 알림 id이다")
+        void hasNext_trimsToSize_andSetsNextCursor() {
+            // given: size=2인데 size+1(=3)건 조회됨 → 다음 페이지 존재
+            given(memberRepository.findById(1L)).willReturn(Optional.of(member));
+            given(notificationRepository.findPageByMember(eq(member), isNull(), any(Pageable.class)))
+                    .willReturn(List.of(notification(5L), notification(4L), notification(3L)));
+            given(notificationRepository.countByMember(member)).willReturn(10L);
+            given(fileService.getUrlFromKey(null)).willReturn(null);
+
+            // when
+            NotificationListResponseDTO result = notificationQueryService.getAllNotifications(1L, null, 2);
+
+            // then
+            assertThat(result.notifications()).hasSize(2);
+            assertThat(result.notifications().get(0).notificationId()).isEqualTo(5L);
+            assertThat(result.notifications().get(1).notificationId()).isEqualTo(4L);
+            assertThat(result.hasNext()).isTrue();
+            assertThat(result.nextCursor()).isEqualTo(4L);   // 이번 페이지의 가장 오래된 id
+            assertThat(result.totalElements()).isEqualTo(10);
+        }
+
+        @Test
+        @DisplayName("size 이하로 조회되면 hasNext=false, nextCursor=null이다")
+        void noNext_returnsAllWithNullCursor() {
+            // given: cursor 전달(다음 페이지 요청), size=5인데 2건만 조회됨
+            given(memberRepository.findById(1L)).willReturn(Optional.of(member));
+            given(notificationRepository.findPageByMember(eq(member), eq(100L), any(Pageable.class)))
+                    .willReturn(List.of(notification(9L), notification(8L)));
+            given(notificationRepository.countByMember(member)).willReturn(2L);
+            given(fileService.getUrlFromKey(null)).willReturn(null);
+
+            // when
+            NotificationListResponseDTO result = notificationQueryService.getAllNotifications(1L, 100L, 5);
+
+            // then
+            assertThat(result.notifications()).hasSize(2);
+            assertThat(result.hasNext()).isFalse();
+            assertThat(result.nextCursor()).isNull();
+            assertThat(result.totalElements()).isEqualTo(2);
+        }
+
+        @Test
+        @DisplayName("hasNext 판정을 위해 size+1건을 조회한다")
+        void fetchesSizePlusOne() {
+            // given
+            given(memberRepository.findById(1L)).willReturn(Optional.of(member));
+            given(notificationRepository.findPageByMember(eq(member), isNull(), any(Pageable.class)))
+                    .willReturn(List.of());
+            given(notificationRepository.countByMember(member)).willReturn(0L);
+
+            // when
+            notificationQueryService.getAllNotifications(1L, null, 20);
+
+            // then
+            ArgumentCaptor<Pageable> captor = ArgumentCaptor.forClass(Pageable.class);
+            then(notificationRepository).should().findPageByMember(eq(member), isNull(), captor.capture());
+            assertThat(captor.getValue().getPageSize()).isEqualTo(21);
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 회원이면 MemberException(MEMBER_NOT_FOUND)을 던진다")
+        void memberNotFound_throwsMemberException() {
+            // given
+            given(memberRepository.findById(999L)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> notificationQueryService.getAllNotifications(999L, null, 20))
+                    .isInstanceOf(MemberException.class)
+                    .satisfies(e -> assertThat(((MemberException) e).getCode())
+                            .isEqualTo(MemberErrorCode.MEMBER_NOT_FOUND));
+        }
+
+        private Notification notification(long id) {
+            Notification n = Notification.builder()
+                    .member(member).partyId(100L).title("알림").content("내용")
+                    .type(NotificationType.SIMPLE).isRead(false).imageKey(null).data("{}").build();
+            ReflectionTestUtils.setField(n, "id", id);
+            return n;
+        }
     }
 
     @Nested


### PR DESCRIPTION
## ❤️ 기능 설명

알림 전체 조회 API를 무제한 조회에서 커서 페이지네이션으로 전환합니다.

### 1. 로직 변경
- `GET /api/notifications`: 응답 `data`가 배열 → 객체로 변경
  - `data.notifications`(배열) + `hasNext` + `nextCursor` + `totalElements`
- 요청 파라미터 추가: `cursor`(notificationId 기준, 첫 페이지 생략), `size`(기본 20)
- 무제한 조회(`findAll`) 제거 → id 커서 조회(`findPageByMember`)로 전환
  - IDENTITY PK라 id 순서 = 생성 순서이므로 id를 커서로 사용
  - hasNext 판정을 위해 size + 1건 조회

### 2. 테스트
- 서비스: hasNext/nextCursor 계산, size+1 조회, 회원 없음 예외
- 컨트롤러(통합): 새 응답 구조 + 커서 traversal(2페이지 왕복), 빈 페이지
- 쿼리카운트: 알림 개수와 무관하게 고정 3쿼리 (N+1 회귀 방지)

<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #684 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 스펙변경은 프론트에 고지 완료 했습니다!

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [ ] 이슈넘버를 적었는가?
