### PR TITLE
[refactor/#669] ChatQueryServiceImpl 상세/메시지 조회 책임 분리

### DIFF
--- a/src/main/java/umc/cockple/demo/domain/chat/service/query/ChatMessageHistoryQueryService.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/query/ChatMessageHistoryQueryService.java
@@ -1,0 +1,65 @@
+package umc.cockple.demo.domain.chat.service.query;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import umc.cockple.demo.domain.chat.converter.ChatConverter;
+import umc.cockple.demo.domain.chat.domain.ChatMessage;
+import umc.cockple.demo.domain.chat.dto.ChatCommonDTO;
+import umc.cockple.demo.domain.chat.dto.ChatMessageDTO;
+import umc.cockple.demo.domain.chat.exception.ChatErrorCode;
+import umc.cockple.demo.domain.chat.exception.ChatException;
+import umc.cockple.demo.domain.chat.repository.ChatMessageRepository;
+import umc.cockple.demo.domain.chat.repository.ChatRoomMemberRepository;
+import umc.cockple.demo.domain.chat.service.ChatProcessor;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ChatMessageHistoryQueryService {
+
+    private final ChatRoomMemberRepository chatRoomMemberRepository;
+    private final ChatMessageRepository chatMessageRepository;
+    private final ChatProcessor chatProcessor;
+    private final ChatConverter chatConverter;
+
+    public ChatMessageDTO.Response getChatMessages(Long roomId, Long memberId, Long cursor, int size) {
+        log.info("[채팅방 과거 메시지 조회 시작] - 채팅방 Id: {}, 멤버 Id: {}, 마지막으로 조회된 메시지 Id: {}, size: {}",
+                roomId, memberId, cursor, size);
+
+        validateChatRoomAccess(roomId, memberId);
+
+        Pageable pageable = PageRequest.of(0, size + 1);
+        List<ChatMessage> messages = chatMessageRepository
+                .findByRoomIdAndIdLessThanOrderByCreatedAtDesc(roomId, cursor, pageable);
+
+        boolean hasNext = messages.size() > size;
+        List<ChatMessage> resultMessages = hasNext
+                ? new ArrayList<>(messages.subList(0, size))
+                : new ArrayList<>(messages);
+
+        Collections.reverse(resultMessages);
+        List<ChatCommonDTO.MessageInfo> commonMessages = chatProcessor.processMessages(memberId, resultMessages);
+        List<ChatMessageDTO.MessageInfo> messageInfos = chatConverter.toChatMessageInfos(commonMessages);
+
+        Long nextCursor = hasNext && !resultMessages.isEmpty()
+                ? resultMessages.get(0).getId() : null;
+
+        log.info("[채팅방 과거 메시지 조회 완료] - 메시지 수: {}, hasNext: {}", resultMessages.size(), hasNext);
+        return chatConverter.toChatMessageResponse(messageInfos, hasNext, nextCursor);
+    }
+
+    private void validateChatRoomAccess(Long roomId, Long memberId) {
+        if (!chatRoomMemberRepository.existsByChatRoomIdAndMemberId(roomId, memberId)) {
+            throw new ChatException(ChatErrorCode.CHAT_ROOM_ACCESS_DENIED);
+        }
+    }
+}

--- a/src/main/java/umc/cockple/demo/domain/chat/service/query/ChatQueryServiceImpl.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/query/ChatQueryServiceImpl.java
@@ -44,6 +44,7 @@ public class ChatQueryServiceImpl implements ChatQueryService {
     private final PartyChatRoomQueryService partyChatRoomQueryService;
     private final DirectChatRoomQueryService directChatRoomQueryService;
     private final PartyChatRoomIdQueryService partyChatRoomIdQueryService;
+    private final ChatMessageHistoryQueryService chatMessageHistoryQueryService;
 
     @Override
     public PartyChatRoomDTO.Response getPartyChatRooms(Long memberId, int page, int size) {
@@ -97,41 +98,12 @@ public class ChatQueryServiceImpl implements ChatQueryService {
 
     @Override
     public ChatMessageDTO.Response getChatMessages(Long roomId, Long memberId, Long cursor, int size) {
-        log.info("[채팅방 과거 메시지 조회 시작] - 채팅방 Id: {}, 멤버 Id: {}, 마지막으로 조회된 메시지 Id: {}, size: {}",
-                roomId, memberId, cursor, size);
-
-        validateChatRoomAccess(roomId, memberId);
-
-        Pageable pageable = PageRequest.of(0, size + 1);
-        List<ChatMessage> messages = findMessagesWithCursor(roomId, cursor, pageable);
-
-        boolean hasNext = messages.size() > size;
-        List<ChatMessage> resultMessages = hasNext
-                ? new ArrayList<>(messages.subList(0, size))
-                : new ArrayList<>(messages);
-
-        Collections.reverse(resultMessages);
-        List<ChatCommonDTO.MessageInfo> commonMessages = chatProcessor.processMessages(memberId, resultMessages);
-        List<ChatMessageDTO.MessageInfo> messageInfos = chatConverter.toChatMessageInfos(commonMessages);
-
-        Long nextCursor = hasNext && !resultMessages.isEmpty()
-                ? resultMessages.get(0).getId() : null;
-
-        log.info("[채팅방 과거 메시지 조회 완료] - 메시지 수: {}, hasNext: {}", resultMessages.size(), hasNext);
-
-        return chatConverter.toChatMessageResponse(messageInfos, hasNext, nextCursor);
+        return chatMessageHistoryQueryService.getChatMessages(roomId, memberId, cursor, size);
     }
 
     @Override
     public PartyChatRoomIdDTO getChatRoomId(Long partyId, Long memberId) {
         return partyChatRoomIdQueryService.getChatRoomId(partyId, memberId);
-    }
-
-    // ========== 검증 로직 ==========
-
-    private void validateChatRoomAccess(Long roomId, Long memberId) {
-        if (!chatRoomMemberRepository.existsByChatRoomIdAndMemberId(roomId, memberId))
-            throw new ChatException(ChatErrorCode.CHAT_ROOM_ACCESS_DENIED);
     }
 
     // ========== 비즈니스 로직 ==========
@@ -211,10 +183,6 @@ public class ChatQueryServiceImpl implements ChatQueryService {
 
     private List<ChatMessage> findRecentMessagesWithImages(Long roomId, Pageable pageable) {
         return chatMessageRepository.findRecentMessagesWithFiles(roomId, pageable);
-    }
-
-    private List<ChatMessage> findMessagesWithCursor(Long roomId, Long cursor, Pageable pageable) {
-        return chatMessageRepository.findByRoomIdAndIdLessThanOrderByCreatedAtDesc(roomId, cursor, pageable);
     }
 
 }

--- a/src/main/java/umc/cockple/demo/domain/chat/service/query/ChatQueryServiceImpl.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/query/ChatQueryServiceImpl.java
@@ -1,50 +1,24 @@
 package umc.cockple.demo.domain.chat.service.query;
 
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-import umc.cockple.demo.domain.chat.converter.ChatConverter;
-import umc.cockple.demo.domain.chat.domain.ChatMessage;
-import umc.cockple.demo.domain.chat.domain.ChatRoom;
-import umc.cockple.demo.domain.chat.domain.ChatRoomMember;
-import umc.cockple.demo.domain.chat.dto.*;
-import umc.cockple.demo.domain.chat.enums.ChatRoomType;
-import umc.cockple.demo.domain.chat.exception.ChatErrorCode;
-import umc.cockple.demo.domain.chat.exception.ChatException;
-import umc.cockple.demo.domain.chat.repository.ChatMessageRepository;
-import umc.cockple.demo.domain.chat.repository.ChatRoomMemberRepository;
-import umc.cockple.demo.domain.chat.repository.ChatRoomRepository;
-import umc.cockple.demo.domain.chat.service.ChatProcessor;
-import umc.cockple.demo.domain.file.service.ImageUrlResolver;
-import umc.cockple.demo.domain.member.domain.Member;
-import umc.cockple.demo.domain.member.domain.ProfileImg;
-import umc.cockple.demo.domain.party.domain.PartyImg;
+import umc.cockple.demo.domain.chat.dto.ChatMessageDTO;
+import umc.cockple.demo.domain.chat.dto.ChatRoomDetailDTO;
+import umc.cockple.demo.domain.chat.dto.ChatUnreadStatusDTO;
+import umc.cockple.demo.domain.chat.dto.DirectChatRoomDTO;
+import umc.cockple.demo.domain.chat.dto.PartyChatRoomDTO;
+import umc.cockple.demo.domain.chat.dto.PartyChatRoomIdDTO;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-
-@Slf4j
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
 public class ChatQueryServiceImpl implements ChatQueryService {
 
-    private final ChatRoomRepository chatRoomRepository;
-    private final ChatRoomMemberRepository chatRoomMemberRepository;
-    private final ChatMessageRepository chatMessageRepository;
-
-    private final ChatUnreadQueryService chatUnreadQueryService;
-    private final ChatConverter chatConverter;
-    private final ImageUrlResolver imageUrlResolver;
-    private final ChatProcessor chatProcessor;
     private final PartyChatRoomQueryService partyChatRoomQueryService;
     private final DirectChatRoomQueryService directChatRoomQueryService;
-    private final PartyChatRoomIdQueryService partyChatRoomIdQueryService;
+    private final ChatUnreadQueryService chatUnreadQueryService;
+    private final ChatRoomDetailQueryService chatRoomDetailQueryService;
     private final ChatMessageHistoryQueryService chatMessageHistoryQueryService;
+    private final PartyChatRoomIdQueryService partyChatRoomIdQueryService;
 
     @Override
     public PartyChatRoomDTO.Response getPartyChatRooms(Long memberId, int page, int size) {
@@ -73,27 +47,7 @@ public class ChatQueryServiceImpl implements ChatQueryService {
 
     @Override
     public ChatRoomDetailDTO.Response getChatRoomDetail(Long roomId, Long memberId) {
-        log.info("[초기 채팅방 조회 시작] - roomId: {}, memberId: {}", roomId, memberId);
-
-        ChatRoom chatRoom = findChatRoomWithPartyOrThrow(roomId);
-        ChatRoomMember myMembership = findChatRoomMembershipOrThrow(roomId, memberId);
-
-        ChatRoomDetailDTO.ChatRoomInfo roomInfo = buildChatRoomInfo(chatRoom, myMembership);
-
-        Pageable pageable = PageRequest.of(0, 50);
-        List<ChatMessage> recentMessages = findRecentMessagesWithImages(roomId, pageable);
-        List<ChatMessage> resultMessages = new ArrayList<>(recentMessages);
-        Collections.reverse(resultMessages);
-        List<ChatCommonDTO.MessageInfo> commonMessages = chatProcessor.processMessages(memberId, resultMessages);
-        List<ChatRoomDetailDTO.MessageInfo> messageInfos = chatConverter.toChatRoomDetailMessageInfos(commonMessages);
-
-        List<ChatRoomMember> participants = findChatRoomMembersWithMemberOrThrow(roomId);
-        List<ChatRoomDetailDTO.MemberInfo> memberInfos = buildMemberInfos(participants);
-
-        log.info("[초기 채팅방 조회 완료] - 메시지 수: {}, 참여자 수: {}",
-                messageInfos.size(), memberInfos.size());
-
-        return chatConverter.toChatRoomDetailResponse(roomInfo, messageInfos, memberInfos);
+        return chatRoomDetailQueryService.getChatRoomDetail(roomId, memberId);
     }
 
     @Override
@@ -105,84 +59,4 @@ public class ChatQueryServiceImpl implements ChatQueryService {
     public PartyChatRoomIdDTO getChatRoomId(Long partyId, Long memberId) {
         return partyChatRoomIdQueryService.getChatRoomId(partyId, memberId);
     }
-
-    // ========== 비즈니스 로직 ==========
-    private ChatRoomDetailDTO.ChatRoomInfo buildChatRoomInfo(ChatRoom chatRoom, ChatRoomMember myMembership) {
-        String displayName;
-        String profileImageUrl = null;
-        boolean isCounterPartWithdrawn = false;
-
-        if (chatRoom.getType() == ChatRoomType.DIRECT) {
-            ChatRoomMember counterPart = findCounterPartWithMemberOrThrow(chatRoom, myMembership);
-            Member member = counterPart.getMember();
-            isCounterPartWithdrawn = isUnavailableMember(member);
-
-            displayName = isCounterPartWithdrawn ? ChatConverter.UNKNOWN_USER_NAME : member.getMemberName();
-            profileImageUrl = isCounterPartWithdrawn
-                    ? null
-                    : imageUrlResolver.resolve(member.getProfileImg(), ProfileImg::getImgKey);
-        } else {
-            displayName = chatRoom.getParty().getPartyName();
-            profileImageUrl = imageUrlResolver.resolve(chatRoom.getParty().getPartyImg(), PartyImg::getImgKey);
-        }
-
-        int memberCount = chatRoomMemberRepository.countByChatRoomId(chatRoom.getId());
-        Long lastReadMessageId = myMembership.getLastReadMessageId();
-
-        return chatConverter.toChatRoomDetailChatRoomInfo(
-                chatRoom,
-                displayName,
-                profileImageUrl,
-                isCounterPartWithdrawn,
-                memberCount,
-                lastReadMessageId);
-    }
-
-    private List<ChatRoomDetailDTO.MemberInfo> buildMemberInfos(List<ChatRoomMember> participants) {
-        return participants.stream()
-                .map(this::buildMemberInfo)
-                .toList();
-    }
-
-    private ChatRoomDetailDTO.MemberInfo buildMemberInfo(ChatRoomMember chatRoomMember) {
-        Member member = chatRoomMember.getMember();
-        String memberProfileImgUrl = isUnavailableMember(member)
-                ? null
-                : imageUrlResolver.resolve(member.getProfileImg(), ProfileImg::getImgKey);
-
-        return chatConverter.toChatRoomDetailMemberInfo(member, memberProfileImgUrl);
-    }
-
-    private boolean isUnavailableMember(Member member) {
-        return member == null || member.isWithdrawn();
-    }
-
-
-    // ========== 조회 메서드 ==========
-
-    private ChatRoom findChatRoomWithPartyOrThrow(Long roomId) {
-        return chatRoomRepository.findChatRoomWithPartyById(roomId)
-                .orElseThrow(() -> new ChatException(ChatErrorCode.CHAT_ROOM_NOT_FOUND));
-    }
-
-    private ChatRoomMember findChatRoomMembershipOrThrow(Long roomId, Long memberId) {
-        return chatRoomMemberRepository
-                .findByChatRoomIdAndMemberId(roomId, memberId)
-                .orElseThrow(() -> new ChatException(ChatErrorCode.CHAT_ROOM_ACCESS_DENIED));
-    }
-
-    private ChatRoomMember findCounterPartWithMemberOrThrow(ChatRoom chatRoom, ChatRoomMember myMembership) {
-        return chatRoomMemberRepository
-                .findCounterPartWithMember(chatRoom.getId(), myMembership.getMember().getId())
-                .orElseThrow(() -> new ChatException(ChatErrorCode.CHAT_ROOM_ACCESS_DENIED));
-    }
-
-    private List<ChatRoomMember> findChatRoomMembersWithMemberOrThrow(Long roomId) {
-        return chatRoomMemberRepository.findChatRoomMembersWithMemberById(roomId);
-    }
-
-    private List<ChatMessage> findRecentMessagesWithImages(Long roomId, Pageable pageable) {
-        return chatMessageRepository.findRecentMessagesWithFiles(roomId, pageable);
-    }
-
 }

--- a/src/main/java/umc/cockple/demo/domain/chat/service/query/ChatQueryServiceImpl.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/query/ChatQueryServiceImpl.java
@@ -21,10 +21,7 @@ import umc.cockple.demo.domain.chat.service.ChatProcessor;
 import umc.cockple.demo.domain.file.service.ImageUrlResolver;
 import umc.cockple.demo.domain.member.domain.Member;
 import umc.cockple.demo.domain.member.domain.ProfileImg;
-import umc.cockple.demo.domain.member.repository.MemberPartyRepository;
-import umc.cockple.demo.domain.party.domain.Party;
 import umc.cockple.demo.domain.party.domain.PartyImg;
-import umc.cockple.demo.domain.party.repository.PartyRepository;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -39,8 +36,6 @@ public class ChatQueryServiceImpl implements ChatQueryService {
     private final ChatRoomRepository chatRoomRepository;
     private final ChatRoomMemberRepository chatRoomMemberRepository;
     private final ChatMessageRepository chatMessageRepository;
-    private final PartyRepository partyRepository;
-    private final MemberPartyRepository memberPartyRepository;
 
     private final ChatUnreadQueryService chatUnreadQueryService;
     private final ChatConverter chatConverter;
@@ -48,6 +43,7 @@ public class ChatQueryServiceImpl implements ChatQueryService {
     private final ChatProcessor chatProcessor;
     private final PartyChatRoomQueryService partyChatRoomQueryService;
     private final DirectChatRoomQueryService directChatRoomQueryService;
+    private final PartyChatRoomIdQueryService partyChatRoomIdQueryService;
 
     @Override
     public PartyChatRoomDTO.Response getPartyChatRooms(Long memberId, int page, int size) {
@@ -128,22 +124,7 @@ public class ChatQueryServiceImpl implements ChatQueryService {
 
     @Override
     public PartyChatRoomIdDTO getChatRoomId(Long partyId, Long memberId) {
-        log.info("채팅방 ID 조회 시작 - partyId: {}, memberId: {}", partyId, memberId);
-
-        //모임 조회
-        Party party = findPartyOrThrow(partyId);
-
-        // 해당 모임의 멤버가 맞는지 검증
-        validateIsMember(partyId, memberId);
-
-        ChatRoom chatRoom = party.getChatRoom();
-        if (chatRoom == null) {
-            throw new ChatException(ChatErrorCode.CHAT_ROOM_NOT_FOUND);
-        }
-
-        log.info("채팅방 ID 조회 완료 - roomId: {}", chatRoom.getId());
-
-        return chatConverter.toChatRoomIdDTO(chatRoom);
+        return partyChatRoomIdQueryService.getChatRoomId(partyId, memberId);
     }
 
     // ========== 검증 로직 ==========
@@ -151,12 +132,6 @@ public class ChatQueryServiceImpl implements ChatQueryService {
     private void validateChatRoomAccess(Long roomId, Long memberId) {
         if (!chatRoomMemberRepository.existsByChatRoomIdAndMemberId(roomId, memberId))
             throw new ChatException(ChatErrorCode.CHAT_ROOM_ACCESS_DENIED);
-    }
-
-    private void validateIsMember(Long partyId, Long memberId) {
-        if (!memberPartyRepository.existsByPartyIdAndMemberId(partyId, memberId)) {
-            throw new ChatException(ChatErrorCode.NOT_PARTY_MEMBER);
-        }
     }
 
     // ========== 비즈니스 로직 ==========
@@ -242,8 +217,4 @@ public class ChatQueryServiceImpl implements ChatQueryService {
         return chatMessageRepository.findByRoomIdAndIdLessThanOrderByCreatedAtDesc(roomId, cursor, pageable);
     }
 
-    private Party findPartyOrThrow(Long partyId) {
-        return partyRepository.findById(partyId)
-                .orElseThrow(() -> new ChatException(ChatErrorCode.PARTY_NOT_FOUND));
-    }
 }

--- a/src/main/java/umc/cockple/demo/domain/chat/service/query/ChatQueryServiceImpl.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/query/ChatQueryServiceImpl.java
@@ -71,13 +71,7 @@ public class ChatQueryServiceImpl implements ChatQueryService {
 
     @Override
     public ChatUnreadStatusDTO.Response getUnreadStatus(Long memberId) {
-        log.info("[채팅 안읽음 여부 조회 시작]- 요청자: {}", memberId);
-        boolean hasPartyUnread = chatUnreadQueryService.hasPartyUnreadMessages(memberId);
-        boolean hasDirectUnread = chatUnreadQueryService.hasDirectUnreadMessages(memberId);
-        boolean hasUnread = hasPartyUnread || hasDirectUnread;
-        log.info("[채팅 안읽음 여부 조회 완료]- hasUnread: {}", hasUnread);
-
-        return chatConverter.toUnreadStatusResponse(hasPartyUnread, hasDirectUnread);
+        return chatUnreadQueryService.getUnreadStatus(memberId);
     }
 
     @Override

--- a/src/main/java/umc/cockple/demo/domain/chat/service/query/ChatRoomDetailQueryService.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/query/ChatRoomDetailQueryService.java
@@ -1,0 +1,142 @@
+package umc.cockple.demo.domain.chat.service.query;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import umc.cockple.demo.domain.chat.converter.ChatConverter;
+import umc.cockple.demo.domain.chat.domain.ChatMessage;
+import umc.cockple.demo.domain.chat.domain.ChatRoom;
+import umc.cockple.demo.domain.chat.domain.ChatRoomMember;
+import umc.cockple.demo.domain.chat.dto.ChatCommonDTO;
+import umc.cockple.demo.domain.chat.dto.ChatRoomDetailDTO;
+import umc.cockple.demo.domain.chat.enums.ChatRoomType;
+import umc.cockple.demo.domain.chat.exception.ChatErrorCode;
+import umc.cockple.demo.domain.chat.exception.ChatException;
+import umc.cockple.demo.domain.chat.repository.ChatMessageRepository;
+import umc.cockple.demo.domain.chat.repository.ChatRoomMemberRepository;
+import umc.cockple.demo.domain.chat.repository.ChatRoomRepository;
+import umc.cockple.demo.domain.chat.service.ChatProcessor;
+import umc.cockple.demo.domain.file.service.ImageUrlResolver;
+import umc.cockple.demo.domain.member.domain.Member;
+import umc.cockple.demo.domain.member.domain.ProfileImg;
+import umc.cockple.demo.domain.party.domain.PartyImg;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ChatRoomDetailQueryService {
+
+    private final ChatRoomRepository chatRoomRepository;
+    private final ChatRoomMemberRepository chatRoomMemberRepository;
+    private final ChatMessageRepository chatMessageRepository;
+    private final ChatConverter chatConverter;
+    private final ImageUrlResolver imageUrlResolver;
+    private final ChatProcessor chatProcessor;
+
+    public ChatRoomDetailDTO.Response getChatRoomDetail(Long roomId, Long memberId) {
+        log.info("[초기 채팅방 조회 시작] - roomId: {}, memberId: {}", roomId, memberId);
+
+        ChatRoom chatRoom = findChatRoomWithPartyOrThrow(roomId);
+        ChatRoomMember myMembership = findChatRoomMembershipOrThrow(roomId, memberId);
+
+        ChatRoomDetailDTO.ChatRoomInfo roomInfo = buildChatRoomInfo(chatRoom, myMembership);
+
+        Pageable pageable = PageRequest.of(0, 50);
+        List<ChatMessage> recentMessages = findRecentMessagesWithImages(roomId, pageable);
+        List<ChatMessage> resultMessages = new ArrayList<>(recentMessages);
+        Collections.reverse(resultMessages);
+        List<ChatCommonDTO.MessageInfo> commonMessages = chatProcessor.processMessages(memberId, resultMessages);
+        List<ChatRoomDetailDTO.MessageInfo> messageInfos = chatConverter.toChatRoomDetailMessageInfos(commonMessages);
+
+        List<ChatRoomMember> participants = findChatRoomMembersWithMemberOrThrow(roomId);
+        List<ChatRoomDetailDTO.MemberInfo> memberInfos = buildMemberInfos(participants);
+
+        log.info("[초기 채팅방 조회 완료] - 메시지 수: {}, 참여자 수: {}",
+                messageInfos.size(), memberInfos.size());
+
+        return chatConverter.toChatRoomDetailResponse(roomInfo, messageInfos, memberInfos);
+    }
+
+    private ChatRoomDetailDTO.ChatRoomInfo buildChatRoomInfo(ChatRoom chatRoom, ChatRoomMember myMembership) {
+        String displayName;
+        String profileImageUrl = null;
+        boolean isCounterPartWithdrawn = false;
+
+        if (chatRoom.getType() == ChatRoomType.DIRECT) {
+            ChatRoomMember counterPart = findCounterPartWithMemberOrThrow(chatRoom, myMembership);
+            Member member = counterPart.getMember();
+            isCounterPartWithdrawn = isUnavailableMember(member);
+
+            displayName = isCounterPartWithdrawn ? ChatConverter.UNKNOWN_USER_NAME : member.getMemberName();
+            profileImageUrl = isCounterPartWithdrawn
+                    ? null
+                    : imageUrlResolver.resolve(member.getProfileImg(), ProfileImg::getImgKey);
+        } else {
+            displayName = chatRoom.getParty().getPartyName();
+            profileImageUrl = imageUrlResolver.resolve(chatRoom.getParty().getPartyImg(), PartyImg::getImgKey);
+        }
+
+        int memberCount = chatRoomMemberRepository.countByChatRoomId(chatRoom.getId());
+        Long lastReadMessageId = myMembership.getLastReadMessageId();
+
+        return chatConverter.toChatRoomDetailChatRoomInfo(
+                chatRoom,
+                displayName,
+                profileImageUrl,
+                isCounterPartWithdrawn,
+                memberCount,
+                lastReadMessageId);
+    }
+
+    private List<ChatRoomDetailDTO.MemberInfo> buildMemberInfos(List<ChatRoomMember> participants) {
+        return participants.stream()
+                .map(this::buildMemberInfo)
+                .toList();
+    }
+
+    private ChatRoomDetailDTO.MemberInfo buildMemberInfo(ChatRoomMember chatRoomMember) {
+        Member member = chatRoomMember.getMember();
+        String memberProfileImgUrl = isUnavailableMember(member)
+                ? null
+                : imageUrlResolver.resolve(member.getProfileImg(), ProfileImg::getImgKey);
+
+        return chatConverter.toChatRoomDetailMemberInfo(member, memberProfileImgUrl);
+    }
+
+    private boolean isUnavailableMember(Member member) {
+        return member == null || member.isWithdrawn();
+    }
+
+    private ChatRoom findChatRoomWithPartyOrThrow(Long roomId) {
+        return chatRoomRepository.findChatRoomWithPartyById(roomId)
+                .orElseThrow(() -> new ChatException(ChatErrorCode.CHAT_ROOM_NOT_FOUND));
+    }
+
+    private ChatRoomMember findChatRoomMembershipOrThrow(Long roomId, Long memberId) {
+        return chatRoomMemberRepository
+                .findByChatRoomIdAndMemberId(roomId, memberId)
+                .orElseThrow(() -> new ChatException(ChatErrorCode.CHAT_ROOM_ACCESS_DENIED));
+    }
+
+    private ChatRoomMember findCounterPartWithMemberOrThrow(ChatRoom chatRoom, ChatRoomMember myMembership) {
+        return chatRoomMemberRepository
+                .findCounterPartWithMember(chatRoom.getId(), myMembership.getMember().getId())
+                .orElseThrow(() -> new ChatException(ChatErrorCode.CHAT_ROOM_ACCESS_DENIED));
+    }
+
+    private List<ChatRoomMember> findChatRoomMembersWithMemberOrThrow(Long roomId) {
+        return chatRoomMemberRepository.findChatRoomMembersWithMemberById(roomId);
+    }
+
+    private List<ChatMessage> findRecentMessagesWithImages(Long roomId, Pageable pageable) {
+        return chatMessageRepository.findRecentMessagesWithFiles(roomId, pageable);
+    }
+}

--- a/src/main/java/umc/cockple/demo/domain/chat/service/query/ChatUnreadQueryService.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/query/ChatUnreadQueryService.java
@@ -1,8 +1,11 @@
 package umc.cockple.demo.domain.chat.service.query;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import umc.cockple.demo.domain.chat.converter.ChatConverter;
+import umc.cockple.demo.domain.chat.dto.ChatUnreadStatusDTO;
 import umc.cockple.demo.domain.chat.repository.MessageReadStatusRepository;
 
 import java.util.HashSet;
@@ -13,10 +16,21 @@ import java.util.Set;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 @Transactional(readOnly = true)
 public class ChatUnreadQueryService {
 
     private final MessageReadStatusRepository messageReadStatusRepository;
+    private final ChatConverter chatConverter;
+
+    public ChatUnreadStatusDTO.Response getUnreadStatus(Long memberId) {
+        log.info("[채팅 안읽음 여부 조회 시작]- 요청자: {}", memberId);
+        boolean hasPartyUnread = hasPartyUnreadMessages(memberId);
+        boolean hasDirectUnread = hasDirectUnreadMessages(memberId);
+        log.info("[채팅 안읽음 여부 조회 완료]- hasUnread: {}", hasPartyUnread || hasDirectUnread);
+
+        return chatConverter.toUnreadStatusResponse(hasPartyUnread, hasDirectUnread);
+    }
 
     public Map<Long, Integer> countUnreadMessagesByChatRooms(Long memberId, List<Long> chatRoomIds) {
         Map<Long, Integer> unreadCounts = initializeZeroCountMap(chatRoomIds);

--- a/src/main/java/umc/cockple/demo/domain/chat/service/query/PartyChatRoomIdQueryService.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/query/PartyChatRoomIdQueryService.java
@@ -1,0 +1,51 @@
+package umc.cockple.demo.domain.chat.service.query;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import umc.cockple.demo.domain.chat.converter.ChatConverter;
+import umc.cockple.demo.domain.chat.domain.ChatRoom;
+import umc.cockple.demo.domain.chat.dto.PartyChatRoomIdDTO;
+import umc.cockple.demo.domain.chat.exception.ChatErrorCode;
+import umc.cockple.demo.domain.chat.exception.ChatException;
+import umc.cockple.demo.domain.member.repository.MemberPartyRepository;
+import umc.cockple.demo.domain.party.domain.Party;
+import umc.cockple.demo.domain.party.repository.PartyRepository;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PartyChatRoomIdQueryService {
+
+    private final PartyRepository partyRepository;
+    private final MemberPartyRepository memberPartyRepository;
+    private final ChatConverter chatConverter;
+
+    public PartyChatRoomIdDTO getChatRoomId(Long partyId, Long memberId) {
+        log.info("채팅방 ID 조회 시작 - partyId: {}, memberId: {}", partyId, memberId);
+
+        Party party = findPartyOrThrow(partyId);
+        validateIsMember(partyId, memberId);
+
+        ChatRoom chatRoom = party.getChatRoom();
+        if (chatRoom == null) {
+            throw new ChatException(ChatErrorCode.CHAT_ROOM_NOT_FOUND);
+        }
+
+        log.info("채팅방 ID 조회 완료 - roomId: {}", chatRoom.getId());
+        return chatConverter.toChatRoomIdDTO(chatRoom);
+    }
+
+    private Party findPartyOrThrow(Long partyId) {
+        return partyRepository.findById(partyId)
+                .orElseThrow(() -> new ChatException(ChatErrorCode.PARTY_NOT_FOUND));
+    }
+
+    private void validateIsMember(Long partyId, Long memberId) {
+        if (!memberPartyRepository.existsByPartyIdAndMemberId(partyId, memberId)) {
+            throw new ChatException(ChatErrorCode.NOT_PARTY_MEMBER);
+        }
+    }
+}

--- a/src/test/java/umc/cockple/demo/domain/chat/service/query/ChatMessageHistoryQueryServiceTest.java
+++ b/src/test/java/umc/cockple/demo/domain/chat/service/query/ChatMessageHistoryQueryServiceTest.java
@@ -1,0 +1,432 @@
+package umc.cockple.demo.domain.chat.service.query;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import umc.cockple.demo.domain.chat.converter.ChatConverter;
+import umc.cockple.demo.domain.chat.domain.ChatMessage;
+import umc.cockple.demo.domain.chat.domain.ChatMessageFile;
+import umc.cockple.demo.domain.chat.domain.ChatRoom;
+import umc.cockple.demo.domain.chat.dto.ChatMessageDTO;
+import umc.cockple.demo.domain.chat.enums.MessageType;
+import umc.cockple.demo.domain.chat.exception.ChatErrorCode;
+import umc.cockple.demo.domain.chat.exception.ChatException;
+import umc.cockple.demo.domain.chat.repository.ChatMessageRepository;
+import umc.cockple.demo.domain.chat.repository.ChatRoomMemberRepository;
+import umc.cockple.demo.domain.chat.service.ChatProcessor;
+import umc.cockple.demo.domain.file.service.FileService;
+import umc.cockple.demo.domain.member.domain.Member;
+import umc.cockple.demo.domain.member.domain.ProfileImg;
+import umc.cockple.demo.domain.party.domain.Party;
+import umc.cockple.demo.global.enums.Gender;
+import umc.cockple.demo.global.enums.Level;
+import umc.cockple.demo.support.fixture.ChatFixture;
+import umc.cockple.demo.support.fixture.MemberFixture;
+import umc.cockple.demo.support.fixture.PartyFixture;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class ChatMessageHistoryQueryServiceTest {
+
+    @Mock private ChatRoomMemberRepository chatRoomMemberRepository;
+    @Mock private ChatMessageRepository chatMessageRepository;
+    @Mock private FileService fileService;
+
+    private ChatMessageHistoryQueryService chatMessageHistoryQueryService;
+
+    @BeforeEach
+    void setUp() {
+        ChatConverter chatConverter = new ChatConverter();
+        ChatProcessor chatProcessor = new ChatProcessor(fileService, chatConverter);
+        chatMessageHistoryQueryService = new ChatMessageHistoryQueryService(
+                chatRoomMemberRepository,
+                chatMessageRepository,
+                chatProcessor,
+                chatConverter
+        );
+    }
+
+    @Nested
+    @DisplayName("getChatMessages - 과거 메시지 조회")
+    class GetChatMessages {
+
+        @Test
+        @DisplayName("cursor 이전 메시지가 size 이하이면 hasNext가 false이고 nextCursor가 null이다")
+        void noMoreMessages_hasNextFalse() {
+            // given
+            Long roomId = 1L;
+            Long memberId = 10L;
+            Long cursor = 100L;
+            int size = 3;
+
+            Member me = MemberFixture.createMemberWithName("홍길동", "길동", Gender.MALE, Level.A, 1001L);
+            ReflectionTestUtils.setField(me, "id", memberId);
+
+            Party party = PartyFixture.createParty("모임", memberId, PartyFixture.createPartyAddr("서울", "강남구"));
+            ReflectionTestUtils.setField(party, "id", 100L);
+
+            ChatRoom chatRoom = ChatFixture.createPartyChatRoom(party);
+            ReflectionTestUtils.setField(chatRoom, "id", roomId);
+
+            // DB는 최신순(id: 3→2→1)으로 반환, size+1=4개 요청했지만 3개만 존재
+            ChatMessage msg1 = ChatFixture.createTextMessage(chatRoom, me, "첫 번째 메시지");
+            ReflectionTestUtils.setField(msg1, "id", 1L);
+            ChatMessage msg2 = ChatFixture.createTextMessage(chatRoom, me, "두 번째 메시지");
+            ReflectionTestUtils.setField(msg2, "id", 2L);
+            ChatMessage msg3 = ChatFixture.createTextMessage(chatRoom, me, "세 번째 메시지");
+            ReflectionTestUtils.setField(msg3, "id", 3L);
+
+            given(chatRoomMemberRepository.existsByChatRoomIdAndMemberId(roomId, memberId)).willReturn(true);
+            given(chatMessageRepository.findByRoomIdAndIdLessThanOrderByCreatedAtDesc(eq(roomId), eq(cursor), any()))
+                    .willReturn(List.of(msg3, msg2, msg1));
+
+            // when
+            ChatMessageDTO.Response result = chatMessageHistoryQueryService.getChatMessages(roomId, memberId, cursor, size);
+
+            // then
+            assertThat(result.hasNext()).isFalse();
+            assertThat(result.nextCursor()).isNull();
+            assertThat(result.messages()).hasSize(3);
+        }
+
+        @Test
+        @DisplayName("cursor 이전 메시지가 size보다 많으면 hasNext가 true이고 nextCursor가 설정된다")
+        void moreMessagesExist_hasNextTrue() {
+            // given
+            Long roomId = 1L;
+            Long memberId = 10L;
+            Long cursor = 100L;
+            int size = 2;
+
+            Member me = MemberFixture.createMemberWithName("홍길동", "길동", Gender.MALE, Level.A, 1001L);
+            ReflectionTestUtils.setField(me, "id", memberId);
+
+            Party party = PartyFixture.createParty("모임", memberId, PartyFixture.createPartyAddr("서울", "강남구"));
+            ReflectionTestUtils.setField(party, "id", 100L);
+
+            ChatRoom chatRoom = ChatFixture.createPartyChatRoom(party);
+            ReflectionTestUtils.setField(chatRoom, "id", roomId);
+
+            // DB는 최신순(3→2→1)으로 size+1=3개 반환 → hasNext=true
+            ChatMessage msg1 = ChatFixture.createTextMessage(chatRoom, me, "첫 번째 메시지");
+            ReflectionTestUtils.setField(msg1, "id", 1L);
+            ChatMessage msg2 = ChatFixture.createTextMessage(chatRoom, me, "두 번째 메시지");
+            ReflectionTestUtils.setField(msg2, "id", 2L);
+            ChatMessage msg3 = ChatFixture.createTextMessage(chatRoom, me, "세 번째 메시지");
+            ReflectionTestUtils.setField(msg3, "id", 3L);
+
+            given(chatRoomMemberRepository.existsByChatRoomIdAndMemberId(roomId, memberId)).willReturn(true);
+            given(chatMessageRepository.findByRoomIdAndIdLessThanOrderByCreatedAtDesc(eq(roomId), eq(cursor), any()))
+                    .willReturn(List.of(msg3, msg2, msg1));
+
+            // when
+            ChatMessageDTO.Response result = chatMessageHistoryQueryService.getChatMessages(roomId, memberId, cursor, size);
+
+            // then
+            assertThat(result.hasNext()).isTrue();
+            // size개 자른 후 가장 오래된 메시지(subList[0])의 id
+            assertThat(result.nextCursor()).isEqualTo(2L);
+            assertThat(result.messages()).hasSize(2);
+        }
+
+        @Test
+        @DisplayName("반환된 메시지는 오래된 순(오름차순)으로 정렬된다")
+        void messages_areInChronologicalOrder() {
+            // given
+            Long roomId = 1L;
+            Long memberId = 10L;
+            Long cursor = 100L;
+            int size = 3;
+
+            Member me = MemberFixture.createMemberWithName("홍길동", "길동", Gender.MALE, Level.A, 1001L);
+            ReflectionTestUtils.setField(me, "id", memberId);
+
+            Party party = PartyFixture.createParty("모임", memberId, PartyFixture.createPartyAddr("서울", "강남구"));
+            ReflectionTestUtils.setField(party, "id", 100L);
+
+            ChatRoom chatRoom = ChatFixture.createPartyChatRoom(party);
+            ReflectionTestUtils.setField(chatRoom, "id", roomId);
+
+            // DB에서 최신순(3→2→1) 반환
+            ChatMessage msg1 = ChatFixture.createTextMessage(chatRoom, me, "첫 번째");
+            ReflectionTestUtils.setField(msg1, "id", 1L);
+            ChatMessage msg2 = ChatFixture.createTextMessage(chatRoom, me, "두 번째");
+            ReflectionTestUtils.setField(msg2, "id", 2L);
+            ChatMessage msg3 = ChatFixture.createTextMessage(chatRoom, me, "세 번째");
+            ReflectionTestUtils.setField(msg3, "id", 3L);
+
+            given(chatRoomMemberRepository.existsByChatRoomIdAndMemberId(roomId, memberId)).willReturn(true);
+            given(chatMessageRepository.findByRoomIdAndIdLessThanOrderByCreatedAtDesc(eq(roomId), eq(cursor), any()))
+                    .willReturn(List.of(msg3, msg2, msg1));
+
+            // when
+            ChatMessageDTO.Response result = chatMessageHistoryQueryService.getChatMessages(roomId, memberId, cursor, size);
+
+            // then: 응답은 오래된 순(1→2→3)
+            List<ChatMessageDTO.MessageInfo> messages = result.messages();
+            assertThat(messages).hasSize(3);
+            assertThat(messages.get(0).messageId()).isEqualTo(1L);
+            assertThat(messages.get(1).messageId()).isEqualTo(2L);
+            assertThat(messages.get(2).messageId()).isEqualTo(3L);
+        }
+
+        @Test
+        @DisplayName("내가 보낸 메시지는 isMyMessage가 true이다")
+        void myMessage_isMyMessageTrue() {
+            // given
+            Long roomId = 1L;
+            Long memberId = 10L;
+            Long cursor = 100L;
+
+            Member me = MemberFixture.createMemberWithName("홍길동", "길동", Gender.MALE, Level.A, 1001L);
+            ReflectionTestUtils.setField(me, "id", memberId);
+
+            Party party = PartyFixture.createParty("모임", memberId, PartyFixture.createPartyAddr("서울", "강남구"));
+            ReflectionTestUtils.setField(party, "id", 100L);
+
+            ChatRoom chatRoom = ChatFixture.createPartyChatRoom(party);
+            ReflectionTestUtils.setField(chatRoom, "id", roomId);
+
+            ChatMessage myMessage = ChatFixture.createTextMessage(chatRoom, me, "내 메시지");
+            ReflectionTestUtils.setField(myMessage, "id", 1L);
+
+            given(chatRoomMemberRepository.existsByChatRoomIdAndMemberId(roomId, memberId)).willReturn(true);
+            given(chatMessageRepository.findByRoomIdAndIdLessThanOrderByCreatedAtDesc(eq(roomId), eq(cursor), any()))
+                    .willReturn(List.of(myMessage));
+
+            // when
+            ChatMessageDTO.Response result = chatMessageHistoryQueryService.getChatMessages(roomId, memberId, cursor, 10);
+
+            // then
+            assertThat(result.messages().get(0).isMyMessage()).isTrue();
+            assertThat(result.messages().get(0).images()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("상대방이 보낸 메시지는 isMyMessage가 false이다")
+        void otherMessage_isMyMessageFalse() {
+            // given
+            Long roomId = 1L;
+            Long memberId = 10L;
+            Long otherId = 20L;
+            Long cursor = 100L;
+
+            Member me = MemberFixture.createMemberWithName("홍길동", "길동", Gender.MALE, Level.A, 1001L);
+            ReflectionTestUtils.setField(me, "id", memberId);
+
+            Member other = MemberFixture.createMemberWithName("김철수", "철수", Gender.MALE, Level.B, 2002L);
+            ReflectionTestUtils.setField(other, "id", otherId);
+
+            Party party = PartyFixture.createParty("모임", memberId, PartyFixture.createPartyAddr("서울", "강남구"));
+            ReflectionTestUtils.setField(party, "id", 100L);
+
+            ChatRoom chatRoom = ChatFixture.createPartyChatRoom(party);
+            ReflectionTestUtils.setField(chatRoom, "id", roomId);
+
+            ChatMessage otherMessage = ChatFixture.createTextMessage(chatRoom, other, "상대방 메시지");
+            ReflectionTestUtils.setField(otherMessage, "id", 1L);
+
+            given(chatRoomMemberRepository.existsByChatRoomIdAndMemberId(roomId, memberId)).willReturn(true);
+            given(chatMessageRepository.findByRoomIdAndIdLessThanOrderByCreatedAtDesc(eq(roomId), eq(cursor), any()))
+                    .willReturn(List.of(otherMessage));
+
+            // when
+            ChatMessageDTO.Response result = chatMessageHistoryQueryService.getChatMessages(roomId, memberId, cursor, 10);
+
+            // then
+            assertThat(result.messages().get(0).isMyMessage()).isFalse();
+            assertThat(result.messages().get(0).senderName()).isEqualTo("김철수");
+        }
+
+        @Test
+        @DisplayName("탈퇴한 사용자가 보낸 메시지는 isSenderWithdrawn이 true이다")
+        void withdrawnSenderMessage_isSenderWithdrawnTrue() {
+            // given
+            Long roomId = 1L;
+            Long memberId = 10L;
+            Long withdrawnId = 30L;
+            Long cursor = 100L;
+
+            Member me = MemberFixture.createMemberWithName("홍길동", "길동", Gender.MALE, Level.A, 1001L);
+            ReflectionTestUtils.setField(me, "id", memberId);
+
+            Member withdrawn = MemberFixture.createWithdrawnMember("탈퇴한사용자", "탈퇴", 3003L);
+            ReflectionTestUtils.setField(withdrawn, "id", withdrawnId);
+            withdrawn.updateProfileImg(ProfileImg.builder()
+                    .imgKey("member/withdrawn-previous.png")
+                    .build());
+
+            Party party = PartyFixture.createParty("모임", memberId, PartyFixture.createPartyAddr("서울", "강남구"));
+            ReflectionTestUtils.setField(party, "id", 100L);
+
+            ChatRoom chatRoom = ChatFixture.createPartyChatRoom(party);
+            ReflectionTestUtils.setField(chatRoom, "id", roomId);
+
+            ChatMessage withdrawnMessage = ChatFixture.createTextMessage(chatRoom, withdrawn, "탈퇴자 메시지");
+            ReflectionTestUtils.setField(withdrawnMessage, "id", 1L);
+
+            given(chatRoomMemberRepository.existsByChatRoomIdAndMemberId(roomId, memberId)).willReturn(true);
+            given(chatMessageRepository.findByRoomIdAndIdLessThanOrderByCreatedAtDesc(eq(roomId), eq(cursor), any()))
+                    .willReturn(List.of(withdrawnMessage));
+
+            // when
+            ChatMessageDTO.Response result = chatMessageHistoryQueryService.getChatMessages(roomId, memberId, cursor, 10);
+
+            // then
+            ChatMessageDTO.MessageInfo messageInfo = result.messages().get(0);
+            assertThat(messageInfo.isSenderWithdrawn()).isTrue();
+            assertThat(messageInfo.senderName()).isEqualTo(ChatConverter.UNKNOWN_USER_NAME);
+            assertThat(messageInfo.senderProfileImageUrl()).isNull();
+            verify(fileService, never()).getUrlFromKey("member/withdrawn-previous.png");
+        }
+
+        @Test
+        @DisplayName("sender가 null인 일반 과거 메시지는 알 수 없는 사용자로 조회된다")
+        void nullSenderPreviousMessage_isMappedToUnknownUser() {
+            // given
+            Long roomId = 1L;
+            Long memberId = 10L;
+            Long cursor = 100L;
+
+            Party party = PartyFixture.createParty("모임", memberId, PartyFixture.createPartyAddr("서울", "강남구"));
+            ReflectionTestUtils.setField(party, "id", 100L);
+
+            ChatRoom chatRoom = ChatFixture.createPartyChatRoom(party);
+            ReflectionTestUtils.setField(chatRoom, "id", roomId);
+
+            ChatMessage deletedSenderMessage = ChatMessage.create(chatRoom, null, "삭제된 사용자 메시지", MessageType.TEXT);
+            ReflectionTestUtils.setField(deletedSenderMessage, "id", 1L);
+
+            given(chatRoomMemberRepository.existsByChatRoomIdAndMemberId(roomId, memberId)).willReturn(true);
+            given(chatMessageRepository.findByRoomIdAndIdLessThanOrderByCreatedAtDesc(eq(roomId), eq(cursor), any()))
+                    .willReturn(List.of(deletedSenderMessage));
+
+            // when
+            ChatMessageDTO.Response result = chatMessageHistoryQueryService.getChatMessages(roomId, memberId, cursor, 10);
+
+            // then
+            ChatMessageDTO.MessageInfo messageInfo = result.messages().get(0);
+            assertThat(messageInfo.senderId()).isNull();
+            assertThat(messageInfo.senderName()).isEqualTo(ChatConverter.UNKNOWN_USER_NAME);
+            assertThat(messageInfo.senderProfileImageUrl()).isNull();
+            assertThat(messageInfo.isSenderWithdrawn()).isTrue();
+            assertThat(messageInfo.isMyMessage()).isFalse();
+        }
+
+        @Test
+        @DisplayName("시스템 메시지는 sender 없이도 과거 메시지 응답에 포함된다")
+        void systemMessage_includedInPreviousMessages() {
+            // given
+            Long roomId = 1L;
+            Long memberId = 10L;
+            Long cursor = 100L;
+
+            Member me = MemberFixture.createMemberWithName("홍길동", "길동", Gender.MALE, Level.A, 1001L);
+            ReflectionTestUtils.setField(me, "id", memberId);
+
+            Party party = PartyFixture.createParty("모임", memberId, PartyFixture.createPartyAddr("서울", "강남구"));
+            ReflectionTestUtils.setField(party, "id", 100L);
+
+            ChatRoom chatRoom = ChatFixture.createPartyChatRoom(party);
+            ReflectionTestUtils.setField(chatRoom, "id", roomId);
+
+            ChatMessage systemMessage = ChatFixture.createSystemMessage(chatRoom, "홍길동님이 모임에 참여하셨습니다.");
+            ReflectionTestUtils.setField(systemMessage, "id", 1L);
+
+            given(chatRoomMemberRepository.existsByChatRoomIdAndMemberId(roomId, memberId)).willReturn(true);
+            given(chatMessageRepository.findByRoomIdAndIdLessThanOrderByCreatedAtDesc(eq(roomId), eq(cursor), any()))
+                    .willReturn(List.of(systemMessage));
+
+            // when
+            ChatMessageDTO.Response result = chatMessageHistoryQueryService.getChatMessages(roomId, memberId, cursor, 10);
+
+            // then
+            assertThat(result.messages()).hasSize(1);
+            ChatMessageDTO.MessageInfo message = result.messages().get(0);
+            assertThat(message.messageType()).isEqualTo(MessageType.SYSTEM);
+            assertThat(message.senderId()).isNull();
+            assertThat(message.senderName()).isEqualTo("시스템");
+            assertThat(message.senderProfileImageUrl()).isNull();
+            assertThat(message.isMyMessage()).isFalse();
+            assertThat(message.isSenderWithdrawn()).isFalse();
+            assertThat(message.content()).isEqualTo("홍길동님이 모임에 참여하셨습니다.");
+        }
+
+        @Test
+        @DisplayName("이미지 메시지 조회 시 images 필드에 파일 정보가 포함된다")
+        void imageMessage_containsFileInfo() {
+            // given
+            Long roomId = 1L;
+            Long memberId = 10L;
+            Long cursor = 100L;
+
+            Member me = MemberFixture.createMemberWithName("홍길동", "길동", Gender.MALE, Level.A, 1001L);
+            ReflectionTestUtils.setField(me, "id", memberId);
+
+            Party party = PartyFixture.createParty("모임", memberId, PartyFixture.createPartyAddr("서울", "강남구"));
+            ReflectionTestUtils.setField(party, "id", 100L);
+
+            ChatRoom chatRoom = ChatFixture.createPartyChatRoom(party);
+            ReflectionTestUtils.setField(chatRoom, "id", roomId);
+
+            ChatMessage imageMessage = ChatFixture.createImageMessage(chatRoom, me, List.of());
+            ReflectionTestUtils.setField(imageMessage, "id", 1L);
+
+            ChatMessageFile file1 = ChatFixture.createChatMessageFile(imageMessage, "chat/img1.png", 1, "photo1.png");
+            ReflectionTestUtils.setField(file1, "id", 100L);
+            ChatMessageFile file2 = ChatFixture.createChatMessageFile(imageMessage, "chat/img2.png", 2, "photo2.png");
+            ReflectionTestUtils.setField(file2, "id", 101L);
+            imageMessage.getChatMessageFiles().addAll(List.of(file1, file2));
+
+            given(chatRoomMemberRepository.existsByChatRoomIdAndMemberId(roomId, memberId)).willReturn(true);
+            given(chatMessageRepository.findByRoomIdAndIdLessThanOrderByCreatedAtDesc(eq(roomId), eq(cursor), any()))
+                    .willReturn(List.of(imageMessage));
+            given(fileService.getUrlFromKey("chat/img1.png")).willReturn("https://storage.example.com/chat/img1.png");
+            given(fileService.getUrlFromKey("chat/img2.png")).willReturn("https://storage.example.com/chat/img2.png");
+
+            // when
+            ChatMessageDTO.Response result = chatMessageHistoryQueryService.getChatMessages(roomId, memberId, cursor, 10);
+
+            // then
+            ChatMessageDTO.MessageInfo message = result.messages().get(0);
+            assertThat(message.messageType()).isEqualTo(MessageType.TEXT);
+            assertThat(message.images()).hasSize(2);
+            assertThat(message.images().get(0).imageUrl()).isEqualTo("https://storage.example.com/chat/img1.png");
+            assertThat(message.images().get(0).imgOrder()).isEqualTo(1);
+            assertThat(message.images().get(0).originalFileName()).isEqualTo("photo1.png");
+            assertThat(message.images().get(0).isEmoji()).isFalse();
+            assertThat(message.images().get(1).imageUrl()).isEqualTo("https://storage.example.com/chat/img2.png");
+            assertThat(message.images().get(1).imgOrder()).isEqualTo(2);
+        }
+
+        @Test
+        @DisplayName("채팅방 멤버가 아닌 사용자가 메시지를 조회하면 ChatException(CHAT_ROOM_ACCESS_DENIED)을 던진다")
+        void fail_notChatRoomMember() {
+            // given
+            Long roomId = 1L;
+            Long outsiderId = 99L;
+            Long cursor = 100L;
+
+            given(chatRoomMemberRepository.existsByChatRoomIdAndMemberId(roomId, outsiderId)).willReturn(false);
+
+            // when & then
+            assertThatThrownBy(() -> chatMessageHistoryQueryService.getChatMessages(roomId, outsiderId, cursor, 10))
+                    .isInstanceOf(ChatException.class)
+                    .satisfies(e -> assertThat(((ChatException) e).getCode()).isEqualTo(ChatErrorCode.CHAT_ROOM_ACCESS_DENIED));
+        }
+    }
+}

--- a/src/test/java/umc/cockple/demo/domain/chat/service/query/ChatQueryServiceTest.java
+++ b/src/test/java/umc/cockple/demo/domain/chat/service/query/ChatQueryServiceTest.java
@@ -7,89 +7,40 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.SliceImpl;
-import org.springframework.test.util.ReflectionTestUtils;
-import umc.cockple.demo.domain.chat.converter.ChatConverter;
-import umc.cockple.demo.domain.chat.domain.ChatMessage;
-import umc.cockple.demo.domain.chat.domain.ChatMessageFile;
-import umc.cockple.demo.domain.chat.domain.ChatRoom;
-import umc.cockple.demo.domain.chat.domain.ChatRoomMember;
-import umc.cockple.demo.domain.chat.dto.DirectChatRoomDTO;
 import umc.cockple.demo.domain.chat.dto.ChatMessageDTO;
 import umc.cockple.demo.domain.chat.dto.ChatRoomDetailDTO;
 import umc.cockple.demo.domain.chat.dto.ChatUnreadStatusDTO;
-import umc.cockple.demo.domain.chat.dto.PartyChatRoomIdDTO;
+import umc.cockple.demo.domain.chat.dto.DirectChatRoomDTO;
 import umc.cockple.demo.domain.chat.dto.PartyChatRoomDTO;
-import umc.cockple.demo.domain.chat.enums.ChatRoomType;
-import umc.cockple.demo.domain.chat.enums.MessageType;
-import umc.cockple.demo.domain.chat.exception.ChatErrorCode;
-import umc.cockple.demo.domain.chat.exception.ChatException;
-import umc.cockple.demo.domain.chat.repository.ChatMessageRepository;
-import umc.cockple.demo.domain.chat.repository.ChatRoomMemberRepository;
-import umc.cockple.demo.domain.chat.repository.ChatRoomRepository;
-import umc.cockple.demo.domain.chat.service.ChatProcessor;
-import umc.cockple.demo.domain.file.service.FileService;
-import umc.cockple.demo.domain.file.service.ImageUrlResolver;
-import umc.cockple.demo.domain.member.domain.Member;
-import umc.cockple.demo.domain.member.domain.ProfileImg;
-import umc.cockple.demo.domain.party.domain.Party;
-import umc.cockple.demo.domain.party.domain.PartyImg;
-import umc.cockple.demo.global.enums.Gender;
-import umc.cockple.demo.global.enums.Level;
-import umc.cockple.demo.support.fixture.ChatFixture;
-import umc.cockple.demo.support.fixture.MemberFixture;
-import umc.cockple.demo.support.fixture.PartyFixture;
+import umc.cockple.demo.domain.chat.dto.PartyChatRoomIdDTO;
 
-import java.time.LocalDateTime;
 import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 class ChatQueryServiceTest {
 
-    // Mocks (외부 I/O)
-    @Mock private ChatRoomRepository chatRoomRepository;
-    @Mock private ChatRoomMemberRepository chatRoomMemberRepository;
-    @Mock private ChatMessageRepository chatMessageRepository;
-    @Mock private FileService fileService;
     @Mock private PartyChatRoomQueryService partyChatRoomQueryService;
     @Mock private DirectChatRoomQueryService directChatRoomQueryService;
     @Mock private ChatUnreadQueryService chatUnreadQueryService;
-    @Mock private PartyChatRoomIdQueryService partyChatRoomIdQueryService;
+    @Mock private ChatRoomDetailQueryService chatRoomDetailQueryService;
     @Mock private ChatMessageHistoryQueryService chatMessageHistoryQueryService;
+    @Mock private PartyChatRoomIdQueryService partyChatRoomIdQueryService;
 
-    private ChatConverter chatConverter;
-    private ChatProcessor chatProcessor;
-    private ImageUrlResolver imageUrlResolver;
     private ChatQueryServiceImpl chatQueryService;
 
     @BeforeEach
     void setUp() {
-        chatConverter = new ChatConverter();
-        chatProcessor = new ChatProcessor(fileService, chatConverter);
-        imageUrlResolver = new ImageUrlResolver(fileService);
         chatQueryService = new ChatQueryServiceImpl(
-                chatRoomRepository,
-                chatRoomMemberRepository,
-                chatMessageRepository,
-                chatUnreadQueryService,
-                chatConverter,
-                imageUrlResolver,
-                chatProcessor,
                 partyChatRoomQueryService,
                 directChatRoomQueryService,
-                partyChatRoomIdQueryService,
-                chatMessageHistoryQueryService
+                chatUnreadQueryService,
+                chatRoomDetailQueryService,
+                chatMessageHistoryQueryService,
+                partyChatRoomIdQueryService
         );
     }
 
@@ -258,524 +209,28 @@ class ChatQueryServiceTest {
     }
 
     @Nested
-    @DisplayName("getChatRoomDetail - 초기 채팅방 조회")
-    class GetChatRoomDetail {
+    @DisplayName("채팅방 상세 조회 위임")
+    class ChatRoomDetailDelegation {
 
         @Test
-        @DisplayName("모임(PARTY) 채팅방 조회 시 파티 이름이 displayName이 된다")
-        void partyChatRoom_success() {
+        @DisplayName("채팅방 상세 조회는 전용 조회 서비스로 위임한다")
+        void delegatesChatRoomDetail() {
             // given
             Long roomId = 1L;
             Long memberId = 10L;
-
-            Member me = MemberFixture.createMemberWithName("홍길동", "길동", Gender.MALE, Level.A, 1001L);
-            ReflectionTestUtils.setField(me, "id", memberId);
-
-            Party party = PartyFixture.createParty("배드민턴 모임", memberId, PartyFixture.createPartyAddr("서울", "강남구"));
-            ReflectionTestUtils.setField(party, "id", 100L);
-
-            ChatRoom chatRoom = ChatFixture.createPartyChatRoom(party);
-            ReflectionTestUtils.setField(chatRoom, "id", roomId);
-
-            ChatRoomMember myMembership = ChatFixture.createJoinedMemberWithLastRead(chatRoom, me, 30L);
-            ReflectionTestUtils.setField(myMembership, "id", 1L);
-
-            List<ChatRoomMember> participants = List.of(myMembership);
-
-            given(chatRoomRepository.findChatRoomWithPartyById(roomId)).willReturn(Optional.of(chatRoom));
-            given(chatRoomMemberRepository.findByChatRoomIdAndMemberId(roomId, memberId)).willReturn(Optional.of(myMembership));
-            given(chatMessageRepository.findRecentMessagesWithFiles(eq(roomId), any())).willReturn(List.of());
-            given(chatRoomMemberRepository.findChatRoomMembersWithMemberById(roomId)).willReturn(participants);
-            given(chatRoomMemberRepository.countByChatRoomId(roomId)).willReturn(1);
+            ChatRoomDetailDTO.Response expected = ChatRoomDetailDTO.Response.builder()
+                    .chatRoomInfo(null)
+                    .messages(Collections.emptyList())
+                    .participants(Collections.emptyList())
+                    .build();
+            given(chatRoomDetailQueryService.getChatRoomDetail(roomId, memberId)).willReturn(expected);
 
             // when
             ChatRoomDetailDTO.Response result = chatQueryService.getChatRoomDetail(roomId, memberId);
 
             // then
-            ChatRoomDetailDTO.ChatRoomInfo roomInfo = result.chatRoomInfo();
-            assertThat(roomInfo.chatRoomId()).isEqualTo(roomId);
-            assertThat(roomInfo.chatRoomType()).isEqualTo(ChatRoomType.PARTY);
-            assertThat(roomInfo.displayName()).isEqualTo("배드민턴 모임");
-            assertThat(roomInfo.memberCount()).isEqualTo(1);
-            assertThat(roomInfo.lastReadMessageId()).isEqualTo(30L);
-            assertThat(roomInfo.isCounterPartWithdrawn()).isFalse();
-            assertThat(result.messages()).isEmpty();
-            assertThat(result.participants()).hasSize(1);
-            assertThat(result.participants().get(0).memberName()).isEqualTo("홍길동");
-        }
-
-        @Test
-        @DisplayName("개인(DIRECT) 채팅방 조회 시 상대방 이름이 displayName이 된다")
-        void directChatRoom_success() {
-            // given
-            Long roomId = 2L;
-            Long memberId = 10L;
-            Long counterPartId = 20L;
-
-            Member me = MemberFixture.createMemberWithName("홍길동", "길동", Gender.MALE, Level.A, 1001L);
-            ReflectionTestUtils.setField(me, "id", memberId);
-
-            Member counterPart = MemberFixture.createMemberWithName("김철수", "철수", Gender.MALE, Level.B, 2002L);
-            ReflectionTestUtils.setField(counterPart, "id", counterPartId);
-
-            ChatRoom chatRoom = ChatFixture.createDirectChatRoom();
-            ReflectionTestUtils.setField(chatRoom, "id", roomId);
-
-            ChatRoomMember myMembership = ChatFixture.createJoinedMember(chatRoom, me);
-            ReflectionTestUtils.setField(myMembership, "id", 1L);
-
-            ChatRoomMember counterPartMembership = ChatFixture.createJoinedMember(chatRoom, counterPart);
-            ReflectionTestUtils.setField(counterPartMembership, "id", 2L);
-
-            List<ChatRoomMember> participants = List.of(myMembership, counterPartMembership);
-
-            given(chatRoomRepository.findChatRoomWithPartyById(roomId)).willReturn(Optional.of(chatRoom));
-            given(chatRoomMemberRepository.findByChatRoomIdAndMemberId(roomId, memberId)).willReturn(Optional.of(myMembership));
-            given(chatRoomMemberRepository.findCounterPartWithMember(roomId, memberId)).willReturn(Optional.of(counterPartMembership));
-            given(chatRoomMemberRepository.countByChatRoomId(roomId)).willReturn(2);
-            given(chatMessageRepository.findRecentMessagesWithFiles(eq(roomId), any())).willReturn(List.of());
-            given(chatRoomMemberRepository.findChatRoomMembersWithMemberById(roomId)).willReturn(participants);
-
-            // when
-            ChatRoomDetailDTO.Response result = chatQueryService.getChatRoomDetail(roomId, memberId);
-
-            // then
-            ChatRoomDetailDTO.ChatRoomInfo roomInfo = result.chatRoomInfo();
-            assertThat(roomInfo.chatRoomType()).isEqualTo(ChatRoomType.DIRECT);
-            assertThat(roomInfo.displayName()).isEqualTo("김철수");
-            assertThat(roomInfo.memberCount()).isEqualTo(2);
-            assertThat(roomInfo.isCounterPartWithdrawn()).isFalse();
-        }
-
-        @Test
-        @DisplayName("개인 채팅방에서 상대방이 탈퇴한 경우 isCounterPartWithdrawn이 true이다")
-        void directChatRoom_counterPartWithdrawn() {
-            // given
-            Long roomId = 3L;
-            Long memberId = 10L;
-            Long counterPartId = 20L;
-
-            Member me = MemberFixture.createMemberWithName("홍길동", "길동", Gender.MALE, Level.A, 1001L);
-            ReflectionTestUtils.setField(me, "id", memberId);
-
-            Member withdrawnCounterPart = MemberFixture.createWithdrawnMember("탈퇴한사용자", "탈퇴", 2002L);
-            ReflectionTestUtils.setField(withdrawnCounterPart, "id", counterPartId);
-            withdrawnCounterPart.updateProfileImg(ProfileImg.builder()
-                    .imgKey("member/withdrawn-detail.png")
-                    .build());
-
-            ChatRoom chatRoom = ChatFixture.createDirectChatRoom();
-            ReflectionTestUtils.setField(chatRoom, "id", roomId);
-
-            ChatRoomMember myMembership = ChatFixture.createJoinedMember(chatRoom, me);
-            ReflectionTestUtils.setField(myMembership, "id", 1L);
-
-            ChatRoomMember withdrawnMembership = ChatFixture.createJoinedMember(chatRoom, withdrawnCounterPart);
-            ReflectionTestUtils.setField(withdrawnMembership, "id", 2L);
-
-            List<ChatRoomMember> participants = List.of(myMembership, withdrawnMembership);
-
-            given(chatRoomRepository.findChatRoomWithPartyById(roomId)).willReturn(Optional.of(chatRoom));
-            given(chatRoomMemberRepository.findByChatRoomIdAndMemberId(roomId, memberId)).willReturn(Optional.of(myMembership));
-            given(chatRoomMemberRepository.findCounterPartWithMember(roomId, memberId)).willReturn(Optional.of(withdrawnMembership));
-            given(chatRoomMemberRepository.countByChatRoomId(roomId)).willReturn(2);
-            given(chatMessageRepository.findRecentMessagesWithFiles(eq(roomId), any())).willReturn(List.of());
-            given(chatRoomMemberRepository.findChatRoomMembersWithMemberById(roomId)).willReturn(participants);
-
-            // when
-            ChatRoomDetailDTO.Response result = chatQueryService.getChatRoomDetail(roomId, memberId);
-
-            // then
-            assertThat(result.chatRoomInfo().displayName()).isEqualTo(ChatConverter.UNKNOWN_USER_NAME);
-            assertThat(result.chatRoomInfo().profileImageUrl()).isNull();
-            assertThat(result.chatRoomInfo().isCounterPartWithdrawn()).isTrue();
-            assertThat(result.participants().get(1).memberName()).isEqualTo(ChatConverter.UNKNOWN_USER_NAME);
-            assertThat(result.participants().get(1).profileImgUrl()).isNull();
-            verify(fileService, never()).getUrlFromKey("member/withdrawn-detail.png");
-        }
-
-        @Test
-        @DisplayName("개인 채팅방에서 상대방 회원이 hard delete된 경우 알 수 없는 사용자로 조회된다")
-        void directChatRoom_counterPartMemberNull() {
-            // given
-            Long roomId = 4L;
-            Long memberId = 10L;
-
-            Member me = MemberFixture.createMemberWithName("홍길동", "길동", Gender.MALE, Level.A, 1001L);
-            ReflectionTestUtils.setField(me, "id", memberId);
-
-            ChatRoom chatRoom = ChatFixture.createDirectChatRoom();
-            ReflectionTestUtils.setField(chatRoom, "id", roomId);
-
-            ChatRoomMember myMembership = ChatFixture.createJoinedMember(chatRoom, me);
-            ReflectionTestUtils.setField(myMembership, "id", 1L);
-
-            ChatRoomMember deletedCounterPartMembership = ChatRoomMember.createJoined(chatRoom, null, "홍길동");
-            ReflectionTestUtils.setField(deletedCounterPartMembership, "id", 2L);
-
-            List<ChatRoomMember> participants = List.of(myMembership, deletedCounterPartMembership);
-
-            given(chatRoomRepository.findChatRoomWithPartyById(roomId)).willReturn(Optional.of(chatRoom));
-            given(chatRoomMemberRepository.findByChatRoomIdAndMemberId(roomId, memberId)).willReturn(Optional.of(myMembership));
-            given(chatRoomMemberRepository.findCounterPartWithMember(roomId, memberId)).willReturn(Optional.of(deletedCounterPartMembership));
-            given(chatRoomMemberRepository.countByChatRoomId(roomId)).willReturn(2);
-            given(chatMessageRepository.findRecentMessagesWithFiles(eq(roomId), any())).willReturn(List.of());
-            given(chatRoomMemberRepository.findChatRoomMembersWithMemberById(roomId)).willReturn(participants);
-
-            // when
-            ChatRoomDetailDTO.Response result = chatQueryService.getChatRoomDetail(roomId, memberId);
-
-            // then
-            assertThat(result.chatRoomInfo().displayName()).isEqualTo(ChatConverter.UNKNOWN_USER_NAME);
-            assertThat(result.chatRoomInfo().profileImageUrl()).isNull();
-            assertThat(result.chatRoomInfo().isCounterPartWithdrawn()).isTrue();
-            assertThat(result.participants().get(1).memberId()).isNull();
-            assertThat(result.participants().get(1).memberName()).isEqualTo(ChatConverter.UNKNOWN_USER_NAME);
-            assertThat(result.participants().get(1).profileImgUrl()).isNull();
-        }
-
-        @Test
-        @DisplayName("메시지가 DB에서 최신순으로 반환되면, 최종 응답에서는 오래된 순으로 뒤집혀야 한다")
-        void messages_areReversedToChronologicalOrder() {
-            // given
-            Long roomId = 1L;
-            Long memberId = 10L;
-
-            Member me = MemberFixture.createMemberWithName("홍길동", "길동", Gender.MALE, Level.A, 1001L);
-            ReflectionTestUtils.setField(me, "id", memberId);
-
-            Party party = PartyFixture.createParty("모임", memberId, PartyFixture.createPartyAddr("서울", "강남구"));
-            ReflectionTestUtils.setField(party, "id", 100L);
-
-            ChatRoom chatRoom = ChatFixture.createPartyChatRoom(party);
-            ReflectionTestUtils.setField(chatRoom, "id", roomId);
-
-            ChatRoomMember myMembership = ChatFixture.createJoinedMember(chatRoom, me);
-            ReflectionTestUtils.setField(myMembership, "id", 1L);
-
-            // DB는 최신순(id: 3→2→1)으로 반환
-            ChatMessage msg1 = ChatFixture.createTextMessage(chatRoom, me, "첫 번째 메시지");
-            ReflectionTestUtils.setField(msg1, "id", 1L);
-            ChatMessage msg2 = ChatFixture.createTextMessage(chatRoom, me, "두 번째 메시지");
-            ReflectionTestUtils.setField(msg2, "id", 2L);
-            ChatMessage msg3 = ChatFixture.createTextMessage(chatRoom, me, "세 번째 메시지");
-            ReflectionTestUtils.setField(msg3, "id", 3L);
-
-            given(chatRoomRepository.findChatRoomWithPartyById(roomId)).willReturn(Optional.of(chatRoom));
-            given(chatRoomMemberRepository.findByChatRoomIdAndMemberId(roomId, memberId)).willReturn(Optional.of(myMembership));
-            given(chatMessageRepository.findRecentMessagesWithFiles(eq(roomId), any())).willReturn(List.of(msg3, msg2, msg1));
-            given(chatRoomMemberRepository.findChatRoomMembersWithMemberById(roomId)).willReturn(List.of(myMembership));
-            given(chatRoomMemberRepository.countByChatRoomId(roomId)).willReturn(1);
-
-            // when
-            ChatRoomDetailDTO.Response result = chatQueryService.getChatRoomDetail(roomId, memberId);
-
-            // then: 응답 메시지는 오래된 순(1→2→3)
-            List<ChatRoomDetailDTO.MessageInfo> messages = result.messages();
-            assertThat(messages).hasSize(3);
-            assertThat(messages.get(0).messageId()).isEqualTo(1L);
-            assertThat(messages.get(1).messageId()).isEqualTo(2L);
-            assertThat(messages.get(2).messageId()).isEqualTo(3L);
-        }
-
-        @Test
-        @DisplayName("메시지 발신자가 나(memberId)이면 isMyMessage가 true이다")
-        void message_isMyMessage_true_whenSenderIsMe() {
-            // given
-            Long roomId = 1L;
-            Long memberId = 10L;
-
-            Member me = MemberFixture.createMemberWithName("홍길동", "길동", Gender.MALE, Level.A, 1001L);
-            ReflectionTestUtils.setField(me, "id", memberId);
-
-            Party party = PartyFixture.createParty("모임", memberId, PartyFixture.createPartyAddr("서울", "강남구"));
-            ReflectionTestUtils.setField(party, "id", 100L);
-
-            ChatRoom chatRoom = ChatFixture.createPartyChatRoom(party);
-            ReflectionTestUtils.setField(chatRoom, "id", roomId);
-
-            ChatRoomMember myMembership = ChatFixture.createJoinedMember(chatRoom, me);
-            ReflectionTestUtils.setField(myMembership, "id", 1L);
-
-            ChatMessage myMessage = ChatFixture.createTextMessage(chatRoom, me, "내 메시지");
-            ReflectionTestUtils.setField(myMessage, "id", 1L);
-
-            given(chatRoomRepository.findChatRoomWithPartyById(roomId)).willReturn(Optional.of(chatRoom));
-            given(chatRoomMemberRepository.findByChatRoomIdAndMemberId(roomId, memberId)).willReturn(Optional.of(myMembership));
-            given(chatMessageRepository.findRecentMessagesWithFiles(eq(roomId), any())).willReturn(List.of(myMessage));
-            given(chatRoomMemberRepository.findChatRoomMembersWithMemberById(roomId)).willReturn(List.of(myMembership));
-            given(chatRoomMemberRepository.countByChatRoomId(roomId)).willReturn(1);
-
-            // when
-            ChatRoomDetailDTO.Response result = chatQueryService.getChatRoomDetail(roomId, memberId);
-
-            // then
-            assertThat(result.messages().get(0).isMyMessage()).isTrue();
-            assertThat(result.messages().get(0).content()).isEqualTo("내 메시지");
-            assertThat(result.messages().get(0).senderName()).isEqualTo("홍길동");
-            assertThat(result.messages().get(0).images()).isEmpty();
-        }
-
-        @Test
-        @DisplayName("메시지 발신자가 상대방이면 isMyMessage가 false이다")
-        void message_isMyMessage_false_whenSenderIsOther() {
-            // given
-            Long roomId = 1L;
-            Long memberId = 10L;
-            Long otherId = 20L;
-
-            Member me = MemberFixture.createMemberWithName("홍길동", "길동", Gender.MALE, Level.A, 1001L);
-            ReflectionTestUtils.setField(me, "id", memberId);
-
-            Member other = MemberFixture.createMemberWithName("김철수", "철수", Gender.MALE, Level.B, 2002L);
-            ReflectionTestUtils.setField(other, "id", otherId);
-
-            Party party = PartyFixture.createParty("모임", memberId, PartyFixture.createPartyAddr("서울", "강남구"));
-            ReflectionTestUtils.setField(party, "id", 100L);
-
-            ChatRoom chatRoom = ChatFixture.createPartyChatRoom(party);
-            ReflectionTestUtils.setField(chatRoom, "id", roomId);
-
-            ChatRoomMember myMembership = ChatFixture.createJoinedMember(chatRoom, me);
-            ReflectionTestUtils.setField(myMembership, "id", 1L);
-
-            ChatRoomMember otherMembership = ChatFixture.createJoinedMember(chatRoom, other);
-            ReflectionTestUtils.setField(otherMembership, "id", 2L);
-
-            ChatMessage otherMessage = ChatFixture.createTextMessage(chatRoom, other, "상대방 메시지");
-            ReflectionTestUtils.setField(otherMessage, "id", 1L);
-
-            given(chatRoomRepository.findChatRoomWithPartyById(roomId)).willReturn(Optional.of(chatRoom));
-            given(chatRoomMemberRepository.findByChatRoomIdAndMemberId(roomId, memberId)).willReturn(Optional.of(myMembership));
-            given(chatMessageRepository.findRecentMessagesWithFiles(eq(roomId), any())).willReturn(List.of(otherMessage));
-            given(chatRoomMemberRepository.findChatRoomMembersWithMemberById(roomId)).willReturn(List.of(myMembership, otherMembership));
-            given(chatRoomMemberRepository.countByChatRoomId(roomId)).willReturn(2);
-
-            // when
-            ChatRoomDetailDTO.Response result = chatQueryService.getChatRoomDetail(roomId, memberId);
-
-            // then
-            assertThat(result.messages().get(0).isMyMessage()).isFalse();
-            assertThat(result.messages().get(0).isSenderWithdrawn()).isFalse();
-        }
-
-        @Test
-        @DisplayName("탈퇴한 사용자가 보낸 메시지는 isSenderWithdrawn이 true이다")
-        void message_isSenderWithdrawn_true() {
-            // given
-            Long roomId = 1L;
-            Long memberId = 10L;
-            Long withdrawnId = 30L;
-
-            Member me = MemberFixture.createMemberWithName("홍길동", "길동", Gender.MALE, Level.A, 1001L);
-            ReflectionTestUtils.setField(me, "id", memberId);
-
-            Member withdrawn = MemberFixture.createWithdrawnMember("탈퇴한사용자", "탈퇴", 3003L);
-            ReflectionTestUtils.setField(withdrawn, "id", withdrawnId);
-            withdrawn.updateProfileImg(ProfileImg.builder()
-                    .imgKey("member/withdrawn-message.png")
-                    .build());
-
-            Party party = PartyFixture.createParty("모임", memberId, PartyFixture.createPartyAddr("서울", "강남구"));
-            ReflectionTestUtils.setField(party, "id", 100L);
-
-            ChatRoom chatRoom = ChatFixture.createPartyChatRoom(party);
-            ReflectionTestUtils.setField(chatRoom, "id", roomId);
-
-            ChatRoomMember myMembership = ChatFixture.createJoinedMember(chatRoom, me);
-            ReflectionTestUtils.setField(myMembership, "id", 1L);
-
-            ChatRoomMember withdrawnMembership = ChatFixture.createJoinedMember(chatRoom, withdrawn);
-            ReflectionTestUtils.setField(withdrawnMembership, "id", 2L);
-
-            ChatMessage withdrawnMessage = ChatFixture.createTextMessage(chatRoom, withdrawn, "탈퇴자 메시지");
-            ReflectionTestUtils.setField(withdrawnMessage, "id", 1L);
-
-            given(chatRoomRepository.findChatRoomWithPartyById(roomId)).willReturn(Optional.of(chatRoom));
-            given(chatRoomMemberRepository.findByChatRoomIdAndMemberId(roomId, memberId)).willReturn(Optional.of(myMembership));
-            given(chatMessageRepository.findRecentMessagesWithFiles(eq(roomId), any())).willReturn(List.of(withdrawnMessage));
-            given(chatRoomMemberRepository.findChatRoomMembersWithMemberById(roomId)).willReturn(List.of(myMembership, withdrawnMembership));
-            given(chatRoomMemberRepository.countByChatRoomId(roomId)).willReturn(2);
-
-            // when
-            ChatRoomDetailDTO.Response result = chatQueryService.getChatRoomDetail(roomId, memberId);
-
-            // then
-            ChatRoomDetailDTO.MessageInfo messageInfo = result.messages().get(0);
-            assertThat(messageInfo.isSenderWithdrawn()).isTrue();
-            assertThat(messageInfo.senderName()).isEqualTo(ChatConverter.UNKNOWN_USER_NAME);
-            assertThat(messageInfo.senderProfileImageUrl()).isNull();
-            verify(fileService, never()).getUrlFromKey("member/withdrawn-message.png");
-        }
-
-        @Test
-        @DisplayName("sender가 null인 일반 메시지는 알 수 없는 사용자로 조회된다")
-        void message_nullSender_isMappedToUnknownUser() {
-            // given
-            Long roomId = 1L;
-            Long memberId = 10L;
-
-            Member me = MemberFixture.createMemberWithName("홍길동", "길동", Gender.MALE, Level.A, 1001L);
-            ReflectionTestUtils.setField(me, "id", memberId);
-
-            Party party = PartyFixture.createParty("모임", memberId, PartyFixture.createPartyAddr("서울", "강남구"));
-            ReflectionTestUtils.setField(party, "id", 100L);
-
-            ChatRoom chatRoom = ChatFixture.createPartyChatRoom(party);
-            ReflectionTestUtils.setField(chatRoom, "id", roomId);
-
-            ChatRoomMember myMembership = ChatFixture.createJoinedMember(chatRoom, me);
-            ReflectionTestUtils.setField(myMembership, "id", 1L);
-
-            ChatMessage deletedSenderMessage = ChatMessage.create(chatRoom, null, "삭제된 사용자 메시지", MessageType.TEXT);
-            ReflectionTestUtils.setField(deletedSenderMessage, "id", 1L);
-
-            given(chatRoomRepository.findChatRoomWithPartyById(roomId)).willReturn(Optional.of(chatRoom));
-            given(chatRoomMemberRepository.findByChatRoomIdAndMemberId(roomId, memberId)).willReturn(Optional.of(myMembership));
-            given(chatMessageRepository.findRecentMessagesWithFiles(eq(roomId), any())).willReturn(List.of(deletedSenderMessage));
-            given(chatRoomMemberRepository.findChatRoomMembersWithMemberById(roomId)).willReturn(List.of(myMembership));
-            given(chatRoomMemberRepository.countByChatRoomId(roomId)).willReturn(1);
-
-            // when
-            ChatRoomDetailDTO.Response result = chatQueryService.getChatRoomDetail(roomId, memberId);
-
-            // then
-            ChatRoomDetailDTO.MessageInfo messageInfo = result.messages().get(0);
-            assertThat(messageInfo.senderId()).isNull();
-            assertThat(messageInfo.senderName()).isEqualTo(ChatConverter.UNKNOWN_USER_NAME);
-            assertThat(messageInfo.senderProfileImageUrl()).isNull();
-            assertThat(messageInfo.isSenderWithdrawn()).isTrue();
-            assertThat(messageInfo.isMyMessage()).isFalse();
-        }
-
-        @Test
-        @DisplayName("시스템 메시지는 sender 없이도 조회되고 시스템 기본값으로 매핑된다")
-        void systemMessage_isMappedWithSystemDefaults() {
-            // given
-            Long roomId = 1L;
-            Long memberId = 10L;
-
-            Member me = MemberFixture.createMemberWithName("홍길동", "길동", Gender.MALE, Level.A, 1001L);
-            ReflectionTestUtils.setField(me, "id", memberId);
-
-            Party party = PartyFixture.createParty("모임", memberId, PartyFixture.createPartyAddr("서울", "강남구"));
-            ReflectionTestUtils.setField(party, "id", 100L);
-
-            ChatRoom chatRoom = ChatFixture.createPartyChatRoom(party);
-            ReflectionTestUtils.setField(chatRoom, "id", roomId);
-
-            ChatRoomMember myMembership = ChatFixture.createJoinedMember(chatRoom, me);
-            ReflectionTestUtils.setField(myMembership, "id", 1L);
-
-            ChatMessage systemMessage = ChatFixture.createSystemMessage(chatRoom, "공지 메시지");
-            ReflectionTestUtils.setField(systemMessage, "id", 1L);
-
-            given(chatRoomRepository.findChatRoomWithPartyById(roomId)).willReturn(Optional.of(chatRoom));
-            given(chatRoomMemberRepository.findByChatRoomIdAndMemberId(roomId, memberId)).willReturn(Optional.of(myMembership));
-            given(chatMessageRepository.findRecentMessagesWithFiles(eq(roomId), any())).willReturn(List.of(systemMessage));
-            given(chatRoomMemberRepository.findChatRoomMembersWithMemberById(roomId)).willReturn(List.of(myMembership));
-            given(chatRoomMemberRepository.countByChatRoomId(roomId)).willReturn(1);
-
-            // when
-            ChatRoomDetailDTO.Response result = chatQueryService.getChatRoomDetail(roomId, memberId);
-
-            // then
-            assertThat(result.messages()).hasSize(1);
-            ChatRoomDetailDTO.MessageInfo message = result.messages().get(0);
-            assertThat(message.messageType()).isEqualTo(MessageType.SYSTEM);
-            assertThat(message.senderId()).isNull();
-            assertThat(message.senderName()).isEqualTo("시스템");
-            assertThat(message.senderProfileImageUrl()).isNull();
-            assertThat(message.isMyMessage()).isFalse();
-            assertThat(message.isSenderWithdrawn()).isFalse();
-            assertThat(message.content()).isEqualTo("공지 메시지");
-        }
-
-        @Test
-        @DisplayName("이미지 메시지 조회 시 images 필드에 파일 정보가 포함된다")
-        void imageMessage_containsFileInfo() {
-            // given
-            Long roomId = 1L;
-            Long memberId = 10L;
-
-            Member me = MemberFixture.createMemberWithName("홍길동", "길동", Gender.MALE, Level.A, 1001L);
-            ReflectionTestUtils.setField(me, "id", memberId);
-
-            Party party = PartyFixture.createParty("모임", memberId, PartyFixture.createPartyAddr("서울", "강남구"));
-            ReflectionTestUtils.setField(party, "id", 100L);
-
-            ChatRoom chatRoom = ChatFixture.createPartyChatRoom(party);
-            ReflectionTestUtils.setField(chatRoom, "id", roomId);
-
-            ChatRoomMember myMembership = ChatFixture.createJoinedMember(chatRoom, me);
-            ReflectionTestUtils.setField(myMembership, "id", 1L);
-
-            ChatMessage imageMessage = ChatFixture.createImageMessage(chatRoom, me, List.of());
-            ReflectionTestUtils.setField(imageMessage, "id", 1L);
-
-            ChatMessageFile file1 = ChatFixture.createChatMessageFile(imageMessage, "chat/img1.png", 1, "photo1.png");
-            ReflectionTestUtils.setField(file1, "id", 100L);
-            ChatMessageFile file2 = ChatFixture.createChatMessageFile(imageMessage, "chat/img2.png", 2, "photo2.png");
-            ReflectionTestUtils.setField(file2, "id", 101L);
-            imageMessage.getChatMessageFiles().addAll(List.of(file1, file2));
-
-            given(chatRoomRepository.findChatRoomWithPartyById(roomId)).willReturn(Optional.of(chatRoom));
-            given(chatRoomMemberRepository.findByChatRoomIdAndMemberId(roomId, memberId)).willReturn(Optional.of(myMembership));
-            given(chatMessageRepository.findRecentMessagesWithFiles(eq(roomId), any())).willReturn(List.of(imageMessage));
-            given(chatRoomMemberRepository.findChatRoomMembersWithMemberById(roomId)).willReturn(List.of(myMembership));
-            given(chatRoomMemberRepository.countByChatRoomId(roomId)).willReturn(1);
-            given(fileService.getUrlFromKey("chat/img1.png")).willReturn("https://storage.example.com/chat/img1.png");
-            given(fileService.getUrlFromKey("chat/img2.png")).willReturn("https://storage.example.com/chat/img2.png");
-
-            // when
-            ChatRoomDetailDTO.Response result = chatQueryService.getChatRoomDetail(roomId, memberId);
-
-            // then
-            ChatRoomDetailDTO.MessageInfo message = result.messages().get(0);
-            assertThat(message.messageType()).isEqualTo(MessageType.TEXT);
-            assertThat(message.images()).hasSize(2);
-            assertThat(message.images().get(0).imageUrl()).isEqualTo("https://storage.example.com/chat/img1.png");
-            assertThat(message.images().get(0).imgOrder()).isEqualTo(1);
-            assertThat(message.images().get(0).originalFileName()).isEqualTo("photo1.png");
-            assertThat(message.images().get(0).isEmoji()).isFalse();
-            assertThat(message.images().get(1).imageUrl()).isEqualTo("https://storage.example.com/chat/img2.png");
-            assertThat(message.images().get(1).imgOrder()).isEqualTo(2);
-        }
-
-        @Test
-        @DisplayName("존재하지 않는 채팅방 조회 시 ChatException(CHAT_ROOM_NOT_FOUND)을 던진다")
-        void fail_chatRoomNotFound() {
-            // given
-            given(chatRoomRepository.findChatRoomWithPartyById(999L)).willReturn(Optional.empty());
-
-            // when & then
-            assertThatThrownBy(() -> chatQueryService.getChatRoomDetail(999L, 10L))
-                    .isInstanceOf(ChatException.class)
-                    .satisfies(e -> assertThat(((ChatException) e).getCode()).isEqualTo(ChatErrorCode.CHAT_ROOM_NOT_FOUND));
-        }
-
-        @Test
-        @DisplayName("채팅방 멤버가 아닌 사용자가 조회하면 ChatException(CHAT_ROOM_ACCESS_DENIED)을 던진다")
-        void fail_notChatRoomMember() {
-            // given
-            Long roomId = 1L;
-            Long outsiderId = 99L;
-
-            Party party = PartyFixture.createParty("모임", 1L, PartyFixture.createPartyAddr("서울", "강남구"));
-            ReflectionTestUtils.setField(party, "id", 100L);
-
-            ChatRoom chatRoom = ChatFixture.createPartyChatRoom(party);
-            ReflectionTestUtils.setField(chatRoom, "id", roomId);
-
-            given(chatRoomRepository.findChatRoomWithPartyById(roomId)).willReturn(Optional.of(chatRoom));
-            given(chatRoomMemberRepository.findByChatRoomIdAndMemberId(roomId, outsiderId)).willReturn(Optional.empty());
-
-            // when & then
-            assertThatThrownBy(() -> chatQueryService.getChatRoomDetail(roomId, outsiderId))
-                    .isInstanceOf(ChatException.class)
-                    .satisfies(e -> assertThat(((ChatException) e).getCode()).isEqualTo(ChatErrorCode.CHAT_ROOM_ACCESS_DENIED));
-
-            verify(chatRoomRepository).findChatRoomWithPartyById(roomId);
+            assertThat(result).isSameAs(expected);
+            verify(chatRoomDetailQueryService).getChatRoomDetail(roomId, memberId);
         }
     }
 }

--- a/src/test/java/umc/cockple/demo/domain/chat/service/query/ChatQueryServiceTest.java
+++ b/src/test/java/umc/cockple/demo/domain/chat/service/query/ChatQueryServiceTest.java
@@ -18,6 +18,7 @@ import umc.cockple.demo.domain.chat.domain.ChatRoomMember;
 import umc.cockple.demo.domain.chat.dto.DirectChatRoomDTO;
 import umc.cockple.demo.domain.chat.dto.ChatMessageDTO;
 import umc.cockple.demo.domain.chat.dto.ChatRoomDetailDTO;
+import umc.cockple.demo.domain.chat.dto.ChatUnreadStatusDTO;
 import umc.cockple.demo.domain.chat.dto.PartyChatRoomDTO;
 import umc.cockple.demo.domain.chat.enums.ChatRoomType;
 import umc.cockple.demo.domain.chat.enums.MessageType;
@@ -26,7 +27,6 @@ import umc.cockple.demo.domain.chat.exception.ChatException;
 import umc.cockple.demo.domain.chat.repository.ChatMessageRepository;
 import umc.cockple.demo.domain.chat.repository.ChatRoomMemberRepository;
 import umc.cockple.demo.domain.chat.repository.ChatRoomRepository;
-import umc.cockple.demo.domain.chat.repository.MessageReadStatusRepository;
 import umc.cockple.demo.domain.chat.service.ChatProcessor;
 import umc.cockple.demo.domain.file.service.FileService;
 import umc.cockple.demo.domain.file.service.ImageUrlResolver;
@@ -50,11 +50,8 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyList;
-import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
@@ -67,14 +64,13 @@ class ChatQueryServiceTest {
     @Mock private ChatMessageRepository chatMessageRepository;
     @Mock private PartyRepository partyRepository;
     @Mock private MemberPartyRepository memberPartyRepository;
-    @Mock private MessageReadStatusRepository messageReadStatusRepository;
     @Mock private FileService fileService;
     @Mock private PartyChatRoomQueryService partyChatRoomQueryService;
     @Mock private DirectChatRoomQueryService directChatRoomQueryService;
+    @Mock private ChatUnreadQueryService chatUnreadQueryService;
 
     private ChatConverter chatConverter;
     private ChatProcessor chatProcessor;
-    private ChatUnreadQueryService chatUnreadQueryService;
     private ImageUrlResolver imageUrlResolver;
     private ChatQueryServiceImpl chatQueryService;
 
@@ -82,7 +78,6 @@ class ChatQueryServiceTest {
     void setUp() {
         chatConverter = new ChatConverter();
         chatProcessor = new ChatProcessor(fileService, chatConverter);
-        chatUnreadQueryService = new ChatUnreadQueryService(messageReadStatusRepository);
         imageUrlResolver = new ImageUrlResolver(fileService);
         chatQueryService = new ChatQueryServiceImpl(
                 chatRoomRepository,
@@ -97,63 +92,30 @@ class ChatQueryServiceTest {
                 partyChatRoomQueryService,
                 directChatRoomQueryService
         );
-        lenient().when(messageReadStatusRepository.countUnreadMessagesByChatRooms(anyLong(), anyList()))
-                .thenReturn(List.of());
     }
 
     @Nested
-    @DisplayName("안 읽은 메시지 여부 조회")
-    class GetUnreadStatus {
+    @DisplayName("안 읽은 메시지 여부 조회 위임")
+    class GetUnreadStatusDelegation {
 
         @Test
-        @DisplayName("모임과 개인 안읽음 여부를 함께 반환한다")
-        void getUnreadStatus_returnsPartyAndDirectUnreadStatus() {
+        @DisplayName("안읽음 여부 조회는 unread 조회 서비스로 위임한다")
+        void delegatesUnreadStatus() {
             // given
             Long memberId = 10L;
-            given(messageReadStatusRepository.existsPartyUnreadMessagesByMemberId(memberId)).willReturn(true);
-            given(messageReadStatusRepository.existsDirectUnreadMessagesByMemberId(memberId)).willReturn(false);
+            ChatUnreadStatusDTO.Response expected = ChatUnreadStatusDTO.Response.builder()
+                    .hasUnread(true)
+                    .hasPartyUnread(true)
+                    .hasDirectUnread(false)
+                    .build();
+            given(chatUnreadQueryService.getUnreadStatus(memberId)).willReturn(expected);
 
             // when
-            var result = chatQueryService.getUnreadStatus(memberId);
+            ChatUnreadStatusDTO.Response result = chatQueryService.getUnreadStatus(memberId);
 
             // then
-            assertThat(result.hasUnread()).isTrue();
-            assertThat(result.hasPartyUnread()).isTrue();
-            assertThat(result.hasDirectUnread()).isFalse();
-        }
-
-        @Test
-        @DisplayName("모임과 개인 모두 안읽음이 없으면 전체 안읽음 여부가 false이다")
-        void getUnreadStatus_returnsFalseWhenNoUnreadExists() {
-            // given
-            Long memberId = 10L;
-            given(messageReadStatusRepository.existsPartyUnreadMessagesByMemberId(memberId)).willReturn(false);
-            given(messageReadStatusRepository.existsDirectUnreadMessagesByMemberId(memberId)).willReturn(false);
-
-            // when
-            var result = chatQueryService.getUnreadStatus(memberId);
-
-            // then
-            assertThat(result.hasUnread()).isFalse();
-            assertThat(result.hasPartyUnread()).isFalse();
-            assertThat(result.hasDirectUnread()).isFalse();
-        }
-
-        @Test
-        @DisplayName("개인 안읽음만 있으면 전체 안읽음 여부가 true이다")
-        void getUnreadStatus_returnsTrueWhenOnlyDirectUnreadExists() {
-            // given
-            Long memberId = 10L;
-            given(messageReadStatusRepository.existsPartyUnreadMessagesByMemberId(memberId)).willReturn(false);
-            given(messageReadStatusRepository.existsDirectUnreadMessagesByMemberId(memberId)).willReturn(true);
-
-            // when
-            var result = chatQueryService.getUnreadStatus(memberId);
-
-            // then
-            assertThat(result.hasUnread()).isTrue();
-            assertThat(result.hasPartyUnread()).isFalse();
-            assertThat(result.hasDirectUnread()).isTrue();
+            assertThat(result).isSameAs(expected);
+            verify(chatUnreadQueryService).getUnreadStatus(memberId);
         }
     }
 

--- a/src/test/java/umc/cockple/demo/domain/chat/service/query/ChatQueryServiceTest.java
+++ b/src/test/java/umc/cockple/demo/domain/chat/service/query/ChatQueryServiceTest.java
@@ -66,6 +66,7 @@ class ChatQueryServiceTest {
     @Mock private DirectChatRoomQueryService directChatRoomQueryService;
     @Mock private ChatUnreadQueryService chatUnreadQueryService;
     @Mock private PartyChatRoomIdQueryService partyChatRoomIdQueryService;
+    @Mock private ChatMessageHistoryQueryService chatMessageHistoryQueryService;
 
     private ChatConverter chatConverter;
     private ChatProcessor chatProcessor;
@@ -87,8 +88,39 @@ class ChatQueryServiceTest {
                 chatProcessor,
                 partyChatRoomQueryService,
                 directChatRoomQueryService,
-                partyChatRoomIdQueryService
+                partyChatRoomIdQueryService,
+                chatMessageHistoryQueryService
         );
+    }
+
+    @Nested
+    @DisplayName("과거 메시지 조회 위임")
+    class ChatMessageHistoryDelegation {
+
+        @Test
+        @DisplayName("과거 메시지 조회는 전용 조회 서비스로 위임한다")
+        void delegatesChatMessageHistory() {
+            // given
+            Long roomId = 1L;
+            Long memberId = 10L;
+            Long cursor = 100L;
+            int size = 20;
+            ChatMessageDTO.Response expected = ChatMessageDTO.Response.builder()
+                    .messages(Collections.emptyList())
+                    .hasNext(false)
+                    .nextCursor(null)
+                    .totalElements(0)
+                    .build();
+            given(chatMessageHistoryQueryService.getChatMessages(roomId, memberId, cursor, size))
+                    .willReturn(expected);
+
+            // when
+            ChatMessageDTO.Response result = chatQueryService.getChatMessages(roomId, memberId, cursor, size);
+
+            // then
+            assertThat(result).isSameAs(expected);
+            verify(chatMessageHistoryQueryService).getChatMessages(roomId, memberId, cursor, size);
+        }
     }
 
     @Nested
@@ -744,376 +776,6 @@ class ChatQueryServiceTest {
                     .satisfies(e -> assertThat(((ChatException) e).getCode()).isEqualTo(ChatErrorCode.CHAT_ROOM_ACCESS_DENIED));
 
             verify(chatRoomRepository).findChatRoomWithPartyById(roomId);
-        }
-    }
-
-    @Nested
-    @DisplayName("getChatMessages - 과거 메시지 조회")
-    class GetChatMessages {
-
-        @Test
-        @DisplayName("cursor 이전 메시지가 size 이하이면 hasNext가 false이고 nextCursor가 null이다")
-        void noMoreMessages_hasNextFalse() {
-            // given
-            Long roomId = 1L;
-            Long memberId = 10L;
-            Long cursor = 100L;
-            int size = 3;
-
-            Member me = MemberFixture.createMemberWithName("홍길동", "길동", Gender.MALE, Level.A, 1001L);
-            ReflectionTestUtils.setField(me, "id", memberId);
-
-            Party party = PartyFixture.createParty("모임", memberId, PartyFixture.createPartyAddr("서울", "강남구"));
-            ReflectionTestUtils.setField(party, "id", 100L);
-
-            ChatRoom chatRoom = ChatFixture.createPartyChatRoom(party);
-            ReflectionTestUtils.setField(chatRoom, "id", roomId);
-
-            // DB는 최신순(id: 3→2→1)으로 반환, size+1=4개 요청했지만 3개만 존재
-            ChatMessage msg1 = ChatFixture.createTextMessage(chatRoom, me, "첫 번째 메시지");
-            ReflectionTestUtils.setField(msg1, "id", 1L);
-            ChatMessage msg2 = ChatFixture.createTextMessage(chatRoom, me, "두 번째 메시지");
-            ReflectionTestUtils.setField(msg2, "id", 2L);
-            ChatMessage msg3 = ChatFixture.createTextMessage(chatRoom, me, "세 번째 메시지");
-            ReflectionTestUtils.setField(msg3, "id", 3L);
-
-            given(chatRoomMemberRepository.existsByChatRoomIdAndMemberId(roomId, memberId)).willReturn(true);
-            given(chatMessageRepository.findByRoomIdAndIdLessThanOrderByCreatedAtDesc(eq(roomId), eq(cursor), any()))
-                    .willReturn(List.of(msg3, msg2, msg1));
-
-            // when
-            ChatMessageDTO.Response result = chatQueryService.getChatMessages(roomId, memberId, cursor, size);
-
-            // then
-            assertThat(result.hasNext()).isFalse();
-            assertThat(result.nextCursor()).isNull();
-            assertThat(result.messages()).hasSize(3);
-        }
-
-        @Test
-        @DisplayName("cursor 이전 메시지가 size보다 많으면 hasNext가 true이고 nextCursor가 설정된다")
-        void moreMessagesExist_hasNextTrue() {
-            // given
-            Long roomId = 1L;
-            Long memberId = 10L;
-            Long cursor = 100L;
-            int size = 2;
-
-            Member me = MemberFixture.createMemberWithName("홍길동", "길동", Gender.MALE, Level.A, 1001L);
-            ReflectionTestUtils.setField(me, "id", memberId);
-
-            Party party = PartyFixture.createParty("모임", memberId, PartyFixture.createPartyAddr("서울", "강남구"));
-            ReflectionTestUtils.setField(party, "id", 100L);
-
-            ChatRoom chatRoom = ChatFixture.createPartyChatRoom(party);
-            ReflectionTestUtils.setField(chatRoom, "id", roomId);
-
-            // DB는 최신순(3→2→1)으로 size+1=3개 반환 → hasNext=true
-            ChatMessage msg1 = ChatFixture.createTextMessage(chatRoom, me, "첫 번째 메시지");
-            ReflectionTestUtils.setField(msg1, "id", 1L);
-            ChatMessage msg2 = ChatFixture.createTextMessage(chatRoom, me, "두 번째 메시지");
-            ReflectionTestUtils.setField(msg2, "id", 2L);
-            ChatMessage msg3 = ChatFixture.createTextMessage(chatRoom, me, "세 번째 메시지");
-            ReflectionTestUtils.setField(msg3, "id", 3L);
-
-            given(chatRoomMemberRepository.existsByChatRoomIdAndMemberId(roomId, memberId)).willReturn(true);
-            given(chatMessageRepository.findByRoomIdAndIdLessThanOrderByCreatedAtDesc(eq(roomId), eq(cursor), any()))
-                    .willReturn(List.of(msg3, msg2, msg1));
-
-            // when
-            ChatMessageDTO.Response result = chatQueryService.getChatMessages(roomId, memberId, cursor, size);
-
-            // then
-            assertThat(result.hasNext()).isTrue();
-            // size개 자른 후 가장 오래된 메시지(subList[0])의 id
-            assertThat(result.nextCursor()).isEqualTo(2L);
-            assertThat(result.messages()).hasSize(2);
-        }
-
-        @Test
-        @DisplayName("반환된 메시지는 오래된 순(오름차순)으로 정렬된다")
-        void messages_areInChronologicalOrder() {
-            // given
-            Long roomId = 1L;
-            Long memberId = 10L;
-            Long cursor = 100L;
-            int size = 3;
-
-            Member me = MemberFixture.createMemberWithName("홍길동", "길동", Gender.MALE, Level.A, 1001L);
-            ReflectionTestUtils.setField(me, "id", memberId);
-
-            Party party = PartyFixture.createParty("모임", memberId, PartyFixture.createPartyAddr("서울", "강남구"));
-            ReflectionTestUtils.setField(party, "id", 100L);
-
-            ChatRoom chatRoom = ChatFixture.createPartyChatRoom(party);
-            ReflectionTestUtils.setField(chatRoom, "id", roomId);
-
-            // DB에서 최신순(3→2→1) 반환
-            ChatMessage msg1 = ChatFixture.createTextMessage(chatRoom, me, "첫 번째");
-            ReflectionTestUtils.setField(msg1, "id", 1L);
-            ChatMessage msg2 = ChatFixture.createTextMessage(chatRoom, me, "두 번째");
-            ReflectionTestUtils.setField(msg2, "id", 2L);
-            ChatMessage msg3 = ChatFixture.createTextMessage(chatRoom, me, "세 번째");
-            ReflectionTestUtils.setField(msg3, "id", 3L);
-
-            given(chatRoomMemberRepository.existsByChatRoomIdAndMemberId(roomId, memberId)).willReturn(true);
-            given(chatMessageRepository.findByRoomIdAndIdLessThanOrderByCreatedAtDesc(eq(roomId), eq(cursor), any()))
-                    .willReturn(List.of(msg3, msg2, msg1));
-
-            // when
-            ChatMessageDTO.Response result = chatQueryService.getChatMessages(roomId, memberId, cursor, size);
-
-            // then: 응답은 오래된 순(1→2→3)
-            List<ChatMessageDTO.MessageInfo> messages = result.messages();
-            assertThat(messages).hasSize(3);
-            assertThat(messages.get(0).messageId()).isEqualTo(1L);
-            assertThat(messages.get(1).messageId()).isEqualTo(2L);
-            assertThat(messages.get(2).messageId()).isEqualTo(3L);
-        }
-
-        @Test
-        @DisplayName("내가 보낸 메시지는 isMyMessage가 true이다")
-        void myMessage_isMyMessageTrue() {
-            // given
-            Long roomId = 1L;
-            Long memberId = 10L;
-            Long cursor = 100L;
-
-            Member me = MemberFixture.createMemberWithName("홍길동", "길동", Gender.MALE, Level.A, 1001L);
-            ReflectionTestUtils.setField(me, "id", memberId);
-
-            Party party = PartyFixture.createParty("모임", memberId, PartyFixture.createPartyAddr("서울", "강남구"));
-            ReflectionTestUtils.setField(party, "id", 100L);
-
-            ChatRoom chatRoom = ChatFixture.createPartyChatRoom(party);
-            ReflectionTestUtils.setField(chatRoom, "id", roomId);
-
-            ChatMessage myMessage = ChatFixture.createTextMessage(chatRoom, me, "내 메시지");
-            ReflectionTestUtils.setField(myMessage, "id", 1L);
-
-            given(chatRoomMemberRepository.existsByChatRoomIdAndMemberId(roomId, memberId)).willReturn(true);
-            given(chatMessageRepository.findByRoomIdAndIdLessThanOrderByCreatedAtDesc(eq(roomId), eq(cursor), any()))
-                    .willReturn(List.of(myMessage));
-
-            // when
-            ChatMessageDTO.Response result = chatQueryService.getChatMessages(roomId, memberId, cursor, 10);
-
-            // then
-            assertThat(result.messages().get(0).isMyMessage()).isTrue();
-            assertThat(result.messages().get(0).images()).isEmpty();
-        }
-
-        @Test
-        @DisplayName("상대방이 보낸 메시지는 isMyMessage가 false이다")
-        void otherMessage_isMyMessageFalse() {
-            // given
-            Long roomId = 1L;
-            Long memberId = 10L;
-            Long otherId = 20L;
-            Long cursor = 100L;
-
-            Member me = MemberFixture.createMemberWithName("홍길동", "길동", Gender.MALE, Level.A, 1001L);
-            ReflectionTestUtils.setField(me, "id", memberId);
-
-            Member other = MemberFixture.createMemberWithName("김철수", "철수", Gender.MALE, Level.B, 2002L);
-            ReflectionTestUtils.setField(other, "id", otherId);
-
-            Party party = PartyFixture.createParty("모임", memberId, PartyFixture.createPartyAddr("서울", "강남구"));
-            ReflectionTestUtils.setField(party, "id", 100L);
-
-            ChatRoom chatRoom = ChatFixture.createPartyChatRoom(party);
-            ReflectionTestUtils.setField(chatRoom, "id", roomId);
-
-            ChatMessage otherMessage = ChatFixture.createTextMessage(chatRoom, other, "상대방 메시지");
-            ReflectionTestUtils.setField(otherMessage, "id", 1L);
-
-            given(chatRoomMemberRepository.existsByChatRoomIdAndMemberId(roomId, memberId)).willReturn(true);
-            given(chatMessageRepository.findByRoomIdAndIdLessThanOrderByCreatedAtDesc(eq(roomId), eq(cursor), any()))
-                    .willReturn(List.of(otherMessage));
-
-            // when
-            ChatMessageDTO.Response result = chatQueryService.getChatMessages(roomId, memberId, cursor, 10);
-
-            // then
-            assertThat(result.messages().get(0).isMyMessage()).isFalse();
-            assertThat(result.messages().get(0).senderName()).isEqualTo("김철수");
-        }
-
-        @Test
-        @DisplayName("탈퇴한 사용자가 보낸 메시지는 isSenderWithdrawn이 true이다")
-        void withdrawnSenderMessage_isSenderWithdrawnTrue() {
-            // given
-            Long roomId = 1L;
-            Long memberId = 10L;
-            Long withdrawnId = 30L;
-            Long cursor = 100L;
-
-            Member me = MemberFixture.createMemberWithName("홍길동", "길동", Gender.MALE, Level.A, 1001L);
-            ReflectionTestUtils.setField(me, "id", memberId);
-
-            Member withdrawn = MemberFixture.createWithdrawnMember("탈퇴한사용자", "탈퇴", 3003L);
-            ReflectionTestUtils.setField(withdrawn, "id", withdrawnId);
-            withdrawn.updateProfileImg(ProfileImg.builder()
-                    .imgKey("member/withdrawn-previous.png")
-                    .build());
-
-            Party party = PartyFixture.createParty("모임", memberId, PartyFixture.createPartyAddr("서울", "강남구"));
-            ReflectionTestUtils.setField(party, "id", 100L);
-
-            ChatRoom chatRoom = ChatFixture.createPartyChatRoom(party);
-            ReflectionTestUtils.setField(chatRoom, "id", roomId);
-
-            ChatMessage withdrawnMessage = ChatFixture.createTextMessage(chatRoom, withdrawn, "탈퇴자 메시지");
-            ReflectionTestUtils.setField(withdrawnMessage, "id", 1L);
-
-            given(chatRoomMemberRepository.existsByChatRoomIdAndMemberId(roomId, memberId)).willReturn(true);
-            given(chatMessageRepository.findByRoomIdAndIdLessThanOrderByCreatedAtDesc(eq(roomId), eq(cursor), any()))
-                    .willReturn(List.of(withdrawnMessage));
-
-            // when
-            ChatMessageDTO.Response result = chatQueryService.getChatMessages(roomId, memberId, cursor, 10);
-
-            // then
-            ChatMessageDTO.MessageInfo messageInfo = result.messages().get(0);
-            assertThat(messageInfo.isSenderWithdrawn()).isTrue();
-            assertThat(messageInfo.senderName()).isEqualTo(ChatConverter.UNKNOWN_USER_NAME);
-            assertThat(messageInfo.senderProfileImageUrl()).isNull();
-            verify(fileService, never()).getUrlFromKey("member/withdrawn-previous.png");
-        }
-
-        @Test
-        @DisplayName("sender가 null인 일반 과거 메시지는 알 수 없는 사용자로 조회된다")
-        void nullSenderPreviousMessage_isMappedToUnknownUser() {
-            // given
-            Long roomId = 1L;
-            Long memberId = 10L;
-            Long cursor = 100L;
-
-            Party party = PartyFixture.createParty("모임", memberId, PartyFixture.createPartyAddr("서울", "강남구"));
-            ReflectionTestUtils.setField(party, "id", 100L);
-
-            ChatRoom chatRoom = ChatFixture.createPartyChatRoom(party);
-            ReflectionTestUtils.setField(chatRoom, "id", roomId);
-
-            ChatMessage deletedSenderMessage = ChatMessage.create(chatRoom, null, "삭제된 사용자 메시지", MessageType.TEXT);
-            ReflectionTestUtils.setField(deletedSenderMessage, "id", 1L);
-
-            given(chatRoomMemberRepository.existsByChatRoomIdAndMemberId(roomId, memberId)).willReturn(true);
-            given(chatMessageRepository.findByRoomIdAndIdLessThanOrderByCreatedAtDesc(eq(roomId), eq(cursor), any()))
-                    .willReturn(List.of(deletedSenderMessage));
-
-            // when
-            ChatMessageDTO.Response result = chatQueryService.getChatMessages(roomId, memberId, cursor, 10);
-
-            // then
-            ChatMessageDTO.MessageInfo messageInfo = result.messages().get(0);
-            assertThat(messageInfo.senderId()).isNull();
-            assertThat(messageInfo.senderName()).isEqualTo(ChatConverter.UNKNOWN_USER_NAME);
-            assertThat(messageInfo.senderProfileImageUrl()).isNull();
-            assertThat(messageInfo.isSenderWithdrawn()).isTrue();
-            assertThat(messageInfo.isMyMessage()).isFalse();
-        }
-
-        @Test
-        @DisplayName("시스템 메시지는 sender 없이도 과거 메시지 응답에 포함된다")
-        void systemMessage_includedInPreviousMessages() {
-            // given
-            Long roomId = 1L;
-            Long memberId = 10L;
-            Long cursor = 100L;
-
-            Member me = MemberFixture.createMemberWithName("홍길동", "길동", Gender.MALE, Level.A, 1001L);
-            ReflectionTestUtils.setField(me, "id", memberId);
-
-            Party party = PartyFixture.createParty("모임", memberId, PartyFixture.createPartyAddr("서울", "강남구"));
-            ReflectionTestUtils.setField(party, "id", 100L);
-
-            ChatRoom chatRoom = ChatFixture.createPartyChatRoom(party);
-            ReflectionTestUtils.setField(chatRoom, "id", roomId);
-
-            ChatMessage systemMessage = ChatFixture.createSystemMessage(chatRoom, "홍길동님이 모임에 참여하셨습니다.");
-            ReflectionTestUtils.setField(systemMessage, "id", 1L);
-
-            given(chatRoomMemberRepository.existsByChatRoomIdAndMemberId(roomId, memberId)).willReturn(true);
-            given(chatMessageRepository.findByRoomIdAndIdLessThanOrderByCreatedAtDesc(eq(roomId), eq(cursor), any()))
-                    .willReturn(List.of(systemMessage));
-
-            // when
-            ChatMessageDTO.Response result = chatQueryService.getChatMessages(roomId, memberId, cursor, 10);
-
-            // then
-            assertThat(result.messages()).hasSize(1);
-            ChatMessageDTO.MessageInfo message = result.messages().get(0);
-            assertThat(message.messageType()).isEqualTo(MessageType.SYSTEM);
-            assertThat(message.senderId()).isNull();
-            assertThat(message.senderName()).isEqualTo("시스템");
-            assertThat(message.senderProfileImageUrl()).isNull();
-            assertThat(message.isMyMessage()).isFalse();
-            assertThat(message.isSenderWithdrawn()).isFalse();
-            assertThat(message.content()).isEqualTo("홍길동님이 모임에 참여하셨습니다.");
-        }
-
-        @Test
-        @DisplayName("이미지 메시지 조회 시 images 필드에 파일 정보가 포함된다")
-        void imageMessage_containsFileInfo() {
-            // given
-            Long roomId = 1L;
-            Long memberId = 10L;
-            Long cursor = 100L;
-
-            Member me = MemberFixture.createMemberWithName("홍길동", "길동", Gender.MALE, Level.A, 1001L);
-            ReflectionTestUtils.setField(me, "id", memberId);
-
-            Party party = PartyFixture.createParty("모임", memberId, PartyFixture.createPartyAddr("서울", "강남구"));
-            ReflectionTestUtils.setField(party, "id", 100L);
-
-            ChatRoom chatRoom = ChatFixture.createPartyChatRoom(party);
-            ReflectionTestUtils.setField(chatRoom, "id", roomId);
-
-            ChatMessage imageMessage = ChatFixture.createImageMessage(chatRoom, me, List.of());
-            ReflectionTestUtils.setField(imageMessage, "id", 1L);
-
-            ChatMessageFile file1 = ChatFixture.createChatMessageFile(imageMessage, "chat/img1.png", 1, "photo1.png");
-            ReflectionTestUtils.setField(file1, "id", 100L);
-            ChatMessageFile file2 = ChatFixture.createChatMessageFile(imageMessage, "chat/img2.png", 2, "photo2.png");
-            ReflectionTestUtils.setField(file2, "id", 101L);
-            imageMessage.getChatMessageFiles().addAll(List.of(file1, file2));
-
-            given(chatRoomMemberRepository.existsByChatRoomIdAndMemberId(roomId, memberId)).willReturn(true);
-            given(chatMessageRepository.findByRoomIdAndIdLessThanOrderByCreatedAtDesc(eq(roomId), eq(cursor), any()))
-                    .willReturn(List.of(imageMessage));
-            given(fileService.getUrlFromKey("chat/img1.png")).willReturn("https://storage.example.com/chat/img1.png");
-            given(fileService.getUrlFromKey("chat/img2.png")).willReturn("https://storage.example.com/chat/img2.png");
-
-            // when
-            ChatMessageDTO.Response result = chatQueryService.getChatMessages(roomId, memberId, cursor, 10);
-
-            // then
-            ChatMessageDTO.MessageInfo message = result.messages().get(0);
-            assertThat(message.messageType()).isEqualTo(MessageType.TEXT);
-            assertThat(message.images()).hasSize(2);
-            assertThat(message.images().get(0).imageUrl()).isEqualTo("https://storage.example.com/chat/img1.png");
-            assertThat(message.images().get(0).imgOrder()).isEqualTo(1);
-            assertThat(message.images().get(0).originalFileName()).isEqualTo("photo1.png");
-            assertThat(message.images().get(0).isEmoji()).isFalse();
-            assertThat(message.images().get(1).imageUrl()).isEqualTo("https://storage.example.com/chat/img2.png");
-            assertThat(message.images().get(1).imgOrder()).isEqualTo(2);
-        }
-
-        @Test
-        @DisplayName("채팅방 멤버가 아닌 사용자가 메시지를 조회하면 ChatException(CHAT_ROOM_ACCESS_DENIED)을 던진다")
-        void fail_notChatRoomMember() {
-            // given
-            Long roomId = 1L;
-            Long outsiderId = 99L;
-            Long cursor = 100L;
-
-            given(chatRoomMemberRepository.existsByChatRoomIdAndMemberId(roomId, outsiderId)).willReturn(false);
-
-            // when & then
-            assertThatThrownBy(() -> chatQueryService.getChatMessages(roomId, outsiderId, cursor, 10))
-                    .isInstanceOf(ChatException.class)
-                    .satisfies(e -> assertThat(((ChatException) e).getCode()).isEqualTo(ChatErrorCode.CHAT_ROOM_ACCESS_DENIED));
         }
     }
 }

--- a/src/test/java/umc/cockple/demo/domain/chat/service/query/ChatQueryServiceTest.java
+++ b/src/test/java/umc/cockple/demo/domain/chat/service/query/ChatQueryServiceTest.java
@@ -19,6 +19,7 @@ import umc.cockple.demo.domain.chat.dto.DirectChatRoomDTO;
 import umc.cockple.demo.domain.chat.dto.ChatMessageDTO;
 import umc.cockple.demo.domain.chat.dto.ChatRoomDetailDTO;
 import umc.cockple.demo.domain.chat.dto.ChatUnreadStatusDTO;
+import umc.cockple.demo.domain.chat.dto.PartyChatRoomIdDTO;
 import umc.cockple.demo.domain.chat.dto.PartyChatRoomDTO;
 import umc.cockple.demo.domain.chat.enums.ChatRoomType;
 import umc.cockple.demo.domain.chat.enums.MessageType;
@@ -32,10 +33,8 @@ import umc.cockple.demo.domain.file.service.FileService;
 import umc.cockple.demo.domain.file.service.ImageUrlResolver;
 import umc.cockple.demo.domain.member.domain.Member;
 import umc.cockple.demo.domain.member.domain.ProfileImg;
-import umc.cockple.demo.domain.member.repository.MemberPartyRepository;
 import umc.cockple.demo.domain.party.domain.Party;
 import umc.cockple.demo.domain.party.domain.PartyImg;
-import umc.cockple.demo.domain.party.repository.PartyRepository;
 import umc.cockple.demo.global.enums.Gender;
 import umc.cockple.demo.global.enums.Level;
 import umc.cockple.demo.support.fixture.ChatFixture;
@@ -62,12 +61,11 @@ class ChatQueryServiceTest {
     @Mock private ChatRoomRepository chatRoomRepository;
     @Mock private ChatRoomMemberRepository chatRoomMemberRepository;
     @Mock private ChatMessageRepository chatMessageRepository;
-    @Mock private PartyRepository partyRepository;
-    @Mock private MemberPartyRepository memberPartyRepository;
     @Mock private FileService fileService;
     @Mock private PartyChatRoomQueryService partyChatRoomQueryService;
     @Mock private DirectChatRoomQueryService directChatRoomQueryService;
     @Mock private ChatUnreadQueryService chatUnreadQueryService;
+    @Mock private PartyChatRoomIdQueryService partyChatRoomIdQueryService;
 
     private ChatConverter chatConverter;
     private ChatProcessor chatProcessor;
@@ -83,15 +81,36 @@ class ChatQueryServiceTest {
                 chatRoomRepository,
                 chatRoomMemberRepository,
                 chatMessageRepository,
-                partyRepository,
-                memberPartyRepository,
                 chatUnreadQueryService,
                 chatConverter,
                 imageUrlResolver,
                 chatProcessor,
                 partyChatRoomQueryService,
-                directChatRoomQueryService
+                directChatRoomQueryService,
+                partyChatRoomIdQueryService
         );
+    }
+
+    @Nested
+    @DisplayName("모임 채팅방 ID 조회 위임")
+    class PartyChatRoomIdDelegation {
+
+        @Test
+        @DisplayName("모임 채팅방 ID 조회는 전용 조회 서비스로 위임한다")
+        void delegatesPartyChatRoomId() {
+            // given
+            Long partyId = 1L;
+            Long memberId = 10L;
+            PartyChatRoomIdDTO expected = PartyChatRoomIdDTO.builder().roomId(100L).build();
+            given(partyChatRoomIdQueryService.getChatRoomId(partyId, memberId)).willReturn(expected);
+
+            // when
+            PartyChatRoomIdDTO result = chatQueryService.getChatRoomId(partyId, memberId);
+
+            // then
+            assertThat(result).isSameAs(expected);
+            verify(partyChatRoomIdQueryService).getChatRoomId(partyId, memberId);
+        }
     }
 
     @Nested

--- a/src/test/java/umc/cockple/demo/domain/chat/service/query/ChatRoomDetailQueryServiceTest.java
+++ b/src/test/java/umc/cockple/demo/domain/chat/service/query/ChatRoomDetailQueryServiceTest.java
@@ -1,0 +1,593 @@
+package umc.cockple.demo.domain.chat.service.query;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import umc.cockple.demo.domain.chat.converter.ChatConverter;
+import umc.cockple.demo.domain.chat.domain.ChatMessage;
+import umc.cockple.demo.domain.chat.domain.ChatMessageFile;
+import umc.cockple.demo.domain.chat.domain.ChatRoom;
+import umc.cockple.demo.domain.chat.domain.ChatRoomMember;
+import umc.cockple.demo.domain.chat.dto.ChatRoomDetailDTO;
+import umc.cockple.demo.domain.chat.enums.ChatRoomType;
+import umc.cockple.demo.domain.chat.enums.MessageType;
+import umc.cockple.demo.domain.chat.exception.ChatErrorCode;
+import umc.cockple.demo.domain.chat.exception.ChatException;
+import umc.cockple.demo.domain.chat.repository.ChatMessageRepository;
+import umc.cockple.demo.domain.chat.repository.ChatRoomMemberRepository;
+import umc.cockple.demo.domain.chat.repository.ChatRoomRepository;
+import umc.cockple.demo.domain.chat.service.ChatProcessor;
+import umc.cockple.demo.domain.file.service.FileService;
+import umc.cockple.demo.domain.file.service.ImageUrlResolver;
+import umc.cockple.demo.domain.member.domain.Member;
+import umc.cockple.demo.domain.member.domain.ProfileImg;
+import umc.cockple.demo.domain.party.domain.Party;
+import umc.cockple.demo.global.enums.Gender;
+import umc.cockple.demo.global.enums.Level;
+import umc.cockple.demo.support.fixture.ChatFixture;
+import umc.cockple.demo.support.fixture.MemberFixture;
+import umc.cockple.demo.support.fixture.PartyFixture;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class ChatRoomDetailQueryServiceTest {
+
+    @Mock private ChatRoomRepository chatRoomRepository;
+    @Mock private ChatRoomMemberRepository chatRoomMemberRepository;
+    @Mock private ChatMessageRepository chatMessageRepository;
+    @Mock private FileService fileService;
+
+    private ChatRoomDetailQueryService chatRoomDetailQueryService;
+
+    @BeforeEach
+    void setUp() {
+        ChatConverter chatConverter = new ChatConverter();
+        ChatProcessor chatProcessor = new ChatProcessor(fileService, chatConverter);
+        ImageUrlResolver imageUrlResolver = new ImageUrlResolver(fileService);
+        chatRoomDetailQueryService = new ChatRoomDetailQueryService(
+                chatRoomRepository,
+                chatRoomMemberRepository,
+                chatMessageRepository,
+                chatConverter,
+                imageUrlResolver,
+                chatProcessor
+        );
+    }
+
+    @Nested
+    @DisplayName("getChatRoomDetail - 초기 채팅방 조회")
+    class GetChatRoomDetail {
+
+        @Test
+        @DisplayName("모임(PARTY) 채팅방 조회 시 파티 이름이 displayName이 된다")
+        void partyChatRoom_success() {
+            // given
+            Long roomId = 1L;
+            Long memberId = 10L;
+
+            Member me = MemberFixture.createMemberWithName("홍길동", "길동", Gender.MALE, Level.A, 1001L);
+            ReflectionTestUtils.setField(me, "id", memberId);
+
+            Party party = PartyFixture.createParty("배드민턴 모임", memberId, PartyFixture.createPartyAddr("서울", "강남구"));
+            ReflectionTestUtils.setField(party, "id", 100L);
+
+            ChatRoom chatRoom = ChatFixture.createPartyChatRoom(party);
+            ReflectionTestUtils.setField(chatRoom, "id", roomId);
+
+            ChatRoomMember myMembership = ChatFixture.createJoinedMemberWithLastRead(chatRoom, me, 30L);
+            ReflectionTestUtils.setField(myMembership, "id", 1L);
+
+            List<ChatRoomMember> participants = List.of(myMembership);
+
+            given(chatRoomRepository.findChatRoomWithPartyById(roomId)).willReturn(Optional.of(chatRoom));
+            given(chatRoomMemberRepository.findByChatRoomIdAndMemberId(roomId, memberId)).willReturn(Optional.of(myMembership));
+            given(chatMessageRepository.findRecentMessagesWithFiles(eq(roomId), any())).willReturn(List.of());
+            given(chatRoomMemberRepository.findChatRoomMembersWithMemberById(roomId)).willReturn(participants);
+            given(chatRoomMemberRepository.countByChatRoomId(roomId)).willReturn(1);
+
+            // when
+            ChatRoomDetailDTO.Response result = chatRoomDetailQueryService.getChatRoomDetail(roomId, memberId);
+
+            // then
+            ChatRoomDetailDTO.ChatRoomInfo roomInfo = result.chatRoomInfo();
+            assertThat(roomInfo.chatRoomId()).isEqualTo(roomId);
+            assertThat(roomInfo.chatRoomType()).isEqualTo(ChatRoomType.PARTY);
+            assertThat(roomInfo.displayName()).isEqualTo("배드민턴 모임");
+            assertThat(roomInfo.memberCount()).isEqualTo(1);
+            assertThat(roomInfo.lastReadMessageId()).isEqualTo(30L);
+            assertThat(roomInfo.isCounterPartWithdrawn()).isFalse();
+            assertThat(result.messages()).isEmpty();
+            assertThat(result.participants()).hasSize(1);
+            assertThat(result.participants().get(0).memberName()).isEqualTo("홍길동");
+        }
+
+        @Test
+        @DisplayName("개인(DIRECT) 채팅방 조회 시 상대방 이름이 displayName이 된다")
+        void directChatRoom_success() {
+            // given
+            Long roomId = 2L;
+            Long memberId = 10L;
+            Long counterPartId = 20L;
+
+            Member me = MemberFixture.createMemberWithName("홍길동", "길동", Gender.MALE, Level.A, 1001L);
+            ReflectionTestUtils.setField(me, "id", memberId);
+
+            Member counterPart = MemberFixture.createMemberWithName("김철수", "철수", Gender.MALE, Level.B, 2002L);
+            ReflectionTestUtils.setField(counterPart, "id", counterPartId);
+
+            ChatRoom chatRoom = ChatFixture.createDirectChatRoom();
+            ReflectionTestUtils.setField(chatRoom, "id", roomId);
+
+            ChatRoomMember myMembership = ChatFixture.createJoinedMember(chatRoom, me);
+            ReflectionTestUtils.setField(myMembership, "id", 1L);
+
+            ChatRoomMember counterPartMembership = ChatFixture.createJoinedMember(chatRoom, counterPart);
+            ReflectionTestUtils.setField(counterPartMembership, "id", 2L);
+
+            List<ChatRoomMember> participants = List.of(myMembership, counterPartMembership);
+
+            given(chatRoomRepository.findChatRoomWithPartyById(roomId)).willReturn(Optional.of(chatRoom));
+            given(chatRoomMemberRepository.findByChatRoomIdAndMemberId(roomId, memberId)).willReturn(Optional.of(myMembership));
+            given(chatRoomMemberRepository.findCounterPartWithMember(roomId, memberId)).willReturn(Optional.of(counterPartMembership));
+            given(chatRoomMemberRepository.countByChatRoomId(roomId)).willReturn(2);
+            given(chatMessageRepository.findRecentMessagesWithFiles(eq(roomId), any())).willReturn(List.of());
+            given(chatRoomMemberRepository.findChatRoomMembersWithMemberById(roomId)).willReturn(participants);
+
+            // when
+            ChatRoomDetailDTO.Response result = chatRoomDetailQueryService.getChatRoomDetail(roomId, memberId);
+
+            // then
+            ChatRoomDetailDTO.ChatRoomInfo roomInfo = result.chatRoomInfo();
+            assertThat(roomInfo.chatRoomType()).isEqualTo(ChatRoomType.DIRECT);
+            assertThat(roomInfo.displayName()).isEqualTo("김철수");
+            assertThat(roomInfo.memberCount()).isEqualTo(2);
+            assertThat(roomInfo.isCounterPartWithdrawn()).isFalse();
+        }
+
+        @Test
+        @DisplayName("개인 채팅방에서 상대방이 탈퇴한 경우 isCounterPartWithdrawn이 true이다")
+        void directChatRoom_counterPartWithdrawn() {
+            // given
+            Long roomId = 3L;
+            Long memberId = 10L;
+            Long counterPartId = 20L;
+
+            Member me = MemberFixture.createMemberWithName("홍길동", "길동", Gender.MALE, Level.A, 1001L);
+            ReflectionTestUtils.setField(me, "id", memberId);
+
+            Member withdrawnCounterPart = MemberFixture.createWithdrawnMember("탈퇴한사용자", "탈퇴", 2002L);
+            ReflectionTestUtils.setField(withdrawnCounterPart, "id", counterPartId);
+            withdrawnCounterPart.updateProfileImg(ProfileImg.builder()
+                    .imgKey("member/withdrawn-detail.png")
+                    .build());
+
+            ChatRoom chatRoom = ChatFixture.createDirectChatRoom();
+            ReflectionTestUtils.setField(chatRoom, "id", roomId);
+
+            ChatRoomMember myMembership = ChatFixture.createJoinedMember(chatRoom, me);
+            ReflectionTestUtils.setField(myMembership, "id", 1L);
+
+            ChatRoomMember withdrawnMembership = ChatFixture.createJoinedMember(chatRoom, withdrawnCounterPart);
+            ReflectionTestUtils.setField(withdrawnMembership, "id", 2L);
+
+            List<ChatRoomMember> participants = List.of(myMembership, withdrawnMembership);
+
+            given(chatRoomRepository.findChatRoomWithPartyById(roomId)).willReturn(Optional.of(chatRoom));
+            given(chatRoomMemberRepository.findByChatRoomIdAndMemberId(roomId, memberId)).willReturn(Optional.of(myMembership));
+            given(chatRoomMemberRepository.findCounterPartWithMember(roomId, memberId)).willReturn(Optional.of(withdrawnMembership));
+            given(chatRoomMemberRepository.countByChatRoomId(roomId)).willReturn(2);
+            given(chatMessageRepository.findRecentMessagesWithFiles(eq(roomId), any())).willReturn(List.of());
+            given(chatRoomMemberRepository.findChatRoomMembersWithMemberById(roomId)).willReturn(participants);
+
+            // when
+            ChatRoomDetailDTO.Response result = chatRoomDetailQueryService.getChatRoomDetail(roomId, memberId);
+
+            // then
+            assertThat(result.chatRoomInfo().displayName()).isEqualTo(ChatConverter.UNKNOWN_USER_NAME);
+            assertThat(result.chatRoomInfo().profileImageUrl()).isNull();
+            assertThat(result.chatRoomInfo().isCounterPartWithdrawn()).isTrue();
+            assertThat(result.participants().get(1).memberName()).isEqualTo(ChatConverter.UNKNOWN_USER_NAME);
+            assertThat(result.participants().get(1).profileImgUrl()).isNull();
+            verify(fileService, never()).getUrlFromKey("member/withdrawn-detail.png");
+        }
+
+        @Test
+        @DisplayName("개인 채팅방에서 상대방 회원이 hard delete된 경우 알 수 없는 사용자로 조회된다")
+        void directChatRoom_counterPartMemberNull() {
+            // given
+            Long roomId = 4L;
+            Long memberId = 10L;
+
+            Member me = MemberFixture.createMemberWithName("홍길동", "길동", Gender.MALE, Level.A, 1001L);
+            ReflectionTestUtils.setField(me, "id", memberId);
+
+            ChatRoom chatRoom = ChatFixture.createDirectChatRoom();
+            ReflectionTestUtils.setField(chatRoom, "id", roomId);
+
+            ChatRoomMember myMembership = ChatFixture.createJoinedMember(chatRoom, me);
+            ReflectionTestUtils.setField(myMembership, "id", 1L);
+
+            ChatRoomMember deletedCounterPartMembership = ChatRoomMember.createJoined(chatRoom, null, "홍길동");
+            ReflectionTestUtils.setField(deletedCounterPartMembership, "id", 2L);
+
+            List<ChatRoomMember> participants = List.of(myMembership, deletedCounterPartMembership);
+
+            given(chatRoomRepository.findChatRoomWithPartyById(roomId)).willReturn(Optional.of(chatRoom));
+            given(chatRoomMemberRepository.findByChatRoomIdAndMemberId(roomId, memberId)).willReturn(Optional.of(myMembership));
+            given(chatRoomMemberRepository.findCounterPartWithMember(roomId, memberId)).willReturn(Optional.of(deletedCounterPartMembership));
+            given(chatRoomMemberRepository.countByChatRoomId(roomId)).willReturn(2);
+            given(chatMessageRepository.findRecentMessagesWithFiles(eq(roomId), any())).willReturn(List.of());
+            given(chatRoomMemberRepository.findChatRoomMembersWithMemberById(roomId)).willReturn(participants);
+
+            // when
+            ChatRoomDetailDTO.Response result = chatRoomDetailQueryService.getChatRoomDetail(roomId, memberId);
+
+            // then
+            assertThat(result.chatRoomInfo().displayName()).isEqualTo(ChatConverter.UNKNOWN_USER_NAME);
+            assertThat(result.chatRoomInfo().profileImageUrl()).isNull();
+            assertThat(result.chatRoomInfo().isCounterPartWithdrawn()).isTrue();
+            assertThat(result.participants().get(1).memberId()).isNull();
+            assertThat(result.participants().get(1).memberName()).isEqualTo(ChatConverter.UNKNOWN_USER_NAME);
+            assertThat(result.participants().get(1).profileImgUrl()).isNull();
+        }
+
+        @Test
+        @DisplayName("메시지가 DB에서 최신순으로 반환되면, 최종 응답에서는 오래된 순으로 뒤집혀야 한다")
+        void messages_areReversedToChronologicalOrder() {
+            // given
+            Long roomId = 1L;
+            Long memberId = 10L;
+
+            Member me = MemberFixture.createMemberWithName("홍길동", "길동", Gender.MALE, Level.A, 1001L);
+            ReflectionTestUtils.setField(me, "id", memberId);
+
+            Party party = PartyFixture.createParty("모임", memberId, PartyFixture.createPartyAddr("서울", "강남구"));
+            ReflectionTestUtils.setField(party, "id", 100L);
+
+            ChatRoom chatRoom = ChatFixture.createPartyChatRoom(party);
+            ReflectionTestUtils.setField(chatRoom, "id", roomId);
+
+            ChatRoomMember myMembership = ChatFixture.createJoinedMember(chatRoom, me);
+            ReflectionTestUtils.setField(myMembership, "id", 1L);
+
+            // DB는 최신순(id: 3→2→1)으로 반환
+            ChatMessage msg1 = ChatFixture.createTextMessage(chatRoom, me, "첫 번째 메시지");
+            ReflectionTestUtils.setField(msg1, "id", 1L);
+            ChatMessage msg2 = ChatFixture.createTextMessage(chatRoom, me, "두 번째 메시지");
+            ReflectionTestUtils.setField(msg2, "id", 2L);
+            ChatMessage msg3 = ChatFixture.createTextMessage(chatRoom, me, "세 번째 메시지");
+            ReflectionTestUtils.setField(msg3, "id", 3L);
+
+            given(chatRoomRepository.findChatRoomWithPartyById(roomId)).willReturn(Optional.of(chatRoom));
+            given(chatRoomMemberRepository.findByChatRoomIdAndMemberId(roomId, memberId)).willReturn(Optional.of(myMembership));
+            given(chatMessageRepository.findRecentMessagesWithFiles(eq(roomId), any())).willReturn(List.of(msg3, msg2, msg1));
+            given(chatRoomMemberRepository.findChatRoomMembersWithMemberById(roomId)).willReturn(List.of(myMembership));
+            given(chatRoomMemberRepository.countByChatRoomId(roomId)).willReturn(1);
+
+            // when
+            ChatRoomDetailDTO.Response result = chatRoomDetailQueryService.getChatRoomDetail(roomId, memberId);
+
+            // then: 응답 메시지는 오래된 순(1→2→3)
+            List<ChatRoomDetailDTO.MessageInfo> messages = result.messages();
+            assertThat(messages).hasSize(3);
+            assertThat(messages.get(0).messageId()).isEqualTo(1L);
+            assertThat(messages.get(1).messageId()).isEqualTo(2L);
+            assertThat(messages.get(2).messageId()).isEqualTo(3L);
+        }
+
+        @Test
+        @DisplayName("메시지 발신자가 나(memberId)이면 isMyMessage가 true이다")
+        void message_isMyMessage_true_whenSenderIsMe() {
+            // given
+            Long roomId = 1L;
+            Long memberId = 10L;
+
+            Member me = MemberFixture.createMemberWithName("홍길동", "길동", Gender.MALE, Level.A, 1001L);
+            ReflectionTestUtils.setField(me, "id", memberId);
+
+            Party party = PartyFixture.createParty("모임", memberId, PartyFixture.createPartyAddr("서울", "강남구"));
+            ReflectionTestUtils.setField(party, "id", 100L);
+
+            ChatRoom chatRoom = ChatFixture.createPartyChatRoom(party);
+            ReflectionTestUtils.setField(chatRoom, "id", roomId);
+
+            ChatRoomMember myMembership = ChatFixture.createJoinedMember(chatRoom, me);
+            ReflectionTestUtils.setField(myMembership, "id", 1L);
+
+            ChatMessage myMessage = ChatFixture.createTextMessage(chatRoom, me, "내 메시지");
+            ReflectionTestUtils.setField(myMessage, "id", 1L);
+
+            given(chatRoomRepository.findChatRoomWithPartyById(roomId)).willReturn(Optional.of(chatRoom));
+            given(chatRoomMemberRepository.findByChatRoomIdAndMemberId(roomId, memberId)).willReturn(Optional.of(myMembership));
+            given(chatMessageRepository.findRecentMessagesWithFiles(eq(roomId), any())).willReturn(List.of(myMessage));
+            given(chatRoomMemberRepository.findChatRoomMembersWithMemberById(roomId)).willReturn(List.of(myMembership));
+            given(chatRoomMemberRepository.countByChatRoomId(roomId)).willReturn(1);
+
+            // when
+            ChatRoomDetailDTO.Response result = chatRoomDetailQueryService.getChatRoomDetail(roomId, memberId);
+
+            // then
+            assertThat(result.messages().get(0).isMyMessage()).isTrue();
+            assertThat(result.messages().get(0).content()).isEqualTo("내 메시지");
+            assertThat(result.messages().get(0).senderName()).isEqualTo("홍길동");
+            assertThat(result.messages().get(0).images()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("메시지 발신자가 상대방이면 isMyMessage가 false이다")
+        void message_isMyMessage_false_whenSenderIsOther() {
+            // given
+            Long roomId = 1L;
+            Long memberId = 10L;
+            Long otherId = 20L;
+
+            Member me = MemberFixture.createMemberWithName("홍길동", "길동", Gender.MALE, Level.A, 1001L);
+            ReflectionTestUtils.setField(me, "id", memberId);
+
+            Member other = MemberFixture.createMemberWithName("김철수", "철수", Gender.MALE, Level.B, 2002L);
+            ReflectionTestUtils.setField(other, "id", otherId);
+
+            Party party = PartyFixture.createParty("모임", memberId, PartyFixture.createPartyAddr("서울", "강남구"));
+            ReflectionTestUtils.setField(party, "id", 100L);
+
+            ChatRoom chatRoom = ChatFixture.createPartyChatRoom(party);
+            ReflectionTestUtils.setField(chatRoom, "id", roomId);
+
+            ChatRoomMember myMembership = ChatFixture.createJoinedMember(chatRoom, me);
+            ReflectionTestUtils.setField(myMembership, "id", 1L);
+
+            ChatRoomMember otherMembership = ChatFixture.createJoinedMember(chatRoom, other);
+            ReflectionTestUtils.setField(otherMembership, "id", 2L);
+
+            ChatMessage otherMessage = ChatFixture.createTextMessage(chatRoom, other, "상대방 메시지");
+            ReflectionTestUtils.setField(otherMessage, "id", 1L);
+
+            given(chatRoomRepository.findChatRoomWithPartyById(roomId)).willReturn(Optional.of(chatRoom));
+            given(chatRoomMemberRepository.findByChatRoomIdAndMemberId(roomId, memberId)).willReturn(Optional.of(myMembership));
+            given(chatMessageRepository.findRecentMessagesWithFiles(eq(roomId), any())).willReturn(List.of(otherMessage));
+            given(chatRoomMemberRepository.findChatRoomMembersWithMemberById(roomId)).willReturn(List.of(myMembership, otherMembership));
+            given(chatRoomMemberRepository.countByChatRoomId(roomId)).willReturn(2);
+
+            // when
+            ChatRoomDetailDTO.Response result = chatRoomDetailQueryService.getChatRoomDetail(roomId, memberId);
+
+            // then
+            assertThat(result.messages().get(0).isMyMessage()).isFalse();
+            assertThat(result.messages().get(0).isSenderWithdrawn()).isFalse();
+        }
+
+        @Test
+        @DisplayName("탈퇴한 사용자가 보낸 메시지는 isSenderWithdrawn이 true이다")
+        void message_isSenderWithdrawn_true() {
+            // given
+            Long roomId = 1L;
+            Long memberId = 10L;
+            Long withdrawnId = 30L;
+
+            Member me = MemberFixture.createMemberWithName("홍길동", "길동", Gender.MALE, Level.A, 1001L);
+            ReflectionTestUtils.setField(me, "id", memberId);
+
+            Member withdrawn = MemberFixture.createWithdrawnMember("탈퇴한사용자", "탈퇴", 3003L);
+            ReflectionTestUtils.setField(withdrawn, "id", withdrawnId);
+            withdrawn.updateProfileImg(ProfileImg.builder()
+                    .imgKey("member/withdrawn-message.png")
+                    .build());
+
+            Party party = PartyFixture.createParty("모임", memberId, PartyFixture.createPartyAddr("서울", "강남구"));
+            ReflectionTestUtils.setField(party, "id", 100L);
+
+            ChatRoom chatRoom = ChatFixture.createPartyChatRoom(party);
+            ReflectionTestUtils.setField(chatRoom, "id", roomId);
+
+            ChatRoomMember myMembership = ChatFixture.createJoinedMember(chatRoom, me);
+            ReflectionTestUtils.setField(myMembership, "id", 1L);
+
+            ChatRoomMember withdrawnMembership = ChatFixture.createJoinedMember(chatRoom, withdrawn);
+            ReflectionTestUtils.setField(withdrawnMembership, "id", 2L);
+
+            ChatMessage withdrawnMessage = ChatFixture.createTextMessage(chatRoom, withdrawn, "탈퇴자 메시지");
+            ReflectionTestUtils.setField(withdrawnMessage, "id", 1L);
+
+            given(chatRoomRepository.findChatRoomWithPartyById(roomId)).willReturn(Optional.of(chatRoom));
+            given(chatRoomMemberRepository.findByChatRoomIdAndMemberId(roomId, memberId)).willReturn(Optional.of(myMembership));
+            given(chatMessageRepository.findRecentMessagesWithFiles(eq(roomId), any())).willReturn(List.of(withdrawnMessage));
+            given(chatRoomMemberRepository.findChatRoomMembersWithMemberById(roomId)).willReturn(List.of(myMembership, withdrawnMembership));
+            given(chatRoomMemberRepository.countByChatRoomId(roomId)).willReturn(2);
+
+            // when
+            ChatRoomDetailDTO.Response result = chatRoomDetailQueryService.getChatRoomDetail(roomId, memberId);
+
+            // then
+            ChatRoomDetailDTO.MessageInfo messageInfo = result.messages().get(0);
+            assertThat(messageInfo.isSenderWithdrawn()).isTrue();
+            assertThat(messageInfo.senderName()).isEqualTo(ChatConverter.UNKNOWN_USER_NAME);
+            assertThat(messageInfo.senderProfileImageUrl()).isNull();
+            verify(fileService, never()).getUrlFromKey("member/withdrawn-message.png");
+        }
+
+        @Test
+        @DisplayName("sender가 null인 일반 메시지는 알 수 없는 사용자로 조회된다")
+        void message_nullSender_isMappedToUnknownUser() {
+            // given
+            Long roomId = 1L;
+            Long memberId = 10L;
+
+            Member me = MemberFixture.createMemberWithName("홍길동", "길동", Gender.MALE, Level.A, 1001L);
+            ReflectionTestUtils.setField(me, "id", memberId);
+
+            Party party = PartyFixture.createParty("모임", memberId, PartyFixture.createPartyAddr("서울", "강남구"));
+            ReflectionTestUtils.setField(party, "id", 100L);
+
+            ChatRoom chatRoom = ChatFixture.createPartyChatRoom(party);
+            ReflectionTestUtils.setField(chatRoom, "id", roomId);
+
+            ChatRoomMember myMembership = ChatFixture.createJoinedMember(chatRoom, me);
+            ReflectionTestUtils.setField(myMembership, "id", 1L);
+
+            ChatMessage deletedSenderMessage = ChatMessage.create(chatRoom, null, "삭제된 사용자 메시지", MessageType.TEXT);
+            ReflectionTestUtils.setField(deletedSenderMessage, "id", 1L);
+
+            given(chatRoomRepository.findChatRoomWithPartyById(roomId)).willReturn(Optional.of(chatRoom));
+            given(chatRoomMemberRepository.findByChatRoomIdAndMemberId(roomId, memberId)).willReturn(Optional.of(myMembership));
+            given(chatMessageRepository.findRecentMessagesWithFiles(eq(roomId), any())).willReturn(List.of(deletedSenderMessage));
+            given(chatRoomMemberRepository.findChatRoomMembersWithMemberById(roomId)).willReturn(List.of(myMembership));
+            given(chatRoomMemberRepository.countByChatRoomId(roomId)).willReturn(1);
+
+            // when
+            ChatRoomDetailDTO.Response result = chatRoomDetailQueryService.getChatRoomDetail(roomId, memberId);
+
+            // then
+            ChatRoomDetailDTO.MessageInfo messageInfo = result.messages().get(0);
+            assertThat(messageInfo.senderId()).isNull();
+            assertThat(messageInfo.senderName()).isEqualTo(ChatConverter.UNKNOWN_USER_NAME);
+            assertThat(messageInfo.senderProfileImageUrl()).isNull();
+            assertThat(messageInfo.isSenderWithdrawn()).isTrue();
+            assertThat(messageInfo.isMyMessage()).isFalse();
+        }
+
+        @Test
+        @DisplayName("시스템 메시지는 sender 없이도 조회되고 시스템 기본값으로 매핑된다")
+        void systemMessage_isMappedWithSystemDefaults() {
+            // given
+            Long roomId = 1L;
+            Long memberId = 10L;
+
+            Member me = MemberFixture.createMemberWithName("홍길동", "길동", Gender.MALE, Level.A, 1001L);
+            ReflectionTestUtils.setField(me, "id", memberId);
+
+            Party party = PartyFixture.createParty("모임", memberId, PartyFixture.createPartyAddr("서울", "강남구"));
+            ReflectionTestUtils.setField(party, "id", 100L);
+
+            ChatRoom chatRoom = ChatFixture.createPartyChatRoom(party);
+            ReflectionTestUtils.setField(chatRoom, "id", roomId);
+
+            ChatRoomMember myMembership = ChatFixture.createJoinedMember(chatRoom, me);
+            ReflectionTestUtils.setField(myMembership, "id", 1L);
+
+            ChatMessage systemMessage = ChatFixture.createSystemMessage(chatRoom, "공지 메시지");
+            ReflectionTestUtils.setField(systemMessage, "id", 1L);
+
+            given(chatRoomRepository.findChatRoomWithPartyById(roomId)).willReturn(Optional.of(chatRoom));
+            given(chatRoomMemberRepository.findByChatRoomIdAndMemberId(roomId, memberId)).willReturn(Optional.of(myMembership));
+            given(chatMessageRepository.findRecentMessagesWithFiles(eq(roomId), any())).willReturn(List.of(systemMessage));
+            given(chatRoomMemberRepository.findChatRoomMembersWithMemberById(roomId)).willReturn(List.of(myMembership));
+            given(chatRoomMemberRepository.countByChatRoomId(roomId)).willReturn(1);
+
+            // when
+            ChatRoomDetailDTO.Response result = chatRoomDetailQueryService.getChatRoomDetail(roomId, memberId);
+
+            // then
+            assertThat(result.messages()).hasSize(1);
+            ChatRoomDetailDTO.MessageInfo message = result.messages().get(0);
+            assertThat(message.messageType()).isEqualTo(MessageType.SYSTEM);
+            assertThat(message.senderId()).isNull();
+            assertThat(message.senderName()).isEqualTo("시스템");
+            assertThat(message.senderProfileImageUrl()).isNull();
+            assertThat(message.isMyMessage()).isFalse();
+            assertThat(message.isSenderWithdrawn()).isFalse();
+            assertThat(message.content()).isEqualTo("공지 메시지");
+        }
+
+        @Test
+        @DisplayName("이미지 메시지 조회 시 images 필드에 파일 정보가 포함된다")
+        void imageMessage_containsFileInfo() {
+            // given
+            Long roomId = 1L;
+            Long memberId = 10L;
+
+            Member me = MemberFixture.createMemberWithName("홍길동", "길동", Gender.MALE, Level.A, 1001L);
+            ReflectionTestUtils.setField(me, "id", memberId);
+
+            Party party = PartyFixture.createParty("모임", memberId, PartyFixture.createPartyAddr("서울", "강남구"));
+            ReflectionTestUtils.setField(party, "id", 100L);
+
+            ChatRoom chatRoom = ChatFixture.createPartyChatRoom(party);
+            ReflectionTestUtils.setField(chatRoom, "id", roomId);
+
+            ChatRoomMember myMembership = ChatFixture.createJoinedMember(chatRoom, me);
+            ReflectionTestUtils.setField(myMembership, "id", 1L);
+
+            ChatMessage imageMessage = ChatFixture.createImageMessage(chatRoom, me, List.of());
+            ReflectionTestUtils.setField(imageMessage, "id", 1L);
+
+            ChatMessageFile file1 = ChatFixture.createChatMessageFile(imageMessage, "chat/img1.png", 1, "photo1.png");
+            ReflectionTestUtils.setField(file1, "id", 100L);
+            ChatMessageFile file2 = ChatFixture.createChatMessageFile(imageMessage, "chat/img2.png", 2, "photo2.png");
+            ReflectionTestUtils.setField(file2, "id", 101L);
+            imageMessage.getChatMessageFiles().addAll(List.of(file1, file2));
+
+            given(chatRoomRepository.findChatRoomWithPartyById(roomId)).willReturn(Optional.of(chatRoom));
+            given(chatRoomMemberRepository.findByChatRoomIdAndMemberId(roomId, memberId)).willReturn(Optional.of(myMembership));
+            given(chatMessageRepository.findRecentMessagesWithFiles(eq(roomId), any())).willReturn(List.of(imageMessage));
+            given(chatRoomMemberRepository.findChatRoomMembersWithMemberById(roomId)).willReturn(List.of(myMembership));
+            given(chatRoomMemberRepository.countByChatRoomId(roomId)).willReturn(1);
+            given(fileService.getUrlFromKey("chat/img1.png")).willReturn("https://storage.example.com/chat/img1.png");
+            given(fileService.getUrlFromKey("chat/img2.png")).willReturn("https://storage.example.com/chat/img2.png");
+
+            // when
+            ChatRoomDetailDTO.Response result = chatRoomDetailQueryService.getChatRoomDetail(roomId, memberId);
+
+            // then
+            ChatRoomDetailDTO.MessageInfo message = result.messages().get(0);
+            assertThat(message.messageType()).isEqualTo(MessageType.TEXT);
+            assertThat(message.images()).hasSize(2);
+            assertThat(message.images().get(0).imageUrl()).isEqualTo("https://storage.example.com/chat/img1.png");
+            assertThat(message.images().get(0).imgOrder()).isEqualTo(1);
+            assertThat(message.images().get(0).originalFileName()).isEqualTo("photo1.png");
+            assertThat(message.images().get(0).isEmoji()).isFalse();
+            assertThat(message.images().get(1).imageUrl()).isEqualTo("https://storage.example.com/chat/img2.png");
+            assertThat(message.images().get(1).imgOrder()).isEqualTo(2);
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 채팅방 조회 시 ChatException(CHAT_ROOM_NOT_FOUND)을 던진다")
+        void fail_chatRoomNotFound() {
+            // given
+            given(chatRoomRepository.findChatRoomWithPartyById(999L)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> chatRoomDetailQueryService.getChatRoomDetail(999L, 10L))
+                    .isInstanceOf(ChatException.class)
+                    .satisfies(e -> assertThat(((ChatException) e).getCode()).isEqualTo(ChatErrorCode.CHAT_ROOM_NOT_FOUND));
+        }
+
+        @Test
+        @DisplayName("채팅방 멤버가 아닌 사용자가 조회하면 ChatException(CHAT_ROOM_ACCESS_DENIED)을 던진다")
+        void fail_notChatRoomMember() {
+            // given
+            Long roomId = 1L;
+            Long outsiderId = 99L;
+
+            Party party = PartyFixture.createParty("모임", 1L, PartyFixture.createPartyAddr("서울", "강남구"));
+            ReflectionTestUtils.setField(party, "id", 100L);
+
+            ChatRoom chatRoom = ChatFixture.createPartyChatRoom(party);
+            ReflectionTestUtils.setField(chatRoom, "id", roomId);
+
+            given(chatRoomRepository.findChatRoomWithPartyById(roomId)).willReturn(Optional.of(chatRoom));
+            given(chatRoomMemberRepository.findByChatRoomIdAndMemberId(roomId, outsiderId)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> chatRoomDetailQueryService.getChatRoomDetail(roomId, outsiderId))
+                    .isInstanceOf(ChatException.class)
+                    .satisfies(e -> assertThat(((ChatException) e).getCode()).isEqualTo(ChatErrorCode.CHAT_ROOM_ACCESS_DENIED));
+
+            verify(chatRoomRepository).findChatRoomWithPartyById(roomId);
+        }
+    }
+}

--- a/src/test/java/umc/cockple/demo/domain/chat/service/query/ChatUnreadQueryServiceTest.java
+++ b/src/test/java/umc/cockple/demo/domain/chat/service/query/ChatUnreadQueryServiceTest.java
@@ -7,6 +7,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import umc.cockple.demo.domain.chat.converter.ChatConverter;
+import umc.cockple.demo.domain.chat.dto.ChatUnreadStatusDTO;
 import umc.cockple.demo.domain.chat.repository.projection.ChatMemberUnreadCountDTO;
 import umc.cockple.demo.domain.chat.repository.projection.ChatRoomUnreadCountDTO;
 import umc.cockple.demo.domain.chat.repository.MessageReadStatusRepository;
@@ -27,11 +29,69 @@ class ChatUnreadQueryServiceTest {
 
     @Mock private MessageReadStatusRepository messageReadStatusRepository;
 
+    private ChatConverter chatConverter;
     private ChatUnreadQueryService chatUnreadQueryService;
 
     @BeforeEach
     void setUp() {
-        chatUnreadQueryService = new ChatUnreadQueryService(messageReadStatusRepository);
+        chatConverter = new ChatConverter();
+        chatUnreadQueryService = new ChatUnreadQueryService(messageReadStatusRepository, chatConverter);
+    }
+
+    @Nested
+    @DisplayName("안 읽은 메시지 여부 조회")
+    class GetUnreadStatus {
+
+        @Test
+        @DisplayName("모임과 개인 안읽음 여부를 함께 반환한다")
+        void getUnreadStatus_returnsPartyAndDirectUnreadStatus() {
+            // given
+            Long memberId = 10L;
+            given(messageReadStatusRepository.existsPartyUnreadMessagesByMemberId(memberId)).willReturn(true);
+            given(messageReadStatusRepository.existsDirectUnreadMessagesByMemberId(memberId)).willReturn(false);
+
+            // when
+            ChatUnreadStatusDTO.Response result = chatUnreadQueryService.getUnreadStatus(memberId);
+
+            // then
+            assertThat(result.hasUnread()).isTrue();
+            assertThat(result.hasPartyUnread()).isTrue();
+            assertThat(result.hasDirectUnread()).isFalse();
+        }
+
+        @Test
+        @DisplayName("모임과 개인 모두 안읽음이 없으면 전체 안읽음 여부가 false이다")
+        void getUnreadStatus_returnsFalseWhenNoUnreadExists() {
+            // given
+            Long memberId = 10L;
+            given(messageReadStatusRepository.existsPartyUnreadMessagesByMemberId(memberId)).willReturn(false);
+            given(messageReadStatusRepository.existsDirectUnreadMessagesByMemberId(memberId)).willReturn(false);
+
+            // when
+            ChatUnreadStatusDTO.Response result = chatUnreadQueryService.getUnreadStatus(memberId);
+
+            // then
+            assertThat(result.hasUnread()).isFalse();
+            assertThat(result.hasPartyUnread()).isFalse();
+            assertThat(result.hasDirectUnread()).isFalse();
+        }
+
+        @Test
+        @DisplayName("개인 안읽음만 있으면 전체 안읽음 여부가 true이다")
+        void getUnreadStatus_returnsTrueWhenOnlyDirectUnreadExists() {
+            // given
+            Long memberId = 10L;
+            given(messageReadStatusRepository.existsPartyUnreadMessagesByMemberId(memberId)).willReturn(false);
+            given(messageReadStatusRepository.existsDirectUnreadMessagesByMemberId(memberId)).willReturn(true);
+
+            // when
+            ChatUnreadStatusDTO.Response result = chatUnreadQueryService.getUnreadStatus(memberId);
+
+            // then
+            assertThat(result.hasUnread()).isTrue();
+            assertThat(result.hasPartyUnread()).isFalse();
+            assertThat(result.hasDirectUnread()).isTrue();
+        }
     }
 
     @Nested

--- a/src/test/java/umc/cockple/demo/domain/chat/service/query/DirectChatRoomQueryServiceTest.java
+++ b/src/test/java/umc/cockple/demo/domain/chat/service/query/DirectChatRoomQueryServiceTest.java
@@ -63,7 +63,7 @@ class DirectChatRoomQueryServiceTest {
     @BeforeEach
     void setUp() {
         chatConverter = new ChatConverter();
-        chatUnreadQueryService = new ChatUnreadQueryService(messageReadStatusRepository);
+        chatUnreadQueryService = new ChatUnreadQueryService(messageReadStatusRepository, chatConverter);
         imageUrlResolver = new ImageUrlResolver(fileService);
         directChatRoomQueryService = new DirectChatRoomQueryService(
                 chatRoomRepository,

--- a/src/test/java/umc/cockple/demo/domain/chat/service/query/PartyChatRoomIdQueryServiceTest.java
+++ b/src/test/java/umc/cockple/demo/domain/chat/service/query/PartyChatRoomIdQueryServiceTest.java
@@ -1,0 +1,129 @@
+package umc.cockple.demo.domain.chat.service.query;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import umc.cockple.demo.domain.chat.converter.ChatConverter;
+import umc.cockple.demo.domain.chat.domain.ChatRoom;
+import umc.cockple.demo.domain.chat.dto.PartyChatRoomIdDTO;
+import umc.cockple.demo.domain.chat.exception.ChatErrorCode;
+import umc.cockple.demo.domain.chat.exception.ChatException;
+import umc.cockple.demo.domain.member.repository.MemberPartyRepository;
+import umc.cockple.demo.domain.party.domain.Party;
+import umc.cockple.demo.domain.party.repository.PartyRepository;
+import umc.cockple.demo.support.fixture.ChatFixture;
+import umc.cockple.demo.support.fixture.PartyFixture;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("PartyChatRoomIdQueryService")
+class PartyChatRoomIdQueryServiceTest {
+
+    @Mock private PartyRepository partyRepository;
+    @Mock private MemberPartyRepository memberPartyRepository;
+
+    private PartyChatRoomIdQueryService partyChatRoomIdQueryService;
+
+    @BeforeEach
+    void setUp() {
+        partyChatRoomIdQueryService = new PartyChatRoomIdQueryService(
+                partyRepository,
+                memberPartyRepository,
+                new ChatConverter()
+        );
+    }
+
+    @Nested
+    @DisplayName("모임 채팅방 ID 조회")
+    class GetChatRoomId {
+
+        @Test
+        @DisplayName("모임 회원이면 연결된 채팅방 ID를 반환한다")
+        void returnsChatRoomId_whenMemberBelongsToParty() {
+            // given
+            Long partyId = 1L;
+            Long memberId = 10L;
+            Long roomId = 100L;
+            Party party = createParty(partyId);
+            ChatRoom chatRoom = ChatFixture.createPartyChatRoom(party);
+            ReflectionTestUtils.setField(chatRoom, "id", roomId);
+            ReflectionTestUtils.setField(party, "chatRoom", chatRoom);
+
+            given(partyRepository.findById(partyId)).willReturn(Optional.of(party));
+            given(memberPartyRepository.existsByPartyIdAndMemberId(partyId, memberId)).willReturn(true);
+
+            // when
+            PartyChatRoomIdDTO result = partyChatRoomIdQueryService.getChatRoomId(partyId, memberId);
+
+            // then
+            assertThat(result.roomId()).isEqualTo(roomId);
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 모임이면 PARTY_NOT_FOUND 예외를 던진다")
+        void throwsPartyNotFound_whenPartyDoesNotExist() {
+            // given
+            Long partyId = 1L;
+            Long memberId = 10L;
+            given(partyRepository.findById(partyId)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> partyChatRoomIdQueryService.getChatRoomId(partyId, memberId))
+                    .isInstanceOf(ChatException.class)
+                    .satisfies(e -> assertThat(((ChatException) e).getCode()).isEqualTo(ChatErrorCode.PARTY_NOT_FOUND));
+            verify(memberPartyRepository, never()).existsByPartyIdAndMemberId(partyId, memberId);
+        }
+
+        @Test
+        @DisplayName("모임 회원이 아니면 NOT_PARTY_MEMBER 예외를 던진다")
+        void throwsNotPartyMember_whenMemberDoesNotBelongToParty() {
+            // given
+            Long partyId = 1L;
+            Long memberId = 10L;
+            Party party = createParty(partyId);
+
+            given(partyRepository.findById(partyId)).willReturn(Optional.of(party));
+            given(memberPartyRepository.existsByPartyIdAndMemberId(partyId, memberId)).willReturn(false);
+
+            // when & then
+            assertThatThrownBy(() -> partyChatRoomIdQueryService.getChatRoomId(partyId, memberId))
+                    .isInstanceOf(ChatException.class)
+                    .satisfies(e -> assertThat(((ChatException) e).getCode()).isEqualTo(ChatErrorCode.NOT_PARTY_MEMBER));
+        }
+
+        @Test
+        @DisplayName("모임에 연결된 채팅방이 없으면 CHAT_ROOM_NOT_FOUND 예외를 던진다")
+        void throwsChatRoomNotFound_whenPartyHasNoChatRoom() {
+            // given
+            Long partyId = 1L;
+            Long memberId = 10L;
+            Party party = createParty(partyId);
+
+            given(partyRepository.findById(partyId)).willReturn(Optional.of(party));
+            given(memberPartyRepository.existsByPartyIdAndMemberId(partyId, memberId)).willReturn(true);
+
+            // when & then
+            assertThatThrownBy(() -> partyChatRoomIdQueryService.getChatRoomId(partyId, memberId))
+                    .isInstanceOf(ChatException.class)
+                    .satisfies(e -> assertThat(((ChatException) e).getCode()).isEqualTo(ChatErrorCode.CHAT_ROOM_NOT_FOUND));
+        }
+    }
+
+    private Party createParty(Long partyId) {
+        Party party = PartyFixture.createParty("모임", 10L, PartyFixture.createPartyAddr("서울", "강남구"));
+        ReflectionTestUtils.setField(party, "id", partyId);
+        return party;
+    }
+}

--- a/src/test/java/umc/cockple/demo/domain/chat/service/query/PartyChatRoomQueryServiceTest.java
+++ b/src/test/java/umc/cockple/demo/domain/chat/service/query/PartyChatRoomQueryServiceTest.java
@@ -55,7 +55,7 @@ class PartyChatRoomQueryServiceTest {
     @BeforeEach
     void setUp() {
         chatConverter = new ChatConverter();
-        chatUnreadQueryService = new ChatUnreadQueryService(messageReadStatusRepository);
+        chatUnreadQueryService = new ChatUnreadQueryService(messageReadStatusRepository, chatConverter);
         imageUrlResolver = new ImageUrlResolver(fileService);
         partyChatRoomQueryService = new PartyChatRoomQueryService(
                 chatRoomRepository,


### PR DESCRIPTION
## ❤️ 기능 설명

`ChatQueryServiceImpl`에 남아 있던 채팅방 상세, 과거 메시지, 안읽음 여부, 모임 채팅방 ID 조회 책임을 use-case별 query service로 분리했습니다.

기존 REST API 경로와 응답 스키마는 유지하고, `ChatQueryServiceImpl`은 컨트롤러가 바라보는 read facade로 남겨 각 전용 서비스에 요청을 위임하도록 정리했습니다.

### 변경 내용
- `ChatRoomDetailQueryService` 추가
  - 채팅방 상세 및 참여자 정보 조립
  - 개인 채팅 상대방 표시명/탈퇴 상태/프로필 이미지 처리
- `ChatMessageHistoryQueryService` 추가
  - cursor 기반 과거 메시지 조회
  - `hasNext`, `nextCursor`, 응답 정렬 계산
- `PartyChatRoomIdQueryService` 추가
  - 모임 회원 검증 및 연결된 채팅방 ID 조회
- `ChatUnreadQueryService`가 안읽음 상태 응답 조립까지 담당하도록 변경
- `ChatQueryServiceImpl`의 실질 조회 로직 제거 및 전용 query service 위임 처리
- 분리된 query service 단위 테스트 추가 및 facade 테스트를 위임 검증 중심으로 정리

<br>

## 연결된 issue

close #669

<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] REST API path/request/response schema 변경 없이 조회 책임만 분리한 PR입니다.
- [ ] `ChatQueryServiceImpl`은 추후 facade 패턴을 제거하며 없앨 예정입니다.

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
