### PR TITLE
[refactor/#672] ChatValidator를 WebSocket request validator로 재배치

### DIFF
--- a/src/main/java/umc/cockple/demo/domain/chat/presentation/websocket/ChatWebSocketCommandHandler.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/presentation/websocket/ChatWebSocketCommandHandler.java
@@ -9,7 +9,7 @@ import umc.cockple.demo.domain.chat.events.ChatListSubscriptionEvent;
 import umc.cockple.demo.domain.chat.events.ChatMessageSendEvent;
 import umc.cockple.demo.domain.chat.events.ChatRoomSubscriptionEvent;
 import umc.cockple.demo.domain.chat.exception.ChatException;
-import umc.cockple.demo.domain.chat.service.ChatValidator;
+import umc.cockple.demo.domain.chat.service.websocket.validation.ChatWebSocketRequestValidator;
 import umc.cockple.demo.domain.chat.service.websocket.command.ChatCommandResponder;
 
 @Component
@@ -17,7 +17,7 @@ import umc.cockple.demo.domain.chat.service.websocket.command.ChatCommandRespond
 @RequiredArgsConstructor
 public class ChatWebSocketCommandHandler {
 
-    private final ChatValidator chatValidator;
+    private final ChatWebSocketRequestValidator chatWebSocketRequestValidator;
     private final ApplicationEventPublisher eventPublisher;
 
     public void handle(
@@ -52,7 +52,7 @@ public class ChatWebSocketCommandHandler {
             ChatCommandResponder responder
     ) {
         try {
-            chatValidator.validateSendRequest(
+            chatWebSocketRequestValidator.validateSendRequest(
                     request.chatRoomId(), request.content(), request.images(), memberId);
 
             ChatMessageSendEvent sendEvent =
@@ -75,7 +75,7 @@ public class ChatWebSocketCommandHandler {
             ChatCommandResponder responder
     ) {
         try {
-            chatValidator.validateSubscriptionRequest(request.chatRoomId(), memberId);
+            chatWebSocketRequestValidator.validateSubscriptionRequest(request.chatRoomId(), memberId);
 
             ChatRoomSubscriptionEvent subscribeEvent =
                     ChatRoomSubscriptionEvent.subscribe(request.chatRoomId(), memberId);
@@ -100,7 +100,7 @@ public class ChatWebSocketCommandHandler {
             ChatCommandResponder responder
     ) {
         try {
-            chatValidator.validateUnsubscriptionRequest(request.chatRoomId(), memberId);
+            chatWebSocketRequestValidator.validateUnsubscriptionRequest(request.chatRoomId(), memberId);
 
             ChatRoomSubscriptionEvent unsubscribeEvent =
                     ChatRoomSubscriptionEvent.unsubscribe(request.chatRoomId(), memberId);
@@ -125,7 +125,7 @@ public class ChatWebSocketCommandHandler {
             ChatCommandResponder responder
     ) {
         try {
-            chatValidator.validateChatListSubscriptionRequest(memberId, request.memberRooms());
+            chatWebSocketRequestValidator.validateChatListSubscriptionRequest(memberId, request.memberRooms());
 
             ChatListSubscriptionEvent subscribeEvent =
                     ChatListSubscriptionEvent.subscribe(memberId, request.memberRooms());
@@ -150,7 +150,7 @@ public class ChatWebSocketCommandHandler {
             ChatCommandResponder responder
     ) {
         try {
-            chatValidator.validateChatListUnsubscriptionRequest(memberId, request.memberRooms());
+            chatWebSocketRequestValidator.validateChatListUnsubscriptionRequest(memberId, request.memberRooms());
 
             ChatListSubscriptionEvent unsubscribeEvent =
                     ChatListSubscriptionEvent.unsubscribe(memberId, request.memberRooms());

--- a/src/main/java/umc/cockple/demo/domain/chat/service/support/reader/ChatRoomMemberReader.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/support/reader/ChatRoomMemberReader.java
@@ -1,0 +1,19 @@
+package umc.cockple.demo.domain.chat.service.support.reader;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import umc.cockple.demo.domain.chat.repository.ChatRoomMemberRepository;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class ChatRoomMemberReader {
+
+    private final ChatRoomMemberRepository chatRoomMemberRepository;
+
+    public boolean exists(Long chatRoomId, Long memberId) {
+        return Boolean.TRUE.equals(
+                chatRoomMemberRepository.existsByChatRoomIdAndMemberId(chatRoomId, memberId));
+    }
+}

--- a/src/main/java/umc/cockple/demo/domain/chat/service/support/reader/ChatRoomReader.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/support/reader/ChatRoomReader.java
@@ -17,6 +17,10 @@ public class ChatRoomReader {
 
     private final ChatRoomRepository chatRoomRepository;
 
+    public boolean exists(Long chatRoomId) {
+        return chatRoomRepository.existsById(chatRoomId);
+    }
+
     public ChatRoom read(Long chatRoomId) {
         return chatRoomRepository.findById(chatRoomId)
                 .orElseThrow(() -> new ChatException(ChatErrorCode.CHAT_ROOM_NOT_FOUND));

--- a/src/main/java/umc/cockple/demo/domain/chat/service/websocket/validation/ChatWebSocketRequestValidator.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/websocket/validation/ChatWebSocketRequestValidator.java
@@ -6,8 +6,8 @@ import org.springframework.stereotype.Service;
 import umc.cockple.demo.domain.chat.dto.WebSocketMessageDTO.Request.FileInfo;
 import umc.cockple.demo.domain.chat.exception.ChatErrorCode;
 import umc.cockple.demo.domain.chat.exception.ChatException;
-import umc.cockple.demo.domain.chat.repository.ChatRoomMemberRepository;
-import umc.cockple.demo.domain.chat.repository.ChatRoomRepository;
+import umc.cockple.demo.domain.chat.service.support.reader.ChatRoomMemberReader;
+import umc.cockple.demo.domain.chat.service.support.reader.ChatRoomReader;
 
 import java.util.List;
 
@@ -16,8 +16,8 @@ import java.util.List;
 @Slf4j
 public class ChatWebSocketRequestValidator {
 
-    private final ChatRoomRepository chatRoomRepository;
-    private final ChatRoomMemberRepository chatRoomMemberRepository;
+    private final ChatRoomReader chatRoomReader;
+    private final ChatRoomMemberReader chatRoomMemberReader;
 
     public void validateSendRequest(Long chatRoomId, String content, List<FileInfo> files, Long senderId) {
         validateChatRoom(chatRoomId);
@@ -52,13 +52,13 @@ public class ChatWebSocketRequestValidator {
             throw new ChatException(ChatErrorCode.CHATROOM_ID_NECESSARY);
         }
 
-        if (!chatRoomRepository.existsById(chatRoomId)) {
+        if (!chatRoomReader.exists(chatRoomId)) {
             throw new ChatException(ChatErrorCode.CHAT_ROOM_NOT_FOUND);
         }
     }
 
     private void validateChatRoomMember(Long chatRoomId, Long memberId) {
-        if (!chatRoomMemberRepository.existsByChatRoomIdAndMemberId(chatRoomId, memberId))
+        if (!chatRoomMemberReader.exists(chatRoomId, memberId))
             throw new ChatException(ChatErrorCode.CHAT_ROOM_ACCESS_DENIED);
     }
 
@@ -93,7 +93,7 @@ public class ChatWebSocketRequestValidator {
                 throw new ChatException(ChatErrorCode.INVALID_CHATROOM_ID);
             }
 
-            if (!chatRoomMemberRepository.existsByChatRoomIdAndMemberId(chatRoomId, memberId)) {
+            if (!chatRoomMemberReader.exists(chatRoomId, memberId)) {
                 throw new ChatException(ChatErrorCode.CHAT_ROOM_ACCESS_DENIED);
             }
         }

--- a/src/main/java/umc/cockple/demo/domain/chat/service/websocket/validation/ChatWebSocketRequestValidator.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/websocket/validation/ChatWebSocketRequestValidator.java
@@ -1,4 +1,4 @@
-package umc.cockple.demo.domain.chat.service;
+package umc.cockple.demo.domain.chat.service.websocket.validation;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -14,7 +14,7 @@ import java.util.List;
 @Service
 @RequiredArgsConstructor
 @Slf4j
-public class ChatValidator {
+public class ChatWebSocketRequestValidator {
 
     private final ChatRoomRepository chatRoomRepository;
     private final ChatRoomMemberRepository chatRoomMemberRepository;

--- a/src/main/java/umc/cockple/demo/domain/chat/service/websocket/validation/ChatWebSocketRequestValidator.java
+++ b/src/main/java/umc/cockple/demo/domain/chat/service/websocket/validation/ChatWebSocketRequestValidator.java
@@ -3,6 +3,7 @@ package umc.cockple.demo.domain.chat.service.websocket.validation;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import umc.cockple.demo.domain.chat.dto.WebSocketMessageDTO.Request.FileInfo;
 import umc.cockple.demo.domain.chat.exception.ChatErrorCode;
 import umc.cockple.demo.domain.chat.exception.ChatException;
@@ -12,6 +13,7 @@ import umc.cockple.demo.domain.chat.service.support.reader.ChatRoomReader;
 import java.util.List;
 
 @Service
+@Transactional(readOnly = true)
 @RequiredArgsConstructor
 @Slf4j
 public class ChatWebSocketRequestValidator {

--- a/src/test/java/umc/cockple/demo/domain/chat/compatibility/ChatWebSocketCompatibilityTest.java
+++ b/src/test/java/umc/cockple/demo/domain/chat/compatibility/ChatWebSocketCompatibilityTest.java
@@ -21,7 +21,7 @@ import umc.cockple.demo.domain.chat.presentation.websocket.ChatWebSocketRequestD
 import umc.cockple.demo.domain.chat.presentation.websocket.WebSocketResponseSender;
 import umc.cockple.demo.domain.chat.presentation.websocket.session.ChatWebSocketSessionRegistry;
 import umc.cockple.demo.domain.chat.presentation.websocket.session.WebSocketMessageSender;
-import umc.cockple.demo.domain.chat.service.ChatValidator;
+import umc.cockple.demo.domain.chat.service.websocket.validation.ChatWebSocketRequestValidator;
 import umc.cockple.demo.domain.chat.service.websocket.session.ChatMessageFanout;
 import umc.cockple.demo.global.realtime.config.RealtimeWebSocketProperties;
 import umc.cockple.demo.global.realtime.message.EncodedRealtimeMessage;
@@ -52,7 +52,7 @@ import static org.mockito.Mockito.never;
 class ChatWebSocketCompatibilityTest {
 
     private ObjectMapper objectMapper;
-    private ChatValidator chatValidator;
+    private ChatWebSocketRequestValidator chatWebSocketRequestValidator;
     private ApplicationEventPublisher eventPublisher;
     private ChatWebSocketCommandHandler commandHandler;
     private RealtimeMessageEncoder messageEncoder;
@@ -63,9 +63,9 @@ class ChatWebSocketCompatibilityTest {
         objectMapper = new ObjectMapper()
                 .findAndRegisterModules()
                 .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
-        chatValidator = mock(ChatValidator.class);
+        chatWebSocketRequestValidator = mock(ChatWebSocketRequestValidator.class);
         eventPublisher = mock(ApplicationEventPublisher.class);
-        commandHandler = new ChatWebSocketCommandHandler(chatValidator, eventPublisher);
+        commandHandler = new ChatWebSocketCommandHandler(chatWebSocketRequestValidator, eventPublisher);
         messageEncoder = new JacksonRealtimeMessageEncoder(objectMapper);
         sessionMessageSender = new WebSocketSessionMessageSender();
     }

--- a/src/test/java/umc/cockple/demo/domain/chat/presentation/websocket/ChatWebSocketCommandHandlerTest.java
+++ b/src/test/java/umc/cockple/demo/domain/chat/presentation/websocket/ChatWebSocketCommandHandlerTest.java
@@ -16,7 +16,7 @@ import umc.cockple.demo.domain.chat.exception.ChatException;
 import umc.cockple.demo.domain.chat.events.ChatListSubscriptionEvent;
 import umc.cockple.demo.domain.chat.events.ChatMessageSendEvent;
 import umc.cockple.demo.domain.chat.events.ChatRoomSubscriptionEvent;
-import umc.cockple.demo.domain.chat.service.ChatValidator;
+import umc.cockple.demo.domain.chat.service.websocket.validation.ChatWebSocketRequestValidator;
 import umc.cockple.demo.domain.chat.service.websocket.command.ChatCommandResponder;
 
 import java.util.List;
@@ -29,7 +29,7 @@ import static org.mockito.BDDMockito.willThrow;
 @DisplayName("ChatWebSocketCommandHandler")
 class ChatWebSocketCommandHandlerTest {
 
-    @Mock private ChatValidator chatValidator;
+    @Mock private ChatWebSocketRequestValidator chatWebSocketRequestValidator;
     @Mock private ChatCommandResponder responder;
     @Mock private ApplicationEventPublisher eventPublisher;
 
@@ -38,7 +38,7 @@ class ChatWebSocketCommandHandlerTest {
     @BeforeEach
     void setUp() {
         commandHandler = new ChatWebSocketCommandHandler(
-                chatValidator,
+                chatWebSocketRequestValidator,
                 eventPublisher
         );
     }
@@ -66,7 +66,7 @@ class ChatWebSocketCommandHandlerTest {
             commandHandler.handle(request, memberId, responder);
 
             // then
-            then(chatValidator).should().validateSendRequest(chatRoomId, "hello", List.of(), memberId);
+            then(chatWebSocketRequestValidator).should().validateSendRequest(chatRoomId, "hello", List.of(), memberId);
 
             ArgumentCaptor<ChatMessageSendEvent> eventCaptor = ArgumentCaptor.forClass(ChatMessageSendEvent.class);
             then(eventPublisher).should().publishEvent(eventCaptor.capture());
@@ -95,7 +95,7 @@ class ChatWebSocketCommandHandlerTest {
                     null
             );
             willThrow(new ChatException(errorCode))
-                    .given(chatValidator)
+                    .given(chatWebSocketRequestValidator)
                     .validateSendRequest(chatRoomId, "hello", List.of(), memberId);
 
             // when
@@ -121,7 +121,7 @@ class ChatWebSocketCommandHandlerTest {
                     null
             );
             willThrow(new IllegalStateException("boom"))
-                    .given(chatValidator)
+                    .given(chatWebSocketRequestValidator)
                     .validateSendRequest(chatRoomId, "hello", List.of(), memberId);
 
             // when
@@ -157,7 +157,7 @@ class ChatWebSocketCommandHandlerTest {
             commandHandler.handle(request, memberId, responder);
 
             // then
-            then(chatValidator).should().validateSubscriptionRequest(chatRoomId, memberId);
+            then(chatWebSocketRequestValidator).should().validateSubscriptionRequest(chatRoomId, memberId);
 
             ArgumentCaptor<ChatRoomSubscriptionEvent> eventCaptor = ArgumentCaptor.forClass(ChatRoomSubscriptionEvent.class);
             then(eventPublisher).should().publishEvent(eventCaptor.capture());
@@ -185,7 +185,7 @@ class ChatWebSocketCommandHandlerTest {
                     null
             );
             willThrow(new ChatException(errorCode))
-                    .given(chatValidator)
+                    .given(chatWebSocketRequestValidator)
                     .validateSubscriptionRequest(chatRoomId, memberId);
 
             // when
@@ -211,7 +211,7 @@ class ChatWebSocketCommandHandlerTest {
                     null
             );
             willThrow(new IllegalStateException("boom"))
-                    .given(chatValidator)
+                    .given(chatWebSocketRequestValidator)
                     .validateSubscriptionRequest(chatRoomId, memberId);
 
             // when
@@ -247,7 +247,7 @@ class ChatWebSocketCommandHandlerTest {
             commandHandler.handle(request, memberId, responder);
 
             // then
-            then(chatValidator).should().validateUnsubscriptionRequest(chatRoomId, memberId);
+            then(chatWebSocketRequestValidator).should().validateUnsubscriptionRequest(chatRoomId, memberId);
 
             ArgumentCaptor<ChatRoomSubscriptionEvent> eventCaptor = ArgumentCaptor.forClass(ChatRoomSubscriptionEvent.class);
             then(eventPublisher).should().publishEvent(eventCaptor.capture());
@@ -275,7 +275,7 @@ class ChatWebSocketCommandHandlerTest {
                     null
             );
             willThrow(new ChatException(errorCode))
-                    .given(chatValidator)
+                    .given(chatWebSocketRequestValidator)
                     .validateUnsubscriptionRequest(chatRoomId, memberId);
 
             // when
@@ -301,7 +301,7 @@ class ChatWebSocketCommandHandlerTest {
                     null
             );
             willThrow(new IllegalStateException("boom"))
-                    .given(chatValidator)
+                    .given(chatWebSocketRequestValidator)
                     .validateUnsubscriptionRequest(chatRoomId, memberId);
 
             // when
@@ -337,7 +337,7 @@ class ChatWebSocketCommandHandlerTest {
             commandHandler.handle(request, memberId, responder);
 
             // then
-            then(chatValidator).should().validateChatListSubscriptionRequest(memberId, chatRoomIds);
+            then(chatWebSocketRequestValidator).should().validateChatListSubscriptionRequest(memberId, chatRoomIds);
 
             ArgumentCaptor<ChatListSubscriptionEvent> eventCaptor = ArgumentCaptor.forClass(ChatListSubscriptionEvent.class);
             then(eventPublisher).should().publishEvent(eventCaptor.capture());
@@ -366,7 +366,7 @@ class ChatWebSocketCommandHandlerTest {
                     null
             );
             willThrow(new ChatException(errorCode))
-                    .given(chatValidator)
+                    .given(chatWebSocketRequestValidator)
                     .validateChatListSubscriptionRequest(memberId, chatRoomIds);
 
             // when
@@ -392,7 +392,7 @@ class ChatWebSocketCommandHandlerTest {
                     null
             );
             willThrow(new IllegalStateException("boom"))
-                    .given(chatValidator)
+                    .given(chatWebSocketRequestValidator)
                     .validateChatListSubscriptionRequest(memberId, chatRoomIds);
 
             // when
@@ -428,7 +428,7 @@ class ChatWebSocketCommandHandlerTest {
             commandHandler.handle(request, memberId, responder);
 
             // then
-            then(chatValidator).should().validateChatListUnsubscriptionRequest(memberId, chatRoomIds);
+            then(chatWebSocketRequestValidator).should().validateChatListUnsubscriptionRequest(memberId, chatRoomIds);
 
             ArgumentCaptor<ChatListSubscriptionEvent> eventCaptor = ArgumentCaptor.forClass(ChatListSubscriptionEvent.class);
             then(eventPublisher).should().publishEvent(eventCaptor.capture());
@@ -457,7 +457,7 @@ class ChatWebSocketCommandHandlerTest {
                     null
             );
             willThrow(new ChatException(errorCode))
-                    .given(chatValidator)
+                    .given(chatWebSocketRequestValidator)
                     .validateChatListUnsubscriptionRequest(memberId, chatRoomIds);
 
             // when
@@ -483,7 +483,7 @@ class ChatWebSocketCommandHandlerTest {
                     null
             );
             willThrow(new IllegalStateException("boom"))
-                    .given(chatValidator)
+                    .given(chatWebSocketRequestValidator)
                     .validateChatListUnsubscriptionRequest(memberId, chatRoomIds);
 
             // when
@@ -516,7 +516,7 @@ class ChatWebSocketCommandHandlerTest {
         // then
         then(responder).should()
                 .sendError("UNKNOWN_TYPE", "알 수 없는 메시지 타입입니다:" + WebSocketMessageType.ERROR);
-        then(chatValidator).shouldHaveNoInteractions();
+        then(chatWebSocketRequestValidator).shouldHaveNoInteractions();
         then(eventPublisher).shouldHaveNoInteractions();
     }
 

--- a/src/test/java/umc/cockple/demo/domain/chat/service/support/reader/ChatRoomMemberReaderTest.java
+++ b/src/test/java/umc/cockple/demo/domain/chat/service/support/reader/ChatRoomMemberReaderTest.java
@@ -1,0 +1,58 @@
+package umc.cockple.demo.domain.chat.service.support.reader;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import umc.cockple.demo.domain.chat.repository.ChatRoomMemberRepository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ChatRoomMemberReader")
+class ChatRoomMemberReaderTest {
+
+    @Mock private ChatRoomMemberRepository chatRoomMemberRepository;
+
+    private ChatRoomMemberReader chatRoomMemberReader;
+
+    @BeforeEach
+    void setUp() {
+        chatRoomMemberReader = new ChatRoomMemberReader(chatRoomMemberRepository);
+    }
+
+    @Test
+    @DisplayName("채팅방 멤버 존재 여부를 반환한다")
+    void exists_returnsRepositoryResult() {
+        // given
+        Long chatRoomId = 1L;
+        Long memberId = 2L;
+        given(chatRoomMemberRepository.existsByChatRoomIdAndMemberId(chatRoomId, memberId))
+                .willReturn(true);
+
+        // when
+        boolean result = chatRoomMemberReader.exists(chatRoomId, memberId);
+
+        // then
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    @DisplayName("채팅방 멤버가 없으면 false를 반환한다")
+    void exists_returnsFalseWhenChatRoomMemberNotFound() {
+        // given
+        Long chatRoomId = 1L;
+        Long memberId = 2L;
+        given(chatRoomMemberRepository.existsByChatRoomIdAndMemberId(chatRoomId, memberId))
+                .willReturn(false);
+
+        // when
+        boolean result = chatRoomMemberReader.exists(chatRoomId, memberId);
+
+        // then
+        assertThat(result).isFalse();
+    }
+}

--- a/src/test/java/umc/cockple/demo/domain/chat/service/support/reader/ChatRoomReaderTest.java
+++ b/src/test/java/umc/cockple/demo/domain/chat/service/support/reader/ChatRoomReaderTest.java
@@ -33,6 +33,34 @@ class ChatRoomReaderTest {
     }
 
     @Test
+    @DisplayName("채팅방 존재 여부를 반환한다")
+    void exists_returnsRepositoryResult() {
+        // given
+        Long chatRoomId = 1L;
+        given(chatRoomRepository.existsById(chatRoomId)).willReturn(true);
+
+        // when
+        boolean result = chatRoomReader.exists(chatRoomId);
+
+        // then
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    @DisplayName("채팅방이 없으면 false를 반환한다")
+    void exists_returnsFalseWhenChatRoomNotFound() {
+        // given
+        Long chatRoomId = 1L;
+        given(chatRoomRepository.existsById(chatRoomId)).willReturn(false);
+
+        // when
+        boolean result = chatRoomReader.exists(chatRoomId);
+
+        // then
+        assertThat(result).isFalse();
+    }
+
+    @Test
     @DisplayName("채팅방 ID로 채팅방을 조회한다")
     void read_returnsChatRoom() {
         // given

--- a/src/test/java/umc/cockple/demo/domain/chat/service/websocket/validation/ChatWebSocketRequestValidatorTest.java
+++ b/src/test/java/umc/cockple/demo/domain/chat/service/websocket/validation/ChatWebSocketRequestValidatorTest.java
@@ -1,4 +1,4 @@
-package umc.cockple.demo.domain.chat.service;
+package umc.cockple.demo.domain.chat.service.websocket.validation;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -26,11 +26,11 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
-@DisplayName("ChatValidator")
-class ChatValidatorTest {
+@DisplayName("ChatWebSocketRequestValidator")
+class ChatWebSocketRequestValidatorTest {
 
     @InjectMocks
-    private ChatValidator chatValidator;
+    private ChatWebSocketRequestValidator chatWebSocketRequestValidator;
 
     @Mock
     private ChatRoomRepository chatRoomRepository;
@@ -47,7 +47,7 @@ class ChatValidatorTest {
         void success_whenContentExists() {
             givenExistingRoomAndMembership(10L, 1L);
 
-            assertThatCode(() -> chatValidator.validateSendRequest(10L, "hello", List.of(), 1L))
+            assertThatCode(() -> chatWebSocketRequestValidator.validateSendRequest(10L, "hello", List.of(), 1L))
                     .doesNotThrowAnyException();
         }
 
@@ -59,7 +59,7 @@ class ChatValidatorTest {
                     new WebSocketMessageDTO.Request.FileInfo("chat/a.webp", 1, "a.webp", 100L, "image/webp")
             );
 
-            assertThatCode(() -> chatValidator.validateSendRequest(10L, null, files, 1L))
+            assertThatCode(() -> chatWebSocketRequestValidator.validateSendRequest(10L, null, files, 1L))
                     .doesNotThrowAnyException();
         }
 
@@ -68,7 +68,7 @@ class ChatValidatorTest {
         void fail_whenChatRoomIdIsNull() {
             assertChatException(
                     ChatErrorCode.CHATROOM_ID_NECESSARY,
-                    () -> chatValidator.validateSendRequest(null, "hello", List.of(), 1L)
+                    () -> chatWebSocketRequestValidator.validateSendRequest(null, "hello", List.of(), 1L)
             );
             verify(chatRoomRepository, never()).existsById(null);
         }
@@ -80,7 +80,7 @@ class ChatValidatorTest {
 
             assertChatException(
                     ChatErrorCode.CHAT_ROOM_NOT_FOUND,
-                    () -> chatValidator.validateSendRequest(10L, "hello", List.of(), 1L)
+                    () -> chatWebSocketRequestValidator.validateSendRequest(10L, "hello", List.of(), 1L)
             );
             verify(chatRoomMemberRepository, never()).existsByChatRoomIdAndMemberId(10L, 1L);
         }
@@ -93,7 +93,7 @@ class ChatValidatorTest {
 
             assertChatException(
                     ChatErrorCode.CHAT_ROOM_ACCESS_DENIED,
-                    () -> chatValidator.validateSendRequest(10L, "hello", List.of(), 1L)
+                    () -> chatWebSocketRequestValidator.validateSendRequest(10L, "hello", List.of(), 1L)
             );
         }
 
@@ -104,7 +104,7 @@ class ChatValidatorTest {
 
             assertChatException(
                     ChatErrorCode.EMPTY_MESSAGE_NOT_ALLOWED,
-                    () -> chatValidator.validateSendRequest(10L, "   ", List.of(), 1L)
+                    () -> chatWebSocketRequestValidator.validateSendRequest(10L, "   ", List.of(), 1L)
             );
         }
 
@@ -116,7 +116,7 @@ class ChatValidatorTest {
 
             assertChatException(
                     ChatErrorCode.MESSAGE_TO_LONG,
-                    () -> chatValidator.validateSendRequest(10L, tooLongContent, List.of(), 1L)
+                    () -> chatWebSocketRequestValidator.validateSendRequest(10L, tooLongContent, List.of(), 1L)
             );
         }
     }
@@ -130,9 +130,9 @@ class ChatValidatorTest {
         void success_whenRoomAndMembershipExist() {
             givenExistingRoomAndMembership(10L, 1L);
 
-            assertThatCode(() -> chatValidator.validateSubscriptionRequest(10L, 1L))
+            assertThatCode(() -> chatWebSocketRequestValidator.validateSubscriptionRequest(10L, 1L))
                     .doesNotThrowAnyException();
-            assertThatCode(() -> chatValidator.validateUnsubscriptionRequest(10L, 1L))
+            assertThatCode(() -> chatWebSocketRequestValidator.validateUnsubscriptionRequest(10L, 1L))
                     .doesNotThrowAnyException();
         }
 
@@ -143,7 +143,7 @@ class ChatValidatorTest {
 
             assertChatException(
                     ChatErrorCode.CHAT_ROOM_NOT_FOUND,
-                    () -> chatValidator.validateSubscriptionRequest(10L, 1L)
+                    () -> chatWebSocketRequestValidator.validateSubscriptionRequest(10L, 1L)
             );
         }
 
@@ -155,7 +155,7 @@ class ChatValidatorTest {
 
             assertChatException(
                     ChatErrorCode.CHAT_ROOM_ACCESS_DENIED,
-                    () -> chatValidator.validateUnsubscriptionRequest(10L, 1L)
+                    () -> chatWebSocketRequestValidator.validateUnsubscriptionRequest(10L, 1L)
             );
         }
     }
@@ -170,7 +170,7 @@ class ChatValidatorTest {
             given(chatRoomMemberRepository.existsByChatRoomIdAndMemberId(10L, 1L)).willReturn(true);
             given(chatRoomMemberRepository.existsByChatRoomIdAndMemberId(20L, 1L)).willReturn(true);
 
-            assertThatCode(() -> chatValidator.validateChatListSubscriptionRequest(1L, List.of(10L, 10L, 20L)))
+            assertThatCode(() -> chatWebSocketRequestValidator.validateChatListSubscriptionRequest(1L, List.of(10L, 10L, 20L)))
                     .doesNotThrowAnyException();
 
             verify(chatRoomMemberRepository, times(1)).existsByChatRoomIdAndMemberId(10L, 1L);
@@ -182,7 +182,7 @@ class ChatValidatorTest {
         void success_unsubscriptionUsesSameValidation() {
             given(chatRoomMemberRepository.existsByChatRoomIdAndMemberId(10L, 1L)).willReturn(true);
 
-            assertThatCode(() -> chatValidator.validateChatListUnsubscriptionRequest(1L, List.of(10L)))
+            assertThatCode(() -> chatWebSocketRequestValidator.validateChatListUnsubscriptionRequest(1L, List.of(10L)))
                     .doesNotThrowAnyException();
         }
 
@@ -191,11 +191,11 @@ class ChatValidatorTest {
         void fail_whenRoomIdsAreNullOrEmpty() {
             assertChatException(
                     ChatErrorCode.CHATROOM_LIST_EMPTY,
-                    () -> chatValidator.validateChatListSubscriptionRequest(1L, null)
+                    () -> chatWebSocketRequestValidator.validateChatListSubscriptionRequest(1L, null)
             );
             assertChatException(
                     ChatErrorCode.CHATROOM_LIST_EMPTY,
-                    () -> chatValidator.validateChatListSubscriptionRequest(1L, Collections.emptyList())
+                    () -> chatWebSocketRequestValidator.validateChatListSubscriptionRequest(1L, Collections.emptyList())
             );
         }
 
@@ -206,7 +206,7 @@ class ChatValidatorTest {
 
             assertChatException(
                     ChatErrorCode.TOO_MANY_CHATROOMS,
-                    () -> chatValidator.validateChatListSubscriptionRequest(1L, tooManyRoomIds)
+                    () -> chatWebSocketRequestValidator.validateChatListSubscriptionRequest(1L, tooManyRoomIds)
             );
         }
 
@@ -215,11 +215,11 @@ class ChatValidatorTest {
         void fail_whenRoomIdIsInvalid() {
             assertChatException(
                     ChatErrorCode.INVALID_CHATROOM_ID,
-                    () -> chatValidator.validateChatListSubscriptionRequest(1L, List.of(0L, 10L))
+                    () -> chatWebSocketRequestValidator.validateChatListSubscriptionRequest(1L, List.of(0L, 10L))
             );
             assertChatException(
                     ChatErrorCode.INVALID_CHATROOM_ID,
-                    () -> chatValidator.validateChatListSubscriptionRequest(1L, Arrays.asList(null, 10L))
+                    () -> chatWebSocketRequestValidator.validateChatListSubscriptionRequest(1L, Arrays.asList(null, 10L))
             );
         }
 
@@ -231,7 +231,7 @@ class ChatValidatorTest {
 
             assertChatException(
                     ChatErrorCode.CHAT_ROOM_ACCESS_DENIED,
-                    () -> chatValidator.validateChatListUnsubscriptionRequest(1L, List.of(10L, 20L))
+                    () -> chatWebSocketRequestValidator.validateChatListUnsubscriptionRequest(1L, List.of(10L, 20L))
             );
         }
     }

--- a/src/test/java/umc/cockple/demo/domain/chat/service/websocket/validation/ChatWebSocketRequestValidatorTest.java
+++ b/src/test/java/umc/cockple/demo/domain/chat/service/websocket/validation/ChatWebSocketRequestValidatorTest.java
@@ -10,8 +10,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import umc.cockple.demo.domain.chat.dto.WebSocketMessageDTO;
 import umc.cockple.demo.domain.chat.exception.ChatErrorCode;
 import umc.cockple.demo.domain.chat.exception.ChatException;
-import umc.cockple.demo.domain.chat.repository.ChatRoomMemberRepository;
-import umc.cockple.demo.domain.chat.repository.ChatRoomRepository;
+import umc.cockple.demo.domain.chat.service.support.reader.ChatRoomMemberReader;
+import umc.cockple.demo.domain.chat.service.support.reader.ChatRoomReader;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -33,10 +33,10 @@ class ChatWebSocketRequestValidatorTest {
     private ChatWebSocketRequestValidator chatWebSocketRequestValidator;
 
     @Mock
-    private ChatRoomRepository chatRoomRepository;
+    private ChatRoomReader chatRoomReader;
 
     @Mock
-    private ChatRoomMemberRepository chatRoomMemberRepository;
+    private ChatRoomMemberReader chatRoomMemberReader;
 
     @Nested
     @DisplayName("validateSendRequest")
@@ -70,26 +70,26 @@ class ChatWebSocketRequestValidatorTest {
                     ChatErrorCode.CHATROOM_ID_NECESSARY,
                     () -> chatWebSocketRequestValidator.validateSendRequest(null, "hello", List.of(), 1L)
             );
-            verify(chatRoomRepository, never()).existsById(null);
+            verify(chatRoomReader, never()).exists(null);
         }
 
         @Test
         @DisplayName("실패 - 채팅방이 없으면 CHAT_ROOM_NOT_FOUND 예외를 던진다")
         void fail_whenChatRoomNotFound() {
-            given(chatRoomRepository.existsById(10L)).willReturn(false);
+            given(chatRoomReader.exists(10L)).willReturn(false);
 
             assertChatException(
                     ChatErrorCode.CHAT_ROOM_NOT_FOUND,
                     () -> chatWebSocketRequestValidator.validateSendRequest(10L, "hello", List.of(), 1L)
             );
-            verify(chatRoomMemberRepository, never()).existsByChatRoomIdAndMemberId(10L, 1L);
+            verify(chatRoomMemberReader, never()).exists(10L, 1L);
         }
 
         @Test
         @DisplayName("실패 - 채팅방 멤버가 아니면 CHAT_ROOM_ACCESS_DENIED 예외를 던진다")
         void fail_whenNotChatRoomMember() {
-            given(chatRoomRepository.existsById(10L)).willReturn(true);
-            given(chatRoomMemberRepository.existsByChatRoomIdAndMemberId(10L, 1L)).willReturn(false);
+            given(chatRoomReader.exists(10L)).willReturn(true);
+            given(chatRoomMemberReader.exists(10L, 1L)).willReturn(false);
 
             assertChatException(
                     ChatErrorCode.CHAT_ROOM_ACCESS_DENIED,
@@ -139,7 +139,7 @@ class ChatWebSocketRequestValidatorTest {
         @Test
         @DisplayName("실패 - 채팅방이 없으면 CHAT_ROOM_NOT_FOUND 예외를 던진다")
         void fail_whenChatRoomNotFound() {
-            given(chatRoomRepository.existsById(10L)).willReturn(false);
+            given(chatRoomReader.exists(10L)).willReturn(false);
 
             assertChatException(
                     ChatErrorCode.CHAT_ROOM_NOT_FOUND,
@@ -150,8 +150,8 @@ class ChatWebSocketRequestValidatorTest {
         @Test
         @DisplayName("실패 - 권한이 없으면 CHAT_ROOM_ACCESS_DENIED 예외를 던진다")
         void fail_whenNotChatRoomMember() {
-            given(chatRoomRepository.existsById(10L)).willReturn(true);
-            given(chatRoomMemberRepository.existsByChatRoomIdAndMemberId(10L, 1L)).willReturn(false);
+            given(chatRoomReader.exists(10L)).willReturn(true);
+            given(chatRoomMemberReader.exists(10L, 1L)).willReturn(false);
 
             assertChatException(
                     ChatErrorCode.CHAT_ROOM_ACCESS_DENIED,
@@ -167,20 +167,20 @@ class ChatWebSocketRequestValidatorTest {
         @Test
         @DisplayName("성공 - 중복 채팅방 ID는 distinct 처리해 권한을 확인한다")
         void success_checksDistinctRoomIds() {
-            given(chatRoomMemberRepository.existsByChatRoomIdAndMemberId(10L, 1L)).willReturn(true);
-            given(chatRoomMemberRepository.existsByChatRoomIdAndMemberId(20L, 1L)).willReturn(true);
+            given(chatRoomMemberReader.exists(10L, 1L)).willReturn(true);
+            given(chatRoomMemberReader.exists(20L, 1L)).willReturn(true);
 
             assertThatCode(() -> chatWebSocketRequestValidator.validateChatListSubscriptionRequest(1L, List.of(10L, 10L, 20L)))
                     .doesNotThrowAnyException();
 
-            verify(chatRoomMemberRepository, times(1)).existsByChatRoomIdAndMemberId(10L, 1L);
-            verify(chatRoomMemberRepository, times(1)).existsByChatRoomIdAndMemberId(20L, 1L);
+            verify(chatRoomMemberReader, times(1)).exists(10L, 1L);
+            verify(chatRoomMemberReader, times(1)).exists(20L, 1L);
         }
 
         @Test
         @DisplayName("성공 - 구독 해제도 동일한 채팅방 목록 검증을 통과한다")
         void success_unsubscriptionUsesSameValidation() {
-            given(chatRoomMemberRepository.existsByChatRoomIdAndMemberId(10L, 1L)).willReturn(true);
+            given(chatRoomMemberReader.exists(10L, 1L)).willReturn(true);
 
             assertThatCode(() -> chatWebSocketRequestValidator.validateChatListUnsubscriptionRequest(1L, List.of(10L)))
                     .doesNotThrowAnyException();
@@ -226,8 +226,8 @@ class ChatWebSocketRequestValidatorTest {
         @Test
         @DisplayName("실패 - 하나라도 접근 권한이 없으면 CHAT_ROOM_ACCESS_DENIED 예외를 던진다")
         void fail_whenAnyRoomAccessDenied() {
-            given(chatRoomMemberRepository.existsByChatRoomIdAndMemberId(10L, 1L)).willReturn(true);
-            given(chatRoomMemberRepository.existsByChatRoomIdAndMemberId(20L, 1L)).willReturn(false);
+            given(chatRoomMemberReader.exists(10L, 1L)).willReturn(true);
+            given(chatRoomMemberReader.exists(20L, 1L)).willReturn(false);
 
             assertChatException(
                     ChatErrorCode.CHAT_ROOM_ACCESS_DENIED,
@@ -237,8 +237,8 @@ class ChatWebSocketRequestValidatorTest {
     }
 
     private void givenExistingRoomAndMembership(Long chatRoomId, Long memberId) {
-        given(chatRoomRepository.existsById(chatRoomId)).willReturn(true);
-        given(chatRoomMemberRepository.existsByChatRoomIdAndMemberId(chatRoomId, memberId)).willReturn(true);
+        given(chatRoomReader.exists(chatRoomId)).willReturn(true);
+        given(chatRoomMemberReader.exists(chatRoomId, memberId)).willReturn(true);
     }
 
     private void assertChatException(ChatErrorCode expectedCode, ThrowingRunnable runnable) {


### PR DESCRIPTION
## ❤️ 기능 설명

넓은 이름과 위치를 갖고 있던 `ChatValidator`를 실제 책임에 맞는 WebSocket request validator로 재배치했습니다.
REST query access validation과 WebSocket request validation의 경계를 분리하면서 기존 검증 순서, 오류 코드와 WebSocket 요청·응답 동작은 유지했습니다.

### 주요 변경사항

1. WebSocket request validator 명확화
- `ChatValidator`를 `service/websocket/validation/ChatWebSocketRequestValidator`로 이동 및 rename
- `ChatWebSocketCommandHandler`의 주입 타입과 필드명을 실제 역할에 맞게 변경
- validator 및 command handler 테스트의 검증 호출·예외 응답 계약 유지

2. 조회 책임을 Reader로 위임
- 채팅방 존재 여부 조회를 `ChatRoomReader.exists`에 위임
- 채팅방 멤버십 존재 여부를 담당하는 `ChatRoomMemberReader` 추가
- validator는 request 검증 정책과 `ChatException` 선택만 담당

3. read-only 트랜잭션 경계 정리
- `ChatWebSocketRequestValidator`에 read-only 트랜잭션을 적용
- 채팅방 목록 검증 시 반복되는 Reader 호출이 하나의 외부 트랜잭션에 참여하도록 정리

<br>

## 연결된 issue

close #672

<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 채팅 방별로 조회하는 로직의 배치화는 별도 이슈에서 다루겠습니다!

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
