### PR TITLE
[refactor/#688] 채팅 알림 발송을 Multicast로 변경

### DIFF
--- a/src/main/java/umc/cockple/demo/domain/notification/fcm/FcmService.java
+++ b/src/main/java/umc/cockple/demo/domain/notification/fcm/FcmService.java
@@ -70,40 +70,6 @@ public class FcmService {
         }
     }
 
-    public void sendChatNotification(Member member, String title, String content,
-                                     Long chatRoomId, ChatRoomType chatRoomType) {
-        if (applyFakeLatencyAndSkip(member.getId())) {
-            return;
-        }
-
-        String fcmToken = member.getFcmToken();
-        if (fcmToken == null || fcmToken.isBlank()) {
-            log.info("FCM 토큰 없음 - memberId: {}, 채팅 알림 전송 생략", member.getId());
-            return;
-        }
-
-        Message message = Message.builder()
-                .setToken(fcmToken)
-                .setNotification(Notification.builder()
-                        .setTitle(title)
-                        .setBody(content)
-                        .build())
-                .putData("chatRoomId", chatRoomId.toString())
-                .putData("chatRoomType", chatRoomType.name())
-                .setWebpushConfig(WebpushConfig.builder()
-                        .setFcmOptions(WebpushFcmOptions.withLink(buildChatLink(chatRoomType, chatRoomId)))
-                        .build())
-                .build();
-
-        try {
-            long start = System.currentTimeMillis();
-            firebaseMessaging.send(message);
-            log.info("[FCM] 채팅 알림 전송 완료 - memberId: {}, chatRoomId: {}, 소요시간: {}ms", member.getId(), chatRoomId, System.currentTimeMillis() - start);
-        } catch (FirebaseMessagingException e) {
-            log.error("채팅 FCM 전송 실패 - memberId: {}, error: {}", member.getId(), e.getMessage());
-        }
-    }
-
     /**
      * 채팅 알림을 수신자 전체에게 한 번의 요청(fan-out)
      */

--- a/src/main/java/umc/cockple/demo/domain/notification/fcm/FcmService.java
+++ b/src/main/java/umc/cockple/demo/domain/notification/fcm/FcmService.java
@@ -1,8 +1,10 @@
 package umc.cockple.demo.domain.notification.fcm;
 
+import com.google.firebase.messaging.BatchResponse;
 import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.FirebaseMessagingException;
 import com.google.firebase.messaging.Message;
+import com.google.firebase.messaging.MulticastMessage;
 import com.google.firebase.messaging.Notification;
 import com.google.firebase.messaging.WebpushConfig;
 import com.google.firebase.messaging.WebpushFcmOptions;
