### PR TITLE
[refactor/#670] ChatProcessor를 message view assembler로 정리

### DIFF
--- a/src/main/java/umc/cockple/demo/domain/chat/service/query/ChatMessageHistoryQueryService.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/query/ChatMessageHistoryQueryService.java
@@ -14,7 +14,7 @@ import umc.cockple.demo.domain.chat.exception.ChatErrorCode;
 import umc.cockple.demo.domain.chat.exception.ChatException;
 import umc.cockple.demo.domain.chat.repository.ChatMessageRepository;
 import umc.cockple.demo.domain.chat.repository.ChatRoomMemberRepository;
-import umc.cockple.demo.domain.chat.service.ChatProcessor;
+import umc.cockple.demo.domain.chat.service.support.assembler.ChatMessageViewAssembler;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -28,7 +28,7 @@ public class ChatMessageHistoryQueryService {
 
     private final ChatRoomMemberRepository chatRoomMemberRepository;
     private final ChatMessageRepository chatMessageRepository;
-    private final ChatProcessor chatProcessor;
+    private final ChatMessageViewAssembler chatMessageViewAssembler;
     private final ChatConverter chatConverter;
 
     public ChatMessageDTO.Response getChatMessages(Long roomId, Long memberId, Long cursor, int size) {
@@ -47,7 +47,7 @@ public class ChatMessageHistoryQueryService {
                 : new ArrayList<>(messages);
 
         Collections.reverse(resultMessages);
-        List<ChatCommonDTO.MessageInfo> commonMessages = chatProcessor.processMessages(memberId, resultMessages);
+        List<ChatCommonDTO.MessageInfo> commonMessages = chatMessageViewAssembler.assembleMessages(memberId, resultMessages);
         List<ChatMessageDTO.MessageInfo> messageInfos = chatConverter.toChatMessageInfos(commonMessages);
 
         Long nextCursor = hasNext && !resultMessages.isEmpty()

--- a/src/main/java/umc/cockple/demo/domain/chat/service/query/ChatRoomDetailQueryService.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/query/ChatRoomDetailQueryService.java
@@ -18,7 +18,7 @@ import umc.cockple.demo.domain.chat.exception.ChatException;
 import umc.cockple.demo.domain.chat.repository.ChatMessageRepository;
 import umc.cockple.demo.domain.chat.repository.ChatRoomMemberRepository;
 import umc.cockple.demo.domain.chat.repository.ChatRoomRepository;
-import umc.cockple.demo.domain.chat.service.ChatProcessor;
+import umc.cockple.demo.domain.chat.service.support.assembler.ChatMessageViewAssembler;
 import umc.cockple.demo.domain.file.service.ImageUrlResolver;
 import umc.cockple.demo.domain.member.domain.Member;
 import umc.cockple.demo.domain.member.domain.ProfileImg;
@@ -39,7 +39,7 @@ public class ChatRoomDetailQueryService {
     private final ChatMessageRepository chatMessageRepository;
     private final ChatConverter chatConverter;
     private final ImageUrlResolver imageUrlResolver;
-    private final ChatProcessor chatProcessor;
+    private final ChatMessageViewAssembler chatMessageViewAssembler;
 
     public ChatRoomDetailDTO.Response getChatRoomDetail(Long roomId, Long memberId) {
         log.info("[초기 채팅방 조회 시작] - roomId: {}, memberId: {}", roomId, memberId);
@@ -53,7 +53,7 @@ public class ChatRoomDetailQueryService {
         List<ChatMessage> recentMessages = findRecentMessagesWithImages(roomId, pageable);
         List<ChatMessage> resultMessages = new ArrayList<>(recentMessages);
         Collections.reverse(resultMessages);
-        List<ChatCommonDTO.MessageInfo> commonMessages = chatProcessor.processMessages(memberId, resultMessages);
+        List<ChatCommonDTO.MessageInfo> commonMessages = chatMessageViewAssembler.assembleMessages(memberId, resultMessages);
         List<ChatRoomDetailDTO.MessageInfo> messageInfos = chatConverter.toChatRoomDetailMessageInfos(commonMessages);
 
         List<ChatRoomMember> participants = findChatRoomMembersWithMemberOrThrow(roomId);

--- a/src/main/java/umc/cockple/demo/domain/chat/service/support/assembler/ChatMessageViewAssembler.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/support/assembler/ChatMessageViewAssembler.java
@@ -1,4 +1,4 @@
-package umc.cockple.demo.domain.chat.service;
+package umc.cockple.demo.domain.chat.service.support.assembler;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -16,27 +16,27 @@ import java.util.List;
 
 @Component
 @RequiredArgsConstructor
-public class ChatProcessor {
+public class ChatMessageViewAssembler {
 
     private final FileService fileService;
     private final ChatConverter chatConverter;
 
-    public List<ChatCommonDTO.MessageInfo> processMessages(Long memberId, List<ChatMessage> recentMessages) {
+    public List<ChatCommonDTO.MessageInfo> assembleMessages(Long memberId, List<ChatMessage> recentMessages) {
         return recentMessages.stream()
-                .map(message -> processAndConvertMessage(message, memberId))
+                .map(message -> assembleMessageInfo(message, memberId))
                 .toList();
     }
 
-    private ChatCommonDTO.MessageInfo processAndConvertMessage(ChatMessage message, Long memberId) {
+    private ChatCommonDTO.MessageInfo assembleMessageInfo(ChatMessage message, Long memberId) {
         Member sender = message.getSender();
         boolean isSystemMessage = message.getType() == MessageType.SYSTEM;
         boolean isSenderWithdrawn = !isSystemMessage && (sender == null || sender.isWithdrawn());
         String senderProfileImageUrl = sender != null && !isSenderWithdrawn
                 ? generateProfileImageUrl(sender.getProfileImg())
                 : null;
-        List<ChatCommonDTO.FileInfo> processedFiles = processMessageFiles(message);
+        List<ChatCommonDTO.FileInfo> fileInfos = assembleSortedFileInfos(message);
         boolean isMyMessage = sender != null && !isSenderWithdrawn && isMyMessage(sender.getId(), memberId);
-        return chatConverter.toCommonMessageInfo(message, senderProfileImageUrl, processedFiles, isMyMessage, isSenderWithdrawn);
+        return chatConverter.toCommonMessageInfo(message, senderProfileImageUrl, fileInfos, isMyMessage, isSenderWithdrawn);
     }
 
     public String generateProfileImageUrl(ProfileImg profileImg) {
@@ -46,14 +46,14 @@ public class ChatProcessor {
         return null;
     }
 
-    private List<ChatCommonDTO.FileInfo> processMessageFiles(ChatMessage message) {
+    private List<ChatCommonDTO.FileInfo> assembleSortedFileInfos(ChatMessage message) {
         return message.getChatMessageFiles().stream()
                 .sorted(Comparator.comparing(ChatMessageFile::getFileOrder))
-                .map(this::processSingleFile)
+                .map(this::assembleFileInfo)
                 .toList();
     }
 
-    private ChatCommonDTO.FileInfo processSingleFile(ChatMessageFile file) {
+    private ChatCommonDTO.FileInfo assembleFileInfo(ChatMessageFile file) {
         String imageUrl = generateFileUrl(file);
         return chatConverter.toFileInfo(file, imageUrl);
     }

--- a/src/main/java/umc/cockple/demo/domain/chat/service/support/assembler/ChatMessageViewAssembler.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/support/assembler/ChatMessageViewAssembler.java
@@ -7,7 +7,7 @@ import umc.cockple.demo.domain.chat.domain.ChatMessage;
 import umc.cockple.demo.domain.chat.domain.ChatMessageFile;
 import umc.cockple.demo.domain.chat.dto.ChatCommonDTO;
 import umc.cockple.demo.domain.chat.enums.MessageType;
-import umc.cockple.demo.domain.file.service.FileService;
+import umc.cockple.demo.domain.file.service.ImageUrlResolver;
 import umc.cockple.demo.domain.member.domain.Member;
 import umc.cockple.demo.domain.member.domain.ProfileImg;
 
@@ -18,7 +18,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class ChatMessageViewAssembler {
 
-    private final FileService fileService;
+    private final ImageUrlResolver imageUrlResolver;
     private final ChatConverter chatConverter;
 
     public List<ChatCommonDTO.MessageInfo> assembleMessages(Long memberId, List<ChatMessage> recentMessages) {
@@ -32,18 +32,11 @@ public class ChatMessageViewAssembler {
         boolean isSystemMessage = message.getType() == MessageType.SYSTEM;
         boolean isSenderWithdrawn = !isSystemMessage && (sender == null || sender.isWithdrawn());
         String senderProfileImageUrl = sender != null && !isSenderWithdrawn
-                ? generateProfileImageUrl(sender.getProfileImg())
+                ? imageUrlResolver.resolve(sender.getProfileImg(), ProfileImg::getImgKey)
                 : null;
         List<ChatCommonDTO.FileInfo> fileInfos = assembleSortedFileInfos(message);
         boolean isMyMessage = sender != null && !isSenderWithdrawn && isMyMessage(sender.getId(), memberId);
         return chatConverter.toCommonMessageInfo(message, senderProfileImageUrl, fileInfos, isMyMessage, isSenderWithdrawn);
-    }
-
-    public String generateProfileImageUrl(ProfileImg profileImg) {
-        if (profileImg != null && profileImg.getImgKey() != null && !profileImg.getImgKey().isBlank()) {
-            return fileService.getUrlFromKey(profileImg.getImgKey());
-        }
-        return null;
     }
 
     private List<ChatCommonDTO.FileInfo> assembleSortedFileInfos(ChatMessage message) {
@@ -53,16 +46,9 @@ public class ChatMessageViewAssembler {
                 .toList();
     }
 
-    private ChatCommonDTO.FileInfo assembleFileInfo(ChatMessageFile file) {
-        String imageUrl = generateFileUrl(file);
+    public ChatCommonDTO.FileInfo assembleFileInfo(ChatMessageFile file) {
+        String imageUrl = imageUrlResolver.resolve(file, ChatMessageFile::getFileKey);
         return chatConverter.toFileInfo(file, imageUrl);
-    }
-
-    public String generateFileUrl(ChatMessageFile file) {
-        if (file != null && file.getFileKey() != null && !file.getFileKey().isBlank()) {
-            return fileService.getUrlFromKey(file.getFileKey());
-        }
-        return null;
     }
 
     private boolean isMyMessage(Long senderId, Long currentUserId) {

--- a/src/main/java/umc/cockple/demo/domain/chat/service/websocket/send/ChatSendService.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/websocket/send/ChatSendService.java
@@ -10,7 +10,7 @@ import umc.cockple.demo.domain.chat.dto.ChatCommonDTO;
 import umc.cockple.demo.domain.chat.dto.WebSocketMessageDTO;
 import umc.cockple.demo.domain.chat.enums.MessageType;
 import umc.cockple.demo.domain.chat.repository.ChatMessageRepository;
-import umc.cockple.demo.domain.chat.service.ChatProcessor;
+import umc.cockple.demo.domain.chat.service.support.assembler.ChatMessageViewAssembler;
 import umc.cockple.demo.domain.chat.service.websocket.send.support.ChatMessageFileAppender;
 import umc.cockple.demo.domain.chat.service.websocket.send.support.ChatSendEventPublisher;
 import umc.cockple.demo.domain.chat.service.websocket.send.support.DirectChatRoomActivationService;
@@ -40,7 +40,7 @@ public class ChatSendService {
     private final ActiveChatRoomSubscriberReader activeChatRoomSubscriberReader;
     private final ChatRoomMessageBroadcaster chatRoomMessageBroadcaster;
     private final MessageReadCreationService messageReadCreationService;
-    private final ChatProcessor chatProcessor;
+    private final ChatMessageViewAssembler chatMessageViewAssembler;
     private final ChatWebSocketResponseAssembler chatWebSocketResponseAssembler;
     private final SentMessageReadStatusService sentMessageReadStatusService;
 
@@ -50,7 +50,7 @@ public class ChatSendService {
         ChatRoom chatRoom = chatRoomReader.read(chatRoomId);
         Member sender = chatMemberReader.readWithProfile(senderId);
 
-        String profileImageUrl = chatProcessor.generateProfileImageUrl(sender.getProfileImg());
+        String profileImageUrl = chatMessageViewAssembler.generateProfileImageUrl(sender.getProfileImg());
 
         ChatMessage chatMessage = ChatMessage.create(chatRoom, sender, content, MessageType.TEXT);
         chatMessageFileAppender.append(chatMessage, files);
@@ -108,7 +108,7 @@ public class ChatSendService {
         return savedFiles.stream()
                 .map(file -> ChatCommonDTO.FileInfo.builder()
                         .imageId(file.getId())
-                        .imageUrl(chatProcessor.generateFileUrl(file))
+                        .imageUrl(chatMessageViewAssembler.generateFileUrl(file))
                         .imgOrder(file.getFileOrder())
                         .isEmoji(file.getIsEmoji())
                         .originalFileName(file.getOriginalFileName())

--- a/src/main/java/umc/cockple/demo/domain/chat/service/websocket/send/ChatSendService.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/websocket/send/ChatSendService.java
@@ -20,7 +20,9 @@ import umc.cockple.demo.domain.chat.service.websocket.send.support.SentMessageRe
 import umc.cockple.demo.domain.chat.service.websocket.send.support.MessageReadCreationService;
 import umc.cockple.demo.domain.chat.service.websocket.broadcast.ChatRoomMessageBroadcaster;
 import umc.cockple.demo.domain.chat.service.websocket.subscription.support.ActiveChatRoomSubscriberReader;
+import umc.cockple.demo.domain.file.service.ImageUrlResolver;
 import umc.cockple.demo.domain.member.domain.Member;
+import umc.cockple.demo.domain.member.domain.ProfileImg;
 
 import java.util.List;
 
@@ -41,6 +43,7 @@ public class ChatSendService {
     private final ChatRoomMessageBroadcaster chatRoomMessageBroadcaster;
     private final MessageReadCreationService messageReadCreationService;
     private final ChatMessageViewAssembler chatMessageViewAssembler;
+    private final ImageUrlResolver imageUrlResolver;
     private final ChatWebSocketResponseAssembler chatWebSocketResponseAssembler;
     private final SentMessageReadStatusService sentMessageReadStatusService;
 
@@ -50,7 +53,7 @@ public class ChatSendService {
         ChatRoom chatRoom = chatRoomReader.read(chatRoomId);
         Member sender = chatMemberReader.readWithProfile(senderId);
 
-        String profileImageUrl = chatMessageViewAssembler.generateProfileImageUrl(sender.getProfileImg());
+        String profileImageUrl = imageUrlResolver.resolve(sender.getProfileImg(), ProfileImg::getImgKey);
 
         ChatMessage chatMessage = ChatMessage.create(chatRoom, sender, content, MessageType.TEXT);
         chatMessageFileAppender.append(chatMessage, files);
@@ -106,15 +109,7 @@ public class ChatSendService {
     private List<ChatCommonDTO.FileInfo> createResponseFileInfos(
             List<ChatMessageFile> savedFiles) {
         return savedFiles.stream()
-                .map(file -> ChatCommonDTO.FileInfo.builder()
-                        .imageId(file.getId())
-                        .imageUrl(chatMessageViewAssembler.generateFileUrl(file))
-                        .imgOrder(file.getFileOrder())
-                        .isEmoji(file.getIsEmoji())
-                        .originalFileName(file.getOriginalFileName())
-                        .fileSize(file.getFileSize())
-                        .fileType(file.getFileType())
-                        .build())
+                .map(chatMessageViewAssembler::assembleFileInfo)
                 .toList();
     }
 

--- a/src/test/java/umc/cockple/demo/domain/chat/service/query/ChatMessageHistoryQueryServiceTest.java
+++ b/src/test/java/umc/cockple/demo/domain/chat/service/query/ChatMessageHistoryQueryServiceTest.java
@@ -20,6 +20,7 @@ import umc.cockple.demo.domain.chat.repository.ChatMessageRepository;
 import umc.cockple.demo.domain.chat.repository.ChatRoomMemberRepository;
 import umc.cockple.demo.domain.chat.service.support.assembler.ChatMessageViewAssembler;
 import umc.cockple.demo.domain.file.service.FileService;
+import umc.cockple.demo.domain.file.service.ImageUrlResolver;
 import umc.cockple.demo.domain.member.domain.Member;
 import umc.cockple.demo.domain.member.domain.ProfileImg;
 import umc.cockple.demo.domain.party.domain.Party;
@@ -51,7 +52,8 @@ class ChatMessageHistoryQueryServiceTest {
     @BeforeEach
     void setUp() {
         ChatConverter chatConverter = new ChatConverter();
-        ChatMessageViewAssembler chatMessageViewAssembler = new ChatMessageViewAssembler(fileService, chatConverter);
+        ChatMessageViewAssembler chatMessageViewAssembler =
+                new ChatMessageViewAssembler(new ImageUrlResolver(fileService), chatConverter);
         chatMessageHistoryQueryService = new ChatMessageHistoryQueryService(
                 chatRoomMemberRepository,
                 chatMessageRepository,

--- a/src/test/java/umc/cockple/demo/domain/chat/service/query/ChatMessageHistoryQueryServiceTest.java
+++ b/src/test/java/umc/cockple/demo/domain/chat/service/query/ChatMessageHistoryQueryServiceTest.java
@@ -18,7 +18,7 @@ import umc.cockple.demo.domain.chat.exception.ChatErrorCode;
 import umc.cockple.demo.domain.chat.exception.ChatException;
 import umc.cockple.demo.domain.chat.repository.ChatMessageRepository;
 import umc.cockple.demo.domain.chat.repository.ChatRoomMemberRepository;
-import umc.cockple.demo.domain.chat.service.ChatProcessor;
+import umc.cockple.demo.domain.chat.service.support.assembler.ChatMessageViewAssembler;
 import umc.cockple.demo.domain.file.service.FileService;
 import umc.cockple.demo.domain.member.domain.Member;
 import umc.cockple.demo.domain.member.domain.ProfileImg;
@@ -51,11 +51,11 @@ class ChatMessageHistoryQueryServiceTest {
     @BeforeEach
     void setUp() {
         ChatConverter chatConverter = new ChatConverter();
-        ChatProcessor chatProcessor = new ChatProcessor(fileService, chatConverter);
+        ChatMessageViewAssembler chatMessageViewAssembler = new ChatMessageViewAssembler(fileService, chatConverter);
         chatMessageHistoryQueryService = new ChatMessageHistoryQueryService(
                 chatRoomMemberRepository,
                 chatMessageRepository,
-                chatProcessor,
+                chatMessageViewAssembler,
                 chatConverter
         );
     }

--- a/src/test/java/umc/cockple/demo/domain/chat/service/query/ChatRoomDetailQueryServiceTest.java
+++ b/src/test/java/umc/cockple/demo/domain/chat/service/query/ChatRoomDetailQueryServiceTest.java
@@ -57,8 +57,8 @@ class ChatRoomDetailQueryServiceTest {
     @BeforeEach
     void setUp() {
         ChatConverter chatConverter = new ChatConverter();
-        ChatMessageViewAssembler chatMessageViewAssembler = new ChatMessageViewAssembler(fileService, chatConverter);
         ImageUrlResolver imageUrlResolver = new ImageUrlResolver(fileService);
+        ChatMessageViewAssembler chatMessageViewAssembler = new ChatMessageViewAssembler(imageUrlResolver, chatConverter);
         chatRoomDetailQueryService = new ChatRoomDetailQueryService(
                 chatRoomRepository,
                 chatRoomMemberRepository,

--- a/src/test/java/umc/cockple/demo/domain/chat/service/query/ChatRoomDetailQueryServiceTest.java
+++ b/src/test/java/umc/cockple/demo/domain/chat/service/query/ChatRoomDetailQueryServiceTest.java
@@ -21,7 +21,7 @@ import umc.cockple.demo.domain.chat.exception.ChatException;
 import umc.cockple.demo.domain.chat.repository.ChatMessageRepository;
 import umc.cockple.demo.domain.chat.repository.ChatRoomMemberRepository;
 import umc.cockple.demo.domain.chat.repository.ChatRoomRepository;
-import umc.cockple.demo.domain.chat.service.ChatProcessor;
+import umc.cockple.demo.domain.chat.service.support.assembler.ChatMessageViewAssembler;
 import umc.cockple.demo.domain.file.service.FileService;
 import umc.cockple.demo.domain.file.service.ImageUrlResolver;
 import umc.cockple.demo.domain.member.domain.Member;
@@ -57,7 +57,7 @@ class ChatRoomDetailQueryServiceTest {
     @BeforeEach
     void setUp() {
         ChatConverter chatConverter = new ChatConverter();
-        ChatProcessor chatProcessor = new ChatProcessor(fileService, chatConverter);
+        ChatMessageViewAssembler chatMessageViewAssembler = new ChatMessageViewAssembler(fileService, chatConverter);
         ImageUrlResolver imageUrlResolver = new ImageUrlResolver(fileService);
         chatRoomDetailQueryService = new ChatRoomDetailQueryService(
                 chatRoomRepository,
@@ -65,7 +65,7 @@ class ChatRoomDetailQueryServiceTest {
                 chatMessageRepository,
                 chatConverter,
                 imageUrlResolver,
-                chatProcessor
+                chatMessageViewAssembler
         );
     }
 

--- a/src/test/java/umc/cockple/demo/domain/chat/service/support/assembler/ChatMessageViewAssemblerTest.java
+++ b/src/test/java/umc/cockple/demo/domain/chat/service/support/assembler/ChatMessageViewAssemblerTest.java
@@ -1,4 +1,4 @@
-package umc.cockple.demo.domain.chat.service;
+package umc.cockple.demo.domain.chat.service.support.assembler;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -31,14 +31,14 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
-@DisplayName("ChatProcessor")
-class ChatProcessorTest {
+@DisplayName("ChatMessageViewAssembler")
+class ChatMessageViewAssemblerTest {
 
     @Mock
     private FileService fileService;
 
     private ChatConverter chatConverter;
-    private ChatProcessor chatProcessor;
+    private ChatMessageViewAssembler chatMessageViewAssembler;
 
     private Member sender;
     private ChatRoom chatRoom;
@@ -46,7 +46,7 @@ class ChatProcessorTest {
     @BeforeEach
     void setUp() {
         chatConverter = new ChatConverter();
-        chatProcessor = new ChatProcessor(fileService, chatConverter);
+        chatMessageViewAssembler = new ChatMessageViewAssembler(fileService, chatConverter);
 
         sender = MemberFixture.createMemberWithName("홍길동", "길동", Gender.MALE, Level.A, 1001L);
         ReflectionTestUtils.setField(sender, "id", 10L);
@@ -66,7 +66,7 @@ class ChatProcessorTest {
         @Test
         @DisplayName("profileImg가 null이면 null을 반환한다")
         void returnsNull_whenProfileImgIsNull() {
-            String result = chatProcessor.generateProfileImageUrl(null);
+            String result = chatMessageViewAssembler.generateProfileImageUrl(null);
 
             assertThat(result).isNull();
             verify(fileService, never()).getUrlFromKey(null);
@@ -79,7 +79,7 @@ class ChatProcessorTest {
                     .imgKey(null)
                     .build();
 
-            String result = chatProcessor.generateProfileImageUrl(profileImg);
+            String result = chatMessageViewAssembler.generateProfileImageUrl(profileImg);
 
             assertThat(result).isNull();
             verify(fileService, never()).getUrlFromKey(null);
@@ -92,7 +92,7 @@ class ChatProcessorTest {
                     .imgKey("   ")
                     .build();
 
-            String result = chatProcessor.generateProfileImageUrl(profileImg);
+            String result = chatMessageViewAssembler.generateProfileImageUrl(profileImg);
 
             assertThat(result).isNull();
             verify(fileService, never()).getUrlFromKey("   ");
@@ -108,7 +108,7 @@ class ChatProcessorTest {
             given(fileService.getUrlFromKey("profile/key123.jpg"))
                     .willReturn("https://cdn.example.com/profile/key123.jpg");
 
-            String result = chatProcessor.generateProfileImageUrl(profileImg);
+            String result = chatMessageViewAssembler.generateProfileImageUrl(profileImg);
 
             assertThat(result).isEqualTo("https://cdn.example.com/profile/key123.jpg");
             verify(fileService).getUrlFromKey("profile/key123.jpg");
@@ -124,7 +124,7 @@ class ChatProcessorTest {
         @Test
         @DisplayName("file이 null이면 null을 반환한다")
         void returnsNull_whenFileIsNull() {
-            String result = chatProcessor.generateFileUrl(null);
+            String result = chatMessageViewAssembler.generateFileUrl(null);
 
             assertThat(result).isNull();
         }
@@ -140,7 +140,7 @@ class ChatProcessorTest {
                     .fileType("image/jpeg")
                     .build();
 
-            String result = chatProcessor.generateFileUrl(img);
+            String result = chatMessageViewAssembler.generateFileUrl(img);
 
             assertThat(result).isNull();
             verify(fileService, never()).getUrlFromKey(null);
@@ -157,7 +157,7 @@ class ChatProcessorTest {
                     .fileType("image/jpeg")
                     .build();
 
-            String result = chatProcessor.generateFileUrl(img);
+            String result = chatMessageViewAssembler.generateFileUrl(img);
 
             assertThat(result).isNull();
             verify(fileService, never()).getUrlFromKey("  ");
@@ -177,23 +177,23 @@ class ChatProcessorTest {
             given(fileService.getUrlFromKey("chat/img456.jpg"))
                     .willReturn("https://cdn.example.com/chat/img456.jpg");
 
-            String result = chatProcessor.generateFileUrl(img);
+            String result = chatMessageViewAssembler.generateFileUrl(img);
 
             assertThat(result).isEqualTo("https://cdn.example.com/chat/img456.jpg");
             verify(fileService).getUrlFromKey("chat/img456.jpg");
         }
     }
 
-    // ========== processMessages ==========
+    // ========== assembleMessages ==========
 
     @Nested
-    @DisplayName("processMessages - 메시지 목록 처리")
+    @DisplayName("assembleMessages - 메시지 목록 처리")
     class ProcessMessages {
 
         @Test
         @DisplayName("빈 메시지 목록을 처리하면 빈 리스트를 반환한다")
         void returnsEmptyList_whenNoMessages() {
-            List<ChatCommonDTO.MessageInfo> result = chatProcessor.processMessages(sender.getId(), List.of());
+            List<ChatCommonDTO.MessageInfo> result = chatMessageViewAssembler.assembleMessages(sender.getId(), List.of());
 
             assertThat(result).isEmpty();
         }
@@ -204,7 +204,7 @@ class ChatProcessorTest {
             ChatMessage message = ChatFixture.createTextMessage(chatRoom, sender, "내 메시지");
             ReflectionTestUtils.setField(message, "id", 1L);
 
-            List<ChatCommonDTO.MessageInfo> result = chatProcessor.processMessages(sender.getId(), List.of(message));
+            List<ChatCommonDTO.MessageInfo> result = chatMessageViewAssembler.assembleMessages(sender.getId(), List.of(message));
 
             assertThat(result).hasSize(1);
             assertThat(result.get(0).isMyMessage()).isTrue();
@@ -219,7 +219,7 @@ class ChatProcessorTest {
             ChatMessage message = ChatFixture.createTextMessage(chatRoom, other, "상대방 메시지");
             ReflectionTestUtils.setField(message, "id", 1L);
 
-            List<ChatCommonDTO.MessageInfo> result = chatProcessor.processMessages(sender.getId(), List.of(message));
+            List<ChatCommonDTO.MessageInfo> result = chatMessageViewAssembler.assembleMessages(sender.getId(), List.of(message));
 
             assertThat(result).hasSize(1);
             assertThat(result.get(0).isMyMessage()).isFalse();
@@ -231,7 +231,7 @@ class ChatProcessorTest {
             ChatMessage message = ChatMessage.create(chatRoom, null, "삭제된 사용자 메시지", MessageType.TEXT);
             ReflectionTestUtils.setField(message, "id", 999L);
 
-            List<ChatCommonDTO.MessageInfo> result = chatProcessor.processMessages(sender.getId(), List.of(message));
+            List<ChatCommonDTO.MessageInfo> result = chatMessageViewAssembler.assembleMessages(sender.getId(), List.of(message));
 
             assertThat(result).hasSize(1);
             ChatCommonDTO.MessageInfo messageInfo = result.get(0);
@@ -256,7 +256,7 @@ class ChatProcessorTest {
             ChatMessage message = ChatFixture.createTextMessage(chatRoom, withdrawn, "탈퇴자 메시지");
             ReflectionTestUtils.setField(message, "id", 1L);
 
-            List<ChatCommonDTO.MessageInfo> result = chatProcessor.processMessages(sender.getId(), List.of(message));
+            List<ChatCommonDTO.MessageInfo> result = chatMessageViewAssembler.assembleMessages(sender.getId(), List.of(message));
 
             assertThat(result).hasSize(1);
             ChatCommonDTO.MessageInfo messageInfo = result.get(0);
@@ -273,7 +273,7 @@ class ChatProcessorTest {
             ChatMessage message = ChatFixture.createTextMessage(chatRoom, sender, "활성 사용자 메시지");
             ReflectionTestUtils.setField(message, "id", 1L);
 
-            List<ChatCommonDTO.MessageInfo> result = chatProcessor.processMessages(sender.getId(), List.of(message));
+            List<ChatCommonDTO.MessageInfo> result = chatMessageViewAssembler.assembleMessages(sender.getId(), List.of(message));
 
             assertThat(result.get(0).isSenderWithdrawn()).isFalse();
         }
@@ -284,7 +284,7 @@ class ChatProcessorTest {
             ChatMessage message = ChatFixture.createTextMessage(chatRoom, sender, "안녕하세요");
             ReflectionTestUtils.setField(message, "id", 1L);
 
-            List<ChatCommonDTO.MessageInfo> result = chatProcessor.processMessages(sender.getId(), List.of(message));
+            List<ChatCommonDTO.MessageInfo> result = chatMessageViewAssembler.assembleMessages(sender.getId(), List.of(message));
 
             ChatCommonDTO.MessageInfo info = result.get(0);
             assertThat(info.messageId()).isEqualTo(1L);
@@ -301,7 +301,7 @@ class ChatProcessorTest {
             ChatMessage message = ChatFixture.createTextMessage(chatRoom, sender, "메시지");
             ReflectionTestUtils.setField(message, "id", 1L);
 
-            List<ChatCommonDTO.MessageInfo> result = chatProcessor.processMessages(sender.getId(), List.of(message));
+            List<ChatCommonDTO.MessageInfo> result = chatMessageViewAssembler.assembleMessages(sender.getId(), List.of(message));
 
             assertThat(result.get(0).senderProfileImageUrl()).isNull();
             verify(fileService, never()).getUrlFromKey(null);
@@ -320,7 +320,7 @@ class ChatProcessorTest {
             ChatMessage msg3 = ChatFixture.createTextMessage(chatRoom, sender, "세 번째");
             ReflectionTestUtils.setField(msg3, "id", 3L);
 
-            List<ChatCommonDTO.MessageInfo> result = chatProcessor.processMessages(sender.getId(), List.of(msg1, msg2, msg3));
+            List<ChatCommonDTO.MessageInfo> result = chatMessageViewAssembler.assembleMessages(sender.getId(), List.of(msg1, msg2, msg3));
 
             assertThat(result).hasSize(3);
             assertThat(result.get(0).messageId()).isEqualTo(1L);
@@ -367,7 +367,7 @@ class ChatProcessorTest {
             given(fileService.getUrlFromKey("img/second.jpg")).willReturn("https://cdn.example.com/second.jpg");
             given(fileService.getUrlFromKey("img/third.jpg")).willReturn("https://cdn.example.com/third.jpg");
 
-            List<ChatCommonDTO.MessageInfo> result = chatProcessor.processMessages(sender.getId(), List.of(message));
+            List<ChatCommonDTO.MessageInfo> result = chatMessageViewAssembler.assembleMessages(sender.getId(), List.of(message));
 
             List<ChatCommonDTO.FileInfo> images = result.get(0).images();
             assertThat(images).hasSize(3);

--- a/src/test/java/umc/cockple/demo/domain/chat/service/support/assembler/ChatMessageViewAssemblerTest.java
+++ b/src/test/java/umc/cockple/demo/domain/chat/service/support/assembler/ChatMessageViewAssemblerTest.java
@@ -15,6 +15,7 @@ import umc.cockple.demo.domain.chat.domain.ChatRoom;
 import umc.cockple.demo.domain.chat.dto.ChatCommonDTO;
 import umc.cockple.demo.domain.chat.enums.MessageType;
 import umc.cockple.demo.domain.file.service.FileService;
+import umc.cockple.demo.domain.file.service.ImageUrlResolver;
 import umc.cockple.demo.domain.member.domain.Member;
 import umc.cockple.demo.domain.member.domain.ProfileImg;
 import umc.cockple.demo.global.enums.Gender;
@@ -46,7 +47,7 @@ class ChatMessageViewAssemblerTest {
     @BeforeEach
     void setUp() {
         chatConverter = new ChatConverter();
-        chatMessageViewAssembler = new ChatMessageViewAssembler(fileService, chatConverter);
+        chatMessageViewAssembler = new ChatMessageViewAssembler(new ImageUrlResolver(fileService), chatConverter);
 
         sender = MemberFixture.createMemberWithName("홍길동", "길동", Gender.MALE, Level.A, 1001L);
         ReflectionTestUtils.setField(sender, "id", 10L);
@@ -57,138 +58,11 @@ class ChatMessageViewAssemblerTest {
         ReflectionTestUtils.setField(chatRoom, "id", 1L);
     }
 
-    // ========== generateProfileImageUrl ==========
-
-    @Nested
-    @DisplayName("generateProfileImageUrl - 프로필 이미지 URL 생성")
-    class GenerateProfileImageUrl {
-
-        @Test
-        @DisplayName("profileImg가 null이면 null을 반환한다")
-        void returnsNull_whenProfileImgIsNull() {
-            String result = chatMessageViewAssembler.generateProfileImageUrl(null);
-
-            assertThat(result).isNull();
-            verify(fileService, never()).getUrlFromKey(null);
-        }
-
-        @Test
-        @DisplayName("imgKey가 null이면 null을 반환하고 imageService를 호출하지 않는다")
-        void returnsNull_whenImgKeyIsNull() {
-            ProfileImg profileImg = ProfileImg.builder()
-                    .imgKey(null)
-                    .build();
-
-            String result = chatMessageViewAssembler.generateProfileImageUrl(profileImg);
-
-            assertThat(result).isNull();
-            verify(fileService, never()).getUrlFromKey(null);
-        }
-
-        @Test
-        @DisplayName("imgKey가 공백 문자열이면 null을 반환하고 imageService를 호출하지 않는다")
-        void returnsNull_whenImgKeyIsBlank() {
-            ProfileImg profileImg = ProfileImg.builder()
-                    .imgKey("   ")
-                    .build();
-
-            String result = chatMessageViewAssembler.generateProfileImageUrl(profileImg);
-
-            assertThat(result).isNull();
-            verify(fileService, never()).getUrlFromKey("   ");
-        }
-
-        @Test
-        @DisplayName("유효한 imgKey가 있으면 imageService로 URL을 생성해서 반환한다")
-        void returnsUrl_whenImgKeyIsValid() {
-            ProfileImg profileImg = ProfileImg.builder()
-                    .imgKey("profile/key123.jpg")
-                    .build();
-
-            given(fileService.getUrlFromKey("profile/key123.jpg"))
-                    .willReturn("https://cdn.example.com/profile/key123.jpg");
-
-            String result = chatMessageViewAssembler.generateProfileImageUrl(profileImg);
-
-            assertThat(result).isEqualTo("https://cdn.example.com/profile/key123.jpg");
-            verify(fileService).getUrlFromKey("profile/key123.jpg");
-        }
-    }
-
-    // ========== generateFileUrl ==========
-
-    @Nested
-    @DisplayName("generateFileUrl - 채팅 파일 URL 생성")
-    class GenerateFileUrl {
-
-        @Test
-        @DisplayName("file이 null이면 null을 반환한다")
-        void returnsNull_whenFileIsNull() {
-            String result = chatMessageViewAssembler.generateFileUrl(null);
-
-            assertThat(result).isNull();
-        }
-
-        @Test
-        @DisplayName("fileKey가 null이면 null을 반환하고 fileService를 호출하지 않는다")
-        void returnsNull_whenFileKeyIsNull() {
-            ChatMessageFile img = ChatMessageFile.builder()
-                    .fileKey(null)
-                    .fileOrder(1)
-                    .originalFileName("photo.jpg")
-                    .fileSize(1024L)
-                    .fileType("image/jpeg")
-                    .build();
-
-            String result = chatMessageViewAssembler.generateFileUrl(img);
-
-            assertThat(result).isNull();
-            verify(fileService, never()).getUrlFromKey(null);
-        }
-
-        @Test
-        @DisplayName("fileKey가 공백 문자열이면 null을 반환하고 fileService를 호출하지 않는다")
-        void returnsNull_whenFileKeyIsBlank() {
-            ChatMessageFile img = ChatMessageFile.builder()
-                    .fileKey("  ")
-                    .fileOrder(1)
-                    .originalFileName("photo.jpg")
-                    .fileSize(1024L)
-                    .fileType("image/jpeg")
-                    .build();
-
-            String result = chatMessageViewAssembler.generateFileUrl(img);
-
-            assertThat(result).isNull();
-            verify(fileService, never()).getUrlFromKey("  ");
-        }
-
-        @Test
-        @DisplayName("유효한 fileKey가 있으면 fileService로 URL을 생성해서 반환한다")
-        void returnsUrl_whenFileKeyIsValid() {
-            ChatMessageFile img = ChatMessageFile.builder()
-                    .fileKey("chat/img456.jpg")
-                    .fileOrder(1)
-                    .originalFileName("photo.jpg")
-                    .fileSize(2048L)
-                    .fileType("image/jpeg")
-                    .build();
-
-            given(fileService.getUrlFromKey("chat/img456.jpg"))
-                    .willReturn("https://cdn.example.com/chat/img456.jpg");
-
-            String result = chatMessageViewAssembler.generateFileUrl(img);
-
-            assertThat(result).isEqualTo("https://cdn.example.com/chat/img456.jpg");
-            verify(fileService).getUrlFromKey("chat/img456.jpg");
-        }
-    }
-
     // ========== assembleMessages ==========
 
     @Nested
     @DisplayName("assembleMessages - 메시지 목록 처리")
-    class ProcessMessages {
+    class AssembleMessages {
 
         @Test
         @DisplayName("빈 메시지 목록을 처리하면 빈 리스트를 반환한다")
@@ -305,6 +179,24 @@ class ChatMessageViewAssemblerTest {
 
             assertThat(result.get(0).senderProfileImageUrl()).isNull();
             verify(fileService, never()).getUrlFromKey(null);
+        }
+
+        @Test
+        @DisplayName("활성 발신자의 프로필 이미지 키는 URL로 해석된다")
+        void senderProfileImageUrl_isResolved_whenProfileImgExists() {
+            sender.updateProfileImg(ProfileImg.builder()
+                    .imgKey("profile/sender.jpg")
+                    .build());
+            ChatMessage message = ChatFixture.createTextMessage(chatRoom, sender, "메시지");
+            ReflectionTestUtils.setField(message, "id", 1L);
+            given(fileService.getUrlFromKey("profile/sender.jpg"))
+                    .willReturn("https://cdn.example.com/profile/sender.jpg");
+
+            List<ChatCommonDTO.MessageInfo> result =
+                    chatMessageViewAssembler.assembleMessages(sender.getId(), List.of(message));
+
+            assertThat(result.get(0).senderProfileImageUrl())
+                    .isEqualTo("https://cdn.example.com/profile/sender.jpg");
         }
 
         @Test

--- a/src/test/java/umc/cockple/demo/domain/chat/service/websocket/send/ChatSendServiceTest.java
+++ b/src/test/java/umc/cockple/demo/domain/chat/service/websocket/send/ChatSendServiceTest.java
@@ -15,7 +15,7 @@ import umc.cockple.demo.domain.chat.domain.ChatRoom;
 import umc.cockple.demo.domain.chat.dto.WebSocketMessageDTO;
 import umc.cockple.demo.domain.chat.enums.MessageType;
 import umc.cockple.demo.domain.chat.repository.ChatMessageRepository;
-import umc.cockple.demo.domain.chat.service.ChatProcessor;
+import umc.cockple.demo.domain.chat.service.support.assembler.ChatMessageViewAssembler;
 import umc.cockple.demo.domain.chat.service.websocket.send.support.ChatMessageFileAppender;
 import umc.cockple.demo.domain.chat.service.websocket.send.support.ChatSendEventPublisher;
 import umc.cockple.demo.domain.chat.service.websocket.send.support.DirectChatRoomActivationService;
@@ -58,7 +58,7 @@ class ChatSendServiceTest {
     @Mock private ActiveChatRoomSubscriberReader activeChatRoomSubscriberReader;
     @Mock private ChatRoomMessageBroadcaster chatRoomMessageBroadcaster;
     @Mock private MessageReadCreationService messageReadCreationService;
-    @Mock private ChatProcessor chatProcessor;
+    @Mock private ChatMessageViewAssembler chatMessageViewAssembler;
     @Mock private SentMessageReadStatusService sentMessageReadStatusService;
 
     private ChatSendService chatSendService;
@@ -77,7 +77,7 @@ class ChatSendServiceTest {
                 activeChatRoomSubscriberReader,
                 chatRoomMessageBroadcaster,
                 messageReadCreationService,
-                chatProcessor,
+                chatMessageViewAssembler,
                 chatWebSocketResponseAssembler,
                 sentMessageReadStatusService
         );
@@ -100,7 +100,7 @@ class ChatSendServiceTest {
 
         given(chatRoomReader.read(roomId)).willReturn(chatRoom);
         given(chatMemberReader.readWithProfile(senderId)).willReturn(sender);
-        given(chatProcessor.generateProfileImageUrl(isNull())).willReturn("https://cdn.example.com/profile");
+        given(chatMessageViewAssembler.generateProfileImageUrl(isNull())).willReturn("https://cdn.example.com/profile");
         given(chatMessageRepository.save(any(ChatMessage.class))).willAnswer(invocation -> {
             ChatMessage savedMessage = invocation.getArgument(0);
             ReflectionTestUtils.setField(savedMessage, "id", 300L);
@@ -171,7 +171,7 @@ class ChatSendServiceTest {
 
         given(chatRoomReader.read(roomId)).willReturn(chatRoom);
         given(chatMemberReader.readWithProfile(senderId)).willReturn(sender);
-        given(chatProcessor.generateProfileImageUrl(isNull())).willReturn("https://cdn.example.com/profile");
+        given(chatMessageViewAssembler.generateProfileImageUrl(isNull())).willReturn("https://cdn.example.com/profile");
         given(chatMessageRepository.save(any(ChatMessage.class))).willAnswer(invocation -> {
             ChatMessage savedMessage = invocation.getArgument(0);
             ReflectionTestUtils.setField(savedMessage, "id", 300L);
@@ -185,7 +185,7 @@ class ChatSendServiceTest {
             ReflectionTestUtils.setField(savedMessage, "chatMessageFiles", List.of(secondFile, firstFile));
             return savedMessage;
         });
-        given(chatProcessor.generateFileUrl(any(ChatMessageFile.class))).willAnswer(invocation -> {
+        given(chatMessageViewAssembler.generateFileUrl(any(ChatMessageFile.class))).willAnswer(invocation -> {
             ChatMessageFile file = invocation.getArgument(0);
             return "https://cdn.example.com/" + file.getFileKey();
         });

--- a/src/test/java/umc/cockple/demo/domain/chat/service/websocket/send/ChatSendServiceTest.java
+++ b/src/test/java/umc/cockple/demo/domain/chat/service/websocket/send/ChatSendServiceTest.java
@@ -10,6 +10,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 import umc.cockple.demo.domain.chat.converter.ChatWebSocketResponseAssembler;
 import umc.cockple.demo.domain.chat.domain.ChatMessage;
+import umc.cockple.demo.domain.chat.domain.ChatMessageFile;
 import umc.cockple.demo.domain.chat.domain.ChatRoom;
 import umc.cockple.demo.domain.chat.dto.WebSocketMessageDTO;
 import umc.cockple.demo.domain.chat.enums.MessageType;
@@ -136,6 +137,84 @@ class ChatSendServiceTest {
                 .publishChatNotificationEvent(chatRoom, savedMessage, sender, List.of(senderId));
         then(chatSendEventPublisher).should().publishChatRoomListUpdateEvent(chatRoom, savedMessage);
         then(chatSendEventPublisher).should().publishUnreadStatusUpdateEvent(chatRoom, senderId);
+    }
+
+    @Test
+    @DisplayName("일반 메시지 응답에는 프로필 URL과 저장된 파일 정보가 저장 순서대로 포함된다")
+    void sendMessage_responseContainsProfileAndFilesInStoredOrder() {
+        // given
+        Long roomId = 20L;
+        Long senderId = 101L;
+        Member sender = MemberFixture.createMemberWithName("홍길동", "길동", Gender.MALE, Level.A, 1001L);
+        ReflectionTestUtils.setField(sender, "id", senderId);
+
+        Party party = PartyFixture.createParty("배드민턴 모임", senderId, PartyFixture.createPartyAddr("서울", "강남구"));
+        ChatRoom chatRoom = ChatFixture.createPartyChatRoom(party);
+        ReflectionTestUtils.setField(chatRoom, "id", roomId);
+
+        List<WebSocketMessageDTO.Request.FileInfo> requestFiles = List.of(
+                WebSocketMessageDTO.Request.FileInfo.builder()
+                        .imgKey("chat/second.jpg")
+                        .imgOrder(2)
+                        .originalFileName("second.jpg")
+                        .fileSize(200L)
+                        .fileType("image/jpeg")
+                        .build(),
+                WebSocketMessageDTO.Request.FileInfo.builder()
+                        .imgKey("chat/first.jpg")
+                        .imgOrder(1)
+                        .originalFileName("first.jpg")
+                        .fileSize(100L)
+                        .fileType("image/jpeg")
+                        .build()
+        );
+
+        given(chatRoomReader.read(roomId)).willReturn(chatRoom);
+        given(chatMemberReader.readWithProfile(senderId)).willReturn(sender);
+        given(chatProcessor.generateProfileImageUrl(isNull())).willReturn("https://cdn.example.com/profile");
+        given(chatMessageRepository.save(any(ChatMessage.class))).willAnswer(invocation -> {
+            ChatMessage savedMessage = invocation.getArgument(0);
+            ReflectionTestUtils.setField(savedMessage, "id", 300L);
+
+            ChatMessageFile secondFile = ChatMessageFile.create(
+                    savedMessage, "chat/second.jpg", 2, "second.jpg", 200L, "image/jpeg");
+            ChatMessageFile firstFile = ChatMessageFile.create(
+                    savedMessage, "chat/first.jpg", 1, "first.jpg", 100L, "image/jpeg");
+            ReflectionTestUtils.setField(secondFile, "id", 302L);
+            ReflectionTestUtils.setField(firstFile, "id", 301L);
+            ReflectionTestUtils.setField(savedMessage, "chatMessageFiles", List.of(secondFile, firstFile));
+            return savedMessage;
+        });
+        given(chatProcessor.generateFileUrl(any(ChatMessageFile.class))).willAnswer(invocation -> {
+            ChatMessageFile file = invocation.getArgument(0);
+            return "https://cdn.example.com/" + file.getFileKey();
+        });
+        given(activeChatRoomSubscriberReader.findActiveSubscribers(roomId)).willReturn(List.of(senderId));
+        given(sentMessageReadStatusService.markActiveSubscribersAsRead(roomId, 300L, List.of(senderId), senderId))
+                .willReturn(2);
+
+        // when
+        chatSendService.sendMessage(roomId, "사진입니다", requestFiles, senderId);
+
+        // then
+        then(chatMessageFileAppender).should().append(any(ChatMessage.class), eq(requestFiles));
+
+        ArgumentCaptor<WebSocketMessageDTO.MessageResponse> responseCaptor =
+                ArgumentCaptor.forClass(WebSocketMessageDTO.MessageResponse.class);
+        then(chatRoomMessageBroadcaster).should()
+                .broadcast(eq(roomId), responseCaptor.capture(), eq(List.of(senderId)), eq(senderId));
+
+        WebSocketMessageDTO.MessageResponse response = responseCaptor.getValue();
+        assertThat(response.senderProfileImageUrl()).isEqualTo("https://cdn.example.com/profile");
+        assertThat(response.images()).extracting(image -> image.imageId())
+                .containsExactly(302L, 301L);
+        assertThat(response.images()).extracting(image -> image.imageUrl())
+                .containsExactly(
+                        "https://cdn.example.com/chat/second.jpg",
+                        "https://cdn.example.com/chat/first.jpg"
+                );
+        assertThat(response.images()).extracting(image -> image.imgOrder())
+                .containsExactly(2, 1);
     }
 
     @Test

--- a/src/test/java/umc/cockple/demo/domain/chat/service/websocket/send/ChatSendServiceTest.java
+++ b/src/test/java/umc/cockple/demo/domain/chat/service/websocket/send/ChatSendServiceTest.java
@@ -12,6 +12,7 @@ import umc.cockple.demo.domain.chat.converter.ChatWebSocketResponseAssembler;
 import umc.cockple.demo.domain.chat.domain.ChatMessage;
 import umc.cockple.demo.domain.chat.domain.ChatMessageFile;
 import umc.cockple.demo.domain.chat.domain.ChatRoom;
+import umc.cockple.demo.domain.chat.dto.ChatCommonDTO;
 import umc.cockple.demo.domain.chat.dto.WebSocketMessageDTO;
 import umc.cockple.demo.domain.chat.enums.MessageType;
 import umc.cockple.demo.domain.chat.repository.ChatMessageRepository;
@@ -26,6 +27,7 @@ import umc.cockple.demo.domain.chat.service.websocket.send.ChatSendService;
 import umc.cockple.demo.domain.chat.service.websocket.send.support.MessageReadCreationService;
 import umc.cockple.demo.domain.chat.service.websocket.broadcast.ChatRoomMessageBroadcaster;
 import umc.cockple.demo.domain.chat.service.websocket.subscription.support.ActiveChatRoomSubscriberReader;
+import umc.cockple.demo.domain.file.service.ImageUrlResolver;
 import umc.cockple.demo.domain.member.domain.Member;
 import umc.cockple.demo.domain.party.domain.Party;
 import umc.cockple.demo.global.enums.Gender;
@@ -59,6 +61,7 @@ class ChatSendServiceTest {
     @Mock private ChatRoomMessageBroadcaster chatRoomMessageBroadcaster;
     @Mock private MessageReadCreationService messageReadCreationService;
     @Mock private ChatMessageViewAssembler chatMessageViewAssembler;
+    @Mock private ImageUrlResolver imageUrlResolver;
     @Mock private SentMessageReadStatusService sentMessageReadStatusService;
 
     private ChatSendService chatSendService;
@@ -78,6 +81,7 @@ class ChatSendServiceTest {
                 chatRoomMessageBroadcaster,
                 messageReadCreationService,
                 chatMessageViewAssembler,
+                imageUrlResolver,
                 chatWebSocketResponseAssembler,
                 sentMessageReadStatusService
         );
@@ -100,7 +104,7 @@ class ChatSendServiceTest {
 
         given(chatRoomReader.read(roomId)).willReturn(chatRoom);
         given(chatMemberReader.readWithProfile(senderId)).willReturn(sender);
-        given(chatMessageViewAssembler.generateProfileImageUrl(isNull())).willReturn("https://cdn.example.com/profile");
+        given(imageUrlResolver.resolve(isNull(), any())).willReturn("https://cdn.example.com/profile");
         given(chatMessageRepository.save(any(ChatMessage.class))).willAnswer(invocation -> {
             ChatMessage savedMessage = invocation.getArgument(0);
             ReflectionTestUtils.setField(savedMessage, "id", 300L);
@@ -171,7 +175,7 @@ class ChatSendServiceTest {
 
         given(chatRoomReader.read(roomId)).willReturn(chatRoom);
         given(chatMemberReader.readWithProfile(senderId)).willReturn(sender);
-        given(chatMessageViewAssembler.generateProfileImageUrl(isNull())).willReturn("https://cdn.example.com/profile");
+        given(imageUrlResolver.resolve(isNull(), any())).willReturn("https://cdn.example.com/profile");
         given(chatMessageRepository.save(any(ChatMessage.class))).willAnswer(invocation -> {
             ChatMessage savedMessage = invocation.getArgument(0);
             ReflectionTestUtils.setField(savedMessage, "id", 300L);
@@ -185,9 +189,17 @@ class ChatSendServiceTest {
             ReflectionTestUtils.setField(savedMessage, "chatMessageFiles", List.of(secondFile, firstFile));
             return savedMessage;
         });
-        given(chatMessageViewAssembler.generateFileUrl(any(ChatMessageFile.class))).willAnswer(invocation -> {
+        given(chatMessageViewAssembler.assembleFileInfo(any(ChatMessageFile.class))).willAnswer(invocation -> {
             ChatMessageFile file = invocation.getArgument(0);
-            return "https://cdn.example.com/" + file.getFileKey();
+            return ChatCommonDTO.FileInfo.builder()
+                    .imageId(file.getId())
+                    .imageUrl("https://cdn.example.com/" + file.getFileKey())
+                    .imgOrder(file.getFileOrder())
+                    .isEmoji(file.getIsEmoji())
+                    .originalFileName(file.getOriginalFileName())
+                    .fileSize(file.getFileSize())
+                    .fileType(file.getFileType())
+                    .build();
         });
         given(activeChatRoomSubscriberReader.findActiveSubscribers(roomId)).willReturn(List.of(senderId));
         given(sentMessageReadStatusService.markActiveSubscribersAsRead(roomId, 300L, List.of(senderId), senderId))


### PR DESCRIPTION
## ❤️ 기능 설명

`ChatProcessor`의 이름과 위치를 실제 역할인 message view assembly에 맞게 정리했습니다.

REST 메시지 조회와 WebSocket 전송에서 사용하는 `ChatCommonDTO` 조립 책임을 `ChatMessageViewAssembler`로 명확히 하고, 이미지 URL 해석은 기존 공용 `ImageUrlResolver`로 통일했습니다.

### 변경 내용
- `ChatProcessor`를 `service/support/assembler/ChatMessageViewAssembler`로 이름 변경 및 위치 이동
- `processMessages`를 `assembleMessages`로 변경하고 query service 의존성 갱신
- SYSTEM 메시지, 탈퇴/삭제된 발신자, `isMyMessage` 판정과 조회 파일 정렬 동작 유지
- 프로필/채팅 파일 URL 처리를 `ImageUrlResolver`로 통일
- WebSocket 파일 응답 조립을 `ChatMessageViewAssembler.assembleFileInfo`에 위임

<br>

## 연결된 issue

close #670

<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [x] REST/WebSocket API path와 DTO schema 변경 없이 내부 조립 책임만 정리한 PR입니다.
- [x] REST 조회 파일은 기존처럼 `fileOrder` 오름차순, WebSocket 응답 파일은 저장된 컬렉션 순서를 유지합니다.

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
