### PR TITLE
[feature/#713] 게임판 코트 관리 관련 기능 구현

### DIFF
--- a/src/main/java/umc/cockple/demo/domain/game/domain/Court.java
+++ b/src/main/java/umc/cockple/demo/domain/game/domain/Court.java
@@ -19,19 +19,27 @@ public class Court extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     private GameBoard gameBoard;
 
-    @Column(nullable = false)
-    private Integer courtNo; // 코트 번호 (표시/이동 기준)
+    private int courtNo; // 코트 번호 (표시/이동 기준)
 
     private String courtName; // 코트명 (생략 시 서비스에서 courtNo 기반 기본값 부여)
 
-    public static Court create(Integer courtNo, String courtName) {
+    public static Court create(GameBoard gameBoard, int courtNo, String courtName) {
         return Court.builder()
+                .gameBoard(gameBoard)
                 .courtNo(courtNo)
                 .courtName(courtName)
                 .build();
     }
 
     public void updateName(String courtName) {
+        this.courtName = courtName;
+    }
+
+    /**
+     * 코트 관리(순서 재배치 + 이름 변경)에서 courtNo와 이름을 함께 갱신한다.
+     */
+    public void update(int courtNo, String courtName) {
+        this.courtNo = courtNo;
         this.courtName = courtName;
     }
 

--- a/src/main/java/umc/cockple/demo/domain/game/domain/Game.java
+++ b/src/main/java/umc/cockple/demo/domain/game/domain/Game.java
@@ -49,6 +49,10 @@ public class Game extends BaseEntity {
                 .build();
     }
 
+    public void changeCourt(Court court) {
+        this.court = court;
+    }
+
     /**
      * 연관관계 매핑 메서드
      */

--- a/src/main/java/umc/cockple/demo/domain/game/domain/Game.java
+++ b/src/main/java/umc/cockple/demo/domain/game/domain/Game.java
@@ -53,9 +53,17 @@ public class Game extends BaseEntity {
         this.court = court;
     }
 
-    /**
-     * 연관관계 매핑 메서드
-     */
+    public void start(Court court, LocalDateTime startedAt) {
+        this.status = GameStatus.PLAYING;
+        this.court = court;
+        this.startedAt = startedAt;
+        this.waitingOrder = null;
+    }
+
+    public void changeWaitingOrder(int waitingOrder) {
+        this.waitingOrder = waitingOrder;
+    }
+
     public void addPlayer(GamePlayer player) {
         this.players.add(player);
         player.setGame(this);

--- a/src/main/java/umc/cockple/demo/domain/game/enums/CourtStatus.java
+++ b/src/main/java/umc/cockple/demo/domain/game/enums/CourtStatus.java
@@ -1,0 +1,10 @@
+package umc.cockple.demo.domain.game.enums;
+
+/**
+ * 코트의 조회 시점 상태(파생값, 저장하지 않음).
+ * 해당 코트에 PLAYING 게임이 올라가 있으면 PLAYING, 아니면 EMPTY.
+ */
+public enum CourtStatus {
+    EMPTY,
+    PLAYING
+}

--- a/src/main/java/umc/cockple/demo/domain/game/events/GameCourtsManagedEvent.java
+++ b/src/main/java/umc/cockple/demo/domain/game/events/GameCourtsManagedEvent.java
@@ -1,0 +1,14 @@
+package umc.cockple.demo.domain.game.events;
+
+/**
+ * 코트 관리(REST)로 게임판의 코트 구성이 바뀌었음을 알리는 이벤트.
+ * 트랜잭션 커밋 후 같은 게임판을 구독 중인 다른 사용자에게 보드 갱신을 브로드캐스트하는 데 쓰인다.
+ *
+ * @param gameBoardId   변경된 게임판
+ * @param actorMemberId 요청자(브로드캐스트 대상에서 제외 — 이미 REST 응답으로 최신 상태를 받았다)
+ */
+public record GameCourtsManagedEvent(
+        Long gameBoardId,
+        Long actorMemberId
+) {
+}

--- a/src/main/java/umc/cockple/demo/domain/game/exception/GameErrorCode.java
+++ b/src/main/java/umc/cockple/demo/domain/game/exception/GameErrorCode.java
@@ -22,6 +22,7 @@ public enum GameErrorCode implements BaseErrorCode {
     GAME_NOT_WAITING(HttpStatus.BAD_REQUEST, "GAME403", "대기 중인 게임이 아닙니다."),
     COURT_ALREADY_IN_USE(HttpStatus.BAD_REQUEST, "GAME404", "이미 게임이 진행 중인 코트입니다."),
     DUPLICATE_COURT_ID(HttpStatus.BAD_REQUEST, "GAME405", "코트 ID가 중복되어 요청되었습니다."),
+    COURT_HAS_ACTIVE_GAME(HttpStatus.BAD_REQUEST, "GAME406", "진행 중인 게임이 있는 코트는 삭제할 수 없습니다."),
 
     ;
 

--- a/src/main/java/umc/cockple/demo/domain/game/exception/GameErrorCode.java
+++ b/src/main/java/umc/cockple/demo/domain/game/exception/GameErrorCode.java
@@ -13,11 +13,14 @@ public enum GameErrorCode implements BaseErrorCode {
     GAME_BOARD_NOT_FOUND(HttpStatus.NOT_FOUND, "GAME201", "게임판을 찾을 수 없습니다."),
     COURT_NOT_FOUND(HttpStatus.NOT_FOUND, "GAME202", "해당 게임판에 존재하지 않는 코트입니다."),
     GAME_NOT_ON_COURT(HttpStatus.NOT_FOUND, "GAME203", "해당 코트에 이동할 게임이 없습니다."),
+    GAME_NOT_FOUND(HttpStatus.NOT_FOUND, "GAME204", "게임을 찾을 수 없습니다."),
 
     GAME_BOARD_ACCESS_DENIED(HttpStatus.FORBIDDEN, "GAME301", "게임판을 관리할 권한이 없습니다."),
 
     GAME_BOARD_ID_REQUIRED(HttpStatus.BAD_REQUEST, "GAME401", "게임판 ID가 필요합니다."),
     INVALID_REALTIME_PAYLOAD(HttpStatus.BAD_REQUEST, "GAME402", "게임 요청 형식이 올바르지 않습니다."),
+    GAME_NOT_WAITING(HttpStatus.BAD_REQUEST, "GAME403", "대기 중인 게임이 아닙니다."),
+    COURT_ALREADY_IN_USE(HttpStatus.BAD_REQUEST, "GAME404", "이미 게임이 진행 중인 코트입니다."),
 
     ;
 

--- a/src/main/java/umc/cockple/demo/domain/game/exception/GameErrorCode.java
+++ b/src/main/java/umc/cockple/demo/domain/game/exception/GameErrorCode.java
@@ -1,0 +1,31 @@
+package umc.cockple.demo.domain.game.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import umc.cockple.demo.global.response.code.BaseErrorCode;
+import umc.cockple.demo.global.response.dto.ErrorReasonDTO;
+
+@Getter
+@RequiredArgsConstructor
+public enum GameErrorCode implements BaseErrorCode {
+
+    GAME_BOARD_NOT_FOUND(HttpStatus.NOT_FOUND, "GAME201", "게임판을 찾을 수 없습니다."),
+    COURT_NOT_FOUND(HttpStatus.NOT_FOUND, "GAME202", "해당 게임판에 존재하지 않는 코트입니다."),
+
+    GAME_BOARD_ACCESS_DENIED(HttpStatus.FORBIDDEN, "GAME301", "게임판을 관리할 권한이 없습니다."),
+
+    GAME_BOARD_ID_REQUIRED(HttpStatus.BAD_REQUEST, "GAME401", "게임판 ID가 필요합니다."),
+    INVALID_REALTIME_PAYLOAD(HttpStatus.BAD_REQUEST, "GAME402", "게임 요청 형식이 올바르지 않습니다."),
+
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    @Override
+    public ErrorReasonDTO getReason() {
+        return ErrorReasonDTO.of(code, message, httpStatus);
+    }
+}

--- a/src/main/java/umc/cockple/demo/domain/game/exception/GameErrorCode.java
+++ b/src/main/java/umc/cockple/demo/domain/game/exception/GameErrorCode.java
@@ -12,6 +12,7 @@ public enum GameErrorCode implements BaseErrorCode {
 
     GAME_BOARD_NOT_FOUND(HttpStatus.NOT_FOUND, "GAME201", "게임판을 찾을 수 없습니다."),
     COURT_NOT_FOUND(HttpStatus.NOT_FOUND, "GAME202", "해당 게임판에 존재하지 않는 코트입니다."),
+    GAME_NOT_ON_COURT(HttpStatus.NOT_FOUND, "GAME203", "해당 코트에 이동할 게임이 없습니다."),
 
     GAME_BOARD_ACCESS_DENIED(HttpStatus.FORBIDDEN, "GAME301", "게임판을 관리할 권한이 없습니다."),
 

--- a/src/main/java/umc/cockple/demo/domain/game/exception/GameErrorCode.java
+++ b/src/main/java/umc/cockple/demo/domain/game/exception/GameErrorCode.java
@@ -21,6 +21,7 @@ public enum GameErrorCode implements BaseErrorCode {
     INVALID_REALTIME_PAYLOAD(HttpStatus.BAD_REQUEST, "GAME402", "게임 요청 형식이 올바르지 않습니다."),
     GAME_NOT_WAITING(HttpStatus.BAD_REQUEST, "GAME403", "대기 중인 게임이 아닙니다."),
     COURT_ALREADY_IN_USE(HttpStatus.BAD_REQUEST, "GAME404", "이미 게임이 진행 중인 코트입니다."),
+    DUPLICATE_COURT_ID(HttpStatus.BAD_REQUEST, "GAME405", "코트 ID가 중복되어 요청되었습니다."),
 
     ;
 

--- a/src/main/java/umc/cockple/demo/domain/game/exception/GameException.java
+++ b/src/main/java/umc/cockple/demo/domain/game/exception/GameException.java
@@ -1,0 +1,11 @@
+package umc.cockple.demo.domain.game.exception;
+
+import umc.cockple.demo.global.exception.GeneralException;
+import umc.cockple.demo.global.response.code.BaseErrorCode;
+
+public class GameException extends GeneralException {
+
+    public GameException(BaseErrorCode code) {
+        super(code);
+    }
+}

--- a/src/main/java/umc/cockple/demo/domain/game/presentation/controller/GameBoardController.java
+++ b/src/main/java/umc/cockple/demo/domain/game/presentation/controller/GameBoardController.java
@@ -1,0 +1,30 @@
+package umc.cockple.demo.domain.game.presentation.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RestController;
+import umc.cockple.demo.domain.game.presentation.controller.api.GameBoardApi;
+import umc.cockple.demo.domain.game.presentation.dto.GameBoardDTO;
+import umc.cockple.demo.domain.game.presentation.mapper.GameBoardMapper;
+import umc.cockple.demo.domain.game.service.query.GameBoardQueryService;
+import umc.cockple.demo.domain.game.service.query.result.GameBoardResult;
+import umc.cockple.demo.global.response.BaseResponse;
+import umc.cockple.demo.global.response.code.status.CommonSuccessCode;
+import umc.cockple.demo.global.security.utils.SecurityUtil;
+
+@RestController
+@RequiredArgsConstructor
+public class GameBoardController implements GameBoardApi {
+
+    private final GameBoardQueryService gameBoardQueryService;
+    private final GameBoardMapper gameBoardMapper;
+
+    @Override
+    public ResponseEntity<BaseResponse<GameBoardDTO.Response>> getBoard(Long gameBoardId) {
+        Long memberId = SecurityUtil.getCurrentMemberId();
+
+        GameBoardResult result = gameBoardQueryService.getBoard(memberId, gameBoardId);
+
+        return BaseResponse.of(CommonSuccessCode.OK, gameBoardMapper.toResponse(result));
+    }
+}

--- a/src/main/java/umc/cockple/demo/domain/game/presentation/controller/GameCourtController.java
+++ b/src/main/java/umc/cockple/demo/domain/game/presentation/controller/GameCourtController.java
@@ -1,0 +1,35 @@
+package umc.cockple.demo.domain.game.presentation.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.RestController;
+import umc.cockple.demo.domain.game.presentation.controller.api.GameCourtApi;
+import umc.cockple.demo.domain.game.presentation.dto.GameCourtDTO;
+import umc.cockple.demo.domain.game.presentation.mapper.GameCourtMapper;
+import umc.cockple.demo.domain.game.service.command.GameCourtCommandService;
+import umc.cockple.demo.domain.game.service.command.model.GameCourtManageCommand;
+import umc.cockple.demo.domain.game.service.command.result.GameCourtManageResult;
+import umc.cockple.demo.global.response.BaseResponse;
+import umc.cockple.demo.global.response.code.status.CommonSuccessCode;
+import umc.cockple.demo.global.security.utils.SecurityUtil;
+
+@RestController
+@RequiredArgsConstructor
+@Validated
+public class GameCourtController implements GameCourtApi {
+
+    private final GameCourtCommandService gameCourtCommandService;
+    private final GameCourtMapper gameCourtMapper;
+
+    @Override
+    public ResponseEntity<BaseResponse<GameCourtDTO.Response>> manageCourts(
+            Long gameBoardId, GameCourtDTO.Request request) {
+        Long memberId = SecurityUtil.getCurrentMemberId();
+
+        GameCourtManageCommand command = gameCourtMapper.toManageCommand(gameBoardId, request);
+        GameCourtManageResult result = gameCourtCommandService.manageCourts(memberId, command);
+
+        return BaseResponse.of(CommonSuccessCode.OK, gameCourtMapper.toResponse(result));
+    }
+}

--- a/src/main/java/umc/cockple/demo/domain/game/presentation/controller/api/GameApiTag.java
+++ b/src/main/java/umc/cockple/demo/domain/game/presentation/controller/api/GameApiTag.java
@@ -1,0 +1,14 @@
+package umc.cockple.demo.domain.game.presentation.controller.api;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Tag(name = "Game", description = "게임판 API")
+public @interface GameApiTag {
+}

--- a/src/main/java/umc/cockple/demo/domain/game/presentation/controller/api/GameBoardApi.java
+++ b/src/main/java/umc/cockple/demo/domain/game/presentation/controller/api/GameBoardApi.java
@@ -1,0 +1,30 @@
+package umc.cockple.demo.domain.game.presentation.controller.api;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import umc.cockple.demo.domain.game.presentation.dto.GameBoardDTO;
+import umc.cockple.demo.global.response.BaseResponse;
+
+@RequestMapping("/api/game-boards")
+@GameApiTag
+public interface GameBoardApi {
+
+    @GetMapping("/{gameBoardId}")
+    @Operation(summary = "코트 보드 조회 (#2)", description = """
+            게임판의 코트와 대기열을 조회합니다. (명단은 제외)
+
+            - `courtCount` 가 0 이면 코트가 없는 상태이므로 프론트에서 코트 관리 화면으로 유도합니다.
+            - `courts[].status` 는 `EMPTY`(빈 코트) / `PLAYING`(게임 진행 중) 이며, `PLAYING` 일 때만 `game` 이 채워집니다.
+            - `waitings[]` 는 대기열의 게임 목록으로 `waitingOrder` 오름차순입니다.
+            - 각 게임의 `players[]` 는 `playerOrder` 순서입니다.
+            """)
+    @ApiResponse(responseCode = "200", description = "조회 성공")
+    @ApiResponse(responseCode = "404", description = "게임판을 찾을 수 없음")
+    ResponseEntity<BaseResponse<GameBoardDTO.Response>> getBoard(
+            @PathVariable Long gameBoardId
+    );
+}

--- a/src/main/java/umc/cockple/demo/domain/game/presentation/controller/api/GameCourtApi.java
+++ b/src/main/java/umc/cockple/demo/domain/game/presentation/controller/api/GameCourtApi.java
@@ -1,0 +1,37 @@
+package umc.cockple.demo.domain.game.presentation.controller.api;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import umc.cockple.demo.domain.game.presentation.dto.GameCourtDTO;
+import umc.cockple.demo.global.response.BaseResponse;
+
+@RequestMapping("/api/game-boards")
+@GameApiTag
+public interface GameCourtApi {
+
+    @PutMapping("/{gameBoardId}/courts")
+    @Operation(summary = "게임 코트 관리 (#1)", description = """
+            게임판의 코트를 일괄 관리합니다. (PUT으로 전체 교체 방식)
+
+            - `courts` 는 관리 후의 **최종 코트 목록**이며, **배열 순서가 곧 코트 순서(courtNo, 1부터)** 가 됩니다.
+            - `courts[].courtId` 가 **null 이면 새 코트 생성**, 값이 있으면 **해당 코트 유지(이름 변경)** 입니다.
+            - 목록에서 **빠진 기존 코트는 삭제**됩니다.
+            - `courts[].courtName` 이 비어 있으면 **'N번 코트' 기본값**이 부여됩니다.
+
+            응답으로 최종 코트 목록을 반환하며, **새로 생성된 코트는 서버가 발급한 `courtId`** 가 채워집니다.
+            (별도로 최신 상태가 필요하면 보드 조회(GET /api/game-boards/{gameBoardId})를 사용하세요.)
+            """)
+    @ApiResponse(responseCode = "200", description = "코트 관리 성공")
+    @ApiResponse(responseCode = "400", description = "입력값 오류")
+    @ApiResponse(responseCode = "404", description = "게임판 또는 코트를 찾을 수 없음")
+    ResponseEntity<BaseResponse<GameCourtDTO.Response>> manageCourts(
+            @PathVariable Long gameBoardId,
+            @Valid @RequestBody GameCourtDTO.Request request
+    );
+}

--- a/src/main/java/umc/cockple/demo/domain/game/presentation/dto/GameBoardDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/game/presentation/dto/GameBoardDTO.java
@@ -1,0 +1,47 @@
+package umc.cockple.demo.domain.game.presentation.dto;
+
+import umc.cockple.demo.domain.game.enums.CourtStatus;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class GameBoardDTO {
+
+    public record Response(
+            int courtCount,
+            List<CourtInfo> courts,
+            List<WaitingInfo> waitings
+    ) {
+    }
+
+    public record CourtInfo(
+            Long courtId,
+            int courtNo,
+            String courtName,
+            CourtStatus status,
+            GameInfo game // status 가 EMPTY 이면 null
+    ) {
+    }
+
+    public record GameInfo(
+            Long gameId,
+            LocalDateTime startedAt,
+            List<PlayerInfo> players
+    ) {
+    }
+
+    public record WaitingInfo(
+            Long gameId,
+            int waitingOrder,
+            List<PlayerInfo> players
+    ) {
+    }
+
+    public record PlayerInfo(
+            Long gameBoardMemberId,
+            String name,
+            String level, // 급수 한글 표기 (예: "준자강", "A조")
+            int playerOrder
+    ) {
+    }
+}

--- a/src/main/java/umc/cockple/demo/domain/game/presentation/dto/GameCourtDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/game/presentation/dto/GameCourtDTO.java
@@ -1,0 +1,35 @@
+package umc.cockple.demo.domain.game.presentation.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.List;
+
+public class GameCourtDTO {
+
+    @Schema(name = "GameCourtManageRequest", description = "게임 코트 관리 요청")
+    public record Request(
+            @NotNull(message = "코트 목록은 필수입니다. (전체 삭제 시 빈 배열)")
+            List<CourtRequest> courts
+    ) {
+    }
+
+    public record CourtRequest(
+            Long courtId,
+            String courtName
+    ) {
+    }
+
+    public record Response(
+            Long gameBoardId,
+            List<CourtInfo> courts
+    ) {
+    }
+
+    public record CourtInfo(
+            Long courtId,
+            int courtNo,
+            String courtName
+    ) {
+    }
+}

--- a/src/main/java/umc/cockple/demo/domain/game/presentation/mapper/GameBoardMapper.java
+++ b/src/main/java/umc/cockple/demo/domain/game/presentation/mapper/GameBoardMapper.java
@@ -1,0 +1,50 @@
+package umc.cockple.demo.domain.game.presentation.mapper;
+
+import org.springframework.stereotype.Component;
+import umc.cockple.demo.domain.game.presentation.dto.GameBoardDTO;
+import umc.cockple.demo.domain.game.service.query.result.GameBoardResult;
+
+/**
+ * 코트 보드 조회: 내부 result → 응답 DTO 변환.
+ */
+@Component
+public class GameBoardMapper {
+
+    public GameBoardDTO.Response toResponse(GameBoardResult result) {
+        return new GameBoardDTO.Response(
+                result.courtCount(),
+                result.courts().stream().map(this::toCourtInfo).toList(),
+                result.waitings().stream().map(this::toWaitingInfo).toList());
+    }
+
+    private GameBoardDTO.CourtInfo toCourtInfo(GameBoardResult.CourtView court) {
+        return new GameBoardDTO.CourtInfo(
+                court.courtId(),
+                court.courtNo(),
+                court.courtName(),
+                court.status(),
+                court.game() == null ? null : toGameInfo(court.game()));
+    }
+
+    private GameBoardDTO.GameInfo toGameInfo(GameBoardResult.GameView game) {
+        return new GameBoardDTO.GameInfo(
+                game.gameId(),
+                game.startedAt(),
+                game.players().stream().map(this::toPlayerInfo).toList());
+    }
+
+    private GameBoardDTO.WaitingInfo toWaitingInfo(GameBoardResult.WaitingView waiting) {
+        return new GameBoardDTO.WaitingInfo(
+                waiting.gameId(),
+                waiting.waitingOrder(),
+                waiting.players().stream().map(this::toPlayerInfo).toList());
+    }
+
+    private GameBoardDTO.PlayerInfo toPlayerInfo(GameBoardResult.PlayerView player) {
+        return new GameBoardDTO.PlayerInfo(
+                player.gameBoardMemberId(),
+                player.name(),
+                player.level().getKoreanName(),
+                player.playerOrder());
+    }
+}

--- a/src/main/java/umc/cockple/demo/domain/game/presentation/mapper/GameCourtMapper.java
+++ b/src/main/java/umc/cockple/demo/domain/game/presentation/mapper/GameCourtMapper.java
@@ -1,0 +1,33 @@
+package umc.cockple.demo.domain.game.presentation.mapper;
+
+import org.springframework.stereotype.Component;
+import umc.cockple.demo.domain.game.presentation.dto.GameCourtDTO;
+import umc.cockple.demo.domain.game.service.command.model.GameCourtManageCommand;
+import umc.cockple.demo.domain.game.service.command.result.GameCourtManageResult;
+
+import java.util.List;
+
+/**
+ * 게임판 코트: 요청 DTO ↔ 내부 command/result ↔ 응답 DTO 변환.
+ * 서비스가 presentation 타입을 모르도록 경계에서만 변환한다.
+ */
+@Component
+public class GameCourtMapper {
+
+    public GameCourtManageCommand toManageCommand(Long gameBoardId, GameCourtDTO.Request request) {
+        List<GameCourtDTO.CourtRequest> items =
+                request.courts() == null ? List.of() : request.courts();
+        List<GameCourtManageCommand.CourtCommand> courts = items.stream()
+                .map(item -> new GameCourtManageCommand.CourtCommand(item.courtId(), item.courtName()))
+                .toList();
+        return new GameCourtManageCommand(gameBoardId, courts);
+    }
+
+    public GameCourtDTO.Response toResponse(GameCourtManageResult result) {
+        List<GameCourtDTO.CourtInfo> courts = result.courts().stream()
+                .map(court -> new GameCourtDTO.CourtInfo(
+                        court.courtId(), court.courtNo(), court.courtName()))
+                .toList();
+        return new GameCourtDTO.Response(result.gameBoardId(), courts);
+    }
+}

--- a/src/main/java/umc/cockple/demo/domain/game/presentation/realtime/GameRealtimeAction.java
+++ b/src/main/java/umc/cockple/demo/domain/game/presentation/realtime/GameRealtimeAction.java
@@ -1,0 +1,7 @@
+package umc.cockple.demo.domain.game.presentation.realtime;
+
+public enum GameRealtimeAction {
+    SUBSCRIBE,    // 게임판 구독 (라이브 업데이트 수신 시작)
+    UNSUBSCRIBE,  // 게임판 구독 해제
+    MOVE_COURT,   // #3 코트 위치 변경 (게임을 다른 코트로 이동)
+}

--- a/src/main/java/umc/cockple/demo/domain/game/presentation/realtime/GameRealtimeAction.java
+++ b/src/main/java/umc/cockple/demo/domain/game/presentation/realtime/GameRealtimeAction.java
@@ -3,5 +3,6 @@ package umc.cockple.demo.domain.game.presentation.realtime;
 public enum GameRealtimeAction {
     SUBSCRIBE,    // 게임판 구독 (라이브 업데이트 수신 시작)
     UNSUBSCRIBE,  // 게임판 구독 해제
-    MOVE_COURT,   // #3 코트 위치 변경 (게임을 다른 코트로 이동)
+    MOVE_COURT,   // 코트 위치 변경 (게임을 다른 코트로 이동)
+    START_GAME,   // 게임 시작 (대기 게임을 코트에 배치)
 }

--- a/src/main/java/umc/cockple/demo/domain/game/presentation/realtime/GameRealtimeDomainHandler.java
+++ b/src/main/java/umc/cockple/demo/domain/game/presentation/realtime/GameRealtimeDomainHandler.java
@@ -1,0 +1,141 @@
+package umc.cockple.demo.domain.game.presentation.realtime;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import umc.cockple.demo.domain.game.exception.GameErrorCode;
+import umc.cockple.demo.domain.game.exception.GameException;
+import umc.cockple.demo.domain.game.presentation.dto.GameBoardDTO;
+import umc.cockple.demo.domain.game.presentation.mapper.GameBoardMapper;
+import umc.cockple.demo.domain.game.realtime.GameRealtimeProtocol;
+import umc.cockple.demo.domain.game.service.command.GameCourtCommandService;
+import umc.cockple.demo.domain.game.service.command.model.GameCourtMoveCommand;
+import umc.cockple.demo.domain.game.service.query.GameBoardQueryService;
+import umc.cockple.demo.domain.game.service.query.result.GameBoardResult;
+import umc.cockple.demo.domain.game.service.websocket.broadcast.GameBoardBroadcaster;
+import umc.cockple.demo.domain.game.service.websocket.subscription.GameBoardSubscriptionService;
+import umc.cockple.demo.global.realtime.routing.RealtimeDomainHandler;
+import umc.cockple.demo.global.realtime.routing.RealtimeRequestContext;
+import umc.cockple.demo.global.realtime.routing.RealtimeResponder;
+
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class GameRealtimeDomainHandler implements RealtimeDomainHandler {
+
+    private static final Set<String> ACTIONS = Arrays.stream(GameRealtimeAction.values())
+            .map(Enum::name)
+            .collect(Collectors.toUnmodifiableSet());
+
+    private final ObjectMapper objectMapper;
+    private final GameBoardSubscriptionService gameBoardSubscriptionService;
+    private final GameCourtCommandService gameCourtCommandService;
+    private final GameBoardQueryService gameBoardQueryService;
+    private final GameBoardMapper gameBoardMapper;
+    private final GameBoardBroadcaster gameBoardBroadcaster;
+
+    @Override
+    public String domain() {
+        return GameRealtimeProtocol.DOMAIN;
+    }
+
+    @Override
+    public Set<String> actions() {
+        return ACTIONS;
+    }
+
+    @Override
+    public void handle(
+            RealtimeRequestContext context,
+            JsonNode payload,
+            RealtimeResponder responder
+    ) {
+        GameRealtimeAction action = findAction(context.action());
+        if (action == null || payload == null || !payload.isObject()) {
+            sendInvalidPayload(responder);
+            return;
+        }
+
+        GameRealtimePayload gamePayload;
+        try {
+            gamePayload = objectMapper.treeToValue(payload, GameRealtimePayload.class);
+        } catch (JsonProcessingException | IllegalArgumentException e) {
+            sendInvalidPayload(responder);
+            return;
+        }
+
+        try {
+            switch (action) {
+                case SUBSCRIBE -> handleSubscribe(context, gamePayload, responder);
+                case UNSUBSCRIBE -> handleUnsubscribe(context, gamePayload, responder);
+                case MOVE_COURT -> handleMoveCourt(context, gamePayload, responder);
+            }
+        } catch (GameException e) {
+            log.warn("게임 실시간 처리 실패 - action: {}, memberId: {}, 이유: {}",
+                    action, context.memberId(), e.getErrorReason().getMessage());
+            responder.sendError(e.getErrorReason().getCode(), e.getErrorReason().getMessage());
+        }
+        // 그 외 RuntimeException 은 공용 라우터가 INTERNAL_ERROR 로 응답
+    }
+
+    private void handleSubscribe(
+            RealtimeRequestContext context, GameRealtimePayload payload, RealtimeResponder responder) {
+        Long gameBoardId = requireGameBoardId(payload);
+        gameBoardSubscriptionService.subscribe(gameBoardId, context.memberId());
+        responder.send(GameRealtimeProtocol.TYPE_SUBSCRIBED, new SubscriptionAck(gameBoardId));
+    }
+
+    private void handleUnsubscribe(
+            RealtimeRequestContext context, GameRealtimePayload payload, RealtimeResponder responder) {
+        Long gameBoardId = requireGameBoardId(payload);
+        gameBoardSubscriptionService.unsubscribe(gameBoardId, context.memberId());
+        responder.send(GameRealtimeProtocol.TYPE_UNSUBSCRIBED, new SubscriptionAck(gameBoardId));
+    }
+
+    private void handleMoveCourt(
+            RealtimeRequestContext context, GameRealtimePayload payload, RealtimeResponder responder) {
+        Long gameBoardId = requireGameBoardId(payload);
+
+        GameCourtMoveCommand command = new GameCourtMoveCommand(
+                gameBoardId, payload.courtId(), payload.targetCourtNo());
+        gameCourtCommandService.moveCourt(context.memberId(), command);
+
+        // 변경 후 최신 보드 스냅샷을 만들어, 호출자에게 ack + 나머지 구독자에게 브로드캐스트
+        GameBoardResult board = gameBoardQueryService.getBoard(context.memberId(), gameBoardId);
+        GameBoardDTO.Response boardDto = gameBoardMapper.toResponse(board);
+
+        responder.send(GameRealtimeProtocol.TYPE_BOARD_UPDATED, boardDto);
+        gameBoardBroadcaster.broadcastBoardUpdate(gameBoardId, boardDto, context.memberId());
+    }
+
+    private Long requireGameBoardId(GameRealtimePayload payload) {
+        if (payload.gameBoardId() == null) {
+            throw new GameException(GameErrorCode.GAME_BOARD_ID_REQUIRED);
+        }
+        return payload.gameBoardId();
+    }
+
+    private GameRealtimeAction findAction(String action) {
+        try {
+            return GameRealtimeAction.valueOf(action);
+        } catch (IllegalArgumentException | NullPointerException e) {
+            return null;
+        }
+    }
+
+    private void sendInvalidPayload(RealtimeResponder responder) {
+        responder.sendError(
+                GameErrorCode.INVALID_REALTIME_PAYLOAD.getCode(),
+                GameErrorCode.INVALID_REALTIME_PAYLOAD.getMessage());
+    }
+
+    private record SubscriptionAck(Long gameBoardId) {
+    }
+}

--- a/src/main/java/umc/cockple/demo/domain/game/presentation/realtime/GameRealtimeDomainHandler.java
+++ b/src/main/java/umc/cockple/demo/domain/game/presentation/realtime/GameRealtimeDomainHandler.java
@@ -11,8 +11,10 @@ import umc.cockple.demo.domain.game.exception.GameException;
 import umc.cockple.demo.domain.game.presentation.dto.GameBoardDTO;
 import umc.cockple.demo.domain.game.presentation.mapper.GameBoardMapper;
 import umc.cockple.demo.domain.game.realtime.GameRealtimeProtocol;
+import umc.cockple.demo.domain.game.service.command.GameCommandService;
 import umc.cockple.demo.domain.game.service.command.GameCourtCommandService;
 import umc.cockple.demo.domain.game.service.command.model.GameCourtMoveCommand;
+import umc.cockple.demo.domain.game.service.command.model.GameStartCommand;
 import umc.cockple.demo.domain.game.service.query.GameBoardQueryService;
 import umc.cockple.demo.domain.game.service.query.result.GameBoardResult;
 import umc.cockple.demo.domain.game.service.websocket.broadcast.GameBoardBroadcaster;
@@ -37,6 +39,7 @@ public class GameRealtimeDomainHandler implements RealtimeDomainHandler {
     private final ObjectMapper objectMapper;
     private final GameBoardSubscriptionService gameBoardSubscriptionService;
     private final GameCourtCommandService gameCourtCommandService;
+    private final GameCommandService gameCommandService;
     private final GameBoardQueryService gameBoardQueryService;
     private final GameBoardMapper gameBoardMapper;
     private final GameBoardBroadcaster gameBoardBroadcaster;
@@ -76,6 +79,7 @@ public class GameRealtimeDomainHandler implements RealtimeDomainHandler {
                 case SUBSCRIBE -> handleSubscribe(context, gamePayload, responder);
                 case UNSUBSCRIBE -> handleUnsubscribe(context, gamePayload, responder);
                 case MOVE_COURT -> handleMoveCourt(context, gamePayload, responder);
+                case START_GAME -> handleStartGame(context, gamePayload, responder);
             }
         } catch (GameException e) {
             log.warn("게임 실시간 처리 실패 - action: {}, memberId: {}, 이유: {}",
@@ -107,7 +111,22 @@ public class GameRealtimeDomainHandler implements RealtimeDomainHandler {
                 gameBoardId, payload.courtId(), payload.targetCourtNo());
         gameCourtCommandService.moveCourt(context.memberId(), command);
 
-        // 변경 후 최신 보드 스냅샷을 만들어, 호출자에게 ack + 나머지 구독자에게 브로드캐스트
+        respondAndBroadcastBoard(context, gameBoardId, responder);
+    }
+
+    private void handleStartGame(
+            RealtimeRequestContext context, GameRealtimePayload payload, RealtimeResponder responder) {
+        Long gameBoardId = requireGameBoardId(payload);
+
+        GameStartCommand command = new GameStartCommand(
+                gameBoardId, payload.gameId(), payload.courtId());
+        gameCommandService.startGame(context.memberId(), command);
+
+        respondAndBroadcastBoard(context, gameBoardId, responder);
+    }
+
+    private void respondAndBroadcastBoard(
+            RealtimeRequestContext context, Long gameBoardId, RealtimeResponder responder) {
         GameBoardResult board = gameBoardQueryService.getBoard(context.memberId(), gameBoardId);
         GameBoardDTO.Response boardDto = gameBoardMapper.toResponse(board);
 

--- a/src/main/java/umc/cockple/demo/domain/game/presentation/realtime/GameRealtimeDomainHandler.java
+++ b/src/main/java/umc/cockple/demo/domain/game/presentation/realtime/GameRealtimeDomainHandler.java
@@ -92,20 +92,21 @@ public class GameRealtimeDomainHandler implements RealtimeDomainHandler {
     private void handleSubscribe(
             RealtimeRequestContext context, GameRealtimePayload payload, RealtimeResponder responder) {
         Long gameBoardId = requireGameBoardId(payload);
-        gameBoardSubscriptionService.subscribe(gameBoardId, context.memberId());
+        gameBoardSubscriptionService.subscribe(gameBoardId, context.memberId(), context.sessionId());
         responder.send(GameRealtimeProtocol.TYPE_SUBSCRIBED, new SubscriptionAck(gameBoardId));
     }
 
     private void handleUnsubscribe(
             RealtimeRequestContext context, GameRealtimePayload payload, RealtimeResponder responder) {
         Long gameBoardId = requireGameBoardId(payload);
-        gameBoardSubscriptionService.unsubscribe(gameBoardId, context.memberId());
+        gameBoardSubscriptionService.unsubscribe(gameBoardId, context.memberId(), context.sessionId());
         responder.send(GameRealtimeProtocol.TYPE_UNSUBSCRIBED, new SubscriptionAck(gameBoardId));
     }
 
     private void handleMoveCourt(
             RealtimeRequestContext context, GameRealtimePayload payload, RealtimeResponder responder) {
         Long gameBoardId = requireGameBoardId(payload);
+        requireMoveCourtPayload(payload);
 
         GameCourtMoveCommand command = new GameCourtMoveCommand(
                 gameBoardId, payload.courtId(), payload.targetCourtNo());
@@ -117,6 +118,7 @@ public class GameRealtimeDomainHandler implements RealtimeDomainHandler {
     private void handleStartGame(
             RealtimeRequestContext context, GameRealtimePayload payload, RealtimeResponder responder) {
         Long gameBoardId = requireGameBoardId(payload);
+        requireStartGamePayload(payload);
 
         GameStartCommand command = new GameStartCommand(
                 gameBoardId, payload.gameId(), payload.courtId());
@@ -131,7 +133,8 @@ public class GameRealtimeDomainHandler implements RealtimeDomainHandler {
         GameBoardDTO.Response boardDto = gameBoardMapper.toResponse(board);
 
         responder.send(GameRealtimeProtocol.TYPE_BOARD_UPDATED, boardDto);
-        gameBoardBroadcaster.broadcastBoardUpdate(gameBoardId, boardDto, context.memberId());
+        // 변경을 일으킨 세션은 위에서 직접 응답을 받았으므로 브로드캐스트 대상에서 제외한다.
+        gameBoardBroadcaster.broadcastBoardUpdate(gameBoardId, boardDto, context.sessionId());
     }
 
     private Long requireGameBoardId(GameRealtimePayload payload) {
@@ -139,6 +142,20 @@ public class GameRealtimeDomainHandler implements RealtimeDomainHandler {
             throw new GameException(GameErrorCode.GAME_BOARD_ID_REQUIRED);
         }
         return payload.gameBoardId();
+    }
+
+    private void requireMoveCourtPayload(GameRealtimePayload payload) {
+        // MOVE_COURT: 원본 코트 ID와 목적지 코트 번호가 모두 필요하다.
+        if (payload.courtId() == null || payload.targetCourtNo() == null) {
+            throw new GameException(GameErrorCode.INVALID_REALTIME_PAYLOAD);
+        }
+    }
+
+    private void requireStartGamePayload(GameRealtimePayload payload) {
+        // START_GAME: 시작할 대기 게임 ID와 목적지 코트 ID가 모두 필요하다.
+        if (payload.gameId() == null || payload.courtId() == null) {
+            throw new GameException(GameErrorCode.INVALID_REALTIME_PAYLOAD);
+        }
     }
 
     private GameRealtimeAction findAction(String action) {

--- a/src/main/java/umc/cockple/demo/domain/game/presentation/realtime/GameRealtimePayload.java
+++ b/src/main/java/umc/cockple/demo/domain/game/presentation/realtime/GameRealtimePayload.java
@@ -1,0 +1,8 @@
+package umc.cockple.demo.domain.game.presentation.realtime;
+
+public record GameRealtimePayload(
+        Long gameBoardId,      // 공통
+        Long courtId,          // 게임이 현재 올라간 원본 코트 ID
+        Integer targetCourtNo  // 이동할 목적지 코트 번호
+) {
+}

--- a/src/main/java/umc/cockple/demo/domain/game/presentation/realtime/GameRealtimePayload.java
+++ b/src/main/java/umc/cockple/demo/domain/game/presentation/realtime/GameRealtimePayload.java
@@ -2,7 +2,8 @@ package umc.cockple.demo.domain.game.presentation.realtime;
 
 public record GameRealtimePayload(
         Long gameBoardId,      // 공통
-        Long courtId,          // 게임이 현재 올라간 원본 코트 ID
-        Integer targetCourtNo  // 이동할 목적지 코트 번호
+        Long courtId,          // MOVE_COURT: 원본 코트 ID / START_GAME: 목적지 코트 ID
+        Integer targetCourtNo, // MOVE_COURT: 이동할 목적지 코트 번호
+        Long gameId            // START_GAME: 시작할 대기 게임 ID
 ) {
 }

--- a/src/main/java/umc/cockple/demo/domain/game/realtime/GameRealtimeProtocol.java
+++ b/src/main/java/umc/cockple/demo/domain/game/realtime/GameRealtimeProtocol.java
@@ -1,0 +1,18 @@
+package umc.cockple.demo.domain.game.realtime;
+
+/**
+ * 게임판 실시간(WebSocket) 프로토콜 상수
+ * envelope.domain 과 응답 type 정의
+ */
+public final class GameRealtimeProtocol {
+
+    public static final String DOMAIN = "GAME";
+
+    // 응답 type
+    public static final String TYPE_SUBSCRIBED = "SUBSCRIBED";
+    public static final String TYPE_UNSUBSCRIBED = "UNSUBSCRIBED";
+    public static final String TYPE_BOARD_UPDATED = "BOARD_UPDATED";
+
+    private GameRealtimeProtocol() {
+    }
+}

--- a/src/main/java/umc/cockple/demo/domain/game/repository/CourtRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/game/repository/CourtRepository.java
@@ -13,4 +13,6 @@ public interface CourtRepository extends JpaRepository<Court, Long> {
     List<Court> findByGameBoardIdOrderByCourtNoAsc(Long gameBoardId);
 
     Optional<Court> findByGameBoardIdAndCourtNo(Long gameBoardId, int courtNo);
+
+    Optional<Court> findByIdAndGameBoardId(Long id, Long gameBoardId);
 }

--- a/src/main/java/umc/cockple/demo/domain/game/repository/CourtRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/game/repository/CourtRepository.java
@@ -4,10 +4,13 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import umc.cockple.demo.domain.game.domain.Court;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface CourtRepository extends JpaRepository<Court, Long> {
 
     List<Court> findByGameBoardId(Long gameBoardId);
 
     List<Court> findByGameBoardIdOrderByCourtNoAsc(Long gameBoardId);
+
+    Optional<Court> findByGameBoardIdAndCourtNo(Long gameBoardId, int courtNo);
 }

--- a/src/main/java/umc/cockple/demo/domain/game/repository/CourtRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/game/repository/CourtRepository.java
@@ -8,4 +8,6 @@ import java.util.List;
 public interface CourtRepository extends JpaRepository<Court, Long> {
 
     List<Court> findByGameBoardId(Long gameBoardId);
+
+    List<Court> findByGameBoardIdOrderByCourtNoAsc(Long gameBoardId);
 }

--- a/src/main/java/umc/cockple/demo/domain/game/repository/CourtRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/game/repository/CourtRepository.java
@@ -1,0 +1,11 @@
+package umc.cockple.demo.domain.game.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import umc.cockple.demo.domain.game.domain.Court;
+
+import java.util.List;
+
+public interface CourtRepository extends JpaRepository<Court, Long> {
+
+    List<Court> findByGameBoardId(Long gameBoardId);
+}

--- a/src/main/java/umc/cockple/demo/domain/game/repository/GameBoardRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/game/repository/GameBoardRepository.java
@@ -1,0 +1,7 @@
+package umc.cockple.demo.domain.game.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import umc.cockple.demo.domain.game.domain.GameBoard;
+
+public interface GameBoardRepository extends JpaRepository<GameBoard, Long> {
+}

--- a/src/main/java/umc/cockple/demo/domain/game/repository/GameRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/game/repository/GameRepository.java
@@ -1,0 +1,25 @@
+package umc.cockple.demo.domain.game.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import umc.cockple.demo.domain.game.domain.Game;
+import umc.cockple.demo.domain.game.enums.GameStatus;
+
+import java.util.Collection;
+import java.util.List;
+
+public interface GameRepository extends JpaRepository<Game, Long> {
+
+    /**
+     * 게임판의 특정 상태 게임들을 코트/플레이어/멤버까지 함께 조회한다. (보드 조회 N+1 방지)
+     */
+    @Query("select distinct g from Game g " +
+            "left join fetch g.court " +
+            "left join fetch g.players p " +
+            "left join fetch p.gameBoardMember " +
+            "where g.gameBoard.id = :gameBoardId and g.status in :statuses")
+    List<Game> findByGameBoardIdAndStatusInWithPlayers(
+            @Param("gameBoardId") Long gameBoardId,
+            @Param("statuses") Collection<GameStatus> statuses);
+}

--- a/src/main/java/umc/cockple/demo/domain/game/repository/GameRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/game/repository/GameRepository.java
@@ -8,12 +8,12 @@ import umc.cockple.demo.domain.game.enums.GameStatus;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 
 public interface GameRepository extends JpaRepository<Game, Long> {
 
-    /**
-     * 게임판의 특정 상태 게임들을 코트/플레이어/멤버까지 함께 조회한다. (보드 조회 N+1 방지)
-     */
+    Optional<Game> findByCourtIdAndStatus(Long courtId, GameStatus status);
+
     @Query("select distinct g from Game g " +
             "left join fetch g.court " +
             "left join fetch g.players p " +

--- a/src/main/java/umc/cockple/demo/domain/game/repository/GameRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/game/repository/GameRepository.java
@@ -14,6 +14,8 @@ public interface GameRepository extends JpaRepository<Game, Long> {
 
     Optional<Game> findByCourtIdAndStatus(Long courtId, GameStatus status);
 
+    boolean existsByCourtIdInAndStatus(Collection<Long> courtIds, GameStatus status);
+
     List<Game> findByGameBoardIdAndStatusOrderByWaitingOrderAsc(Long gameBoardId, GameStatus status);
 
     @Query("select distinct g from Game g " +

--- a/src/main/java/umc/cockple/demo/domain/game/repository/GameRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/game/repository/GameRepository.java
@@ -14,6 +14,8 @@ public interface GameRepository extends JpaRepository<Game, Long> {
 
     Optional<Game> findByCourtIdAndStatus(Long courtId, GameStatus status);
 
+    List<Game> findByGameBoardIdAndStatusOrderByWaitingOrderAsc(Long gameBoardId, GameStatus status);
+
     @Query("select distinct g from Game g " +
             "left join fetch g.court " +
             "left join fetch g.players p " +

--- a/src/main/java/umc/cockple/demo/domain/game/repository/redis/GameBoardSubscriber.java
+++ b/src/main/java/umc/cockple/demo/domain/game/repository/redis/GameBoardSubscriber.java
@@ -1,0 +1,23 @@
+package umc.cockple.demo.domain.game.repository.redis;
+
+/**
+ * 게임판을 구독 중인 하나의 세션. 같은 회원이 여러 세션으로 구독할 수 있으므로
+ * 구독 단위는 (memberId, sessionId)다. 발행 시 memberId로 세션을 찾고 sessionId로 그 세션만 겨냥한다.
+ */
+public record GameBoardSubscriber(
+        Long memberId,
+        String sessionId
+) {
+    private static final String DELIMITER = ":";
+
+    public String toToken() {
+        return memberId + DELIMITER + sessionId;
+    }
+
+    public static GameBoardSubscriber fromToken(String token) {
+        int idx = token.indexOf(DELIMITER);
+        Long memberId = Long.parseLong(token.substring(0, idx));
+        String sessionId = token.substring(idx + 1);
+        return new GameBoardSubscriber(memberId, sessionId);
+    }
+}

--- a/src/main/java/umc/cockple/demo/domain/game/repository/redis/GameBoardSubscriptionStore.java
+++ b/src/main/java/umc/cockple/demo/domain/game/repository/redis/GameBoardSubscriptionStore.java
@@ -10,7 +10,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
- * 게임판 구독자(memberId) 집합을 Redis Set 으로 관리한다. (멀티 인스턴스 대응, chat 구독 방식 미러링)
+ * 게임판 구독자 집합을 Redis Set 으로 관리한다. (멀티 인스턴스 대응, chat 구독 방식 미러링)
+ * 멤버당 다중 세션을 지원하므로 구독 단위는 세션이며, {@code memberId:sessionId} 토큰을 저장한다.
  */
 @Component
 @RequiredArgsConstructor
@@ -22,21 +23,21 @@ public class GameBoardSubscriptionStore {
     private static final String GAME_BOARD_SUBSCRIBERS = "gameboard:subscribers:";
     private static final Duration SUBSCRIPTION_TTL = Duration.ofHours(2);
 
-    public void addSubscriber(Long gameBoardId, Long memberId) {
+    public void addSubscriber(Long gameBoardId, Long memberId, String sessionId) {
         try {
             String key = GAME_BOARD_SUBSCRIBERS + gameBoardId;
-            stringRedisTemplate.opsForSet().add(key, memberId.toString());
+            stringRedisTemplate.opsForSet().add(key, new GameBoardSubscriber(memberId, sessionId).toToken());
             stringRedisTemplate.expire(key, SUBSCRIPTION_TTL);
-            log.info("게임판 구독 추가 - gameBoardId: {}, memberId: {}", gameBoardId, memberId);
+            log.info("게임판 구독 추가 - gameBoardId: {}, memberId: {}, sessionId: {}", gameBoardId, memberId, sessionId);
         } catch (Exception e) {
-            log.error("게임판 구독 추가 실패 - gameBoardId: {}, memberId: {}", gameBoardId, memberId, e);
+            log.error("게임판 구독 추가 실패 - gameBoardId: {}, memberId: {}, sessionId: {}", gameBoardId, memberId, sessionId, e);
         }
     }
 
-    public void removeSubscriber(Long gameBoardId, Long memberId) {
+    public void removeSubscriber(Long gameBoardId, Long memberId, String sessionId) {
         try {
             String key = GAME_BOARD_SUBSCRIBERS + gameBoardId;
-            stringRedisTemplate.opsForSet().remove(key, memberId.toString());
+            stringRedisTemplate.opsForSet().remove(key, new GameBoardSubscriber(memberId, sessionId).toToken());
 
             Long remaining = stringRedisTemplate.opsForSet().size(key);
             if (remaining != null && remaining == 0) {
@@ -44,20 +45,22 @@ public class GameBoardSubscriptionStore {
             } else {
                 stringRedisTemplate.expire(key, SUBSCRIPTION_TTL);
             }
-            log.info("게임판 구독 제거 - gameBoardId: {}, memberId: {}", gameBoardId, memberId);
+            log.info("게임판 구독 제거 - gameBoardId: {}, memberId: {}, sessionId: {}", gameBoardId, memberId, sessionId);
         } catch (Exception e) {
-            log.error("게임판 구독 제거 실패 - gameBoardId: {}, memberId: {}", gameBoardId, memberId, e);
+            log.error("게임판 구독 제거 실패 - gameBoardId: {}, memberId: {}, sessionId: {}", gameBoardId, memberId, sessionId, e);
         }
     }
 
-    public Set<Long> getSubscribers(Long gameBoardId) {
+    public Set<GameBoardSubscriber> getSubscribers(Long gameBoardId) {
         try {
             String key = GAME_BOARD_SUBSCRIBERS + gameBoardId;
-            Set<String> members = stringRedisTemplate.opsForSet().members(key);
-            if (members == null || members.isEmpty()) {
+            Set<String> tokens = stringRedisTemplate.opsForSet().members(key);
+            if (tokens == null || tokens.isEmpty()) {
                 return Set.of();
             }
-            return members.stream().map(Long::parseLong).collect(Collectors.toSet());
+            return tokens.stream()
+                    .map(GameBoardSubscriber::fromToken)
+                    .collect(Collectors.toSet());
         } catch (Exception e) {
             log.error("게임판 구독자 조회 실패 - gameBoardId: {}", gameBoardId, e);
             return Set.of();

--- a/src/main/java/umc/cockple/demo/domain/game/repository/redis/GameBoardSubscriptionStore.java
+++ b/src/main/java/umc/cockple/demo/domain/game/repository/redis/GameBoardSubscriptionStore.java
@@ -1,0 +1,66 @@
+package umc.cockple.demo.domain.game.repository.redis;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * 게임판 구독자(memberId) 집합을 Redis Set 으로 관리한다. (멀티 인스턴스 대응, chat 구독 방식 미러링)
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class GameBoardSubscriptionStore {
+
+    private final StringRedisTemplate stringRedisTemplate;
+
+    private static final String GAME_BOARD_SUBSCRIBERS = "gameboard:subscribers:";
+    private static final Duration SUBSCRIPTION_TTL = Duration.ofHours(2);
+
+    public void addSubscriber(Long gameBoardId, Long memberId) {
+        try {
+            String key = GAME_BOARD_SUBSCRIBERS + gameBoardId;
+            stringRedisTemplate.opsForSet().add(key, memberId.toString());
+            stringRedisTemplate.expire(key, SUBSCRIPTION_TTL);
+            log.info("게임판 구독 추가 - gameBoardId: {}, memberId: {}", gameBoardId, memberId);
+        } catch (Exception e) {
+            log.error("게임판 구독 추가 실패 - gameBoardId: {}, memberId: {}", gameBoardId, memberId, e);
+        }
+    }
+
+    public void removeSubscriber(Long gameBoardId, Long memberId) {
+        try {
+            String key = GAME_BOARD_SUBSCRIBERS + gameBoardId;
+            stringRedisTemplate.opsForSet().remove(key, memberId.toString());
+
+            Long remaining = stringRedisTemplate.opsForSet().size(key);
+            if (remaining != null && remaining == 0) {
+                stringRedisTemplate.delete(key);
+            } else {
+                stringRedisTemplate.expire(key, SUBSCRIPTION_TTL);
+            }
+            log.info("게임판 구독 제거 - gameBoardId: {}, memberId: {}", gameBoardId, memberId);
+        } catch (Exception e) {
+            log.error("게임판 구독 제거 실패 - gameBoardId: {}, memberId: {}", gameBoardId, memberId, e);
+        }
+    }
+
+    public Set<Long> getSubscribers(Long gameBoardId) {
+        try {
+            String key = GAME_BOARD_SUBSCRIBERS + gameBoardId;
+            Set<String> members = stringRedisTemplate.opsForSet().members(key);
+            if (members == null || members.isEmpty()) {
+                return Set.of();
+            }
+            return members.stream().map(Long::parseLong).collect(Collectors.toSet());
+        } catch (Exception e) {
+            log.error("게임판 구독자 조회 실패 - gameBoardId: {}", gameBoardId, e);
+            return Set.of();
+        }
+    }
+}

--- a/src/main/java/umc/cockple/demo/domain/game/service/command/GameCommandService.java
+++ b/src/main/java/umc/cockple/demo/domain/game/service/command/GameCommandService.java
@@ -1,0 +1,70 @@
+package umc.cockple.demo.domain.game.service.command;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import umc.cockple.demo.domain.game.domain.Court;
+import umc.cockple.demo.domain.game.domain.Game;
+import umc.cockple.demo.domain.game.domain.GameBoard;
+import umc.cockple.demo.domain.game.enums.GameStatus;
+import umc.cockple.demo.domain.game.exception.GameErrorCode;
+import umc.cockple.demo.domain.game.exception.GameException;
+import umc.cockple.demo.domain.game.repository.CourtRepository;
+import umc.cockple.demo.domain.game.repository.GameRepository;
+import umc.cockple.demo.domain.game.service.command.model.GameStartCommand;
+import umc.cockple.demo.domain.game.service.support.reader.GameBoardReader;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+@Slf4j
+public class GameCommandService {
+
+    private final GameBoardReader gameBoardReader;
+    private final GameRepository gameRepository;
+    private final CourtRepository courtRepository;
+
+    /**
+     * @param memberId 요청자(추후 게임판 관리 권한 검증에 사용 예정)
+     */
+    public void startGame(Long memberId, GameStartCommand command) {
+        GameBoard gameBoard = gameBoardReader.read(command.gameBoardId());
+
+        Game game = gameRepository.findById(command.gameId())
+                .orElseThrow(() -> new GameException(GameErrorCode.GAME_NOT_FOUND));
+        if (!game.getGameBoard().getId().equals(gameBoard.getId())) {
+            throw new GameException(GameErrorCode.GAME_NOT_FOUND);
+        }
+        if (game.getStatus() != GameStatus.WAITING) {
+            throw new GameException(GameErrorCode.GAME_NOT_WAITING);
+        }
+
+        Court court = courtRepository.findByIdAndGameBoardId(command.courtId(), gameBoard.getId())
+                .orElseThrow(() -> new GameException(GameErrorCode.COURT_NOT_FOUND));
+        if (gameRepository.findByCourtIdAndStatus(court.getId(), GameStatus.PLAYING).isPresent()) {
+            throw new GameException(GameErrorCode.COURT_ALREADY_IN_USE);
+        }
+
+        game.start(court, LocalDateTime.now());
+        resequenceWaitingQueue(gameBoard.getId());
+
+        log.info("게임 시작 - gameBoardId: {}, gameId: {}, courtId: {}",
+                gameBoard.getId(), game.getId(), court.getId());
+    }
+
+    /**
+     * 대기열에 남은 게임들의 순서를 현재 순서 기준으로 1부터 다시 매긴다. (빈 순서 제거)
+     */
+    private void resequenceWaitingQueue(Long gameBoardId) {
+        List<Game> waitingGames = gameRepository
+                .findByGameBoardIdAndStatusOrderByWaitingOrderAsc(gameBoardId, GameStatus.WAITING);
+        int order = 1;
+        for (Game waitingGame : waitingGames) {
+            waitingGame.changeWaitingOrder(order++);
+        }
+    }
+}

--- a/src/main/java/umc/cockple/demo/domain/game/service/command/GameCourtCommandService.java
+++ b/src/main/java/umc/cockple/demo/domain/game/service/command/GameCourtCommandService.java
@@ -2,6 +2,7 @@ package umc.cockple.demo.domain.game.service.command;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
@@ -9,6 +10,7 @@ import umc.cockple.demo.domain.game.domain.Court;
 import umc.cockple.demo.domain.game.domain.Game;
 import umc.cockple.demo.domain.game.domain.GameBoard;
 import umc.cockple.demo.domain.game.enums.GameStatus;
+import umc.cockple.demo.domain.game.events.GameCourtsManagedEvent;
 import umc.cockple.demo.domain.game.exception.GameErrorCode;
 import umc.cockple.demo.domain.game.exception.GameException;
 import umc.cockple.demo.domain.game.repository.CourtRepository;
@@ -36,6 +38,7 @@ public class GameCourtCommandService {
     private final GameBoardReader gameBoardReader;
     private final CourtRepository courtRepository;
     private final GameRepository gameRepository;
+    private final ApplicationEventPublisher eventPublisher;
 
     /**
      * 게임 코트 관리
@@ -60,6 +63,10 @@ public class GameCourtCommandService {
         List<Court> finalCourts = upsertCourtsInOrder(gameBoard, requestedCourts, existingCourtsById);
 
         log.info("게임 코트 관리 완료 - gameBoardId: {}, 코트 수: {}", gameBoard.getId(), finalCourts.size());
+
+        // 커밋 후 같은 게임판 구독자에게 보드 갱신을 브로드캐스트하도록 이벤트 발행
+        eventPublisher.publishEvent(new GameCourtsManagedEvent(gameBoard.getId(), memberId));
+
         return toResult(gameBoard.getId(), finalCourts);
     }
 

--- a/src/main/java/umc/cockple/demo/domain/game/service/command/GameCourtCommandService.java
+++ b/src/main/java/umc/cockple/demo/domain/game/service/command/GameCourtCommandService.java
@@ -6,11 +6,15 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 import umc.cockple.demo.domain.game.domain.Court;
+import umc.cockple.demo.domain.game.domain.Game;
 import umc.cockple.demo.domain.game.domain.GameBoard;
+import umc.cockple.demo.domain.game.enums.GameStatus;
 import umc.cockple.demo.domain.game.exception.GameErrorCode;
 import umc.cockple.demo.domain.game.exception.GameException;
 import umc.cockple.demo.domain.game.repository.CourtRepository;
+import umc.cockple.demo.domain.game.repository.GameRepository;
 import umc.cockple.demo.domain.game.service.command.model.GameCourtManageCommand;
+import umc.cockple.demo.domain.game.service.command.model.GameCourtMoveCommand;
 import umc.cockple.demo.domain.game.service.command.result.GameCourtManageResult;
 import umc.cockple.demo.domain.game.service.support.reader.GameBoardReader;
 
@@ -18,6 +22,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -30,6 +35,7 @@ public class GameCourtCommandService {
 
     private final GameBoardReader gameBoardReader;
     private final CourtRepository courtRepository;
+    private final GameRepository gameRepository;
 
     /**
      * 게임 코트 관리
@@ -55,6 +61,39 @@ public class GameCourtCommandService {
 
         log.info("게임 코트 관리 완료 - gameBoardId: {}, 코트 수: {}", gameBoard.getId(), finalCourts.size());
         return toResult(gameBoard.getId(), finalCourts);
+    }
+
+    /**
+     * 코트 위치 변경
+     * 목적지 코트에 이미 게임이 있으면 두 게임의 코트를 SWAP
+     *
+     * @param memberId 요청자(추후 게임판 관리 권한 검증에 사용 예정)
+     */
+    public void moveCourt(Long memberId, GameCourtMoveCommand command) {
+        GameBoard gameBoard = gameBoardReader.read(command.gameBoardId());
+
+        Game sourceGame = gameRepository.findByCourtIdAndStatus(command.courtId(), GameStatus.PLAYING)
+                .orElseThrow(() -> new GameException(GameErrorCode.GAME_NOT_ON_COURT));
+        if (!sourceGame.getGameBoard().getId().equals(gameBoard.getId())) {
+            throw new GameException(GameErrorCode.COURT_NOT_FOUND);
+        }
+
+        Court sourceCourt = sourceGame.getCourt();
+        Court targetCourt = courtRepository
+                .findByGameBoardIdAndCourtNo(gameBoard.getId(), command.targetCourtNo())
+                .orElseThrow(() -> new GameException(GameErrorCode.COURT_NOT_FOUND));
+
+        if (targetCourt.getId().equals(sourceCourt.getId())) {
+            return; // 같은 코트로의 이동은 무시
+        }
+
+        Optional<Game> targetGame = gameRepository.findByCourtIdAndStatus(targetCourt.getId(), GameStatus.PLAYING);
+
+        sourceGame.changeCourt(targetCourt);
+        targetGame.ifPresent(game -> game.changeCourt(sourceCourt));
+
+        log.info("게임 코트 위치 변경 완료 - gameBoardId: {}, {}번코트 → {}번코트, swap: {}",
+                gameBoard.getId(), sourceCourt.getCourtNo(), targetCourt.getCourtNo(), targetGame.isPresent());
     }
 
     private void validateRequestedCourtsBelongToBoard(

--- a/src/main/java/umc/cockple/demo/domain/game/service/command/GameCourtCommandService.java
+++ b/src/main/java/umc/cockple/demo/domain/game/service/command/GameCourtCommandService.java
@@ -18,6 +18,7 @@ import umc.cockple.demo.domain.game.repository.GameRepository;
 import umc.cockple.demo.domain.game.service.command.model.GameCourtManageCommand;
 import umc.cockple.demo.domain.game.service.command.model.GameCourtMoveCommand;
 import umc.cockple.demo.domain.game.service.command.result.GameCourtManageResult;
+import umc.cockple.demo.domain.game.service.support.reader.CourtReader;
 import umc.cockple.demo.domain.game.service.support.reader.GameBoardReader;
 
 import java.util.ArrayList;
@@ -36,6 +37,7 @@ import java.util.stream.Collectors;
 public class GameCourtCommandService {
 
     private final GameBoardReader gameBoardReader;
+    private final CourtReader courtReader;
     private final CourtRepository courtRepository;
     private final GameRepository gameRepository;
     private final ApplicationEventPublisher eventPublisher;
@@ -47,14 +49,10 @@ public class GameCourtCommandService {
      * @param memberId 요청자(추후 게임판 관리 권한 검증에 사용 예정)
      */
     public GameCourtManageResult manageCourts(Long memberId, GameCourtManageCommand command) {
-        if (command.gameBoardId() == null) {
-            throw new GameException(GameErrorCode.GAME_BOARD_ID_REQUIRED);
-        }
-
         GameBoard gameBoard = gameBoardReader.read(command.gameBoardId());
         List<GameCourtManageCommand.CourtCommand> requestedCourts = command.courts();
 
-        Map<Long, Court> existingCourtsById = courtRepository.findByGameBoardId(gameBoard.getId()).stream()
+        Map<Long, Court> existingCourtsById = courtReader.readAllByGameBoard(gameBoard.getId()).stream()
                 .collect(Collectors.toMap(Court::getId, Function.identity()));
 
         validateRequestedCourtsBelongToBoard(requestedCourts, existingCourtsById);
@@ -126,8 +124,24 @@ public class GameCourtCommandService {
         List<Court> removedCourts = existingCourtsById.values().stream()
                 .filter(court -> !keepCourtIds.contains(court.getId()))
                 .toList();
-        if (!removedCourts.isEmpty()) {
-            courtRepository.deleteAll(removedCourts);
+        if (removedCourts.isEmpty()) {
+            return;
+        }
+
+        validateNoActiveGameOnCourts(removedCourts);
+        courtRepository.deleteAll(removedCourts);
+    }
+
+    /**
+     * 진행 중(PLAYING)인 게임이 배정된 코트는 삭제할 수 없다.
+     * 삭제하면 코트 위에서 진행되던 게임이 유실되므로 사전에 차단한다.
+     */
+    private void validateNoActiveGameOnCourts(List<Court> removedCourts) {
+        List<Long> removedCourtIds = removedCourts.stream()
+                .map(Court::getId)
+                .toList();
+        if (gameRepository.existsByCourtIdInAndStatus(removedCourtIds, GameStatus.PLAYING)) {
+            throw new GameException(GameErrorCode.COURT_HAS_ACTIVE_GAME);
         }
     }
 

--- a/src/main/java/umc/cockple/demo/domain/game/service/command/GameCourtCommandService.java
+++ b/src/main/java/umc/cockple/demo/domain/game/service/command/GameCourtCommandService.java
@@ -1,0 +1,120 @@
+package umc.cockple.demo.domain.game.service.command;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+import umc.cockple.demo.domain.game.domain.Court;
+import umc.cockple.demo.domain.game.domain.GameBoard;
+import umc.cockple.demo.domain.game.exception.GameErrorCode;
+import umc.cockple.demo.domain.game.exception.GameException;
+import umc.cockple.demo.domain.game.repository.CourtRepository;
+import umc.cockple.demo.domain.game.service.command.model.GameCourtManageCommand;
+import umc.cockple.demo.domain.game.service.command.result.GameCourtManageResult;
+import umc.cockple.demo.domain.game.service.support.reader.GameBoardReader;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+@Slf4j
+public class GameCourtCommandService {
+
+    private final GameBoardReader gameBoardReader;
+    private final CourtRepository courtRepository;
+
+    /**
+     * 게임 코트 관리
+     * 전달된 courts 목록을 "관리 후 최종 상태"로 간주
+     *
+     * @param memberId 요청자(추후 게임판 관리 권한 검증에 사용 예정)
+     */
+    public GameCourtManageResult manageCourts(Long memberId, GameCourtManageCommand command) {
+        if (command.gameBoardId() == null) {
+            throw new GameException(GameErrorCode.GAME_BOARD_ID_REQUIRED);
+        }
+
+        GameBoard gameBoard = gameBoardReader.read(command.gameBoardId());
+        List<GameCourtManageCommand.CourtCommand> requestedCourts = command.courts();
+
+        Map<Long, Court> existingCourtsById = courtRepository.findByGameBoardId(gameBoard.getId()).stream()
+                .collect(Collectors.toMap(Court::getId, Function.identity()));
+
+        validateRequestedCourtsBelongToBoard(requestedCourts, existingCourtsById);
+        deleteRemovedCourts(requestedCourts, existingCourtsById);
+
+        List<Court> finalCourts = upsertCourtsInOrder(gameBoard, requestedCourts, existingCourtsById);
+
+        log.info("게임 코트 관리 완료 - gameBoardId: {}, 코트 수: {}", gameBoard.getId(), finalCourts.size());
+        return toResult(gameBoard.getId(), finalCourts);
+    }
+
+    private void validateRequestedCourtsBelongToBoard(
+            List<GameCourtManageCommand.CourtCommand> requestedCourts,
+            Map<Long, Court> existingCourtsById) {
+        boolean hasForeignCourt = requestedCourts.stream()
+                .map(GameCourtManageCommand.CourtCommand::courtId)
+                .filter(Objects::nonNull)
+                .anyMatch(courtId -> !existingCourtsById.containsKey(courtId));
+        if (hasForeignCourt) {
+            throw new GameException(GameErrorCode.COURT_NOT_FOUND);
+        }
+    }
+
+    private void deleteRemovedCourts(
+            List<GameCourtManageCommand.CourtCommand> requestedCourts,
+            Map<Long, Court> existingCourtsById) {
+        Set<Long> keepCourtIds = requestedCourts.stream()
+                .map(GameCourtManageCommand.CourtCommand::courtId)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toSet());
+
+        List<Court> removedCourts = existingCourtsById.values().stream()
+                .filter(court -> !keepCourtIds.contains(court.getId()))
+                .toList();
+        if (!removedCourts.isEmpty()) {
+            courtRepository.deleteAll(removedCourts);
+        }
+    }
+
+    private List<Court> upsertCourtsInOrder(
+            GameBoard gameBoard,
+            List<GameCourtManageCommand.CourtCommand> requestedCourts,
+            Map<Long, Court> existingCourtsById) {
+        List<Court> finalCourts = new ArrayList<>();
+        int courtNo = 1;
+        for (GameCourtManageCommand.CourtCommand requested : requestedCourts) {
+            String courtName = resolveCourtName(requested.courtName(), courtNo);
+            if (requested.courtId() != null) {
+                Court court = existingCourtsById.get(requested.courtId());
+                court.update(courtNo, courtName);
+                finalCourts.add(court);
+            } else {
+                Court court = Court.create(gameBoard, courtNo, courtName);
+                finalCourts.add(courtRepository.save(court));
+            }
+            courtNo++;
+        }
+        return finalCourts;
+    }
+
+    private String resolveCourtName(String requestedName, int courtNo) {
+        return StringUtils.hasText(requestedName) ? requestedName : courtNo + "번 코트";
+    }
+
+    private GameCourtManageResult toResult(Long gameBoardId, List<Court> courts) {
+        List<GameCourtManageResult.CourtResult> courtResults = courts.stream()
+                .map(court -> new GameCourtManageResult.CourtResult(
+                        court.getId(), court.getCourtNo(), court.getCourtName()))
+                .toList();
+        return new GameCourtManageResult(gameBoardId, courtResults);
+    }
+}

--- a/src/main/java/umc/cockple/demo/domain/game/service/command/model/GameCourtManageCommand.java
+++ b/src/main/java/umc/cockple/demo/domain/game/service/command/model/GameCourtManageCommand.java
@@ -13,7 +13,14 @@ public record GameCourtManageCommand(
         List<CourtCommand> courts
 ) {
     public GameCourtManageCommand {
+        validateGameBoardId(gameBoardId);
         validateNoDuplicateCourtIds(courts);
+    }
+
+    private static void validateGameBoardId(Long gameBoardId) {
+        if (gameBoardId == null) {
+            throw new GameException(GameErrorCode.GAME_BOARD_ID_REQUIRED);
+        }
     }
 
     /**

--- a/src/main/java/umc/cockple/demo/domain/game/service/command/model/GameCourtManageCommand.java
+++ b/src/main/java/umc/cockple/demo/domain/game/service/command/model/GameCourtManageCommand.java
@@ -1,11 +1,39 @@
 package umc.cockple.demo.domain.game.service.command.model;
 
+import umc.cockple.demo.domain.game.exception.GameErrorCode;
+import umc.cockple.demo.domain.game.exception.GameException;
+
+import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
+import java.util.Set;
 
 public record GameCourtManageCommand(
         Long gameBoardId,
         List<CourtCommand> courts
 ) {
+    public GameCourtManageCommand {
+        validateNoDuplicateCourtIds(courts);
+    }
+
+    /**
+     * 같은 courtId가 두 번 이상 들어오면(ex. courtId 10이 중복) 400을 던진다.
+     * 중복을 허용하면 같은 코트를 두 번 upsert 하며 courtNo가 꼬이므로 경계에서 차단한다.
+     */
+    private static void validateNoDuplicateCourtIds(List<CourtCommand> courts) {
+        if (courts == null) {
+            return;
+        }
+        Set<Long> seen = new HashSet<>();
+        boolean hasDuplicate = courts.stream()
+                .map(CourtCommand::courtId)
+                .filter(Objects::nonNull)
+                .anyMatch(courtId -> !seen.add(courtId));
+        if (hasDuplicate) {
+            throw new GameException(GameErrorCode.DUPLICATE_COURT_ID);
+        }
+    }
+
     /**
      * @param courtId   기존 코트면 값 존재(유지 대상), null 이면 신규 생성 대상
      * @param courtName 생략(null/blank) 시 서비스에서 courtNo 기반 기본값 부여

--- a/src/main/java/umc/cockple/demo/domain/game/service/command/model/GameCourtManageCommand.java
+++ b/src/main/java/umc/cockple/demo/domain/game/service/command/model/GameCourtManageCommand.java
@@ -1,0 +1,18 @@
+package umc.cockple.demo.domain.game.service.command.model;
+
+import java.util.List;
+
+public record GameCourtManageCommand(
+        Long gameBoardId,
+        List<CourtCommand> courts
+) {
+    /**
+     * @param courtId   기존 코트면 값 존재(유지 대상), null 이면 신규 생성 대상
+     * @param courtName 생략(null/blank) 시 서비스에서 courtNo 기반 기본값 부여
+     */
+    public record CourtCommand(
+            Long courtId,
+            String courtName
+    ) {
+    }
+}

--- a/src/main/java/umc/cockple/demo/domain/game/service/command/model/GameCourtMoveCommand.java
+++ b/src/main/java/umc/cockple/demo/domain/game/service/command/model/GameCourtMoveCommand.java
@@ -1,0 +1,15 @@
+package umc.cockple.demo.domain.game.service.command.model;
+
+/**
+ * 코트 위치 변경 내부 command 모델
+ *
+ * @param gameBoardId  게임판 ID
+ * @param courtId      게임이 현재 올라가 있는 원본 코트 ID
+ * @param targetCourtNo 이동할 목적지 코트 번호
+ */
+public record GameCourtMoveCommand(
+        Long gameBoardId,
+        Long courtId,
+        Integer targetCourtNo
+) {
+}

--- a/src/main/java/umc/cockple/demo/domain/game/service/command/model/GameStartCommand.java
+++ b/src/main/java/umc/cockple/demo/domain/game/service/command/model/GameStartCommand.java
@@ -1,0 +1,15 @@
+package umc.cockple.demo.domain.game.service.command.model;
+
+/**
+ * 게임 시작 내부 command 모델
+ *
+ * @param gameBoardId 게임판 ID
+ * @param gameId      시작할 대기(WAITING) 게임 ID
+ * @param courtId     게임을 올릴 목적지 코트 ID
+ */
+public record GameStartCommand(
+        Long gameBoardId,
+        Long gameId,
+        Long courtId
+) {
+}

--- a/src/main/java/umc/cockple/demo/domain/game/service/command/result/GameCourtManageResult.java
+++ b/src/main/java/umc/cockple/demo/domain/game/service/command/result/GameCourtManageResult.java
@@ -1,0 +1,18 @@
+package umc.cockple.demo.domain.game.service.command.result;
+
+import java.util.List;
+
+/**
+ * 코트 관리 후의 최종 코트 목록
+ */
+public record GameCourtManageResult(
+        Long gameBoardId,
+        List<CourtResult> courts
+) {
+    public record CourtResult(
+            Long courtId,
+            int courtNo,
+            String courtName
+    ) {
+    }
+}

--- a/src/main/java/umc/cockple/demo/domain/game/service/listener/GameCourtsManagedEventListener.java
+++ b/src/main/java/umc/cockple/demo/domain/game/service/listener/GameCourtsManagedEventListener.java
@@ -1,0 +1,44 @@
+package umc.cockple.demo.domain.game.service.listener;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+import umc.cockple.demo.domain.game.events.GameCourtsManagedEvent;
+import umc.cockple.demo.domain.game.presentation.dto.GameBoardDTO;
+import umc.cockple.demo.domain.game.presentation.mapper.GameBoardMapper;
+import umc.cockple.demo.domain.game.service.query.GameBoardQueryService;
+import umc.cockple.demo.domain.game.service.query.result.GameBoardResult;
+import umc.cockple.demo.domain.game.service.websocket.broadcast.GameBoardBroadcaster;
+
+/**
+ * 코트 관리(REST) 커밋 후, 같은 게임판을 구독 중인 다른 사용자에게 최신 보드를 push 한다.
+ * 실시간 코트 이동/게임 시작이 브로드캐스트하는 것과 동일하게 화면을 동기화한다.
+ *
+ * <p>커밋 이후에 발행하므로 롤백된 변경을 브로드캐스트하지 않으며,
+ * 별도 스레드에서 조회/발행해 요청 스레드의 응답 지연과 격리한다.
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class GameCourtsManagedEventListener {
+
+    private final GameBoardQueryService gameBoardQueryService;
+    private final GameBoardMapper gameBoardMapper;
+    private final GameBoardBroadcaster gameBoardBroadcaster;
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleCourtsManaged(GameCourtsManagedEvent event) {
+        try {
+            GameBoardResult board = gameBoardQueryService.getBoard(event.actorMemberId(), event.gameBoardId());
+            GameBoardDTO.Response boardDto = gameBoardMapper.toResponse(board);
+            gameBoardBroadcaster.broadcastBoardUpdate(event.gameBoardId(), boardDto, event.actorMemberId());
+        } catch (Exception e) {
+            // 브로드캐스트 실패가 이미 커밋된 코트 관리를 되돌리지 않도록 여기서 흡수한다.
+            log.error("코트 관리 브로드캐스트 실패 - gameBoardId: {}", event.gameBoardId(), e);
+        }
+    }
+}

--- a/src/main/java/umc/cockple/demo/domain/game/service/listener/GameCourtsManagedEventListener.java
+++ b/src/main/java/umc/cockple/demo/domain/game/service/listener/GameCourtsManagedEventListener.java
@@ -35,7 +35,8 @@ public class GameCourtsManagedEventListener {
         try {
             GameBoardResult board = gameBoardQueryService.getBoard(event.actorMemberId(), event.gameBoardId());
             GameBoardDTO.Response boardDto = gameBoardMapper.toResponse(board);
-            gameBoardBroadcaster.broadcastBoardUpdate(event.gameBoardId(), boardDto, event.actorMemberId());
+            // REST 요청에는 제외할 WebSocket 세션이 없으므로 구독 세션 전체에 브로드캐스트한다.
+            gameBoardBroadcaster.broadcastBoardUpdate(event.gameBoardId(), boardDto, null);
         } catch (Exception e) {
             // 브로드캐스트 실패가 이미 커밋된 코트 관리를 되돌리지 않도록 여기서 흡수한다.
             log.error("코트 관리 브로드캐스트 실패 - gameBoardId: {}", event.gameBoardId(), e);

--- a/src/main/java/umc/cockple/demo/domain/game/service/query/GameBoardQueryService.java
+++ b/src/main/java/umc/cockple/demo/domain/game/service/query/GameBoardQueryService.java
@@ -1,0 +1,92 @@
+package umc.cockple.demo.domain.game.service.query;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import umc.cockple.demo.domain.game.domain.Court;
+import umc.cockple.demo.domain.game.domain.Game;
+import umc.cockple.demo.domain.game.domain.GameBoard;
+import umc.cockple.demo.domain.game.domain.GamePlayer;
+import umc.cockple.demo.domain.game.enums.CourtStatus;
+import umc.cockple.demo.domain.game.enums.GameStatus;
+import umc.cockple.demo.domain.game.repository.CourtRepository;
+import umc.cockple.demo.domain.game.repository.GameRepository;
+import umc.cockple.demo.domain.game.service.query.result.GameBoardResult;
+import umc.cockple.demo.domain.game.service.support.reader.GameBoardReader;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class GameBoardQueryService {
+
+    private static final List<GameStatus> ACTIVE_STATUSES = List.of(GameStatus.PLAYING, GameStatus.WAITING);
+
+    private final GameBoardReader gameBoardReader;
+    private final CourtRepository courtRepository;
+    private final GameRepository gameRepository;
+
+    /**
+     * 코트 보드 조회 
+     *
+     * @param memberId 요청자(추후 게임판 접근 권한 검증에 사용 예정)
+     */
+    public GameBoardResult getBoard(Long memberId, Long gameBoardId) {
+        GameBoard gameBoard = gameBoardReader.read(gameBoardId);
+
+        List<Court> courts = courtRepository.findByGameBoardIdOrderByCourtNoAsc(gameBoard.getId());
+        List<Game> activeGames = gameRepository.findByGameBoardIdAndStatusInWithPlayers(
+                gameBoard.getId(), ACTIVE_STATUSES);
+
+        Map<Long, Game> playingGameByCourtId = activeGames.stream()
+                .filter(game -> game.getStatus() == GameStatus.PLAYING && game.getCourt() != null)
+                .collect(Collectors.toMap(game -> game.getCourt().getId(), Function.identity(), (a, b) -> a));
+
+        List<GameBoardResult.CourtView> courtViews = courts.stream()
+                .map(court -> toCourtView(court, playingGameByCourtId.get(court.getId())))
+                .toList();
+
+        List<GameBoardResult.WaitingView> waitingViews = activeGames.stream()
+                .filter(game -> game.getStatus() == GameStatus.WAITING)
+                .sorted(Comparator.comparing(Game::getWaitingOrder,
+                        Comparator.nullsLast(Comparator.naturalOrder())))
+                .map(this::toWaitingView)
+                .toList();
+
+        return new GameBoardResult(courts.size(), courtViews, waitingViews);
+    }
+
+    private GameBoardResult.CourtView toCourtView(Court court, Game playingGame) {
+        boolean playing = playingGame != null;
+        return new GameBoardResult.CourtView(
+                court.getId(),
+                court.getCourtNo(),
+                court.getCourtName(),
+                playing ? CourtStatus.PLAYING : CourtStatus.EMPTY,
+                playing ? toGameView(playingGame) : null);
+    }
+
+    private GameBoardResult.GameView toGameView(Game game) {
+        return new GameBoardResult.GameView(game.getId(), game.getStartedAt(), toPlayerViews(game));
+    }
+
+    private GameBoardResult.WaitingView toWaitingView(Game game) {
+        return new GameBoardResult.WaitingView(game.getId(), game.getWaitingOrder(), toPlayerViews(game));
+    }
+
+    private List<GameBoardResult.PlayerView> toPlayerViews(Game game) {
+        return game.getPlayers().stream()
+                .sorted(Comparator.comparingInt(GamePlayer::getPlayerOrder))
+                .map(player -> new GameBoardResult.PlayerView(
+                        player.getGameBoardMember().getId(),
+                        player.getGameBoardMember().getName(),
+                        player.getGameBoardMember().getLevel(),
+                        player.getPlayerOrder()))
+                .toList();
+    }
+}

--- a/src/main/java/umc/cockple/demo/domain/game/service/query/result/GameBoardResult.java
+++ b/src/main/java/umc/cockple/demo/domain/game/service/query/result/GameBoardResult.java
@@ -1,0 +1,47 @@
+package umc.cockple.demo.domain.game.service.query.result;
+
+import umc.cockple.demo.domain.game.enums.CourtStatus;
+import umc.cockple.demo.global.enums.Level;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * 코트 보드 조회(#2) 내부 result 모델. (명단 제외한 코트/대기열)
+ */
+public record GameBoardResult(
+        int courtCount,
+        List<CourtView> courts,
+        List<WaitingView> waitings
+) {
+    public record CourtView(
+            Long courtId,
+            int courtNo,
+            String courtName,
+            CourtStatus status,
+            GameView game // EMPTY 이면 null
+    ) {
+    }
+
+    public record GameView(
+            Long gameId,
+            LocalDateTime startedAt,
+            List<PlayerView> players
+    ) {
+    }
+
+    public record WaitingView(
+            Long gameId,
+            int waitingOrder,
+            List<PlayerView> players
+    ) {
+    }
+
+    public record PlayerView(
+            Long gameBoardMemberId,
+            String name,
+            Level level,
+            int playerOrder
+    ) {
+    }
+}

--- a/src/main/java/umc/cockple/demo/domain/game/service/support/reader/CourtReader.java
+++ b/src/main/java/umc/cockple/demo/domain/game/service/support/reader/CourtReader.java
@@ -1,0 +1,21 @@
+package umc.cockple.demo.domain.game.service.support.reader;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import umc.cockple.demo.domain.game.domain.Court;
+import umc.cockple.demo.domain.game.repository.CourtRepository;
+
+import java.util.List;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class CourtReader {
+
+    private final CourtRepository courtRepository;
+
+    public List<Court> readAllByGameBoard(Long gameBoardId) {
+        return courtRepository.findByGameBoardId(gameBoardId);
+    }
+}

--- a/src/main/java/umc/cockple/demo/domain/game/service/support/reader/GameBoardReader.java
+++ b/src/main/java/umc/cockple/demo/domain/game/service/support/reader/GameBoardReader.java
@@ -1,0 +1,22 @@
+package umc.cockple.demo.domain.game.service.support.reader;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import umc.cockple.demo.domain.game.domain.GameBoard;
+import umc.cockple.demo.domain.game.exception.GameErrorCode;
+import umc.cockple.demo.domain.game.exception.GameException;
+import umc.cockple.demo.domain.game.repository.GameBoardRepository;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class GameBoardReader {
+
+    private final GameBoardRepository gameBoardRepository;
+
+    public GameBoard read(Long gameBoardId) {
+        return gameBoardRepository.findById(gameBoardId)
+                .orElseThrow(() -> new GameException(GameErrorCode.GAME_BOARD_NOT_FOUND));
+    }
+}

--- a/src/main/java/umc/cockple/demo/domain/game/service/websocket/broadcast/GameBoardBroadcaster.java
+++ b/src/main/java/umc/cockple/demo/domain/game/service/websocket/broadcast/GameBoardBroadcaster.java
@@ -1,0 +1,50 @@
+package umc.cockple.demo.domain.game.service.websocket.broadcast;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import umc.cockple.demo.domain.game.realtime.GameRealtimeProtocol;
+import umc.cockple.demo.domain.game.repository.redis.GameBoardSubscriptionStore;
+import umc.cockple.demo.global.realtime.publish.RealtimeMessagePublisher;
+import umc.cockple.demo.global.realtime.publish.RealtimePublishResult;
+
+import java.util.Set;
+
+/**
+ * 게임판 변경을 그 게임판 구독자 전원에게 실시간 push 한다.
+ * 공용 발행기는 memberId 단위라, 구독자 집합을 순회하며 각자에게 발행한다.
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class GameBoardBroadcaster {
+
+    private final GameBoardSubscriptionStore subscriptionStore;
+    private final RealtimeMessagePublisher realtimeMessagePublisher;
+
+    public void broadcastBoardUpdate(Long gameBoardId, Object boardData, Long excludedMemberId) {
+        Set<Long> subscribers = subscriptionStore.getSubscribers(gameBoardId);
+        if (subscribers.isEmpty()) {
+            log.info("게임판 {} 구독자가 없어 브로드캐스트를 생략합니다.", gameBoardId);
+            return;
+        }
+
+        int deliveredCount = 0;
+        for (Long memberId : subscribers) {
+            if (memberId.equals(excludedMemberId)) {
+                continue;
+            }
+            RealtimePublishResult result = realtimeMessagePublisher.publish(
+                    memberId,
+                    GameRealtimeProtocol.DOMAIN,
+                    GameRealtimeProtocol.TYPE_BOARD_UPDATED,
+                    boardData);
+            if (result.deliveredToAnySession()) {
+                deliveredCount++;
+            }
+        }
+
+        log.info("게임판 브로드캐스트 완료 - gameBoardId: {}, 구독자: {}명, 전달: {}명",
+                gameBoardId, subscribers.size(), deliveredCount);
+    }
+}

--- a/src/main/java/umc/cockple/demo/domain/game/service/websocket/broadcast/GameBoardBroadcaster.java
+++ b/src/main/java/umc/cockple/demo/domain/game/service/websocket/broadcast/GameBoardBroadcaster.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import umc.cockple.demo.domain.game.realtime.GameRealtimeProtocol;
+import umc.cockple.demo.domain.game.repository.redis.GameBoardSubscriber;
 import umc.cockple.demo.domain.game.repository.redis.GameBoardSubscriptionStore;
 import umc.cockple.demo.global.realtime.publish.RealtimeMessagePublisher;
 import umc.cockple.demo.global.realtime.publish.RealtimePublishResult;
@@ -12,7 +13,8 @@ import java.util.Set;
 
 /**
  * 게임판 변경을 그 게임판 구독자 전원에게 실시간 push 한다.
- * 공용 발행기는 memberId 단위라, 구독자 집합을 순회하며 각자에게 발행한다.
+ * 구독 단위가 세션이므로, 구독 세션 각각을 겨냥해 발행한다.
+ * 변경을 유발한 세션(excludedSessionId)은 이미 직접 응답을 받았으므로 제외한다.
  */
 @Component
 @RequiredArgsConstructor
@@ -22,20 +24,21 @@ public class GameBoardBroadcaster {
     private final GameBoardSubscriptionStore subscriptionStore;
     private final RealtimeMessagePublisher realtimeMessagePublisher;
 
-    public void broadcastBoardUpdate(Long gameBoardId, Object boardData, Long excludedMemberId) {
-        Set<Long> subscribers = subscriptionStore.getSubscribers(gameBoardId);
+    public void broadcastBoardUpdate(Long gameBoardId, Object boardData, String excludedSessionId) {
+        Set<GameBoardSubscriber> subscribers = subscriptionStore.getSubscribers(gameBoardId);
         if (subscribers.isEmpty()) {
             log.info("게임판 {} 구독자가 없어 브로드캐스트를 생략합니다.", gameBoardId);
             return;
         }
 
         int deliveredCount = 0;
-        for (Long memberId : subscribers) {
-            if (memberId.equals(excludedMemberId)) {
+        for (GameBoardSubscriber subscriber : subscribers) {
+            if (subscriber.sessionId().equals(excludedSessionId)) {
                 continue;
             }
-            RealtimePublishResult result = realtimeMessagePublisher.publish(
-                    memberId,
+            RealtimePublishResult result = realtimeMessagePublisher.publishToSession(
+                    subscriber.memberId(),
+                    subscriber.sessionId(),
                     GameRealtimeProtocol.DOMAIN,
                     GameRealtimeProtocol.TYPE_BOARD_UPDATED,
                     boardData);
@@ -44,7 +47,7 @@ public class GameBoardBroadcaster {
             }
         }
 
-        log.info("게임판 브로드캐스트 완료 - gameBoardId: {}, 구독자: {}명, 전달: {}명",
+        log.info("게임판 브로드캐스트 완료 - gameBoardId: {}, 구독 세션: {}개, 전달: {}개",
                 gameBoardId, subscribers.size(), deliveredCount);
     }
 }

--- a/src/main/java/umc/cockple/demo/domain/game/service/websocket/subscription/GameBoardSubscriptionService.java
+++ b/src/main/java/umc/cockple/demo/domain/game/service/websocket/subscription/GameBoardSubscriptionService.java
@@ -1,0 +1,28 @@
+package umc.cockple.demo.domain.game.service.websocket.subscription;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import umc.cockple.demo.domain.game.repository.redis.GameBoardSubscriptionStore;
+import umc.cockple.demo.domain.game.service.support.reader.GameBoardReader;
+
+/**
+ * 게임판 구독/구독 해제. 구독한 멤버는 이후 코트 변경 등 라이브 업데이트를 push 받는다.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class GameBoardSubscriptionService {
+
+    private final GameBoardReader gameBoardReader;
+    private final GameBoardSubscriptionStore subscriptionStore;
+
+    public void subscribe(Long gameBoardId, Long memberId) {
+        gameBoardReader.read(gameBoardId); // 존재 검증 (없으면 GAME_BOARD_NOT_FOUND)
+        subscriptionStore.addSubscriber(gameBoardId, memberId);
+    }
+
+    public void unsubscribe(Long gameBoardId, Long memberId) {
+        subscriptionStore.removeSubscriber(gameBoardId, memberId);
+    }
+}

--- a/src/main/java/umc/cockple/demo/domain/game/service/websocket/subscription/GameBoardSubscriptionService.java
+++ b/src/main/java/umc/cockple/demo/domain/game/service/websocket/subscription/GameBoardSubscriptionService.java
@@ -17,12 +17,12 @@ public class GameBoardSubscriptionService {
     private final GameBoardReader gameBoardReader;
     private final GameBoardSubscriptionStore subscriptionStore;
 
-    public void subscribe(Long gameBoardId, Long memberId) {
+    public void subscribe(Long gameBoardId, Long memberId, String sessionId) {
         gameBoardReader.read(gameBoardId); // 존재 검증 (없으면 GAME_BOARD_NOT_FOUND)
-        subscriptionStore.addSubscriber(gameBoardId, memberId);
+        subscriptionStore.addSubscriber(gameBoardId, memberId, sessionId);
     }
 
-    public void unsubscribe(Long gameBoardId, Long memberId) {
-        subscriptionStore.removeSubscriber(gameBoardId, memberId);
+    public void unsubscribe(Long gameBoardId, Long memberId, String sessionId) {
+        subscriptionStore.removeSubscriber(gameBoardId, memberId, sessionId);
     }
 }

--- a/src/main/java/umc/cockple/demo/global/realtime/publish/RealtimeMessagePublisher.java
+++ b/src/main/java/umc/cockple/demo/global/realtime/publish/RealtimeMessagePublisher.java
@@ -8,4 +8,16 @@ public interface RealtimeMessagePublisher {
             String type,
             Object data
     );
+
+    /**
+     * 회원의 특정 세션 하나에만 발행한다.
+     * 같은 회원이 여러 세션(탭/기기)을 열어둔 경우, 구독한 세션에만 전달해야 할 때 사용한다.
+     */
+    RealtimePublishResult publishToSession(
+            Long memberId,
+            String sessionId,
+            String domain,
+            String type,
+            Object data
+    );
 }

--- a/src/main/java/umc/cockple/demo/global/realtime/publish/WebSocketRealtimeMessagePublisher.java
+++ b/src/main/java/umc/cockple/demo/global/realtime/publish/WebSocketRealtimeMessagePublisher.java
@@ -41,49 +41,85 @@ public class WebSocketRealtimeMessagePublisher implements RealtimeMessagePublish
                     memberId,
                     RealtimeWebSocketEndpoint.SESSION_ENDPOINT
             );
-            if (targetSessions.isEmpty()) {
-                log.debug("공용 실시간 메시지 발행 대상 세션 없음 - domain: {}, type: {}", normalizedDomain, normalizedType);
-                return RealtimePublishResult.noTarget();
-            }
-
-            RealtimeOutboundEnvelope envelope = RealtimeOutboundEnvelope.success(
-                    normalizedDomain,
-                    normalizedType,
-                    null,
-                    data
-            );
-            EncodedRealtimeMessage encodedMessage = messageEncoder.encode(envelope).orElse(null);
-            if (encodedMessage == null) {
-                log.error("공용 실시간 메시지 직렬화 실패 - domain: {}, type: {}", normalizedDomain, normalizedType);
-                return RealtimePublishResult.failed(targetSessions.size());
-            }
-
-            int successCount = 0;
-            for (RealtimeSession targetSession : targetSessions) {
-                if (messageSender.send(targetSession.webSocketSession(), encodedMessage)) {
-                    successCount++;
-                    continue;
-                }
-
-                if (!targetSession.isOpen()) {
-                    sessionRegistry.remove(memberId, targetSession.webSocketSession());
-                }
-            }
-
-            RealtimePublishResult result = new RealtimePublishResult(
-                    targetSessions.size(),
-                    successCount
-            );
-            log.debug(
-                    "공용 실시간 메시지 발행 완료 - domain: {}, type: {}, 대상: {}, 성공: {}, 실패: {}",
-                    normalizedDomain,
-                    normalizedType,
-                    result.targetSessionCount(),
-                    result.successCount(),
-                    result.failureCount()
-            );
-            return result;
+            return deliver(memberId, targetSessions, normalizedDomain, normalizedType, data);
         }
+    }
+
+    @Override
+    public RealtimePublishResult publishToSession(
+            Long memberId,
+            String sessionId,
+            String domain,
+            String type,
+            Object data
+    ) {
+        Objects.requireNonNull(memberId, "memberId는 null일 수 없습니다.");
+        if (sessionId == null || sessionId.isBlank()) {
+            throw new IllegalArgumentException("sessionId는 비어 있을 수 없습니다.");
+        }
+        String normalizedDomain = normalize(domain, "domain");
+        String normalizedType = normalize(type, "type");
+
+        try (WebSocketMdcSupport.MdcScope ignored = WebSocketMdcSupport.open(memberId)) {
+            List<RealtimeSession> targetSessions = sessionRegistry.findOpenSessions(
+                            memberId,
+                            RealtimeWebSocketEndpoint.SESSION_ENDPOINT
+                    ).stream()
+                    .filter(session -> sessionId.equals(session.sessionId()))
+                    .toList();
+            return deliver(memberId, targetSessions, normalizedDomain, normalizedType, data);
+        }
+    }
+
+    private RealtimePublishResult deliver(
+            Long memberId,
+            List<RealtimeSession> targetSessions,
+            String normalizedDomain,
+            String normalizedType,
+            Object data
+    ) {
+        if (targetSessions.isEmpty()) {
+            log.debug("공용 실시간 메시지 발행 대상 세션 없음 - domain: {}, type: {}", normalizedDomain, normalizedType);
+            return RealtimePublishResult.noTarget();
+        }
+
+        RealtimeOutboundEnvelope envelope = RealtimeOutboundEnvelope.success(
+                normalizedDomain,
+                normalizedType,
+                null,
+                data
+        );
+        EncodedRealtimeMessage encodedMessage = messageEncoder.encode(envelope).orElse(null);
+        if (encodedMessage == null) {
+            log.error("공용 실시간 메시지 직렬화 실패 - domain: {}, type: {}", normalizedDomain, normalizedType);
+            return RealtimePublishResult.failed(targetSessions.size());
+        }
+
+        int successCount = 0;
+        for (RealtimeSession targetSession : targetSessions) {
+            if (messageSender.send(targetSession.webSocketSession(), encodedMessage)) {
+                successCount++;
+                continue;
+            }
+
+            if (!targetSession.isOpen()) {
+                sessionRegistry.remove(memberId, targetSession.webSocketSession());
+            }
+        }
+
+        RealtimePublishResult result = new RealtimePublishResult(
+                targetSessions.size(),
+                successCount
+        );
+        log.debug(
+                "공용 실시간 메시지 발행 완료 - domain: {}, type: {}, 대상: {}, 성공: {}, 실패: {}",
+                normalizedDomain,
+                normalizedType,
+                result.targetSessionCount(),
+                result.successCount(),
+                result.failureCount()
+        );
+        return result;
     }
 
     private String normalize(String value, String fieldName) {

--- a/src/test/java/umc/cockple/demo/domain/game/repository/redis/GameBoardSubscriberTest.java
+++ b/src/test/java/umc/cockple/demo/domain/game/repository/redis/GameBoardSubscriberTest.java
@@ -1,0 +1,29 @@
+package umc.cockple.demo.domain.game.repository.redis;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("GameBoardSubscriber")
+class GameBoardSubscriberTest {
+
+    @Test
+    @DisplayName("토큰으로 직렬화 후 역직렬화하면 원본 (memberId, sessionId)가 보존된다")
+    void tokenRoundTrip() {
+        GameBoardSubscriber original = new GameBoardSubscriber(42L, "ws-session-abc123");
+
+        GameBoardSubscriber restored = GameBoardSubscriber.fromToken(original.toToken());
+
+        assertThat(restored).isEqualTo(original);
+    }
+
+    @Test
+    @DisplayName("sessionId에 구분자와 같은 문자가 있어도 첫 구분자 기준으로 memberId만 분리한다")
+    void tokenSplitsOnFirstDelimiterOnly() {
+        GameBoardSubscriber restored = GameBoardSubscriber.fromToken("42:a:b:c");
+
+        assertThat(restored.memberId()).isEqualTo(42L);
+        assertThat(restored.sessionId()).isEqualTo("a:b:c");
+    }
+}

--- a/src/test/java/umc/cockple/demo/domain/game/service/command/GameCommandServiceTest.java
+++ b/src/test/java/umc/cockple/demo/domain/game/service/command/GameCommandServiceTest.java
@@ -1,0 +1,172 @@
+package umc.cockple.demo.domain.game.service.command;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import umc.cockple.demo.domain.game.domain.Court;
+import umc.cockple.demo.domain.game.domain.Game;
+import umc.cockple.demo.domain.game.domain.GameBoard;
+import umc.cockple.demo.domain.game.enums.GameStatus;
+import umc.cockple.demo.domain.game.exception.GameErrorCode;
+import umc.cockple.demo.domain.game.exception.GameException;
+import umc.cockple.demo.domain.game.repository.CourtRepository;
+import umc.cockple.demo.domain.game.repository.GameRepository;
+import umc.cockple.demo.domain.game.service.command.model.GameStartCommand;
+import umc.cockple.demo.domain.game.service.support.reader.GameBoardReader;
+import umc.cockple.demo.support.fixture.GameFixture;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("GameCommandService")
+class GameCommandServiceTest {
+
+    @Mock private GameBoardReader gameBoardReader;
+    @Mock private GameRepository gameRepository;
+    @Mock private CourtRepository courtRepository;
+
+    @InjectMocks private GameCommandService gameCommandService;
+
+    private static final Long MEMBER_ID = 100L;
+    private static final Long BOARD_ID = 1L;
+    private static final Long GAME_ID = 50L;
+    private static final Long COURT_ID = 10L;
+
+    private GameBoard board;
+    private Court court;
+
+    @BeforeEach
+    void setUp() {
+        board = GameFixture.gameBoard(BOARD_ID);
+        court = GameFixture.court(COURT_ID, board, 1, "1번 코트");
+    }
+
+    @Nested
+    @DisplayName("startGame (#4 게임 시작)")
+    class StartGame {
+
+        @Test
+        @DisplayName("대기 게임을 코트에 배치해 진행 상태로 만든다")
+        void startGame_placesWaitingGameOnCourt() {
+            // given
+            Game waiting = GameFixture.waitingGame(GAME_ID, board, 1);
+            given(gameBoardReader.read(BOARD_ID)).willReturn(board);
+            given(gameRepository.findById(GAME_ID)).willReturn(Optional.of(waiting));
+            given(courtRepository.findByIdAndGameBoardId(COURT_ID, BOARD_ID)).willReturn(Optional.of(court));
+            given(gameRepository.findByCourtIdAndStatus(COURT_ID, GameStatus.PLAYING)).willReturn(Optional.empty());
+            given(gameRepository.findByGameBoardIdAndStatusOrderByWaitingOrderAsc(BOARD_ID, GameStatus.WAITING))
+                    .willReturn(List.of());
+
+            // when
+            gameCommandService.startGame(MEMBER_ID, new GameStartCommand(BOARD_ID, GAME_ID, COURT_ID));
+
+            // then
+            assertThat(waiting.getStatus()).isEqualTo(GameStatus.PLAYING);
+            assertThat(waiting.getCourt()).isEqualTo(court);
+            assertThat(waiting.getStartedAt()).isNotNull();
+            assertThat(waiting.getWaitingOrder()).isNull();
+        }
+
+        @Test
+        @DisplayName("시작 후 남은 대기열의 순서를 1부터 다시 매긴다")
+        void startGame_resequencesWaitingQueue() {
+            // given
+            Game waiting = GameFixture.waitingGame(GAME_ID, board, 1);
+            Game remaining1 = GameFixture.waitingGame(51L, board, 2);
+            Game remaining2 = GameFixture.waitingGame(52L, board, 3);
+            given(gameBoardReader.read(BOARD_ID)).willReturn(board);
+            given(gameRepository.findById(GAME_ID)).willReturn(Optional.of(waiting));
+            given(courtRepository.findByIdAndGameBoardId(COURT_ID, BOARD_ID)).willReturn(Optional.of(court));
+            given(gameRepository.findByCourtIdAndStatus(COURT_ID, GameStatus.PLAYING)).willReturn(Optional.empty());
+            given(gameRepository.findByGameBoardIdAndStatusOrderByWaitingOrderAsc(BOARD_ID, GameStatus.WAITING))
+                    .willReturn(List.of(remaining1, remaining2));
+
+            // when
+            gameCommandService.startGame(MEMBER_ID, new GameStartCommand(BOARD_ID, GAME_ID, COURT_ID));
+
+            // then
+            assertThat(remaining1.getWaitingOrder()).isEqualTo(1);
+            assertThat(remaining2.getWaitingOrder()).isEqualTo(2);
+        }
+
+        @Test
+        @DisplayName("게임을 찾을 수 없으면 GAME_NOT_FOUND 예외")
+        void startGame_gameNotFound() {
+            given(gameBoardReader.read(BOARD_ID)).willReturn(board);
+            given(gameRepository.findById(GAME_ID)).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> gameCommandService.startGame(MEMBER_ID, new GameStartCommand(BOARD_ID, GAME_ID, COURT_ID)))
+                    .isInstanceOf(GameException.class)
+                    .extracting(e -> ((GameException) e).getCode())
+                    .isEqualTo(GameErrorCode.GAME_NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("다른 게임판의 게임이면 GAME_NOT_FOUND 예외")
+        void startGame_gameOfOtherBoard() {
+            GameBoard otherBoard = GameFixture.gameBoard(2L);
+            Game gameOfOtherBoard = GameFixture.waitingGame(GAME_ID, otherBoard, 1);
+            given(gameBoardReader.read(BOARD_ID)).willReturn(board);
+            given(gameRepository.findById(GAME_ID)).willReturn(Optional.of(gameOfOtherBoard));
+
+            assertThatThrownBy(() -> gameCommandService.startGame(MEMBER_ID, new GameStartCommand(BOARD_ID, GAME_ID, COURT_ID)))
+                    .isInstanceOf(GameException.class)
+                    .extracting(e -> ((GameException) e).getCode())
+                    .isEqualTo(GameErrorCode.GAME_NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("대기 상태가 아닌 게임이면 GAME_NOT_WAITING 예외")
+        void startGame_notWaiting() {
+            Game playing = GameFixture.playingGame(GAME_ID, board, court, LocalDateTime.now());
+            given(gameBoardReader.read(BOARD_ID)).willReturn(board);
+            given(gameRepository.findById(GAME_ID)).willReturn(Optional.of(playing));
+
+            assertThatThrownBy(() -> gameCommandService.startGame(MEMBER_ID, new GameStartCommand(BOARD_ID, GAME_ID, COURT_ID)))
+                    .isInstanceOf(GameException.class)
+                    .extracting(e -> ((GameException) e).getCode())
+                    .isEqualTo(GameErrorCode.GAME_NOT_WAITING);
+        }
+
+        @Test
+        @DisplayName("목적지 코트가 없으면 COURT_NOT_FOUND 예외")
+        void startGame_courtNotFound() {
+            Game waiting = GameFixture.waitingGame(GAME_ID, board, 1);
+            given(gameBoardReader.read(BOARD_ID)).willReturn(board);
+            given(gameRepository.findById(GAME_ID)).willReturn(Optional.of(waiting));
+            given(courtRepository.findByIdAndGameBoardId(COURT_ID, BOARD_ID)).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> gameCommandService.startGame(MEMBER_ID, new GameStartCommand(BOARD_ID, GAME_ID, COURT_ID)))
+                    .isInstanceOf(GameException.class)
+                    .extracting(e -> ((GameException) e).getCode())
+                    .isEqualTo(GameErrorCode.COURT_NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("목적지 코트에 이미 진행 중인 게임이 있으면 COURT_ALREADY_IN_USE 예외")
+        void startGame_courtAlreadyInUse() {
+            Game waiting = GameFixture.waitingGame(GAME_ID, board, 1);
+            Game occupying = GameFixture.playingGame(99L, board, court, LocalDateTime.now());
+            given(gameBoardReader.read(BOARD_ID)).willReturn(board);
+            given(gameRepository.findById(GAME_ID)).willReturn(Optional.of(waiting));
+            given(courtRepository.findByIdAndGameBoardId(COURT_ID, BOARD_ID)).willReturn(Optional.of(court));
+            given(gameRepository.findByCourtIdAndStatus(COURT_ID, GameStatus.PLAYING)).willReturn(Optional.of(occupying));
+
+            assertThatThrownBy(() -> gameCommandService.startGame(MEMBER_ID, new GameStartCommand(BOARD_ID, GAME_ID, COURT_ID)))
+                    .isInstanceOf(GameException.class)
+                    .extracting(e -> ((GameException) e).getCode())
+                    .isEqualTo(GameErrorCode.COURT_ALREADY_IN_USE);
+        }
+    }
+}

--- a/src/test/java/umc/cockple/demo/domain/game/service/command/GameCourtCommandServiceTest.java
+++ b/src/test/java/umc/cockple/demo/domain/game/service/command/GameCourtCommandServiceTest.java
@@ -9,6 +9,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 import umc.cockple.demo.domain.game.domain.Court;
 import umc.cockple.demo.domain.game.domain.Game;
 import umc.cockple.demo.domain.game.domain.GameBoard;
@@ -17,6 +18,7 @@ import umc.cockple.demo.domain.game.exception.GameErrorCode;
 import umc.cockple.demo.domain.game.exception.GameException;
 import umc.cockple.demo.domain.game.repository.CourtRepository;
 import umc.cockple.demo.domain.game.repository.GameRepository;
+import umc.cockple.demo.domain.game.events.GameCourtsManagedEvent;
 import umc.cockple.demo.domain.game.service.command.model.GameCourtManageCommand;
 import umc.cockple.demo.domain.game.service.command.model.GameCourtManageCommand.CourtCommand;
 import umc.cockple.demo.domain.game.service.command.model.GameCourtMoveCommand;
@@ -42,6 +44,7 @@ class GameCourtCommandServiceTest {
     @Mock private GameBoardReader gameBoardReader;
     @Mock private CourtRepository courtRepository;
     @Mock private GameRepository gameRepository;
+    @Mock private ApplicationEventPublisher eventPublisher;
 
     @InjectMocks private GameCourtCommandService gameCourtCommandService;
 
@@ -95,6 +98,21 @@ class GameCourtCommandServiceTest {
             // 결과는 최종 코트 2개
             assertThat(result.gameBoardId()).isEqualTo(BOARD_ID);
             assertThat(result.courts()).hasSize(2);
+
+            // 구독자 브로드캐스트용 이벤트가 발행된다
+            then(eventPublisher).should().publishEvent(any(GameCourtsManagedEvent.class));
+        }
+
+        @Test
+        @DisplayName("같은 courtId가 중복되면 command 생성 단계에서 DUPLICATE_COURT_ID 예외")
+        void manageCourts_duplicateCourtId() {
+            assertThatThrownBy(() -> new GameCourtManageCommand(BOARD_ID, List.of(
+                    new CourtCommand(10L, "코트A"),
+                    new CourtCommand(10L, "코트B")
+            )))
+                    .isInstanceOf(GameException.class)
+                    .extracting(e -> ((GameException) e).getCode())
+                    .isEqualTo(GameErrorCode.DUPLICATE_COURT_ID);
         }
 
         @Test

--- a/src/test/java/umc/cockple/demo/domain/game/service/command/GameCourtCommandServiceTest.java
+++ b/src/test/java/umc/cockple/demo/domain/game/service/command/GameCourtCommandServiceTest.java
@@ -1,0 +1,241 @@
+package umc.cockple.demo.domain.game.service.command;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import umc.cockple.demo.domain.game.domain.Court;
+import umc.cockple.demo.domain.game.domain.Game;
+import umc.cockple.demo.domain.game.domain.GameBoard;
+import umc.cockple.demo.domain.game.enums.GameStatus;
+import umc.cockple.demo.domain.game.exception.GameErrorCode;
+import umc.cockple.demo.domain.game.exception.GameException;
+import umc.cockple.demo.domain.game.repository.CourtRepository;
+import umc.cockple.demo.domain.game.repository.GameRepository;
+import umc.cockple.demo.domain.game.service.command.model.GameCourtManageCommand;
+import umc.cockple.demo.domain.game.service.command.model.GameCourtManageCommand.CourtCommand;
+import umc.cockple.demo.domain.game.service.command.model.GameCourtMoveCommand;
+import umc.cockple.demo.domain.game.service.command.result.GameCourtManageResult;
+import umc.cockple.demo.domain.game.service.support.reader.GameBoardReader;
+import umc.cockple.demo.support.fixture.GameFixture;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.times;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("GameCourtCommandService")
+class GameCourtCommandServiceTest {
+
+    @Mock private GameBoardReader gameBoardReader;
+    @Mock private CourtRepository courtRepository;
+    @Mock private GameRepository gameRepository;
+
+    @InjectMocks private GameCourtCommandService gameCourtCommandService;
+
+    private static final Long MEMBER_ID = 100L;
+    private static final Long BOARD_ID = 1L;
+    private GameBoard board;
+
+    @BeforeEach
+    void setUp() {
+        board = GameFixture.gameBoard(BOARD_ID);
+    }
+
+    @Nested
+    @DisplayName("manageCourts (#1 코트 관리)")
+    class ManageCourts {
+
+        @Test
+        @DisplayName("유지(이름변경)/신규생성/삭제를 한 번에 반영하고 courtNo를 배열 순서로 재부여한다")
+        void manageCourts_upsertAndDeleteInOrder() {
+            // given
+            Court kept = GameFixture.court(10L, board, 1, "기존코트");
+            Court removed = GameFixture.court(11L, board, 2, "삭제될코트");
+            given(gameBoardReader.read(BOARD_ID)).willReturn(board);
+            given(courtRepository.findByGameBoardId(BOARD_ID)).willReturn(List.of(kept, removed));
+            given(courtRepository.save(any(Court.class))).willAnswer(inv -> inv.getArgument(0));
+
+            GameCourtManageCommand command = new GameCourtManageCommand(BOARD_ID, List.of(
+                    new CourtCommand(10L, "새이름"), // 유지 + 이름변경 → courtNo 1
+                    new CourtCommand(null, "신규코트") // 신규 → courtNo 2
+            )); // 기존 removed(11L)는 목록에 없으므로 삭제
+
+            // when
+            GameCourtManageResult result = gameCourtCommandService.manageCourts(MEMBER_ID, command);
+
+            // then - 유지 코트는 이름/순서 갱신
+            assertThat(kept.getCourtNo()).isEqualTo(1);
+            assertThat(kept.getCourtName()).isEqualTo("새이름");
+
+            // 빠진 코트는 삭제
+            @SuppressWarnings("unchecked")
+            ArgumentCaptor<List<Court>> deleteCaptor = ArgumentCaptor.forClass(List.class);
+            then(courtRepository).should().deleteAll(deleteCaptor.capture());
+            assertThat(deleteCaptor.getValue()).containsExactly(removed);
+
+            // 신규 코트는 courtNo 2로 저장
+            ArgumentCaptor<Court> saveCaptor = ArgumentCaptor.forClass(Court.class);
+            then(courtRepository).should().save(saveCaptor.capture());
+            assertThat(saveCaptor.getValue().getCourtNo()).isEqualTo(2);
+            assertThat(saveCaptor.getValue().getCourtName()).isEqualTo("신규코트");
+
+            // 결과는 최종 코트 2개
+            assertThat(result.gameBoardId()).isEqualTo(BOARD_ID);
+            assertThat(result.courts()).hasSize(2);
+        }
+
+        @Test
+        @DisplayName("courtName이 비어 있으면 'N번 코트' 기본값을 부여한다")
+        void manageCourts_defaultCourtName() {
+            // given
+            given(gameBoardReader.read(BOARD_ID)).willReturn(board);
+            given(courtRepository.findByGameBoardId(BOARD_ID)).willReturn(List.of());
+            given(courtRepository.save(any(Court.class))).willAnswer(inv -> inv.getArgument(0));
+
+            GameCourtManageCommand command = new GameCourtManageCommand(BOARD_ID, List.of(
+                    new CourtCommand(null, null),
+                    new CourtCommand(null, "   ") // 공백도 기본값 처리
+            ));
+
+            // when
+            gameCourtCommandService.manageCourts(MEMBER_ID, command);
+
+            // then
+            ArgumentCaptor<Court> saveCaptor = ArgumentCaptor.forClass(Court.class);
+            then(courtRepository).should(times(2)).save(saveCaptor.capture());
+            assertThat(saveCaptor.getAllValues())
+                    .extracting(Court::getCourtName)
+                    .containsExactly("1번 코트", "2번 코트");
+        }
+
+        @Test
+        @DisplayName("gameBoardId가 null이면 GAME_BOARD_ID_REQUIRED 예외")
+        void manageCourts_nullBoardId() {
+            GameCourtManageCommand command = new GameCourtManageCommand(null, List.of());
+
+            assertThatThrownBy(() -> gameCourtCommandService.manageCourts(MEMBER_ID, command))
+                    .isInstanceOf(GameException.class)
+                    .extracting(e -> ((GameException) e).getCode())
+                    .isEqualTo(GameErrorCode.GAME_BOARD_ID_REQUIRED);
+        }
+
+        @Test
+        @DisplayName("요청 courtId가 해당 게임판에 없으면 COURT_NOT_FOUND 예외")
+        void manageCourts_foreignCourtId() {
+            given(gameBoardReader.read(BOARD_ID)).willReturn(board);
+            given(courtRepository.findByGameBoardId(BOARD_ID))
+                    .willReturn(List.of(GameFixture.court(10L, board, 1, "코트")));
+
+            GameCourtManageCommand command = new GameCourtManageCommand(BOARD_ID, List.of(
+                    new CourtCommand(999L, "없는코트")
+            ));
+
+            assertThatThrownBy(() -> gameCourtCommandService.manageCourts(MEMBER_ID, command))
+                    .isInstanceOf(GameException.class)
+                    .extracting(e -> ((GameException) e).getCode())
+                    .isEqualTo(GameErrorCode.COURT_NOT_FOUND);
+        }
+    }
+
+    @Nested
+    @DisplayName("moveCourt (#3 코트 위치 변경)")
+    class MoveCourt {
+
+        @Test
+        @DisplayName("목적지 코트가 비어 있으면 게임을 그 코트로 이동한다")
+        void moveCourt_toEmptyCourt() {
+            // given
+            Court source = GameFixture.court(10L, board, 1, "1번");
+            Court target = GameFixture.court(11L, board, 2, "2번");
+            Game sourceGame = GameFixture.playingGame(50L, board, source, LocalDateTime.now());
+
+            given(gameBoardReader.read(BOARD_ID)).willReturn(board);
+            given(gameRepository.findByCourtIdAndStatus(10L, GameStatus.PLAYING)).willReturn(Optional.of(sourceGame));
+            given(courtRepository.findByGameBoardIdAndCourtNo(BOARD_ID, 2)).willReturn(Optional.of(target));
+            given(gameRepository.findByCourtIdAndStatus(11L, GameStatus.PLAYING)).willReturn(Optional.empty());
+
+            // when
+            gameCourtCommandService.moveCourt(MEMBER_ID, new GameCourtMoveCommand(BOARD_ID, 10L, 2));
+
+            // then
+            assertThat(sourceGame.getCourt()).isEqualTo(target);
+        }
+
+        @Test
+        @DisplayName("목적지 코트에 게임이 있으면 두 게임의 코트를 맞바꾼다(swap)")
+        void moveCourt_swap() {
+            // given
+            Court source = GameFixture.court(10L, board, 1, "1번");
+            Court target = GameFixture.court(11L, board, 2, "2번");
+            Game sourceGame = GameFixture.playingGame(50L, board, source, LocalDateTime.now());
+            Game targetGame = GameFixture.playingGame(51L, board, target, LocalDateTime.now());
+
+            given(gameBoardReader.read(BOARD_ID)).willReturn(board);
+            given(gameRepository.findByCourtIdAndStatus(10L, GameStatus.PLAYING)).willReturn(Optional.of(sourceGame));
+            given(courtRepository.findByGameBoardIdAndCourtNo(BOARD_ID, 2)).willReturn(Optional.of(target));
+            given(gameRepository.findByCourtIdAndStatus(11L, GameStatus.PLAYING)).willReturn(Optional.of(targetGame));
+
+            // when
+            gameCourtCommandService.moveCourt(MEMBER_ID, new GameCourtMoveCommand(BOARD_ID, 10L, 2));
+
+            // then
+            assertThat(sourceGame.getCourt()).isEqualTo(target);
+            assertThat(targetGame.getCourt()).isEqualTo(source);
+        }
+
+        @Test
+        @DisplayName("원본 코트에 진행 중인 게임이 없으면 GAME_NOT_ON_COURT 예외")
+        void moveCourt_noGameOnSource() {
+            given(gameBoardReader.read(BOARD_ID)).willReturn(board);
+            given(gameRepository.findByCourtIdAndStatus(10L, GameStatus.PLAYING)).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> gameCourtCommandService.moveCourt(MEMBER_ID, new GameCourtMoveCommand(BOARD_ID, 10L, 2)))
+                    .isInstanceOf(GameException.class)
+                    .extracting(e -> ((GameException) e).getCode())
+                    .isEqualTo(GameErrorCode.GAME_NOT_ON_COURT);
+        }
+
+        @Test
+        @DisplayName("목적지 코트 번호가 존재하지 않으면 COURT_NOT_FOUND 예외")
+        void moveCourt_targetCourtNotFound() {
+            Court source = GameFixture.court(10L, board, 1, "1번");
+            Game sourceGame = GameFixture.playingGame(50L, board, source, LocalDateTime.now());
+            given(gameBoardReader.read(BOARD_ID)).willReturn(board);
+            given(gameRepository.findByCourtIdAndStatus(10L, GameStatus.PLAYING)).willReturn(Optional.of(sourceGame));
+            given(courtRepository.findByGameBoardIdAndCourtNo(BOARD_ID, 9)).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> gameCourtCommandService.moveCourt(MEMBER_ID, new GameCourtMoveCommand(BOARD_ID, 10L, 9)))
+                    .isInstanceOf(GameException.class)
+                    .extracting(e -> ((GameException) e).getCode())
+                    .isEqualTo(GameErrorCode.COURT_NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("같은 코트로의 이동은 아무 것도 바꾸지 않는다")
+        void moveCourt_sameCourtNoop() {
+            Court source = GameFixture.court(10L, board, 1, "1번");
+            Game sourceGame = GameFixture.playingGame(50L, board, source, LocalDateTime.now());
+            given(gameBoardReader.read(BOARD_ID)).willReturn(board);
+            given(gameRepository.findByCourtIdAndStatus(10L, GameStatus.PLAYING)).willReturn(Optional.of(sourceGame));
+            given(courtRepository.findByGameBoardIdAndCourtNo(BOARD_ID, 1)).willReturn(Optional.of(source));
+
+            gameCourtCommandService.moveCourt(MEMBER_ID, new GameCourtMoveCommand(BOARD_ID, 10L, 1));
+
+            // 코트가 그대로 유지된다(조기 반환)
+            assertThat(sourceGame.getCourt()).isEqualTo(source);
+        }
+    }
+}

--- a/src/test/java/umc/cockple/demo/domain/game/service/command/GameCourtCommandServiceTest.java
+++ b/src/test/java/umc/cockple/demo/domain/game/service/command/GameCourtCommandServiceTest.java
@@ -23,6 +23,7 @@ import umc.cockple.demo.domain.game.service.command.model.GameCourtManageCommand
 import umc.cockple.demo.domain.game.service.command.model.GameCourtManageCommand.CourtCommand;
 import umc.cockple.demo.domain.game.service.command.model.GameCourtMoveCommand;
 import umc.cockple.demo.domain.game.service.command.result.GameCourtManageResult;
+import umc.cockple.demo.domain.game.service.support.reader.CourtReader;
 import umc.cockple.demo.domain.game.service.support.reader.GameBoardReader;
 import umc.cockple.demo.support.fixture.GameFixture;
 
@@ -35,6 +36,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 
 @ExtendWith(MockitoExtension.class)
@@ -42,6 +44,7 @@ import static org.mockito.Mockito.times;
 class GameCourtCommandServiceTest {
 
     @Mock private GameBoardReader gameBoardReader;
+    @Mock private CourtReader courtReader;
     @Mock private CourtRepository courtRepository;
     @Mock private GameRepository gameRepository;
     @Mock private ApplicationEventPublisher eventPublisher;
@@ -68,7 +71,7 @@ class GameCourtCommandServiceTest {
             Court kept = GameFixture.court(10L, board, 1, "기존코트");
             Court removed = GameFixture.court(11L, board, 2, "삭제될코트");
             given(gameBoardReader.read(BOARD_ID)).willReturn(board);
-            given(courtRepository.findByGameBoardId(BOARD_ID)).willReturn(List.of(kept, removed));
+            given(courtReader.readAllByGameBoard(BOARD_ID)).willReturn(List.of(kept, removed));
             given(courtRepository.save(any(Court.class))).willAnswer(inv -> inv.getArgument(0));
 
             GameCourtManageCommand command = new GameCourtManageCommand(BOARD_ID, List.of(
@@ -120,7 +123,7 @@ class GameCourtCommandServiceTest {
         void manageCourts_defaultCourtName() {
             // given
             given(gameBoardReader.read(BOARD_ID)).willReturn(board);
-            given(courtRepository.findByGameBoardId(BOARD_ID)).willReturn(List.of());
+            given(courtReader.readAllByGameBoard(BOARD_ID)).willReturn(List.of());
             given(courtRepository.save(any(Court.class))).willAnswer(inv -> inv.getArgument(0));
 
             GameCourtManageCommand command = new GameCourtManageCommand(BOARD_ID, List.of(
@@ -140,21 +143,42 @@ class GameCourtCommandServiceTest {
         }
 
         @Test
-        @DisplayName("gameBoardId가 null이면 GAME_BOARD_ID_REQUIRED 예외")
+        @DisplayName("gameBoardId가 null이면 command 생성 단계에서 GAME_BOARD_ID_REQUIRED 예외")
         void manageCourts_nullBoardId() {
-            GameCourtManageCommand command = new GameCourtManageCommand(null, List.of());
-
-            assertThatThrownBy(() -> gameCourtCommandService.manageCourts(MEMBER_ID, command))
+            assertThatThrownBy(() -> new GameCourtManageCommand(null, List.of()))
                     .isInstanceOf(GameException.class)
                     .extracting(e -> ((GameException) e).getCode())
                     .isEqualTo(GameErrorCode.GAME_BOARD_ID_REQUIRED);
         }
 
         @Test
+        @DisplayName("삭제 대상 코트에 진행 중인 게임이 있으면 COURT_HAS_ACTIVE_GAME 예외")
+        void manageCourts_deleteCourtWithActiveGame() {
+            // given - 목록에서 빠져 삭제 대상이 되는 코트(11L)에 PLAYING 게임이 있음
+            Court kept = GameFixture.court(10L, board, 1, "유지코트");
+            Court removed = GameFixture.court(11L, board, 2, "진행중코트");
+            given(gameBoardReader.read(BOARD_ID)).willReturn(board);
+            given(courtReader.readAllByGameBoard(BOARD_ID)).willReturn(List.of(kept, removed));
+            given(gameRepository.existsByCourtIdInAndStatus(List.of(11L), GameStatus.PLAYING))
+                    .willReturn(true);
+
+            GameCourtManageCommand command = new GameCourtManageCommand(BOARD_ID, List.of(
+                    new CourtCommand(10L, "유지코트")
+            ));
+
+            // when & then
+            assertThatThrownBy(() -> gameCourtCommandService.manageCourts(MEMBER_ID, command))
+                    .isInstanceOf(GameException.class)
+                    .extracting(e -> ((GameException) e).getCode())
+                    .isEqualTo(GameErrorCode.COURT_HAS_ACTIVE_GAME);
+            then(courtRepository).should(never()).deleteAll(any());
+        }
+
+        @Test
         @DisplayName("요청 courtId가 해당 게임판에 없으면 COURT_NOT_FOUND 예외")
         void manageCourts_foreignCourtId() {
             given(gameBoardReader.read(BOARD_ID)).willReturn(board);
-            given(courtRepository.findByGameBoardId(BOARD_ID))
+            given(courtReader.readAllByGameBoard(BOARD_ID))
                     .willReturn(List.of(GameFixture.court(10L, board, 1, "코트")));
 
             GameCourtManageCommand command = new GameCourtManageCommand(BOARD_ID, List.of(

--- a/src/test/java/umc/cockple/demo/domain/game/service/query/GameBoardQueryServiceTest.java
+++ b/src/test/java/umc/cockple/demo/domain/game/service/query/GameBoardQueryServiceTest.java
@@ -1,0 +1,128 @@
+package umc.cockple.demo.domain.game.service.query;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import umc.cockple.demo.domain.game.domain.Court;
+import umc.cockple.demo.domain.game.domain.Game;
+import umc.cockple.demo.domain.game.domain.GameBoard;
+import umc.cockple.demo.domain.game.domain.GameBoardMember;
+import umc.cockple.demo.domain.game.enums.CourtStatus;
+import umc.cockple.demo.domain.game.repository.CourtRepository;
+import umc.cockple.demo.domain.game.repository.GameRepository;
+import umc.cockple.demo.domain.game.service.query.result.GameBoardResult;
+import umc.cockple.demo.domain.game.service.support.reader.GameBoardReader;
+import umc.cockple.demo.global.enums.Level;
+import umc.cockple.demo.support.fixture.GameFixture;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("GameBoardQueryService")
+class GameBoardQueryServiceTest {
+
+    @Mock private GameBoardReader gameBoardReader;
+    @Mock private CourtRepository courtRepository;
+    @Mock private GameRepository gameRepository;
+
+    @InjectMocks private GameBoardQueryService gameBoardQueryService;
+
+    private static final Long MEMBER_ID = 100L;
+    private static final Long BOARD_ID = 1L;
+    private GameBoard board;
+
+    @BeforeEach
+    void setUp() {
+        board = GameFixture.gameBoard(BOARD_ID);
+    }
+
+    @Test
+    @DisplayName("PLAYING 코트는 status PLAYING+game, 빈 코트는 EMPTY+null 로 반환하고 courtCount를 채운다")
+    void getBoard_courtsWithStatus() {
+        // given
+        Court court1 = GameFixture.court(10L, board, 1, "1번");
+        Court court2 = GameFixture.court(11L, board, 2, "2번");
+        GameBoardMember member = GameFixture.member(7L, board, "김세익", Level.SEMI_EXPERT);
+        Game playing = GameFixture.playingGame(50L, board, court1, LocalDateTime.now(),
+                GameFixture.player(member, 0));
+
+        given(gameBoardReader.read(BOARD_ID)).willReturn(board);
+        given(courtRepository.findByGameBoardIdOrderByCourtNoAsc(BOARD_ID)).willReturn(List.of(court1, court2));
+        given(gameRepository.findByGameBoardIdAndStatusInWithPlayers(eq(BOARD_ID), anyList()))
+                .willReturn(List.of(playing));
+
+        // when
+        GameBoardResult result = gameBoardQueryService.getBoard(MEMBER_ID, BOARD_ID);
+
+        // then
+        assertThat(result.courtCount()).isEqualTo(2);
+        assertThat(result.courts()).extracting(GameBoardResult.CourtView::status)
+                .containsExactly(CourtStatus.PLAYING, CourtStatus.EMPTY);
+
+        GameBoardResult.CourtView playingCourt = result.courts().get(0);
+        assertThat(playingCourt.game()).isNotNull();
+        assertThat(playingCourt.game().gameId()).isEqualTo(50L);
+
+        assertThat(result.courts().get(1).game()).isNull();
+    }
+
+    @Test
+    @DisplayName("players는 playerOrder 순서로, gameBoardMemberId·이름·급수를 담아 반환한다")
+    void getBoard_playersOrderedWithInfo() {
+        // given
+        Court court1 = GameFixture.court(10L, board, 1, "1번");
+        GameBoardMember a = GameFixture.member(7L, board, "선수A", Level.A);
+        GameBoardMember b = GameFixture.member(8L, board, "선수B", Level.SEMI_EXPERT);
+        // 입력 순서를 일부러 뒤집어 정렬을 검증
+        Game playing = GameFixture.playingGame(50L, board, court1, LocalDateTime.now(),
+                GameFixture.player(b, 1), GameFixture.player(a, 0));
+
+        given(gameBoardReader.read(BOARD_ID)).willReturn(board);
+        given(courtRepository.findByGameBoardIdOrderByCourtNoAsc(BOARD_ID)).willReturn(List.of(court1));
+        given(gameRepository.findByGameBoardIdAndStatusInWithPlayers(eq(BOARD_ID), anyList()))
+                .willReturn(List.of(playing));
+
+        // when
+        GameBoardResult result = gameBoardQueryService.getBoard(MEMBER_ID, BOARD_ID);
+
+        // then
+        List<GameBoardResult.PlayerView> players = result.courts().get(0).game().players();
+        assertThat(players).extracting(GameBoardResult.PlayerView::playerOrder).containsExactly(0, 1);
+        assertThat(players.get(0).gameBoardMemberId()).isEqualTo(7L);
+        assertThat(players.get(0).name()).isEqualTo("선수A");
+        assertThat(players.get(0).level()).isEqualTo(Level.A);
+    }
+
+    @Test
+    @DisplayName("대기열은 waitingOrder 오름차순으로 정렬해 반환한다")
+    void getBoard_waitingsSortedByOrder() {
+        // given
+        Game waitingSecond = GameFixture.waitingGame(52L, board, 2);
+        Game waitingFirst = GameFixture.waitingGame(53L, board, 1);
+
+        given(gameBoardReader.read(BOARD_ID)).willReturn(board);
+        given(courtRepository.findByGameBoardIdOrderByCourtNoAsc(BOARD_ID)).willReturn(List.of());
+        given(gameRepository.findByGameBoardIdAndStatusInWithPlayers(eq(BOARD_ID), anyList()))
+                .willReturn(List.of(waitingSecond, waitingFirst));
+
+        // when
+        GameBoardResult result = gameBoardQueryService.getBoard(MEMBER_ID, BOARD_ID);
+
+        // then
+        assertThat(result.courtCount()).isZero();
+        assertThat(result.waitings()).extracting(GameBoardResult.WaitingView::gameId)
+                .containsExactly(53L, 52L);
+        assertThat(result.waitings()).extracting(GameBoardResult.WaitingView::waitingOrder)
+                .containsExactly(1, 2);
+    }
+}

--- a/src/test/java/umc/cockple/demo/domain/game/service/websocket/broadcast/GameBoardBroadcasterTest.java
+++ b/src/test/java/umc/cockple/demo/domain/game/service/websocket/broadcast/GameBoardBroadcasterTest.java
@@ -1,0 +1,86 @@
+package umc.cockple.demo.domain.game.service.websocket.broadcast;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import umc.cockple.demo.domain.game.realtime.GameRealtimeProtocol;
+import umc.cockple.demo.domain.game.repository.redis.GameBoardSubscriber;
+import umc.cockple.demo.domain.game.repository.redis.GameBoardSubscriptionStore;
+import umc.cockple.demo.global.realtime.publish.RealtimeMessagePublisher;
+import umc.cockple.demo.global.realtime.publish.RealtimePublishResult;
+
+import java.util.Set;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("GameBoardBroadcaster")
+class GameBoardBroadcasterTest {
+
+    @Mock private GameBoardSubscriptionStore subscriptionStore;
+    @Mock private RealtimeMessagePublisher realtimeMessagePublisher;
+
+    @InjectMocks private GameBoardBroadcaster gameBoardBroadcaster;
+
+    private static final Long BOARD_ID = 1L;
+    private static final Object BOARD_DATA = new Object();
+
+    @Test
+    @DisplayName("변경을 일으킨 세션은 제외하고, 나머지 구독 세션 각각에 세션 단위로 발행한다")
+    void broadcastPerSessionExcludingActor() {
+        GameBoardSubscriber actor = new GameBoardSubscriber(10L, "session-actor");
+        GameBoardSubscriber otherTabSameMember = new GameBoardSubscriber(10L, "session-other-tab");
+        GameBoardSubscriber anotherMember = new GameBoardSubscriber(20L, "session-b");
+        given(subscriptionStore.getSubscribers(BOARD_ID))
+                .willReturn(Set.of(actor, otherTabSameMember, anotherMember));
+        given(realtimeMessagePublisher.publishToSession(any(), any(), any(), any(), any()))
+                .willReturn(new RealtimePublishResult(1, 1));
+
+        gameBoardBroadcaster.broadcastBoardUpdate(BOARD_ID, BOARD_DATA, "session-actor");
+
+        // 같은 회원의 다른 탭 세션에도 전달된다 (memberId가 아니라 sessionId로 제외하므로)
+        then(realtimeMessagePublisher).should().publishToSession(
+                eq(10L), eq("session-other-tab"),
+                eq(GameRealtimeProtocol.DOMAIN), eq(GameRealtimeProtocol.TYPE_BOARD_UPDATED), eq(BOARD_DATA));
+        then(realtimeMessagePublisher).should().publishToSession(
+                eq(20L), eq("session-b"),
+                eq(GameRealtimeProtocol.DOMAIN), eq(GameRealtimeProtocol.TYPE_BOARD_UPDATED), eq(BOARD_DATA));
+        // 변경을 일으킨 세션에는 전달하지 않는다
+        then(realtimeMessagePublisher).should(never()).publishToSession(
+                eq(10L), eq("session-actor"), any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("구독 세션이 없으면 발행하지 않는다")
+    void noSubscribersNoPublish() {
+        given(subscriptionStore.getSubscribers(BOARD_ID)).willReturn(Set.of());
+
+        gameBoardBroadcaster.broadcastBoardUpdate(BOARD_ID, BOARD_DATA, null);
+
+        then(realtimeMessagePublisher).should(never()).publishToSession(any(), any(), any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("excludedSessionId가 null이면(REST 경로) 모든 구독 세션에 발행한다")
+    void restPathBroadcastsToAllSessions() {
+        GameBoardSubscriber s1 = new GameBoardSubscriber(10L, "session-1");
+        GameBoardSubscriber s2 = new GameBoardSubscriber(20L, "session-2");
+        given(subscriptionStore.getSubscribers(BOARD_ID)).willReturn(Set.of(s1, s2));
+        given(realtimeMessagePublisher.publishToSession(any(), any(), any(), any(), any()))
+                .willReturn(new RealtimePublishResult(1, 1));
+
+        gameBoardBroadcaster.broadcastBoardUpdate(BOARD_ID, BOARD_DATA, null);
+
+        then(realtimeMessagePublisher).should().publishToSession(
+                eq(10L), eq("session-1"), any(), any(), eq(BOARD_DATA));
+        then(realtimeMessagePublisher).should().publishToSession(
+                eq(20L), eq("session-2"), any(), any(), eq(BOARD_DATA));
+    }
+}

--- a/src/test/java/umc/cockple/demo/global/realtime/publish/WebSocketRealtimeMessagePublisherTest.java
+++ b/src/test/java/umc/cockple/demo/global/realtime/publish/WebSocketRealtimeMessagePublisherTest.java
@@ -142,6 +142,59 @@ class WebSocketRealtimeMessagePublisherTest {
     }
 
     @Test
+    @DisplayName("publishToSession은 회원의 여러 세션 중 지정한 세션에만 전송한다")
+    void publishToSpecificSessionOnly() {
+        Long memberId = 10L;
+        WebSocketSession targetWebSocketSession = session("session-1", true);
+        WebSocketSession otherWebSocketSession = session("session-2", true);
+        List<RealtimeSession> sessions = List.of(
+                realtimeSession(memberId, targetWebSocketSession, 2L),
+                realtimeSession(memberId, otherWebSocketSession, 1L)
+        );
+        EncodedRealtimeMessage encodedMessage = new EncodedRealtimeMessage("encoded");
+        given(sessionRegistry.findOpenSessions(memberId, RealtimeWebSocketEndpoint.SESSION_ENDPOINT))
+                .willReturn(sessions);
+        given(messageEncoder.encode(any(RealtimeOutboundEnvelope.class)))
+                .willReturn(Optional.of(encodedMessage));
+        given(messageSender.send(targetWebSocketSession, encodedMessage)).willReturn(true);
+
+        RealtimePublishResult result = publisher.publishToSession(
+                memberId, "session-1", "GAME", "BOARD_UPDATED", "data");
+
+        assertThat(result.targetSessionCount()).isEqualTo(1);
+        assertThat(result.successCount()).isEqualTo(1);
+        then(messageSender).should().send(targetWebSocketSession, encodedMessage);
+        then(messageSender).should(org.mockito.Mockito.never()).send(otherWebSocketSession, encodedMessage);
+    }
+
+    @Test
+    @DisplayName("publishToSession 대상 세션이 열려 있지 않으면 발행하지 않는다")
+    void publishToSessionSkipsWhenSessionAbsent() {
+        Long memberId = 10L;
+        WebSocketSession otherWebSocketSession = session("session-2", true);
+        List<RealtimeSession> sessions = List.of(realtimeSession(memberId, otherWebSocketSession, 1L));
+        given(sessionRegistry.findOpenSessions(memberId, RealtimeWebSocketEndpoint.SESSION_ENDPOINT))
+                .willReturn(sessions);
+
+        RealtimePublishResult result = publisher.publishToSession(
+                memberId, "session-1", "GAME", "BOARD_UPDATED", "data");
+
+        assertThat(result).isEqualTo(RealtimePublishResult.noTarget());
+        then(messageEncoder).shouldHaveNoInteractions();
+        then(messageSender).shouldHaveNoInteractions();
+    }
+
+    @Test
+    @DisplayName("publishToSession은 sessionId가 비어 있으면 거부한다")
+    void publishToSessionRejectsBlankSessionId() {
+        assertThatThrownBy(() -> publisher.publishToSession(10L, " ", "GAME", "BOARD_UPDATED", "data"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("sessionId");
+
+        then(sessionRegistry).shouldHaveNoInteractions();
+    }
+
+    @Test
     @DisplayName("domain이나 type이 비어 있으면 세션을 조회하기 전에 거부한다")
     void rejectsBlankMessageIdentifier() {
         assertThatThrownBy(() -> publisher.publish(10L, " ", "MESSAGE_RECEIVED", "data"))

--- a/src/test/java/umc/cockple/demo/support/fixture/GameFixture.java
+++ b/src/test/java/umc/cockple/demo/support/fixture/GameFixture.java
@@ -1,0 +1,74 @@
+package umc.cockple.demo.support.fixture;
+
+import umc.cockple.demo.domain.game.domain.Court;
+import umc.cockple.demo.domain.game.domain.Game;
+import umc.cockple.demo.domain.game.domain.GameBoard;
+import umc.cockple.demo.domain.game.domain.GameBoardMember;
+import umc.cockple.demo.domain.game.domain.GamePlayer;
+import umc.cockple.demo.domain.game.enums.GameStatus;
+import umc.cockple.demo.global.enums.Gender;
+import umc.cockple.demo.global.enums.Level;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 게임판 도메인 테스트용 픽스처. 엔티티 @Builder 로 id 까지 세팅해 유닛 테스트에서 사용한다.
+ */
+public class GameFixture {
+
+    public static GameBoard gameBoard(Long id) {
+        return GameBoard.builder().id(id).build();
+    }
+
+    public static Court court(Long id, GameBoard gameBoard, int courtNo, String courtName) {
+        return Court.builder()
+                .id(id)
+                .gameBoard(gameBoard)
+                .courtNo(courtNo)
+                .courtName(courtName)
+                .build();
+    }
+
+    public static GameBoardMember member(Long id, GameBoard gameBoard, String name, Level level) {
+        return GameBoardMember.builder()
+                .id(id)
+                .gameBoard(gameBoard)
+                .name(name)
+                .gender(Gender.MALE)
+                .level(level)
+                .shuttlecockSubmitted(false)
+                .participating(true)
+                .gameCount(0)
+                .build();
+    }
+
+    public static GamePlayer player(GameBoardMember member, int playerOrder) {
+        return GamePlayer.builder()
+                .gameBoardMember(member)
+                .playerOrder(playerOrder)
+                .build();
+    }
+
+    public static Game playingGame(Long id, GameBoard gameBoard, Court court, LocalDateTime startedAt, GamePlayer... players) {
+        return Game.builder()
+                .id(id)
+                .gameBoard(gameBoard)
+                .court(court)
+                .status(GameStatus.PLAYING)
+                .startedAt(startedAt)
+                .players(new ArrayList<>(List.of(players)))
+                .build();
+    }
+
+    public static Game waitingGame(Long id, GameBoard gameBoard, int waitingOrder, GamePlayer... players) {
+        return Game.builder()
+                .id(id)
+                .gameBoard(gameBoard)
+                .status(GameStatus.WAITING)
+                .waitingOrder(waitingOrder)
+                .players(new ArrayList<>(List.of(players)))
+                .build();
+    }
+}


### PR DESCRIPTION
## ❤️ 기능 설명
게임판의 코트 구성·게임 진행 기능을 구현했습니다.
설정성 동작은 REST, 라이브 보드가 바뀌는 동작은 WebSocket 실시간 브로드캐스트로 처리했습니다.

- **코트 관리** `PUT /api/game-boards/{id}/courts` : 전체 교체(유지/생성/삭제), courtNo 순서 재부여, 이름 생략 시 `N번 코트`
- **보드 조회** `GET /api/game-boards/{id}` : 코트 상태(EMPTY/PLAYING)·대기열 반환(명단 제외), fetch join으로 N+1 방지
- **코트 이동** WS `MOVE_COURT` : 대상 코트에 게임 있으면 swap
- **게임 시작** WS `START_GAME` : 대기→진행 배치, 남은 대기열 순서 재정렬
- **구독** WS `SUBSCRIBE`/`UNSUBSCRIBE` : Redis 기반, 변경 시 구독자에게 보드 스냅샷 push


<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #713
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!



<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [ ] 이슈넘버를 적었는가?