@@ -17,10 +19,14 @@ import umc.cockple.demo.domain.member.exception.MemberErrorCode;
 import umc.cockple.demo.domain.member.exception.MemberException;
 import umc.cockple.demo.domain.member.repository.MemberRepository;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 @Slf4j
 public class FcmService {
+
+    private static final int FCM_MULTICAST_MAX = 500;   // MulticastMessage 토큰 한도
 
     private final MemberRepository memberRepository;
     private final FirebaseMessaging firebaseMessaging;
@@ -99,25 +105,82 @@ public class FcmService {
     }
 
     /**
-     * 부하테스트용 FCM 지연 주입.
+     * 채팅 알림을 수신자 전체에게 한 번의 요청(fan-out)
      */
+    public void sendChatMulticast(List<Member> recipients, String title, String content,
+                                  Long chatRoomId, ChatRoomType chatRoomType) {
+        List<String> tokens = recipients.stream()
+                .map(Member::getFcmToken)
+                .filter(token -> token != null && !token.isBlank())
+                .toList();
+
+        if (tokens.isEmpty()) {
+            log.info("[FCM] 채팅 멀티캐스트 대상 토큰 없음 - chatRoomId: {}", chatRoomId);
+            return;
+        }
+
+        // 부하테스트용 지연 주입
+        if (fakeLatencyMs > 0) {
+            sleepQuietly(fakeLatencyMs);
+            log.info("[FCM][FAKE] 멀티캐스트 지연주입 {}ms 후 실전송 스킵 - chatRoomId: {}, 수신자: {}",
+                    fakeLatencyMs, chatRoomId, tokens.size());
+            return;
+        }
+
+        Notification notification = Notification.builder()
+                .setTitle(title)
+                .setBody(content)
+                .build();
+        WebpushConfig webpushConfig = WebpushConfig.builder()
+                .setFcmOptions(WebpushFcmOptions.withLink(buildChatLink(chatRoomType, chatRoomId)))
+                .build();
+
+        long start = System.currentTimeMillis();
+        int successCount = 0;
+        int failureCount = 0;
+
+        for (int from = 0; from < tokens.size(); from += FCM_MULTICAST_MAX) {
+            List<String> chunk = tokens.subList(from, Math.min(from + FCM_MULTICAST_MAX, tokens.size()));
+            MulticastMessage message = MulticastMessage.builder()
+                    .addAllTokens(chunk)
+                    .setNotification(notification)
+                    .putData("chatRoomId", chatRoomId.toString())
+                    .putData("chatRoomType", chatRoomType.name())
+                    .setWebpushConfig(webpushConfig)
+                    .build();
+            try {
+                BatchResponse response = firebaseMessaging.sendEachForMulticast(message);
+                successCount += response.getSuccessCount();
+                failureCount += response.getFailureCount();
+            } catch (FirebaseMessagingException e) {
+                failureCount += chunk.size();
+                log.error("[FCM] 채팅 멀티캐스트 청크 전송 실패 - chatRoomId: {}, size: {}, error: {}",
+                        chatRoomId, chunk.size(), e.getMessage());
+            }
+        }
+
+        log.info("[FCM] 채팅 멀티캐스트 전송 완료 - chatRoomId: {}, 수신자: {}, 성공: {}, 실패: {}, 소요시간: {}ms",
+                chatRoomId, tokens.size(), successCount, failureCount, System.currentTimeMillis() - start);
+    }
+
+    // 부하테스트용 FCM 지연 주입
     private boolean applyFakeLatencyAndSkip(Long memberId) {
         if (fakeLatencyMs <= 0) {
             return false;
         }
-        try {
-            Thread.sleep(fakeLatencyMs);
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-        }
+        sleepQuietly(fakeLatencyMs);
         log.info("[FCM][FAKE] 지연주입 {}ms 후 실전송 스킵 - memberId: {}", fakeLatencyMs, memberId);
         return true;
     }
 
-    /**
-     * 채팅 알림 클릭 시 이동할 경로(상대경로)를 생성한다.
-     * webpush.fcm_options.link 로 전달되어 FCM이 클릭 시 네이티브로 이동시킨다.
-     */
+    private void sleepQuietly(long millis) {
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
     private String buildChatLink(ChatRoomType chatRoomType, Long chatRoomId) {
         return switch (chatRoomType) {
             case PARTY -> "/chat/group/" + chatRoomId;

--- a/src/main/java/umc/cockple/demo/domain/notification/service/ChatPushNotificationService.java
+++ b/src/main/java/umc/cockple/demo/domain/notification/service/ChatPushNotificationService.java
@@ -4,9 +4,12 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import umc.cockple.demo.domain.chat.enums.ChatRoomMemberStatus;
+import umc.cockple.demo.domain.member.domain.Member;
 import umc.cockple.demo.domain.notification.events.ChatNotificationEvent;
 import umc.cockple.demo.domain.chat.repository.ChatRoomMemberRepository;
 import umc.cockple.demo.domain.notification.fcm.FcmService;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -17,14 +20,18 @@ public class ChatPushNotificationService {
     private final ChatRoomMemberRepository chatRoomMemberRepository;
 
     public void sendPush(ChatNotificationEvent event) {
-        chatRoomMemberRepository
+        // 발신자 본인과 현재 채팅방을 보고 있는(active) 구독자는 푸시 대상에서 제외
+        List<Member> recipients = chatRoomMemberRepository
                 .findByChatRoomIdAndStatusWithMember(event.chatRoomId(), ChatRoomMemberStatus.JOINED)
                 .stream()
                 .filter(crm -> !crm.getMember().getId().equals(event.senderId()))
                 .filter(crm -> !event.activeSubscriberIds().contains(crm.getMember().getId()))
-                .forEach(crm -> fcmService.sendChatNotification(
-                        crm.getMember(), event.notificationTitle(), event.notificationContent(),
-                        event.chatRoomId(), event.chatRoomType()
-                ));
+                .map(crm -> crm.getMember())
+                .toList();
+
+        // 수신자 전체에게 한 번의 멀티캐스트로 전송
+        fcmService.sendChatMulticast(
+                recipients, event.notificationTitle(), event.notificationContent(),
+                event.chatRoomId(), event.chatRoomType());
     }
 }

--- a/src/test/java/umc/cockple/demo/domain/notification/fcm/FcmServiceTest.java
+++ b/src/test/java/umc/cockple/demo/domain/notification/fcm/FcmServiceTest.java
@@ -1,5 +1,6 @@
 package umc.cockple.demo.domain.notification.fcm;
 
+import com.google.firebase.messaging.BatchResponse;
 import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.FirebaseMessagingException;
 import org.junit.jupiter.api.BeforeEach;
@@ -11,11 +12,15 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
+import umc.cockple.demo.domain.chat.enums.ChatRoomType;
 import umc.cockple.demo.domain.member.domain.Member;
 import umc.cockple.demo.domain.member.repository.MemberRepository;
 import umc.cockple.demo.global.enums.Gender;
 import umc.cockple.demo.global.enums.Level;
 import umc.cockple.demo.support.fixture.MemberFixture;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.ArgumentMatchers.any;
@@ -23,6 +28,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("FcmService")
@@ -95,5 +101,65 @@ class FcmServiceTest {
                         .doesNotThrowAnyException();
             }
         }
+    }
+
+    @Nested
+    @DisplayName("sendChatMulticast - 채팅 알림 fan-out")
+    class SendChatMulticast {
+
+        @Test
+        @DisplayName("수신자가 여러 명이어도 멀티캐스트를 1회만 호출한다(fan-out N→1)")
+        void 수신자_여러명이면_멀티캐스트_1회() throws FirebaseMessagingException {
+            // given
+            given(firebaseMessaging.sendEachForMulticast(any())).willReturn(mock(BatchResponse.class));
+            List<Member> recipients = List.of(
+                    memberWith(1L, "t1"), memberWith(2L, "t2"), memberWith(3L, "t3"));
+
+            // when
+            fcmService.sendChatMulticast(recipients, "제목", "내용", 10L, ChatRoomType.PARTY);
+
+            // then: 개별 send가 아니라 멀티캐스트 1회
+            then(firebaseMessaging).should(times(1)).sendEachForMulticast(any());
+            then(firebaseMessaging).should(never()).send(any());
+        }
+
+        @Test
+        @DisplayName("수신자가 500명을 초과하면 500씩 나눠 호출한다")
+        void 오백명_초과시_청킹() throws FirebaseMessagingException {
+            // given
+            given(firebaseMessaging.sendEachForMulticast(any())).willReturn(mock(BatchResponse.class));
+            List<Member> recipients = new ArrayList<>();
+            for (int i = 0; i < 501; i++) {
+                recipients.add(memberWith((long) i, "t" + i));
+            }
+
+            // when
+            fcmService.sendChatMulticast(recipients, "제목", "내용", 10L, ChatRoomType.PARTY);
+
+            // then: 501명 → 500 + 1 = 2회
+            then(firebaseMessaging).should(times(2)).sendEachForMulticast(any());
+        }
+
+        @Test
+        @DisplayName("유효한 토큰이 하나도 없으면 전송하지 않는다")
+        void 토큰_전부_없으면_전송안함() throws FirebaseMessagingException {
+            // given
+            List<Member> recipients = List.of(memberWith(1L, null), memberWith(2L, ""));
+
+            // when
+            fcmService.sendChatMulticast(recipients, "제목", "내용", 10L, ChatRoomType.PARTY);
+
+            // then
+            then(firebaseMessaging).should(never()).sendEachForMulticast(any());
+        }
+    }
+
+    private Member memberWith(long id, String token) {
+        Member member = MemberFixture.createMember("m" + id, Gender.MALE, Level.C, 3000L + id);
+        ReflectionTestUtils.setField(member, "id", id);
+        if (token != null) {
+            ReflectionTestUtils.setField(member, "fcmToken", token);
+        }
+        return member;
     }
 }

--- a/src/test/java/umc/cockple/demo/domain/notification/service/ChatPushNotificationServiceTest.java
+++ b/src/test/java/umc/cockple/demo/domain/notification/service/ChatPushNotificationServiceTest.java
@@ -30,8 +30,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("ChatPushNotificationService")
@@ -62,6 +60,17 @@ class ChatPushNotificationServiceTest {
         ReflectionTestUtils.setField(offlineMember, "id", 3L);
     }
 
+    /**
+     * sendPush는 필터링된 수신자 전체를 sendChatMulticast에 한 번 넘긴다.
+     * 필터 검증은 "멀티캐스트가 받은 수신자 목록"으로 확인한다(개별 전송 → 묶음 전송으로 전환).
+     */
+    @SuppressWarnings("unchecked")
+    private List<Member> captureMulticastRecipients() {
+        ArgumentCaptor<List<Member>> captor = ArgumentCaptor.forClass(List.class);
+        then(fcmService).should().sendChatMulticast(captor.capture(), any(), any(), any(), any());
+        return captor.getValue();
+    }
+
     @Nested
     @DisplayName("단체채팅")
     class PartyChatRoom {
@@ -77,7 +86,7 @@ class ChatPushNotificationServiceTest {
         }
 
         @Test
-        @DisplayName("오프라인 멤버에게 FCM을 전송한다")
+        @DisplayName("오프라인 멤버를 멀티캐스트 수신자로 전달한다")
         void sendPush_toOfflineMember() {
             // given
             ChatNotificationEvent event = ChatNotificationEvent.create(
@@ -95,8 +104,8 @@ class ChatPushNotificationServiceTest {
             // when
             chatPushNotificationService.sendPush(event);
 
-            // then
-            then(fcmService).should(times(1)).sendChatNotification(any(), any(), any(), any(), any());
+            // then: 개별 전송이 아니라 멀티캐스트 1회, 수신자는 오프라인 멤버 1명
+            assertThat(captureMulticastRecipients()).containsExactly(offlineMember);
         }
 
         @Test
@@ -121,7 +130,7 @@ class ChatPushNotificationServiceTest {
             chatPushNotificationService.sendPush(event);
 
             // then
-            then(fcmService).should().sendChatNotification(
+            then(fcmService).should().sendChatMulticast(
                     any(), titleCaptor.capture(), contentCaptor.capture(), any(), any()
             );
             assertThat(titleCaptor.getValue()).isEqualTo("테스트모임");
@@ -129,7 +138,7 @@ class ChatPushNotificationServiceTest {
         }
 
         @Test
-        @DisplayName("sender는 FCM 대상에서 제외된다")
+        @DisplayName("sender는 수신자에서 제외된다")
         void sendPush_excludesSender() {
             // given
             ChatNotificationEvent event = ChatNotificationEvent.create(
@@ -143,12 +152,12 @@ class ChatPushNotificationServiceTest {
             // when
             chatPushNotificationService.sendPush(event);
 
-            // then
-            then(fcmService).should(never()).sendChatNotification(any(), any(), any(), any(), any());
+            // then: 수신자 목록이 비어 있음
+            assertThat(captureMulticastRecipients()).isEmpty();
         }
 
         @Test
-        @DisplayName("활성 구독자는 FCM 대상에서 제외된다")
+        @DisplayName("활성 구독자는 수신자에서 제외된다")
         void sendPush_excludesActiveSubscribers() {
             // given
             ChatNotificationEvent event = ChatNotificationEvent.create(
@@ -166,11 +175,11 @@ class ChatPushNotificationServiceTest {
             chatPushNotificationService.sendPush(event);
 
             // then
-            then(fcmService).should(never()).sendChatNotification(any(), any(), any(), any(), any());
+            assertThat(captureMulticastRecipients()).isEmpty();
         }
 
         @Test
-        @DisplayName("오프라인 멤버가 여러 명이면 모두에게 FCM을 전송한다")
+        @DisplayName("오프라인 멤버가 여러 명이면 모두 한 번의 멀티캐스트 수신자로 전달한다")
         void sendPush_toMultipleOfflineMembers() {
             // given
             Member anotherOffline = MemberFixture.createMember("또다른오프라인", Gender.FEMALE, Level.A, 1004L);
@@ -191,8 +200,8 @@ class ChatPushNotificationServiceTest {
             // when
             chatPushNotificationService.sendPush(event);
 
-            // then
-            then(fcmService).should(times(2)).sendChatNotification(any(), any(), any(), any(), any());
+            // then: 개별 2회가 아니라 멀티캐스트 1회에 수신자 2명
+            assertThat(captureMulticastRecipients()).containsExactly(offlineMember, anotherOffline);
         }
     }
 
@@ -209,7 +218,7 @@ class ChatPushNotificationServiceTest {
         }
 
         @Test
-        @DisplayName("오프라인 상대방에게 FCM을 전송한다")
+        @DisplayName("오프라인 상대방을 멀티캐스트 수신자로 전달한다")
         void sendPush_toOfflineCounterPart() {
             // given
             ChatNotificationEvent event = ChatNotificationEvent.create(
@@ -227,7 +236,7 @@ class ChatPushNotificationServiceTest {
             chatPushNotificationService.sendPush(event);
 
             // then
-            then(fcmService).should(times(1)).sendChatNotification(any(), any(), any(), any(), any());
+            assertThat(captureMulticastRecipients()).containsExactly(offlineMember);
         }
 
         @Test
@@ -252,7 +261,7 @@ class ChatPushNotificationServiceTest {
             chatPushNotificationService.sendPush(event);
 
             // then
-            then(fcmService).should().sendChatNotification(
+            then(fcmService).should().sendChatMulticast(
                     any(), titleCaptor.capture(), contentCaptor.capture(), any(), any()
             );
             assertThat(titleCaptor.getValue()).isEqualTo("발신자");
@@ -260,7 +269,7 @@ class ChatPushNotificationServiceTest {
         }
 
         @Test
-        @DisplayName("상대방이 활성 구독자면 FCM을 전송하지 않는다")
+        @DisplayName("상대방이 활성 구독자면 수신자에서 제외된다")
         void sendPush_excludesActiveCounterPart() {
             // given
             ChatNotificationEvent event = ChatNotificationEvent.create(
@@ -278,7 +287,7 @@ class ChatPushNotificationServiceTest {
             chatPushNotificationService.sendPush(event);
 
             // then
-            then(fcmService).should(never()).sendChatNotification(any(), any(), any(), any(), any());
+            assertThat(captureMulticastRecipients()).isEmpty();
         }
     }
 }


### PR DESCRIPTION
## ❤️ 기능 설명

채팅 알림 푸시를 수신자별 개별 전송에서 멀티캐스트 한 번으로 전환합니다.

### 변경
- `FcmService.sendChatMulticast` 추가 - 수신자 전체를 `sendEachForMulticast`로 묶어 전송
  - 토큰 500개 초과 시 청킹, 부분 실패는 `BatchResponse`로 카운트 로깅
- `ChatPushNotificationService.sendPush` - 개별 전송 루프 → 필터링된 수신자 목록으로 멀티캐스트 1회로 수정
- 더이상 이용하지 않는 기존 단건 `sendChatNotification` 제거

### 효과
FCM 호출은 외부 네트워크 왕복이므로, 호출 수 N→1 감소가 알림 전송 완료 지연을 단축합니다. 사실 이미 비동기로 되어있어서 사용자 체감효과는 미미할 거 같지만, 스레드 점유시간을 개선했습니다.


<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #695
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 기본 알림은 notification 도메인 구조를 리팩토링해야 할 거 같아서, 그걸 먼저 진행한 후 별도 PR로 분리하겠습니다.

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
