### PR TITLE
[feature/#718] 게임판 명단 관리 API 구현

### DIFF
--- a/src/main/java/umc/cockple/demo/domain/exercise/repository/ExerciseRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/repository/ExerciseRepository.java
@@ -18,6 +18,8 @@ import java.util.Optional;
 
 public interface ExerciseRepository extends JpaRepository<Exercise, Long>, ExerciseRepositoryCustom {
 
+    Optional<Exercise> findByGameBoardId(Long gameBoardId);
+
     @Modifying(flushAutomatically = true)
     @Query(value = """
             UPDATE exercise e

--- a/src/main/java/umc/cockple/demo/domain/exercise/service/command/ExerciseGuestCommandService.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/service/command/ExerciseGuestCommandService.java
@@ -2,6 +2,7 @@ package umc.cockple.demo.domain.exercise.service.command;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import umc.cockple.demo.domain.exercise.domain.Exercise;
@@ -14,6 +15,7 @@ import umc.cockple.demo.domain.exercise.service.command.result.ExerciseCancelRes
 import umc.cockple.demo.domain.exercise.service.command.result.ExerciseGuestInviteResult;
 import umc.cockple.demo.domain.exercise.service.support.reader.ExerciseReader;
 import umc.cockple.demo.domain.exercise.service.support.reader.GuestReader;
+import umc.cockple.demo.domain.game.events.GameBoardMembersChangedEvent;
 import umc.cockple.demo.domain.member.domain.Member;
 import umc.cockple.demo.domain.member.service.query.lookup.MemberLookupService;
 
@@ -27,6 +29,7 @@ public class ExerciseGuestCommandService {
     private final ExerciseReader exerciseReader;
     private final GuestReader guestReader;
     private final MemberLookupService memberLookupService;
+    private final ApplicationEventPublisher eventPublisher;
 
     private final ExerciseValidator exerciseValidator;
     private final ExerciseGameAssignmentValidator exerciseGameAssignmentValidator;
@@ -44,6 +47,7 @@ public class ExerciseGuestCommandService {
         exercise.addGuest(guest);
 
         Guest savedGuest = guestRepository.save(guest);
+        publishGameBoardMembersChanged(exercise, command.inviterId());
 
         log.info("게스트 초대 완료 - guestId: {}", savedGuest.getId());
         return new ExerciseGuestInviteResult(
@@ -64,9 +68,15 @@ public class ExerciseGuestCommandService {
 
         exercise.removeGuest(guest);
         guestRepository.delete(guest);
+        publishGameBoardMembersChanged(exercise, memberId);
 
         log.info("게스트 초대 취소 완료 - exerciseId: {}, guestId: {}, memberId: {}",
                 exercise.getId(), guest.getId(), member.getId());
         return new ExerciseCancelResult(guest.getGuestName(), exercise.getNowCapacity());
+    }
+
+    private void publishGameBoardMembersChanged(Exercise exercise, Long actorMemberId) {
+        eventPublisher.publishEvent(GameBoardMembersChangedEvent.membersOnly(
+                exercise.getGameBoard().getId(), actorMemberId));
     }
 }

--- a/src/main/java/umc/cockple/demo/domain/exercise/service/command/ExerciseParticipationCommandService.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/service/command/ExerciseParticipationCommandService.java
@@ -25,6 +25,7 @@ import umc.cockple.demo.domain.exercise.events.ExerciseAttendanceChangedEvent;
 import umc.cockple.demo.domain.exercise.exception.ExerciseErrorCode;
 import umc.cockple.demo.domain.exercise.exception.ExerciseException;
 import umc.cockple.demo.domain.exercise.repository.MemberExerciseRepository;
+import umc.cockple.demo.domain.game.events.GameBoardMembersChangedEvent;
 import umc.cockple.demo.domain.member.enums.MemberPartyStatus;
 import umc.cockple.demo.domain.member.service.query.lookup.MemberLookupService;
 import umc.cockple.demo.domain.member.service.query.lookup.MemberPartyLookupService;
@@ -71,6 +72,7 @@ public class ExerciseParticipationCommandService {
 
         MemberExercise savedMemberExercise = saveParticipation(memberExercise);
         publishAttendanceChangedEvent(exercise, member.getId());
+        publishGameBoardMembersChanged(exercise, memberId);
 
         log.info("운동 신청 종료 - memberExerciseId: {}, isPartyMember : {}"
                 , savedMemberExercise.getId(), isPartyMember);
@@ -129,6 +131,7 @@ public class ExerciseParticipationCommandService {
 
         memberExerciseRepository.delete(memberExercise);
         publishAttendanceChangedEvent(exercise, member.getId());
+        publishGameBoardMembersChanged(exercise, memberId);
 
         log.info("운동 참여 취소 완료 - exerciseId: {}, memberId: {}, 현재 참여자 수: {}",
                 exercise.getId(), member.getId(), exercise.getNowCapacity());
@@ -147,6 +150,7 @@ public class ExerciseParticipationCommandService {
         exerciseValidator.validateCancelCommonParticipationByManager(exercise, manager);
 
         ExerciseCancelResult result = executeParticipantCancellation(exercise, participantId, command);
+        publishGameBoardMembersChanged(exercise, managerId);
 
         log.info("매니저에 의한 운동 참여 취소 완료 - exerciseId: {}, participantId: {}, 현재 참여자 수: {}",
                 exercise.getId(), participantId, exercise.getNowCapacity());
@@ -213,5 +217,10 @@ public class ExerciseParticipationCommandService {
                 subjectMemberId,
                 recipientMemberIds
         ));
+    }
+
+    private void publishGameBoardMembersChanged(Exercise exercise, Long actorMemberId) {
+        eventPublisher.publishEvent(GameBoardMembersChangedEvent.membersOnly(
+                exercise.getGameBoard().getId(), actorMemberId));
     }
 }

--- a/src/main/java/umc/cockple/demo/domain/game/domain/GameBoardMember.java
+++ b/src/main/java/umc/cockple/demo/domain/game/domain/GameBoardMember.java
@@ -108,6 +108,17 @@ public class GameBoardMember extends BaseEntity {
         this.gameCount++;
     }
 
+    public void updateInfo(String name, Gender gender, Level level, AgeGroup ageGroup) {
+        this.name = name;
+        this.gender = gender;
+        this.level = level;
+        this.ageGroup = ageGroup;
+    }
+
+    public void changeParticipation(boolean participating) {
+        this.participating = participating;
+    }
+
     /**
      * member FK의 ON DELETE SET NULL과 guest FK의 ON DELETE CASCADE 때문에
      * MySQL CHECK 제약으로 같은 규칙을 중복 선언할 수 없어 애플리케이션 경계에서 검증한다.

--- a/src/main/java/umc/cockple/demo/domain/game/events/GameBoardMembersChangedEvent.java
+++ b/src/main/java/umc/cockple/demo/domain/game/events/GameBoardMembersChangedEvent.java
@@ -6,9 +6,18 @@ package umc.cockple.demo.domain.game.events;
  *
  * @param gameBoardId   변경된 게임판
  * @param actorMemberId REST 요청자
+ * @param includeBoardSnapshot 명단과 함께 게임판 snapshot도 전파할지 여부
  */
 public record GameBoardMembersChangedEvent(
         Long gameBoardId,
-        Long actorMemberId
+        Long actorMemberId,
+        boolean includeBoardSnapshot
 ) {
+    public static GameBoardMembersChangedEvent membersAndBoard(Long gameBoardId, Long actorMemberId) {
+        return new GameBoardMembersChangedEvent(gameBoardId, actorMemberId, true);
+    }
+
+    public static GameBoardMembersChangedEvent membersOnly(Long gameBoardId, Long actorMemberId) {
+        return new GameBoardMembersChangedEvent(gameBoardId, actorMemberId, false);
+    }
 }

--- a/src/main/java/umc/cockple/demo/domain/game/events/GameBoardMembersChangedEvent.java
+++ b/src/main/java/umc/cockple/demo/domain/game/events/GameBoardMembersChangedEvent.java
@@ -1,0 +1,14 @@
+package umc.cockple.demo.domain.game.events;
+
+/**
+ * REST 명단 관리로 게임판 명단이 변경되었음을 알리는 이벤트.
+ * 트랜잭션 커밋 후 명단과 게임판 최신 상태를 구독자에게 전파하는 데 사용한다.
+ *
+ * @param gameBoardId   변경된 게임판
+ * @param actorMemberId REST 요청자
+ */
+public record GameBoardMembersChangedEvent(
+        Long gameBoardId,
+        Long actorMemberId
+) {
+}

--- a/src/main/java/umc/cockple/demo/domain/game/events/GameBoardMembersChangedEvent.java
+++ b/src/main/java/umc/cockple/demo/domain/game/events/GameBoardMembersChangedEvent.java
@@ -1,11 +1,12 @@
 package umc.cockple.demo.domain.game.events;
 
 /**
- * REST 명단 관리로 게임판 명단이 변경되었음을 알리는 이벤트.
- * 트랜잭션 커밋 후 명단과 게임판 최신 상태를 구독자에게 전파하는 데 사용한다.
+ * 명단 정보, 운동 참가자, 활성 게임 상태 변경으로
+ * 게임판 명단 projection이 바뀌었음을 알리는 이벤트.
+ * 트랜잭션 커밋 후 필요한 snapshot을 구독자에게 전파하는 데 사용한다.
  *
  * @param gameBoardId   변경된 게임판
- * @param actorMemberId REST 요청자
+ * @param actorMemberId 변경 요청자
  * @param includeBoardSnapshot 명단과 함께 게임판 snapshot도 전파할지 여부
  */
 public record GameBoardMembersChangedEvent(

--- a/src/main/java/umc/cockple/demo/domain/game/exception/GameErrorCode.java
+++ b/src/main/java/umc/cockple/demo/domain/game/exception/GameErrorCode.java
@@ -30,7 +30,8 @@ public enum GameErrorCode implements BaseErrorCode {
     INVALID_AGE_GROUP_FORMAT(HttpStatus.BAD_REQUEST, "GAME410", "올바른 연령대를 입력해주세요. (10대, 20대, 30대, 40대, 50대, 60대, 70대)"),
     GAME_ALREADY_COMPLETED(HttpStatus.BAD_REQUEST, "GAME411", "이미 완료된 게임은 취소할 수 없습니다."),
     INVALID_CURSOR(HttpStatus.BAD_REQUEST, "GAME412", "커서 형식이 올바르지 않습니다."),
-    ACTIVE_GAME_MEMBER_CANNOT_BE_INACTIVE(HttpStatus.BAD_REQUEST, "GAME413", "진행 또는 대기 중인 게임에 포함된 선수는 참여 해제할 수 없습니다.")
+    ACTIVE_GAME_MEMBER_CANNOT_BE_INACTIVE(HttpStatus.BAD_REQUEST, "GAME413", "진행 또는 대기 중인 게임에 포함된 선수는 참여 해제할 수 없습니다."),
+    INACTIVE_GAME_PLAYER(HttpStatus.BAD_REQUEST, "GAME414", "불참 상태의 선수는 게임에 추가할 수 없습니다.")
 
     ;
 

--- a/src/main/java/umc/cockple/demo/domain/game/exception/GameErrorCode.java
+++ b/src/main/java/umc/cockple/demo/domain/game/exception/GameErrorCode.java
@@ -17,6 +17,7 @@ public enum GameErrorCode implements BaseErrorCode {
     GAME_BOARD_MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "GAME205", "게임판 명단에 없는 멤버가 포함되어 있습니다."),
 
     GAME_BOARD_ACCESS_DENIED(HttpStatus.FORBIDDEN, "GAME301", "게임판을 관리할 권한이 없습니다."),
+    GAME_BOARD_VIEW_ACCESS_DENIED(HttpStatus.FORBIDDEN, "GAME302", "해당 운동 참가자 또는 게임 진행자만 게임판 명단을 조회할 수 있습니다."),
 
     GAME_BOARD_ID_REQUIRED(HttpStatus.BAD_REQUEST, "GAME401", "게임판 ID가 필요합니다."),
     INVALID_REALTIME_PAYLOAD(HttpStatus.BAD_REQUEST, "GAME402", "게임 요청 형식이 올바르지 않습니다."),

--- a/src/main/java/umc/cockple/demo/domain/game/exception/GameErrorCode.java
+++ b/src/main/java/umc/cockple/demo/domain/game/exception/GameErrorCode.java
@@ -29,7 +29,8 @@ public enum GameErrorCode implements BaseErrorCode {
     DUPLICATE_GAME_PLAYER(HttpStatus.BAD_REQUEST, "GAME409", "같은 플레이어를 중복으로 넣을 수 없습니다."),
     INVALID_AGE_GROUP_FORMAT(HttpStatus.BAD_REQUEST, "GAME410", "올바른 연령대를 입력해주세요. (10대, 20대, 30대, 40대, 50대, 60대, 70대)"),
     GAME_ALREADY_COMPLETED(HttpStatus.BAD_REQUEST, "GAME411", "이미 완료된 게임은 취소할 수 없습니다."),
-    INVALID_CURSOR(HttpStatus.BAD_REQUEST, "GAME412", "커서 형식이 올바르지 않습니다.")
+    INVALID_CURSOR(HttpStatus.BAD_REQUEST, "GAME412", "커서 형식이 올바르지 않습니다."),
+    ACTIVE_GAME_MEMBER_CANNOT_BE_INACTIVE(HttpStatus.BAD_REQUEST, "GAME413", "진행 또는 대기 중인 게임에 포함된 선수는 참여 해제할 수 없습니다.")
 
     ;
 

--- a/src/main/java/umc/cockple/demo/domain/game/presentation/controller/GameBoardMemberController.java
+++ b/src/main/java/umc/cockple/demo/domain/game/presentation/controller/GameBoardMemberController.java
@@ -8,6 +8,7 @@ import umc.cockple.demo.domain.game.presentation.dto.GameBoardMemberDTO;
 import umc.cockple.demo.domain.game.presentation.mapper.GameBoardMemberMapper;
 import umc.cockple.demo.domain.game.service.command.GameBoardMemberCommandService;
 import umc.cockple.demo.domain.game.service.command.model.GameBoardMemberCreateCommand;
+import umc.cockple.demo.domain.game.service.command.model.GameBoardMemberParticipationCommand;
 import umc.cockple.demo.domain.game.service.command.model.GameBoardMemberUpdateCommand;
 import umc.cockple.demo.domain.game.service.query.GameBoardMemberQueryService;
 import umc.cockple.demo.domain.game.service.query.model.GameBoardMemberSearchQuery;
@@ -25,6 +26,20 @@ public class GameBoardMemberController implements GameBoardMemberApi {
     private final GameBoardMemberCommandService gameBoardMemberCommandService;
     private final GameBoardMemberQueryService gameBoardMemberQueryService;
     private final GameBoardMemberMapper gameBoardMemberMapper;
+
+    @Override
+    public ResponseEntity<BaseResponse<Void>> changeParticipation(
+            Long gameBoardId,
+            Long gameBoardMemberId,
+            GameBoardMemberDTO.ParticipationRequest request) {
+        Long memberId = SecurityUtil.getCurrentMemberId();
+        GameBoardMemberParticipationCommand command = gameBoardMemberMapper.toParticipationCommand(
+                gameBoardId, gameBoardMemberId, request);
+
+        gameBoardMemberCommandService.changeParticipation(memberId, command);
+
+        return BaseResponse.of(CommonSuccessCode.OK);
+    }
 
     @Override
     public ResponseEntity<BaseResponse<Void>> updateMember(

--- a/src/main/java/umc/cockple/demo/domain/game/presentation/controller/GameBoardMemberController.java
+++ b/src/main/java/umc/cockple/demo/domain/game/presentation/controller/GameBoardMemberController.java
@@ -1,0 +1,35 @@
+package umc.cockple.demo.domain.game.presentation.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RestController;
+import umc.cockple.demo.domain.game.presentation.controller.api.GameBoardMemberApi;
+import umc.cockple.demo.domain.game.presentation.dto.GameBoardMemberDTO;
+import umc.cockple.demo.domain.game.presentation.mapper.GameBoardMemberMapper;
+import umc.cockple.demo.domain.game.service.query.GameBoardMemberQueryService;
+import umc.cockple.demo.domain.game.service.query.model.GameBoardMemberSearchQuery;
+import umc.cockple.demo.domain.game.service.query.result.GameBoardMemberResult;
+import umc.cockple.demo.global.response.BaseResponse;
+import umc.cockple.demo.global.response.code.status.CommonSuccessCode;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class GameBoardMemberController implements GameBoardMemberApi {
+
+    private final GameBoardMemberQueryService gameBoardMemberQueryService;
+    private final GameBoardMemberMapper gameBoardMemberMapper;
+
+    @Override
+    public ResponseEntity<BaseResponse<GameBoardMemberDTO.Response>> getMembers(
+            Long gameBoardId, List<String> levels, String gender, Boolean shuttlecockSubmitted) {
+        GameBoardMemberSearchQuery searchQuery = gameBoardMemberMapper.toSearchQuery(
+                levels, gender, shuttlecockSubmitted);
+
+        GameBoardMemberResult result = gameBoardMemberQueryService.getMembers(
+                gameBoardId, searchQuery);
+
+        return BaseResponse.of(CommonSuccessCode.OK, gameBoardMemberMapper.toResponse(result));
+    }
+}

--- a/src/main/java/umc/cockple/demo/domain/game/presentation/controller/GameBoardMemberController.java
+++ b/src/main/java/umc/cockple/demo/domain/game/presentation/controller/GameBoardMemberController.java
@@ -71,11 +71,12 @@ public class GameBoardMemberController implements GameBoardMemberApi {
     @Override
     public ResponseEntity<BaseResponse<GameBoardMemberDTO.Response>> getMembers(
             Long gameBoardId, List<String> levels, String gender, Boolean shuttlecockSubmitted) {
+        Long memberId = SecurityUtil.getCurrentMemberId();
         GameBoardMemberSearchQuery searchQuery = gameBoardMemberMapper.toSearchQuery(
                 levels, gender, shuttlecockSubmitted);
 
         GameBoardMemberResult result = gameBoardMemberQueryService.getMembers(
-                gameBoardId, searchQuery);
+                memberId, gameBoardId, searchQuery);
 
         return BaseResponse.of(CommonSuccessCode.OK, gameBoardMemberMapper.toResponse(result));
     }

--- a/src/main/java/umc/cockple/demo/domain/game/presentation/controller/GameBoardMemberController.java
+++ b/src/main/java/umc/cockple/demo/domain/game/presentation/controller/GameBoardMemberController.java
@@ -8,6 +8,7 @@ import umc.cockple.demo.domain.game.presentation.dto.GameBoardMemberDTO;
 import umc.cockple.demo.domain.game.presentation.mapper.GameBoardMemberMapper;
 import umc.cockple.demo.domain.game.service.command.GameBoardMemberCommandService;
 import umc.cockple.demo.domain.game.service.command.model.GameBoardMemberCreateCommand;
+import umc.cockple.demo.domain.game.service.command.model.GameBoardMemberUpdateCommand;
 import umc.cockple.demo.domain.game.service.query.GameBoardMemberQueryService;
 import umc.cockple.demo.domain.game.service.query.model.GameBoardMemberSearchQuery;
 import umc.cockple.demo.domain.game.service.query.result.GameBoardMemberResult;
@@ -24,6 +25,20 @@ public class GameBoardMemberController implements GameBoardMemberApi {
     private final GameBoardMemberCommandService gameBoardMemberCommandService;
     private final GameBoardMemberQueryService gameBoardMemberQueryService;
     private final GameBoardMemberMapper gameBoardMemberMapper;
+
+    @Override
+    public ResponseEntity<BaseResponse<Void>> updateMember(
+            Long gameBoardId,
+            Long gameBoardMemberId,
+            GameBoardMemberDTO.UpdateRequest request) {
+        Long memberId = SecurityUtil.getCurrentMemberId();
+        GameBoardMemberUpdateCommand command = gameBoardMemberMapper.toUpdateCommand(
+                gameBoardId, gameBoardMemberId, request);
+
+        gameBoardMemberCommandService.updateMember(memberId, command);
+
+        return BaseResponse.of(CommonSuccessCode.OK);
+    }
 
     @Override
     public ResponseEntity<BaseResponse<GameBoardMemberDTO.CreateResponse>> createMember(

--- a/src/main/java/umc/cockple/demo/domain/game/presentation/controller/GameBoardMemberController.java
+++ b/src/main/java/umc/cockple/demo/domain/game/presentation/controller/GameBoardMemberController.java
@@ -6,11 +6,14 @@ import org.springframework.web.bind.annotation.RestController;
 import umc.cockple.demo.domain.game.presentation.controller.api.GameBoardMemberApi;
 import umc.cockple.demo.domain.game.presentation.dto.GameBoardMemberDTO;
 import umc.cockple.demo.domain.game.presentation.mapper.GameBoardMemberMapper;
+import umc.cockple.demo.domain.game.service.command.GameBoardMemberCommandService;
+import umc.cockple.demo.domain.game.service.command.model.GameBoardMemberCreateCommand;
 import umc.cockple.demo.domain.game.service.query.GameBoardMemberQueryService;
 import umc.cockple.demo.domain.game.service.query.model.GameBoardMemberSearchQuery;
 import umc.cockple.demo.domain.game.service.query.result.GameBoardMemberResult;
 import umc.cockple.demo.global.response.BaseResponse;
 import umc.cockple.demo.global.response.code.status.CommonSuccessCode;
+import umc.cockple.demo.global.security.utils.SecurityUtil;
 
 import java.util.List;
 
@@ -18,8 +21,22 @@ import java.util.List;
 @RequiredArgsConstructor
 public class GameBoardMemberController implements GameBoardMemberApi {
 
+    private final GameBoardMemberCommandService gameBoardMemberCommandService;
     private final GameBoardMemberQueryService gameBoardMemberQueryService;
     private final GameBoardMemberMapper gameBoardMemberMapper;
+
+    @Override
+    public ResponseEntity<BaseResponse<GameBoardMemberDTO.CreateResponse>> createMember(
+            Long gameBoardId, GameBoardMemberDTO.CreateRequest request) {
+        Long memberId = SecurityUtil.getCurrentMemberId();
+        GameBoardMemberCreateCommand command = gameBoardMemberMapper.toCreateCommand(gameBoardId, request);
+
+        Long gameBoardMemberId = gameBoardMemberCommandService.createMember(memberId, command);
+
+        return BaseResponse.of(
+                CommonSuccessCode.OK,
+                gameBoardMemberMapper.toCreateResponse(gameBoardMemberId));
+    }
 
     @Override
     public ResponseEntity<BaseResponse<GameBoardMemberDTO.Response>> getMembers(

--- a/src/main/java/umc/cockple/demo/domain/game/presentation/controller/api/GameBoardMemberApi.java
+++ b/src/main/java/umc/cockple/demo/domain/game/presentation/controller/api/GameBoardMemberApi.java
@@ -82,6 +82,7 @@ public interface GameBoardMemberApi {
             - `shuttlecockSubmitted`: 셔틀콕 제출 여부입니다.
             - 서로 다른 종류의 필터는 AND 조건입니다.
             - `totalCount`는 필터와 무관한 전체 명단 수입니다.
+            - 명단의 `gender`, `level`, `ageGroup`은 한글 표시값으로 반환합니다.
             """)
     @ApiResponse(responseCode = "200", description = "조회 성공")
     @ApiResponse(responseCode = "401", description = "인증 필요")

--- a/src/main/java/umc/cockple/demo/domain/game/presentation/controller/api/GameBoardMemberApi.java
+++ b/src/main/java/umc/cockple/demo/domain/game/presentation/controller/api/GameBoardMemberApi.java
@@ -2,9 +2,12 @@ package umc.cockple.demo.domain.game.presentation.controller.api;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import umc.cockple.demo.domain.game.presentation.dto.GameBoardMemberDTO;
@@ -15,6 +18,23 @@ import java.util.List;
 @RequestMapping("/api/game-boards")
 @GameApiTag
 public interface GameBoardMemberApi {
+
+    @PostMapping("/{gameBoardId}/gameBoardMembers")
+    @Operation(summary = "게임판 명단 추가", description = """
+            게임 진행자가 수동 명단을 추가합니다.
+
+            - `name`, `gender`, `level`은 필수입니다.
+            - `gender`, `level`, `ageGroup`은 한글 표시값으로 입력합니다.
+            - 수동 명단은 회원과 연결되지 않으며 참여 상태로 생성됩니다.
+            """)
+    @ApiResponse(responseCode = "200", description = "추가 성공")
+    @ApiResponse(responseCode = "400", description = "입력값 오류")
+    @ApiResponse(responseCode = "403", description = "게임판 관리 권한 없음")
+    @ApiResponse(responseCode = "404", description = "게임판을 찾을 수 없음")
+    ResponseEntity<BaseResponse<GameBoardMemberDTO.CreateResponse>> createMember(
+            @PathVariable Long gameBoardId,
+            @Valid @RequestBody GameBoardMemberDTO.CreateRequest request
+    );
 
     @GetMapping("/{gameBoardId}/gameBoardMembers")
     @Operation(summary = "게임판 명단 조회", description = """

--- a/src/main/java/umc/cockple/demo/domain/game/presentation/controller/api/GameBoardMemberApi.java
+++ b/src/main/java/umc/cockple/demo/domain/game/presentation/controller/api/GameBoardMemberApi.java
@@ -83,9 +83,11 @@ public interface GameBoardMemberApi {
             - 서로 다른 종류의 필터는 AND 조건입니다.
             - `totalCount`는 필터와 무관한 전체 명단 수입니다.
             - 명단의 `gender`, `level`, `ageGroup`은 한글 표시값으로 반환합니다.
+            - 해당 운동에 참여 중인 회원 또는 게임 진행자만 조회할 수 있습니다.
             """)
     @ApiResponse(responseCode = "200", description = "조회 성공")
     @ApiResponse(responseCode = "401", description = "인증 필요")
+    @ApiResponse(responseCode = "403", description = "운동 참가자 또는 게임 진행자가 아닌 회원")
     @ApiResponse(responseCode = "404", description = "게임판을 찾을 수 없음")
     ResponseEntity<BaseResponse<GameBoardMemberDTO.Response>> getMembers(
             @PathVariable Long gameBoardId,

--- a/src/main/java/umc/cockple/demo/domain/game/presentation/controller/api/GameBoardMemberApi.java
+++ b/src/main/java/umc/cockple/demo/domain/game/presentation/controller/api/GameBoardMemberApi.java
@@ -20,6 +20,24 @@ import java.util.List;
 @GameApiTag
 public interface GameBoardMemberApi {
 
+    @PatchMapping("/{gameBoardId}/gameBoardMembers/{gameBoardMemberId}/participation")
+    @Operation(summary = "게임판 명단 참여 상태 변경", description = """
+            게임 진행자가 명단의 참여/불참 상태를 변경합니다.
+
+            - `participating`은 필수 Boolean입니다.
+            - PLAYING 또는 WAITING 게임에 포함된 선수는 참여 해제할 수 없습니다.
+            - 현재 값과 같은 요청은 성공하는 멱등 동작입니다.
+            """)
+    @ApiResponse(responseCode = "200", description = "변경 성공")
+    @ApiResponse(responseCode = "400", description = "입력값 오류 또는 활성 게임 선수 참여 해제")
+    @ApiResponse(responseCode = "403", description = "게임판 관리 권한 없음")
+    @ApiResponse(responseCode = "404", description = "게임판 또는 명단을 찾을 수 없음")
+    ResponseEntity<BaseResponse<Void>> changeParticipation(
+            @PathVariable Long gameBoardId,
+            @PathVariable Long gameBoardMemberId,
+            @Valid @RequestBody GameBoardMemberDTO.ParticipationRequest request
+    );
+
     @PatchMapping("/{gameBoardId}/gameBoardMembers/{gameBoardMemberId}")
     @Operation(summary = "게임판 명단 정보 수정", description = """
             게임 진행자가 명단의 이름, 성별, 급수, 연령대를 수정합니다.

--- a/src/main/java/umc/cockple/demo/domain/game/presentation/controller/api/GameBoardMemberApi.java
+++ b/src/main/java/umc/cockple/demo/domain/game/presentation/controller/api/GameBoardMemberApi.java
@@ -1,0 +1,38 @@
+package umc.cockple.demo.domain.game.presentation.controller.api;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import umc.cockple.demo.domain.game.presentation.dto.GameBoardMemberDTO;
+import umc.cockple.demo.global.response.BaseResponse;
+
+import java.util.List;
+
+@RequestMapping("/api/game-boards")
+@GameApiTag
+public interface GameBoardMemberApi {
+
+    @GetMapping("/{gameBoardId}/gameBoardMembers")
+    @Operation(summary = "게임판 명단 조회", description = """
+            게임판 전체 명단 수와 필터된 명단을 조회합니다.
+
+            - `level`: 한글 급수를 반복 전달하며 여러 값은 OR 조건입니다. (예: `level=A조&level=B조`)
+            - `gender`: 한글 성별입니다. (예: `남성`)
+            - `shuttlecockSubmitted`: 셔틀콕 제출 여부입니다.
+            - 서로 다른 종류의 필터는 AND 조건입니다.
+            - `totalCount`는 필터와 무관한 전체 명단 수입니다.
+            """)
+    @ApiResponse(responseCode = "200", description = "조회 성공")
+    @ApiResponse(responseCode = "401", description = "인증 필요")
+    @ApiResponse(responseCode = "404", description = "게임판을 찾을 수 없음")
+    ResponseEntity<BaseResponse<GameBoardMemberDTO.Response>> getMembers(
+            @PathVariable Long gameBoardId,
+            @RequestParam(value = "level", required = false) List<String> levels,
+            @RequestParam(value = "gender", required = false) String gender,
+            @RequestParam(value = "shuttlecockSubmitted", required = false) Boolean shuttlecockSubmitted
+    );
+}

--- a/src/main/java/umc/cockple/demo/domain/game/presentation/controller/api/GameBoardMemberApi.java
+++ b/src/main/java/umc/cockple/demo/domain/game/presentation/controller/api/GameBoardMemberApi.java
@@ -6,6 +6,7 @@ import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -18,6 +19,24 @@ import java.util.List;
 @RequestMapping("/api/game-boards")
 @GameApiTag
 public interface GameBoardMemberApi {
+
+    @PatchMapping("/{gameBoardId}/gameBoardMembers/{gameBoardMemberId}")
+    @Operation(summary = "게임판 명단 정보 수정", description = """
+            게임 진행자가 명단의 이름, 성별, 급수, 연령대를 수정합니다.
+
+            - `name`, `gender`, `level`은 필수입니다.
+            - `ageGroup`을 null로 전달하거나 생략하면 기존 연령대를 제거합니다.
+            - 진행 또는 대기 중인 게임에 포함된 선수도 정보를 수정할 수 있습니다.
+            """)
+    @ApiResponse(responseCode = "200", description = "수정 성공")
+    @ApiResponse(responseCode = "400", description = "입력값 오류")
+    @ApiResponse(responseCode = "403", description = "게임판 관리 권한 없음")
+    @ApiResponse(responseCode = "404", description = "게임판 또는 명단을 찾을 수 없음")
+    ResponseEntity<BaseResponse<Void>> updateMember(
+            @PathVariable Long gameBoardId,
+            @PathVariable Long gameBoardMemberId,
+            @Valid @RequestBody GameBoardMemberDTO.UpdateRequest request
+    );
 
     @PostMapping("/{gameBoardId}/gameBoardMembers")
     @Operation(summary = "게임판 명단 추가", description = """

--- a/src/main/java/umc/cockple/demo/domain/game/presentation/dto/GameBoardMemberDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/game/presentation/dto/GameBoardMemberDTO.java
@@ -2,6 +2,7 @@ package umc.cockple.demo.domain.game.presentation.dto;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 
 import java.util.List;
 
@@ -9,6 +10,7 @@ public class GameBoardMemberDTO {
 
     public record CreateRequest(
             @NotBlank(message = "이름은 필수입니다.")
+            @Size(max = 255, message = "이름은 255자 이하여야 합니다.")
             String name,
             @NotBlank(message = "성별은 필수입니다.")
             String gender,
@@ -25,6 +27,7 @@ public class GameBoardMemberDTO {
 
     public record UpdateRequest(
             @NotBlank(message = "이름은 필수입니다.")
+            @Size(max = 255, message = "이름은 255자 이하여야 합니다.")
             String name,
             @NotBlank(message = "성별은 필수입니다.")
             String gender,

--- a/src/main/java/umc/cockple/demo/domain/game/presentation/dto/GameBoardMemberDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/game/presentation/dto/GameBoardMemberDTO.java
@@ -1,8 +1,26 @@
 package umc.cockple.demo.domain.game.presentation.dto;
 
+import jakarta.validation.constraints.NotBlank;
+
 import java.util.List;
 
 public class GameBoardMemberDTO {
+
+    public record CreateRequest(
+            @NotBlank(message = "이름은 필수입니다.")
+            String name,
+            @NotBlank(message = "성별은 필수입니다.")
+            String gender,
+            @NotBlank(message = "급수는 필수입니다.")
+            String level,
+            String ageGroup
+    ) {
+    }
+
+    public record CreateResponse(
+            Long gameBoardMemberId
+    ) {
+    }
 
     public record Response(
             int totalCount,

--- a/src/main/java/umc/cockple/demo/domain/game/presentation/dto/GameBoardMemberDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/game/presentation/dto/GameBoardMemberDTO.java
@@ -54,6 +54,7 @@ public class GameBoardMemberDTO {
             int gameCount,
             String profileImageUrl,
             String name,
+            String gender,
             String ageGroup,
             String level,
             boolean shuttlecockSubmitted

--- a/src/main/java/umc/cockple/demo/domain/game/presentation/dto/GameBoardMemberDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/game/presentation/dto/GameBoardMemberDTO.java
@@ -22,6 +22,17 @@ public class GameBoardMemberDTO {
     ) {
     }
 
+    public record UpdateRequest(
+            @NotBlank(message = "이름은 필수입니다.")
+            String name,
+            @NotBlank(message = "성별은 필수입니다.")
+            String gender,
+            @NotBlank(message = "급수는 필수입니다.")
+            String level,
+            String ageGroup
+    ) {
+    }
+
     public record Response(
             int totalCount,
             List<MemberInfo> gameBoardMembers

--- a/src/main/java/umc/cockple/demo/domain/game/presentation/dto/GameBoardMemberDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/game/presentation/dto/GameBoardMemberDTO.java
@@ -1,6 +1,7 @@
 package umc.cockple.demo.domain.game.presentation.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
 import java.util.List;
 
@@ -30,6 +31,12 @@ public class GameBoardMemberDTO {
             @NotBlank(message = "급수는 필수입니다.")
             String level,
             String ageGroup
+    ) {
+    }
+
+    public record ParticipationRequest(
+            @NotNull(message = "참여 상태는 필수입니다.")
+            Boolean participating
     ) {
     }
 

--- a/src/main/java/umc/cockple/demo/domain/game/presentation/dto/GameBoardMemberDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/game/presentation/dto/GameBoardMemberDTO.java
@@ -1,0 +1,26 @@
+package umc.cockple.demo.domain.game.presentation.dto;
+
+import java.util.List;
+
+public class GameBoardMemberDTO {
+
+    public record Response(
+            int totalCount,
+            List<MemberInfo> gameBoardMembers
+    ) {
+    }
+
+    public record MemberInfo(
+            Long gameBoardMemberId,
+            boolean inGame,
+            boolean waiting,
+            boolean participating,
+            int gameCount,
+            String profileImageUrl,
+            String name,
+            String ageGroup,
+            String level,
+            boolean shuttlecockSubmitted
+    ) {
+    }
+}

--- a/src/main/java/umc/cockple/demo/domain/game/presentation/mapper/GameBoardMemberMapper.java
+++ b/src/main/java/umc/cockple/demo/domain/game/presentation/mapper/GameBoardMemberMapper.java
@@ -1,0 +1,43 @@
+package umc.cockple.demo.domain.game.presentation.mapper;
+
+import org.springframework.stereotype.Component;
+import umc.cockple.demo.domain.game.service.query.model.GameBoardMemberSearchQuery;
+import umc.cockple.demo.domain.game.service.query.result.GameBoardMemberResult;
+import umc.cockple.demo.domain.game.presentation.dto.GameBoardMemberDTO;
+import umc.cockple.demo.global.enums.Gender;
+import umc.cockple.demo.global.enums.Level;
+
+import java.util.List;
+
+@Component
+public class GameBoardMemberMapper {
+
+    public GameBoardMemberSearchQuery toSearchQuery(
+            List<String> levels, String gender, Boolean shuttlecockSubmitted) {
+        List<Level> levelEnums = levels == null
+                ? List.of()
+                : levels.stream().map(Level::fromKorean).toList();
+        Gender genderEnum = gender == null ? null : Gender.fromKorean(gender);
+        return new GameBoardMemberSearchQuery(levelEnums, genderEnum, shuttlecockSubmitted);
+    }
+
+    public GameBoardMemberDTO.Response toResponse(GameBoardMemberResult result) {
+        return new GameBoardMemberDTO.Response(
+                result.totalCount(),
+                result.gameBoardMembers().stream().map(this::toMemberInfo).toList());
+    }
+
+    private GameBoardMemberDTO.MemberInfo toMemberInfo(GameBoardMemberResult.MemberView member) {
+        return new GameBoardMemberDTO.MemberInfo(
+                member.gameBoardMemberId(),
+                member.inGame(),
+                member.waiting(),
+                member.participating(),
+                member.gameCount(),
+                member.profileImageUrl(),
+                member.name(),
+                member.ageGroup() == null ? null : member.ageGroup().getKoreanName(),
+                member.level().getKoreanName(),
+                member.shuttlecockSubmitted());
+    }
+}

--- a/src/main/java/umc/cockple/demo/domain/game/presentation/mapper/GameBoardMemberMapper.java
+++ b/src/main/java/umc/cockple/demo/domain/game/presentation/mapper/GameBoardMemberMapper.java
@@ -4,6 +4,7 @@ import org.springframework.stereotype.Component;
 import umc.cockple.demo.domain.game.enums.AgeGroup;
 import umc.cockple.demo.domain.game.presentation.dto.GameBoardMemberDTO;
 import umc.cockple.demo.domain.game.service.command.model.GameBoardMemberCreateCommand;
+import umc.cockple.demo.domain.game.service.command.model.GameBoardMemberParticipationCommand;
 import umc.cockple.demo.domain.game.service.command.model.GameBoardMemberUpdateCommand;
 import umc.cockple.demo.domain.game.service.query.model.GameBoardMemberSearchQuery;
 import umc.cockple.demo.domain.game.service.query.result.GameBoardMemberResult;
@@ -46,6 +47,14 @@ public class GameBoardMemberMapper {
                 Gender.fromKorean(request.gender()),
                 Level.fromKorean(request.level()),
                 ageGroup);
+    }
+
+    public GameBoardMemberParticipationCommand toParticipationCommand(
+            Long gameBoardId,
+            Long gameBoardMemberId,
+            GameBoardMemberDTO.ParticipationRequest request) {
+        return new GameBoardMemberParticipationCommand(
+                gameBoardId, gameBoardMemberId, request.participating());
     }
 
     public GameBoardMemberSearchQuery toSearchQuery(

--- a/src/main/java/umc/cockple/demo/domain/game/presentation/mapper/GameBoardMemberMapper.java
+++ b/src/main/java/umc/cockple/demo/domain/game/presentation/mapper/GameBoardMemberMapper.java
@@ -1,9 +1,11 @@
 package umc.cockple.demo.domain.game.presentation.mapper;
 
 import org.springframework.stereotype.Component;
+import umc.cockple.demo.domain.game.enums.AgeGroup;
+import umc.cockple.demo.domain.game.presentation.dto.GameBoardMemberDTO;
+import umc.cockple.demo.domain.game.service.command.model.GameBoardMemberCreateCommand;
 import umc.cockple.demo.domain.game.service.query.model.GameBoardMemberSearchQuery;
 import umc.cockple.demo.domain.game.service.query.result.GameBoardMemberResult;
-import umc.cockple.demo.domain.game.presentation.dto.GameBoardMemberDTO;
 import umc.cockple.demo.global.enums.Gender;
 import umc.cockple.demo.global.enums.Level;
 
@@ -11,6 +13,23 @@ import java.util.List;
 
 @Component
 public class GameBoardMemberMapper {
+
+    public GameBoardMemberCreateCommand toCreateCommand(
+            Long gameBoardId, GameBoardMemberDTO.CreateRequest request) {
+        AgeGroup ageGroup = request.ageGroup() == null
+                ? null
+                : AgeGroup.fromKorean(request.ageGroup());
+        return new GameBoardMemberCreateCommand(
+                gameBoardId,
+                request.name().trim(),
+                Gender.fromKorean(request.gender()),
+                Level.fromKorean(request.level()),
+                ageGroup);
+    }
+
+    public GameBoardMemberDTO.CreateResponse toCreateResponse(Long gameBoardMemberId) {
+        return new GameBoardMemberDTO.CreateResponse(gameBoardMemberId);
+    }
 
     public GameBoardMemberSearchQuery toSearchQuery(
             List<String> levels, String gender, Boolean shuttlecockSubmitted) {

--- a/src/main/java/umc/cockple/demo/domain/game/presentation/mapper/GameBoardMemberMapper.java
+++ b/src/main/java/umc/cockple/demo/domain/game/presentation/mapper/GameBoardMemberMapper.java
@@ -81,6 +81,7 @@ public class GameBoardMemberMapper {
                 member.gameCount(),
                 member.profileImageUrl(),
                 member.name(),
+                member.gender().getKoreanName(),
                 member.ageGroup() == null ? null : member.ageGroup().getKoreanName(),
                 member.level().getKoreanName(),
                 member.shuttlecockSubmitted());

--- a/src/main/java/umc/cockple/demo/domain/game/presentation/mapper/GameBoardMemberMapper.java
+++ b/src/main/java/umc/cockple/demo/domain/game/presentation/mapper/GameBoardMemberMapper.java
@@ -4,6 +4,7 @@ import org.springframework.stereotype.Component;
 import umc.cockple.demo.domain.game.enums.AgeGroup;
 import umc.cockple.demo.domain.game.presentation.dto.GameBoardMemberDTO;
 import umc.cockple.demo.domain.game.service.command.model.GameBoardMemberCreateCommand;
+import umc.cockple.demo.domain.game.service.command.model.GameBoardMemberUpdateCommand;
 import umc.cockple.demo.domain.game.service.query.model.GameBoardMemberSearchQuery;
 import umc.cockple.demo.domain.game.service.query.result.GameBoardMemberResult;
 import umc.cockple.demo.global.enums.Gender;
@@ -29,6 +30,22 @@ public class GameBoardMemberMapper {
 
     public GameBoardMemberDTO.CreateResponse toCreateResponse(Long gameBoardMemberId) {
         return new GameBoardMemberDTO.CreateResponse(gameBoardMemberId);
+    }
+
+    public GameBoardMemberUpdateCommand toUpdateCommand(
+            Long gameBoardId,
+            Long gameBoardMemberId,
+            GameBoardMemberDTO.UpdateRequest request) {
+        AgeGroup ageGroup = request.ageGroup() == null
+                ? null
+                : AgeGroup.fromKorean(request.ageGroup());
+        return new GameBoardMemberUpdateCommand(
+                gameBoardId,
+                gameBoardMemberId,
+                request.name().trim(),
+                Gender.fromKorean(request.gender()),
+                Level.fromKorean(request.level()),
+                ageGroup);
     }
 
     public GameBoardMemberSearchQuery toSearchQuery(

--- a/src/main/java/umc/cockple/demo/domain/game/realtime/GameRealtimeProtocol.java
+++ b/src/main/java/umc/cockple/demo/domain/game/realtime/GameRealtimeProtocol.java
@@ -12,6 +12,7 @@ public final class GameRealtimeProtocol {
     public static final String TYPE_SUBSCRIBED = "SUBSCRIBED";
     public static final String TYPE_UNSUBSCRIBED = "UNSUBSCRIBED";
     public static final String TYPE_BOARD_UPDATED = "BOARD_UPDATED";
+    public static final String TYPE_MEMBERS_UPDATED = "MEMBERS_UPDATED";
     public static final String TYPE_GAME_CREATED = "GAME_CREATED";
     public static final String TYPE_GAME_DELETED = "GAME_DELETED";
 

--- a/src/main/java/umc/cockple/demo/domain/game/repository/GameBoardMemberRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/game/repository/GameBoardMemberRepository.java
@@ -12,11 +12,13 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
-public interface GameBoardMemberRepository extends JpaRepository<GameBoardMember, Long> {
+public interface GameBoardMemberRepository extends JpaRepository<GameBoardMember, Long>, GameBoardMemberRepositoryCustom {
 
     Optional<GameBoardMember> findByIdAndGameBoardId(Long id, Long gameBoardId);
 
     List<GameBoardMember> findByGameBoardIdAndIdIn(Long gameBoardId, Collection<Long> ids);
+
+    long countByGameBoardId(Long gameBoardId);
 
     @Modifying(flushAutomatically = true)
     @Query(value = """

--- a/src/main/java/umc/cockple/demo/domain/game/repository/GameBoardMemberRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/game/repository/GameBoardMemberRepository.java
@@ -20,6 +20,8 @@ public interface GameBoardMemberRepository extends JpaRepository<GameBoardMember
 
     long countByGameBoardId(Long gameBoardId);
 
+    boolean existsByGameBoardIdAndMemberId(Long gameBoardId, Long memberId);
+
     @Modifying(flushAutomatically = true)
     @Query(value = """
             DELETE game_board_member

--- a/src/main/java/umc/cockple/demo/domain/game/repository/GameBoardMemberRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/game/repository/GameBoardMemberRepository.java
@@ -10,9 +10,12 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 
 public interface GameBoardMemberRepository extends JpaRepository<GameBoardMember, Long> {
-  
+
+    Optional<GameBoardMember> findByIdAndGameBoardId(Long id, Long gameBoardId);
+
     List<GameBoardMember> findByGameBoardIdAndIdIn(Long gameBoardId, Collection<Long> ids);
 
     @Modifying(flushAutomatically = true)

--- a/src/main/java/umc/cockple/demo/domain/game/repository/GameBoardMemberRepositoryCustom.java
+++ b/src/main/java/umc/cockple/demo/domain/game/repository/GameBoardMemberRepositoryCustom.java
@@ -1,0 +1,16 @@
+package umc.cockple.demo.domain.game.repository;
+
+import umc.cockple.demo.domain.game.domain.GameBoardMember;
+import umc.cockple.demo.global.enums.Gender;
+import umc.cockple.demo.global.enums.Level;
+
+import java.util.List;
+
+public interface GameBoardMemberRepositoryCustom {
+
+    List<GameBoardMember> findAllByFilters(
+            Long gameBoardId,
+            List<Level> levels,
+            Gender gender,
+            Boolean shuttlecockSubmitted);
+}

--- a/src/main/java/umc/cockple/demo/domain/game/repository/GameBoardMemberRepositoryCustomImpl.java
+++ b/src/main/java/umc/cockple/demo/domain/game/repository/GameBoardMemberRepositoryCustomImpl.java
@@ -1,0 +1,52 @@
+package umc.cockple.demo.domain.game.repository;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import umc.cockple.demo.domain.game.domain.GameBoardMember;
+import umc.cockple.demo.domain.game.domain.QGameBoardMember;
+import umc.cockple.demo.domain.member.domain.QMember;
+import umc.cockple.demo.domain.member.domain.QProfileImg;
+import umc.cockple.demo.global.enums.Gender;
+import umc.cockple.demo.global.enums.Level;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class GameBoardMemberRepositoryCustomImpl implements GameBoardMemberRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    private final QGameBoardMember gameBoardMember = QGameBoardMember.gameBoardMember;
+    private final QMember member = QMember.member;
+    private final QProfileImg profileImg = QProfileImg.profileImg;
+
+    @Override
+    public List<GameBoardMember> findAllByFilters(
+            Long gameBoardId,
+            List<Level> levels,
+            Gender gender,
+            Boolean shuttlecockSubmitted) {
+        BooleanBuilder conditions = new BooleanBuilder(gameBoardMember.gameBoard.id.eq(gameBoardId));
+
+        if (levels != null && !levels.isEmpty()) {
+            conditions.and(gameBoardMember.level.in(levels));
+        }
+        if (gender != null) {
+            conditions.and(gameBoardMember.gender.eq(gender));
+        }
+        if (shuttlecockSubmitted != null) {
+            conditions.and(gameBoardMember.shuttlecockSubmitted.eq(shuttlecockSubmitted));
+        }
+
+        return queryFactory
+                .selectFrom(gameBoardMember)
+                .leftJoin(gameBoardMember.member, member).fetchJoin()
+                .leftJoin(member.profileImg, profileImg).fetchJoin()
+                .where(conditions)
+                .orderBy(gameBoardMember.id.asc())
+                .fetch();
+    }
+}

--- a/src/main/java/umc/cockple/demo/domain/game/repository/GameBoardRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/game/repository/GameBoardRepository.java
@@ -1,7 +1,17 @@
 package umc.cockple.demo.domain.game.repository;
 
+import jakarta.persistence.LockModeType;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import umc.cockple.demo.domain.game.domain.GameBoard;
 
+import java.util.Optional;
+
 public interface GameBoardRepository extends JpaRepository<GameBoard, Long> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select gameBoard from GameBoard gameBoard where gameBoard.id = :gameBoardId")
+    Optional<GameBoard> findByIdForUpdate(@Param("gameBoardId") Long gameBoardId);
 }

--- a/src/main/java/umc/cockple/demo/domain/game/repository/GameRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/game/repository/GameRepository.java
@@ -22,6 +22,13 @@ public interface GameRepository extends JpaRepository<Game, Long> {
 
     long countByGameBoardIdAndStatus(Long gameBoardId, GameStatus status);
 
+    @Query("select (count(g) > 0) from Game g " +
+            "join g.players p " +
+            "where p.gameBoardMember.id = :gameBoardMemberId and g.status in :statuses")
+    boolean existsByGameBoardMemberIdAndStatusIn(
+            @Param("gameBoardMemberId") Long gameBoardMemberId,
+            @Param("statuses") Collection<GameStatus> statuses);
+
     @Query("select distinct g from Game g " +
             "left join fetch g.court " +
             "left join fetch g.players p " +

--- a/src/main/java/umc/cockple/demo/domain/game/service/command/GameBoardMemberCommandService.java
+++ b/src/main/java/umc/cockple/demo/domain/game/service/command/GameBoardMemberCommandService.java
@@ -6,21 +6,32 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import umc.cockple.demo.domain.game.domain.GameBoard;
 import umc.cockple.demo.domain.game.domain.GameBoardMember;
+import umc.cockple.demo.domain.game.enums.GameStatus;
 import umc.cockple.demo.domain.game.events.GameBoardMembersChangedEvent;
+import umc.cockple.demo.domain.game.exception.GameErrorCode;
+import umc.cockple.demo.domain.game.exception.GameException;
 import umc.cockple.demo.domain.game.repository.GameBoardMemberRepository;
 import umc.cockple.demo.domain.game.service.command.model.GameBoardMemberCreateCommand;
+import umc.cockple.demo.domain.game.service.command.model.GameBoardMemberParticipationCommand;
 import umc.cockple.demo.domain.game.service.command.model.GameBoardMemberUpdateCommand;
 import umc.cockple.demo.domain.game.service.support.reader.GameBoardMemberReader;
 import umc.cockple.demo.domain.game.service.support.reader.GameBoardReader;
+import umc.cockple.demo.domain.game.service.support.reader.GameReader;
 import umc.cockple.demo.domain.game.service.support.validator.GameBoardAccessValidator;
+
+import java.util.List;
 
 @Service
 @Transactional
 @RequiredArgsConstructor
 public class GameBoardMemberCommandService {
 
+    private static final List<GameStatus> ACTIVE_STATUSES =
+            List.of(GameStatus.PLAYING, GameStatus.WAITING);
+
     private final GameBoardReader gameBoardReader;
     private final GameBoardMemberReader gameBoardMemberReader;
+    private final GameReader gameReader;
     private final GameBoardAccessValidator gameBoardAccessValidator;
     private final GameBoardMemberRepository gameBoardMemberRepository;
     private final ApplicationEventPublisher eventPublisher;
@@ -46,6 +57,24 @@ public class GameBoardMemberCommandService {
         gameBoardMember.updateInfo(
                 command.name(), command.gender(), command.level(), command.ageGroup());
 
+        eventPublisher.publishEvent(new GameBoardMembersChangedEvent(command.gameBoardId(), memberId));
+    }
+
+    public void changeParticipation(Long memberId, GameBoardMemberParticipationCommand command) {
+        gameBoardAccessValidator.validateGameHost(command.gameBoardId(), memberId);
+        GameBoardMember gameBoardMember = gameBoardMemberReader.read(
+                command.gameBoardId(), command.gameBoardMemberId());
+
+        if (gameBoardMember.getParticipating() == command.participating()) {
+            return;
+        }
+        if (!command.participating()
+                && gameReader.existsByGameBoardMemberAndStatuses(
+                        command.gameBoardMemberId(), ACTIVE_STATUSES)) {
+            throw new GameException(GameErrorCode.ACTIVE_GAME_MEMBER_CANNOT_BE_INACTIVE);
+        }
+
+        gameBoardMember.changeParticipation(command.participating());
         eventPublisher.publishEvent(new GameBoardMembersChangedEvent(command.gameBoardId(), memberId));
     }
 }

--- a/src/main/java/umc/cockple/demo/domain/game/service/command/GameBoardMemberCommandService.java
+++ b/src/main/java/umc/cockple/demo/domain/game/service/command/GameBoardMemberCommandService.java
@@ -61,6 +61,7 @@ public class GameBoardMemberCommandService {
     }
 
     public void changeParticipation(Long memberId, GameBoardMemberParticipationCommand command) {
+        gameBoardReader.readForUpdate(command.gameBoardId());
         gameBoardAccessValidator.validateGameHost(command.gameBoardId(), memberId);
         GameBoardMember gameBoardMember = gameBoardMemberReader.read(
                 command.gameBoardId(), command.gameBoardMemberId());

--- a/src/main/java/umc/cockple/demo/domain/game/service/command/GameBoardMemberCommandService.java
+++ b/src/main/java/umc/cockple/demo/domain/game/service/command/GameBoardMemberCommandService.java
@@ -61,8 +61,8 @@ public class GameBoardMemberCommandService {
     }
 
     public void changeParticipation(Long memberId, GameBoardMemberParticipationCommand command) {
-        gameBoardReader.readForUpdate(command.gameBoardId());
         gameBoardAccessValidator.validateGameHost(command.gameBoardId(), memberId);
+        gameBoardReader.readForUpdate(command.gameBoardId());
         GameBoardMember gameBoardMember = gameBoardMemberReader.read(
                 command.gameBoardId(), command.gameBoardMemberId());
 

--- a/src/main/java/umc/cockple/demo/domain/game/service/command/GameBoardMemberCommandService.java
+++ b/src/main/java/umc/cockple/demo/domain/game/service/command/GameBoardMemberCommandService.java
@@ -9,6 +9,8 @@ import umc.cockple.demo.domain.game.domain.GameBoardMember;
 import umc.cockple.demo.domain.game.events.GameBoardMembersChangedEvent;
 import umc.cockple.demo.domain.game.repository.GameBoardMemberRepository;
 import umc.cockple.demo.domain.game.service.command.model.GameBoardMemberCreateCommand;
+import umc.cockple.demo.domain.game.service.command.model.GameBoardMemberUpdateCommand;
+import umc.cockple.demo.domain.game.service.support.reader.GameBoardMemberReader;
 import umc.cockple.demo.domain.game.service.support.reader.GameBoardReader;
 import umc.cockple.demo.domain.game.service.support.validator.GameBoardAccessValidator;
 
@@ -18,6 +20,7 @@ import umc.cockple.demo.domain.game.service.support.validator.GameBoardAccessVal
 public class GameBoardMemberCommandService {
 
     private final GameBoardReader gameBoardReader;
+    private final GameBoardMemberReader gameBoardMemberReader;
     private final GameBoardAccessValidator gameBoardAccessValidator;
     private final GameBoardMemberRepository gameBoardMemberRepository;
     private final ApplicationEventPublisher eventPublisher;
@@ -33,5 +36,16 @@ public class GameBoardMemberCommandService {
 
         eventPublisher.publishEvent(new GameBoardMembersChangedEvent(gameBoard.getId(), memberId));
         return savedMember.getId();
+    }
+
+    public void updateMember(Long memberId, GameBoardMemberUpdateCommand command) {
+        gameBoardAccessValidator.validateGameHost(command.gameBoardId(), memberId);
+        GameBoardMember gameBoardMember = gameBoardMemberReader.read(
+                command.gameBoardId(), command.gameBoardMemberId());
+
+        gameBoardMember.updateInfo(
+                command.name(), command.gender(), command.level(), command.ageGroup());
+
+        eventPublisher.publishEvent(new GameBoardMembersChangedEvent(command.gameBoardId(), memberId));
     }
 }

--- a/src/main/java/umc/cockple/demo/domain/game/service/command/GameBoardMemberCommandService.java
+++ b/src/main/java/umc/cockple/demo/domain/game/service/command/GameBoardMemberCommandService.java
@@ -61,8 +61,8 @@ public class GameBoardMemberCommandService {
     }
 
     public void changeParticipation(Long memberId, GameBoardMemberParticipationCommand command) {
-        gameBoardAccessValidator.validateGameHost(command.gameBoardId(), memberId);
         gameBoardReader.readForUpdate(command.gameBoardId());
+        gameBoardAccessValidator.validateGameHost(command.gameBoardId(), memberId);
         GameBoardMember gameBoardMember = gameBoardMemberReader.read(
                 command.gameBoardId(), command.gameBoardMemberId());
 

--- a/src/main/java/umc/cockple/demo/domain/game/service/command/GameBoardMemberCommandService.java
+++ b/src/main/java/umc/cockple/demo/domain/game/service/command/GameBoardMemberCommandService.java
@@ -1,0 +1,37 @@
+package umc.cockple.demo.domain.game.service.command;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import umc.cockple.demo.domain.game.domain.GameBoard;
+import umc.cockple.demo.domain.game.domain.GameBoardMember;
+import umc.cockple.demo.domain.game.events.GameBoardMembersChangedEvent;
+import umc.cockple.demo.domain.game.repository.GameBoardMemberRepository;
+import umc.cockple.demo.domain.game.service.command.model.GameBoardMemberCreateCommand;
+import umc.cockple.demo.domain.game.service.support.reader.GameBoardReader;
+import umc.cockple.demo.domain.game.service.support.validator.GameBoardAccessValidator;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class GameBoardMemberCommandService {
+
+    private final GameBoardReader gameBoardReader;
+    private final GameBoardAccessValidator gameBoardAccessValidator;
+    private final GameBoardMemberRepository gameBoardMemberRepository;
+    private final ApplicationEventPublisher eventPublisher;
+
+    public Long createMember(Long memberId, GameBoardMemberCreateCommand command) {
+        gameBoardAccessValidator.validateGameHost(command.gameBoardId(), memberId);
+        GameBoard gameBoard = gameBoardReader.read(command.gameBoardId());
+
+        GameBoardMember gameBoardMember = GameBoardMember.create(
+                command.name(), command.gender(), command.level(), command.ageGroup());
+        gameBoard.addGameBoardMember(gameBoardMember);
+        GameBoardMember savedMember = gameBoardMemberRepository.save(gameBoardMember);
+
+        eventPublisher.publishEvent(new GameBoardMembersChangedEvent(gameBoard.getId(), memberId));
+        return savedMember.getId();
+    }
+}

--- a/src/main/java/umc/cockple/demo/domain/game/service/command/GameBoardMemberCommandService.java
+++ b/src/main/java/umc/cockple/demo/domain/game/service/command/GameBoardMemberCommandService.java
@@ -45,7 +45,7 @@ public class GameBoardMemberCommandService {
         gameBoard.addGameBoardMember(gameBoardMember);
         GameBoardMember savedMember = gameBoardMemberRepository.save(gameBoardMember);
 
-        eventPublisher.publishEvent(new GameBoardMembersChangedEvent(gameBoard.getId(), memberId));
+        eventPublisher.publishEvent(GameBoardMembersChangedEvent.membersAndBoard(gameBoard.getId(), memberId));
         return savedMember.getId();
     }
 
@@ -57,7 +57,7 @@ public class GameBoardMemberCommandService {
         gameBoardMember.updateInfo(
                 command.name(), command.gender(), command.level(), command.ageGroup());
 
-        eventPublisher.publishEvent(new GameBoardMembersChangedEvent(command.gameBoardId(), memberId));
+        eventPublisher.publishEvent(GameBoardMembersChangedEvent.membersAndBoard(command.gameBoardId(), memberId));
     }
 
     public void changeParticipation(Long memberId, GameBoardMemberParticipationCommand command) {
@@ -75,6 +75,6 @@ public class GameBoardMemberCommandService {
         }
 
         gameBoardMember.changeParticipation(command.participating());
-        eventPublisher.publishEvent(new GameBoardMembersChangedEvent(command.gameBoardId(), memberId));
+        eventPublisher.publishEvent(GameBoardMembersChangedEvent.membersAndBoard(command.gameBoardId(), memberId));
     }
 }

--- a/src/main/java/umc/cockple/demo/domain/game/service/command/GameCommandService.java
+++ b/src/main/java/umc/cockple/demo/domain/game/service/command/GameCommandService.java
@@ -50,13 +50,17 @@ public class GameCommandService {
      * @return 생성된 게임 ID
      */
     public Long createGame(Long memberId, GameCreateCommand command) {
-        GameBoard gameBoard = gameBoardReader.read(command.gameBoardId());
+        GameBoard gameBoard = gameBoardReader.readForUpdate(command.gameBoardId());
 
         Map<Long, GameBoardMember> membersById = gameBoardMemberRepository
                 .findByGameBoardIdAndIdIn(gameBoard.getId(), command.gameBoardMemberIds()).stream()
                 .collect(Collectors.toMap(GameBoardMember::getId, Function.identity()));
         if (membersById.size() != command.gameBoardMemberIds().size()) {
             throw new GameException(GameErrorCode.GAME_BOARD_MEMBER_NOT_FOUND);
+        }
+        if (membersById.values().stream()
+                .anyMatch(gameBoardMember -> !Boolean.TRUE.equals(gameBoardMember.getParticipating()))) {
+            throw new GameException(GameErrorCode.INACTIVE_GAME_PLAYER);
         }
 
         int nextWaitingOrder = (int) gameRepository

--- a/src/main/java/umc/cockple/demo/domain/game/service/command/GameCommandService.java
+++ b/src/main/java/umc/cockple/demo/domain/game/service/command/GameCommandService.java
@@ -126,6 +126,7 @@ public class GameCommandService {
         }
 
         completeInternal(game);
+        publishMembersChanged(gameBoard.getId(), memberId);
 
         log.info("게임 완료 - gameBoardId: {}, gameId: {}", gameBoard.getId(), game.getId());
     }

--- a/src/main/java/umc/cockple/demo/domain/game/service/command/GameCommandService.java
+++ b/src/main/java/umc/cockple/demo/domain/game/service/command/GameCommandService.java
@@ -2,6 +2,7 @@ package umc.cockple.demo.domain.game.service.command;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import umc.cockple.demo.domain.game.domain.Court;
@@ -10,6 +11,7 @@ import umc.cockple.demo.domain.game.domain.GameBoard;
 import umc.cockple.demo.domain.game.domain.GameBoardMember;
 import umc.cockple.demo.domain.game.domain.GamePlayer;
 import umc.cockple.demo.domain.game.enums.GameStatus;
+import umc.cockple.demo.domain.game.events.GameBoardMembersChangedEvent;
 import umc.cockple.demo.domain.game.exception.GameErrorCode;
 import umc.cockple.demo.domain.game.exception.GameException;
 import umc.cockple.demo.domain.game.repository.CourtRepository;
@@ -39,6 +41,7 @@ public class GameCommandService {
     private final GameRepository gameRepository;
     private final CourtRepository courtRepository;
     private final GameBoardMemberRepository gameBoardMemberRepository;
+    private final ApplicationEventPublisher eventPublisher;
 
     /**
      * 게임 대기 생성
@@ -66,6 +69,7 @@ public class GameCommandService {
         }
 
         Game savedGame = gameRepository.save(game);
+        publishMembersChanged(gameBoard.getId(), memberId);
         log.info("게임 대기 생성 - gameBoardId: {}, gameId: {}, 인원: {}",
                 gameBoard.getId(), savedGame.getId(), command.gameBoardMemberIds().size());
         return savedGame.getId();
@@ -94,6 +98,7 @@ public class GameCommandService {
 
         game.start(court, LocalDateTime.now());
         resequenceWaitingQueue(gameBoard.getId());
+        publishMembersChanged(gameBoard.getId(), memberId);
 
         log.info("게임 시작 - gameBoardId: {}, gameId: {}, courtId: {}",
                 gameBoard.getId(), game.getId(), court.getId());
@@ -154,6 +159,7 @@ public class GameCommandService {
         if (wasWaiting) {
             resequenceWaitingQueue(gameBoard.getId());
         }
+        publishMembersChanged(gameBoard.getId(), memberId);
 
         log.info("게임 삭제 - gameBoardId: {}, gameId: {}, wasWaiting: {}, restore: {}",
                 gameBoard.getId(), deletedGameId, wasWaiting, command.restore());
@@ -181,6 +187,7 @@ public class GameCommandService {
 
         game.returnToWaiting(0);
         resequenceWaitingQueue(gameBoard.getId());
+        publishMembersChanged(gameBoard.getId(), memberId);
 
         log.info("대기열 이동 - gameBoardId: {}, gameId: {}", gameBoard.getId(), game.getId());
     }
@@ -206,5 +213,9 @@ public class GameCommandService {
         for (Game waitingGame : waitingGames) {
             waitingGame.changeWaitingOrder(order++);
         }
+    }
+
+    private void publishMembersChanged(Long gameBoardId, Long memberId) {
+        eventPublisher.publishEvent(GameBoardMembersChangedEvent.membersOnly(gameBoardId, memberId));
     }
 }

--- a/src/main/java/umc/cockple/demo/domain/game/service/command/model/GameBoardMemberCreateCommand.java
+++ b/src/main/java/umc/cockple/demo/domain/game/service/command/model/GameBoardMemberCreateCommand.java
@@ -1,0 +1,14 @@
+package umc.cockple.demo.domain.game.service.command.model;
+
+import umc.cockple.demo.domain.game.enums.AgeGroup;
+import umc.cockple.demo.global.enums.Gender;
+import umc.cockple.demo.global.enums.Level;
+
+public record GameBoardMemberCreateCommand(
+        Long gameBoardId,
+        String name,
+        Gender gender,
+        Level level,
+        AgeGroup ageGroup
+) {
+}

--- a/src/main/java/umc/cockple/demo/domain/game/service/command/model/GameBoardMemberParticipationCommand.java
+++ b/src/main/java/umc/cockple/demo/domain/game/service/command/model/GameBoardMemberParticipationCommand.java
@@ -1,0 +1,8 @@
+package umc.cockple.demo.domain.game.service.command.model;
+
+public record GameBoardMemberParticipationCommand(
+        Long gameBoardId,
+        Long gameBoardMemberId,
+        boolean participating
+) {
+}

--- a/src/main/java/umc/cockple/demo/domain/game/service/command/model/GameBoardMemberUpdateCommand.java
+++ b/src/main/java/umc/cockple/demo/domain/game/service/command/model/GameBoardMemberUpdateCommand.java
@@ -1,0 +1,15 @@
+package umc.cockple.demo.domain.game.service.command.model;
+
+import umc.cockple.demo.domain.game.enums.AgeGroup;
+import umc.cockple.demo.global.enums.Gender;
+import umc.cockple.demo.global.enums.Level;
+
+public record GameBoardMemberUpdateCommand(
+        Long gameBoardId,
+        Long gameBoardMemberId,
+        String name,
+        Gender gender,
+        Level level,
+        AgeGroup ageGroup
+) {
+}

--- a/src/main/java/umc/cockple/demo/domain/game/service/listener/GameBoardMembersChangedEventListener.java
+++ b/src/main/java/umc/cockple/demo/domain/game/service/listener/GameBoardMembersChangedEventListener.java
@@ -39,17 +39,12 @@ public class GameBoardMembersChangedEventListener {
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleMembersChanged(GameBoardMembersChangedEvent event) {
         GameBoardMemberDTO.Response membersDto;
-        GameBoardDTO.Response boardDto;
         try {
             GameBoardMemberResult members = gameBoardMemberQueryService.getMembers(
                     event.gameBoardId(), NO_FILTERS);
             membersDto = gameBoardMemberMapper.toResponse(members);
-
-            GameBoardResult board = gameBoardQueryService.getBoard(
-                    event.actorMemberId(), event.gameBoardId());
-            boardDto = gameBoardMapper.toResponse(board);
         } catch (Exception e) {
-            log.error("게임판 명단 변경 snapshot 조회 실패 - gameBoardId: {}", event.gameBoardId(), e);
+            log.error("게임판 명단 snapshot 조회 실패 - gameBoardId: {}", event.gameBoardId(), e);
             return;
         }
 
@@ -58,6 +53,21 @@ public class GameBoardMembersChangedEventListener {
                 event,
                 GameRealtimeProtocol.TYPE_MEMBERS_UPDATED,
                 () -> gameBoardBroadcaster.broadcastMembersUpdate(event.gameBoardId(), membersDto, null));
+
+        if (!event.includeBoardSnapshot()) {
+            return;
+        }
+
+        GameBoardDTO.Response boardDto;
+        try {
+            GameBoardResult board = gameBoardQueryService.getBoard(
+                    event.actorMemberId(), event.gameBoardId());
+            boardDto = gameBoardMapper.toResponse(board);
+        } catch (Exception e) {
+            log.error("게임판 snapshot 조회 실패 - gameBoardId: {}", event.gameBoardId(), e);
+            return;
+        }
+
         broadcastSafely(
                 event,
                 GameRealtimeProtocol.TYPE_BOARD_UPDATED,

--- a/src/main/java/umc/cockple/demo/domain/game/service/listener/GameBoardMembersChangedEventListener.java
+++ b/src/main/java/umc/cockple/demo/domain/game/service/listener/GameBoardMembersChangedEventListener.java
@@ -1,0 +1,77 @@
+package umc.cockple.demo.domain.game.service.listener;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+import umc.cockple.demo.domain.game.events.GameBoardMembersChangedEvent;
+import umc.cockple.demo.domain.game.presentation.dto.GameBoardDTO;
+import umc.cockple.demo.domain.game.presentation.dto.GameBoardMemberDTO;
+import umc.cockple.demo.domain.game.presentation.mapper.GameBoardMapper;
+import umc.cockple.demo.domain.game.presentation.mapper.GameBoardMemberMapper;
+import umc.cockple.demo.domain.game.realtime.GameRealtimeProtocol;
+import umc.cockple.demo.domain.game.service.query.GameBoardMemberQueryService;
+import umc.cockple.demo.domain.game.service.query.GameBoardQueryService;
+import umc.cockple.demo.domain.game.service.query.model.GameBoardMemberSearchQuery;
+import umc.cockple.demo.domain.game.service.query.result.GameBoardMemberResult;
+import umc.cockple.demo.domain.game.service.query.result.GameBoardResult;
+import umc.cockple.demo.domain.game.service.websocket.broadcast.GameBoardBroadcaster;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class GameBoardMembersChangedEventListener {
+
+    private static final GameBoardMemberSearchQuery NO_FILTERS =
+            new GameBoardMemberSearchQuery(List.of(), null, null);
+
+    private final GameBoardMemberQueryService gameBoardMemberQueryService;
+    private final GameBoardMemberMapper gameBoardMemberMapper;
+    private final GameBoardQueryService gameBoardQueryService;
+    private final GameBoardMapper gameBoardMapper;
+    private final GameBoardBroadcaster gameBoardBroadcaster;
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleMembersChanged(GameBoardMembersChangedEvent event) {
+        GameBoardMemberDTO.Response membersDto;
+        GameBoardDTO.Response boardDto;
+        try {
+            GameBoardMemberResult members = gameBoardMemberQueryService.getMembers(
+                    event.gameBoardId(), NO_FILTERS);
+            membersDto = gameBoardMemberMapper.toResponse(members);
+
+            GameBoardResult board = gameBoardQueryService.getBoard(
+                    event.actorMemberId(), event.gameBoardId());
+            boardDto = gameBoardMapper.toResponse(board);
+        } catch (Exception e) {
+            log.error("게임판 명단 변경 snapshot 조회 실패 - gameBoardId: {}", event.gameBoardId(), e);
+            return;
+        }
+
+        // REST 요청은 제외할 WebSocket 세션이 없으므로 요청자를 포함한 전체 구독 세션에 전파한다.
+        broadcastSafely(
+                event,
+                GameRealtimeProtocol.TYPE_MEMBERS_UPDATED,
+                () -> gameBoardBroadcaster.broadcastMembersUpdate(event.gameBoardId(), membersDto, null));
+        broadcastSafely(
+                event,
+                GameRealtimeProtocol.TYPE_BOARD_UPDATED,
+                () -> gameBoardBroadcaster.broadcastBoardUpdate(event.gameBoardId(), boardDto, null));
+    }
+
+    private void broadcastSafely(
+            GameBoardMembersChangedEvent event, String type, Runnable broadcast) {
+        try {
+            broadcast.run();
+        } catch (Exception e) {
+            // 일부 전파 실패가 이미 커밋된 REST 변경과 다른 snapshot 전파에 영향을 주지 않도록 흡수한다.
+            log.error("게임판 명단 변경 {} 브로드캐스트 실패 - gameBoardId: {}",
+                    type, event.gameBoardId(), e);
+        }
+    }
+}

--- a/src/main/java/umc/cockple/demo/domain/game/service/listener/GameBoardMembersChangedEventListener.java
+++ b/src/main/java/umc/cockple/demo/domain/game/service/listener/GameBoardMembersChangedEventListener.java
@@ -40,7 +40,7 @@ public class GameBoardMembersChangedEventListener {
     public void handleMembersChanged(GameBoardMembersChangedEvent event) {
         GameBoardMemberDTO.Response membersDto;
         try {
-            GameBoardMemberResult members = gameBoardMemberQueryService.getMembers(
+            GameBoardMemberResult members = gameBoardMemberQueryService.getMembersSnapshot(
                     event.gameBoardId(), NO_FILTERS);
             membersDto = gameBoardMemberMapper.toResponse(members);
         } catch (Exception e) {

--- a/src/main/java/umc/cockple/demo/domain/game/service/query/GameBoardMemberQueryService.java
+++ b/src/main/java/umc/cockple/demo/domain/game/service/query/GameBoardMemberQueryService.java
@@ -81,6 +81,7 @@ public class GameBoardMemberQueryService {
                 gameBoardMember.getGameCount(),
                 profileImageUrl,
                 gameBoardMember.getName(),
+                gameBoardMember.getGender(),
                 gameBoardMember.getAgeGroup(),
                 gameBoardMember.getLevel(),
                 gameBoardMember.getShuttlecockSubmitted());

--- a/src/main/java/umc/cockple/demo/domain/game/service/query/GameBoardMemberQueryService.java
+++ b/src/main/java/umc/cockple/demo/domain/game/service/query/GameBoardMemberQueryService.java
@@ -1,0 +1,92 @@
+package umc.cockple.demo.domain.game.service.query;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import umc.cockple.demo.domain.file.service.ImageUrlResolver;
+import umc.cockple.demo.domain.game.domain.Game;
+import umc.cockple.demo.domain.game.domain.GameBoardMember;
+import umc.cockple.demo.domain.game.domain.GamePlayer;
+import umc.cockple.demo.domain.game.enums.GameStatus;
+import umc.cockple.demo.domain.game.service.query.model.GameBoardMemberSearchQuery;
+import umc.cockple.demo.domain.game.service.query.result.GameBoardMemberResult;
+import umc.cockple.demo.domain.game.service.support.reader.GameBoardMemberReader;
+import umc.cockple.demo.domain.game.service.support.reader.GameBoardReader;
+import umc.cockple.demo.domain.game.service.support.reader.GameReader;
+import umc.cockple.demo.domain.member.domain.Member;
+import umc.cockple.demo.domain.member.domain.ProfileImg;
+
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class GameBoardMemberQueryService {
+
+    private static final List<GameStatus> ACTIVE_STATUSES = List.of(GameStatus.PLAYING, GameStatus.WAITING);
+
+    private final GameBoardReader gameBoardReader;
+    private final GameBoardMemberReader gameBoardMemberReader;
+    private final GameReader gameReader;
+    private final ImageUrlResolver imageUrlResolver;
+
+    public GameBoardMemberResult getMembers(Long gameBoardId, GameBoardMemberSearchQuery searchQuery) {
+        gameBoardReader.read(gameBoardId);
+
+        int totalCount = Math.toIntExact(gameBoardMemberReader.countByGameBoard(gameBoardId));
+        List<GameBoardMember> members = gameBoardMemberReader.readAllByFilters(
+                gameBoardId,
+                searchQuery.levels(),
+                searchQuery.gender(),
+                searchQuery.shuttlecockSubmitted());
+        Map<Long, EnumSet<GameStatus>> activeStatusesByMemberId = loadActiveStatuses(gameBoardId);
+
+        List<GameBoardMemberResult.MemberView> memberViews = members.stream()
+                .map(member -> toView(member, activeStatusesByMemberId.get(member.getId())))
+                .toList();
+
+        return new GameBoardMemberResult(totalCount, memberViews);
+    }
+
+    private Map<Long, EnumSet<GameStatus>> loadActiveStatuses(Long gameBoardId) {
+        List<Game> activeGames = gameReader.readAllByGameBoardAndStatuses(
+                gameBoardId, ACTIVE_STATUSES);
+        Map<Long, EnumSet<GameStatus>> statusesByMemberId = new HashMap<>();
+
+        for (Game game : activeGames) {
+            for (GamePlayer player : game.getPlayers()) {
+                statusesByMemberId
+                        .computeIfAbsent(player.getGameBoardMember().getId(), ignored -> EnumSet.noneOf(GameStatus.class))
+                        .add(game.getStatus());
+            }
+        }
+        return statusesByMemberId;
+    }
+
+    private GameBoardMemberResult.MemberView toView(
+            GameBoardMember gameBoardMember, EnumSet<GameStatus> activeStatuses) {
+        Member sourceMember = gameBoardMember.getMember();
+        String profileImageUrl = sourceMember == null
+                ? null
+                : imageUrlResolver.resolve(sourceMember.getProfileImg(), ProfileImg::getImgKey);
+
+        return new GameBoardMemberResult.MemberView(
+                gameBoardMember.getId(),
+                hasStatus(activeStatuses, GameStatus.PLAYING),
+                hasStatus(activeStatuses, GameStatus.WAITING),
+                gameBoardMember.getParticipating(),
+                gameBoardMember.getGameCount(),
+                profileImageUrl,
+                gameBoardMember.getName(),
+                gameBoardMember.getAgeGroup(),
+                gameBoardMember.getLevel(),
+                gameBoardMember.getShuttlecockSubmitted());
+    }
+
+    private boolean hasStatus(EnumSet<GameStatus> statuses, GameStatus status) {
+        return statuses != null && statuses.contains(status);
+    }
+}

--- a/src/main/java/umc/cockple/demo/domain/game/service/query/GameBoardMemberQueryService.java
+++ b/src/main/java/umc/cockple/demo/domain/game/service/query/GameBoardMemberQueryService.java
@@ -13,6 +13,7 @@ import umc.cockple.demo.domain.game.service.query.result.GameBoardMemberResult;
 import umc.cockple.demo.domain.game.service.support.reader.GameBoardMemberReader;
 import umc.cockple.demo.domain.game.service.support.reader.GameBoardReader;
 import umc.cockple.demo.domain.game.service.support.reader.GameReader;
+import umc.cockple.demo.domain.game.service.support.validator.GameBoardAccessValidator;
 import umc.cockple.demo.domain.member.domain.Member;
 import umc.cockple.demo.domain.member.domain.ProfileImg;
 
@@ -31,11 +32,26 @@ public class GameBoardMemberQueryService {
     private final GameBoardReader gameBoardReader;
     private final GameBoardMemberReader gameBoardMemberReader;
     private final GameReader gameReader;
+    private final GameBoardAccessValidator gameBoardAccessValidator;
     private final ImageUrlResolver imageUrlResolver;
 
-    public GameBoardMemberResult getMembers(Long gameBoardId, GameBoardMemberSearchQuery searchQuery) {
+    public GameBoardMemberResult getMembers(
+            Long memberId, Long gameBoardId, GameBoardMemberSearchQuery searchQuery) {
+        gameBoardReader.read(gameBoardId);
+        gameBoardAccessValidator.validateViewer(gameBoardId, memberId);
+
+        return loadMembers(gameBoardId, searchQuery);
+    }
+
+    public GameBoardMemberResult getMembersSnapshot(
+            Long gameBoardId, GameBoardMemberSearchQuery searchQuery) {
         gameBoardReader.read(gameBoardId);
 
+        return loadMembers(gameBoardId, searchQuery);
+    }
+
+    private GameBoardMemberResult loadMembers(
+            Long gameBoardId, GameBoardMemberSearchQuery searchQuery) {
         int totalCount = Math.toIntExact(gameBoardMemberReader.countByGameBoard(gameBoardId));
         List<GameBoardMember> members = gameBoardMemberReader.readAllByFilters(
                 gameBoardId,

--- a/src/main/java/umc/cockple/demo/domain/game/service/query/model/GameBoardMemberSearchQuery.java
+++ b/src/main/java/umc/cockple/demo/domain/game/service/query/model/GameBoardMemberSearchQuery.java
@@ -1,0 +1,16 @@
+package umc.cockple.demo.domain.game.service.query.model;
+
+import umc.cockple.demo.global.enums.Gender;
+import umc.cockple.demo.global.enums.Level;
+
+import java.util.List;
+
+public record GameBoardMemberSearchQuery(
+        List<Level> levels,
+        Gender gender,
+        Boolean shuttlecockSubmitted
+) {
+    public GameBoardMemberSearchQuery {
+        levels = levels == null ? List.of() : List.copyOf(levels);
+    }
+}

--- a/src/main/java/umc/cockple/demo/domain/game/service/query/result/GameBoardMemberResult.java
+++ b/src/main/java/umc/cockple/demo/domain/game/service/query/result/GameBoardMemberResult.java
@@ -1,0 +1,25 @@
+package umc.cockple.demo.domain.game.service.query.result;
+
+import umc.cockple.demo.domain.game.enums.AgeGroup;
+import umc.cockple.demo.global.enums.Level;
+
+import java.util.List;
+
+public record GameBoardMemberResult(
+        int totalCount,
+        List<MemberView> gameBoardMembers
+) {
+    public record MemberView(
+            Long gameBoardMemberId,
+            boolean inGame,
+            boolean waiting,
+            boolean participating,
+            int gameCount,
+            String profileImageUrl,
+            String name,
+            AgeGroup ageGroup,
+            Level level,
+            boolean shuttlecockSubmitted
+    ) {
+    }
+}

--- a/src/main/java/umc/cockple/demo/domain/game/service/query/result/GameBoardMemberResult.java
+++ b/src/main/java/umc/cockple/demo/domain/game/service/query/result/GameBoardMemberResult.java
@@ -1,6 +1,7 @@
 package umc.cockple.demo.domain.game.service.query.result;
 
 import umc.cockple.demo.domain.game.enums.AgeGroup;
+import umc.cockple.demo.global.enums.Gender;
 import umc.cockple.demo.global.enums.Level;
 
 import java.util.List;
@@ -17,6 +18,7 @@ public record GameBoardMemberResult(
             int gameCount,
             String profileImageUrl,
             String name,
+            Gender gender,
             AgeGroup ageGroup,
             Level level,
             boolean shuttlecockSubmitted

--- a/src/main/java/umc/cockple/demo/domain/game/service/support/reader/GameBoardMemberReader.java
+++ b/src/main/java/umc/cockple/demo/domain/game/service/support/reader/GameBoardMemberReader.java
@@ -1,0 +1,22 @@
+package umc.cockple.demo.domain.game.service.support.reader;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import umc.cockple.demo.domain.game.domain.GameBoardMember;
+import umc.cockple.demo.domain.game.exception.GameErrorCode;
+import umc.cockple.demo.domain.game.exception.GameException;
+import umc.cockple.demo.domain.game.repository.GameBoardMemberRepository;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class GameBoardMemberReader {
+
+    private final GameBoardMemberRepository gameBoardMemberRepository;
+
+    public GameBoardMember read(Long gameBoardId, Long gameBoardMemberId) {
+        return gameBoardMemberRepository.findByIdAndGameBoardId(gameBoardMemberId, gameBoardId)
+                .orElseThrow(() -> new GameException(GameErrorCode.GAME_BOARD_MEMBER_NOT_FOUND));
+    }
+}

--- a/src/main/java/umc/cockple/demo/domain/game/service/support/reader/GameBoardMemberReader.java
+++ b/src/main/java/umc/cockple/demo/domain/game/service/support/reader/GameBoardMemberReader.java
@@ -7,6 +7,10 @@ import umc.cockple.demo.domain.game.domain.GameBoardMember;
 import umc.cockple.demo.domain.game.exception.GameErrorCode;
 import umc.cockple.demo.domain.game.exception.GameException;
 import umc.cockple.demo.domain.game.repository.GameBoardMemberRepository;
+import umc.cockple.demo.global.enums.Gender;
+import umc.cockple.demo.global.enums.Level;
+
+import java.util.List;
 
 @Service
 @Transactional(readOnly = true)
@@ -18,5 +22,18 @@ public class GameBoardMemberReader {
     public GameBoardMember read(Long gameBoardId, Long gameBoardMemberId) {
         return gameBoardMemberRepository.findByIdAndGameBoardId(gameBoardMemberId, gameBoardId)
                 .orElseThrow(() -> new GameException(GameErrorCode.GAME_BOARD_MEMBER_NOT_FOUND));
+    }
+
+    public long countByGameBoard(Long gameBoardId) {
+        return gameBoardMemberRepository.countByGameBoardId(gameBoardId);
+    }
+
+    public List<GameBoardMember> readAllByFilters(
+            Long gameBoardId,
+            List<Level> levels,
+            Gender gender,
+            Boolean shuttlecockSubmitted) {
+        return gameBoardMemberRepository.findAllByFilters(
+                gameBoardId, levels, gender, shuttlecockSubmitted);
     }
 }

--- a/src/main/java/umc/cockple/demo/domain/game/service/support/reader/GameBoardReader.java
+++ b/src/main/java/umc/cockple/demo/domain/game/service/support/reader/GameBoardReader.java
@@ -19,4 +19,10 @@ public class GameBoardReader {
         return gameBoardRepository.findById(gameBoardId)
                 .orElseThrow(() -> new GameException(GameErrorCode.GAME_BOARD_NOT_FOUND));
     }
+
+    @Transactional
+    public GameBoard readForUpdate(Long gameBoardId) {
+        return gameBoardRepository.findByIdForUpdate(gameBoardId)
+                .orElseThrow(() -> new GameException(GameErrorCode.GAME_BOARD_NOT_FOUND));
+    }
 }

--- a/src/main/java/umc/cockple/demo/domain/game/service/support/reader/GameReader.java
+++ b/src/main/java/umc/cockple/demo/domain/game/service/support/reader/GameReader.java
@@ -21,4 +21,9 @@ public class GameReader {
             Long gameBoardId, Collection<GameStatus> statuses) {
         return gameRepository.findByGameBoardIdAndStatusInWithPlayers(gameBoardId, statuses);
     }
+
+    public boolean existsByGameBoardMemberAndStatuses(
+            Long gameBoardMemberId, Collection<GameStatus> statuses) {
+        return gameRepository.existsByGameBoardMemberIdAndStatusIn(gameBoardMemberId, statuses);
+    }
 }

--- a/src/main/java/umc/cockple/demo/domain/game/service/support/reader/GameReader.java
+++ b/src/main/java/umc/cockple/demo/domain/game/service/support/reader/GameReader.java
@@ -1,0 +1,24 @@
+package umc.cockple.demo.domain.game.service.support.reader;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import umc.cockple.demo.domain.game.domain.Game;
+import umc.cockple.demo.domain.game.enums.GameStatus;
+import umc.cockple.demo.domain.game.repository.GameRepository;
+
+import java.util.Collection;
+import java.util.List;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class GameReader {
+
+    private final GameRepository gameRepository;
+
+    public List<Game> readAllByGameBoardAndStatuses(
+            Long gameBoardId, Collection<GameStatus> statuses) {
+        return gameRepository.findByGameBoardIdAndStatusInWithPlayers(gameBoardId, statuses);
+    }
+}

--- a/src/main/java/umc/cockple/demo/domain/game/service/support/validator/GameBoardAccessValidator.java
+++ b/src/main/java/umc/cockple/demo/domain/game/service/support/validator/GameBoardAccessValidator.java
@@ -1,0 +1,28 @@
+package umc.cockple.demo.domain.game.service.support.validator;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import umc.cockple.demo.domain.exercise.domain.Exercise;
+import umc.cockple.demo.domain.exercise.repository.ExerciseRepository;
+import umc.cockple.demo.domain.game.exception.GameErrorCode;
+import umc.cockple.demo.domain.game.exception.GameException;
+
+import java.util.Objects;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class GameBoardAccessValidator {
+
+    private final ExerciseRepository exerciseRepository;
+
+    public void validateGameHost(Long gameBoardId, Long memberId) {
+        Exercise exercise = exerciseRepository.findByGameBoardId(gameBoardId)
+                .orElseThrow(() -> new GameException(GameErrorCode.GAME_BOARD_NOT_FOUND));
+
+        if (!Objects.equals(exercise.getGameHostId(), memberId)) {
+            throw new GameException(GameErrorCode.GAME_BOARD_ACCESS_DENIED);
+        }
+    }
+}

--- a/src/main/java/umc/cockple/demo/domain/game/service/support/validator/GameBoardAccessValidator.java
+++ b/src/main/java/umc/cockple/demo/domain/game/service/support/validator/GameBoardAccessValidator.java
@@ -7,6 +7,7 @@ import umc.cockple.demo.domain.exercise.domain.Exercise;
 import umc.cockple.demo.domain.exercise.repository.ExerciseRepository;
 import umc.cockple.demo.domain.game.exception.GameErrorCode;
 import umc.cockple.demo.domain.game.exception.GameException;
+import umc.cockple.demo.domain.game.repository.GameBoardMemberRepository;
 
 import java.util.Objects;
 
@@ -16,6 +17,7 @@ import java.util.Objects;
 public class GameBoardAccessValidator {
 
     private final ExerciseRepository exerciseRepository;
+    private final GameBoardMemberRepository gameBoardMemberRepository;
 
     public void validateGameHost(Long gameBoardId, Long memberId) {
         Exercise exercise = exerciseRepository.findByGameBoardId(gameBoardId)
@@ -23,6 +25,18 @@ public class GameBoardAccessValidator {
 
         if (!Objects.equals(exercise.getGameHostId(), memberId)) {
             throw new GameException(GameErrorCode.GAME_BOARD_ACCESS_DENIED);
+        }
+    }
+
+    public void validateViewer(Long gameBoardId, Long memberId) {
+        if (gameBoardMemberRepository.existsByGameBoardIdAndMemberId(gameBoardId, memberId)) {
+            return;
+        }
+
+        Exercise exercise = exerciseRepository.findByGameBoardId(gameBoardId)
+                .orElseThrow(() -> new GameException(GameErrorCode.GAME_BOARD_NOT_FOUND));
+        if (!Objects.equals(exercise.getGameHostId(), memberId)) {
+            throw new GameException(GameErrorCode.GAME_BOARD_VIEW_ACCESS_DENIED);
         }
     }
 }

--- a/src/main/java/umc/cockple/demo/domain/game/service/websocket/broadcast/GameBoardBroadcaster.java
+++ b/src/main/java/umc/cockple/demo/domain/game/service/websocket/broadcast/GameBoardBroadcaster.java
@@ -25,9 +25,29 @@ public class GameBoardBroadcaster {
     private final RealtimeMessagePublisher realtimeMessagePublisher;
 
     public void broadcastBoardUpdate(Long gameBoardId, Object boardData, String excludedSessionId) {
+        broadcastUpdate(
+                gameBoardId,
+                GameRealtimeProtocol.TYPE_BOARD_UPDATED,
+                boardData,
+                excludedSessionId);
+    }
+
+    public void broadcastMembersUpdate(Long gameBoardId, Object membersData, String excludedSessionId) {
+        broadcastUpdate(
+                gameBoardId,
+                GameRealtimeProtocol.TYPE_MEMBERS_UPDATED,
+                membersData,
+                excludedSessionId);
+    }
+
+    private void broadcastUpdate(
+            Long gameBoardId,
+            String type,
+            Object data,
+            String excludedSessionId) {
         Set<GameBoardSubscriber> subscribers = subscriptionStore.getSubscribers(gameBoardId);
         if (subscribers.isEmpty()) {
-            log.info("게임판 {} 구독자가 없어 브로드캐스트를 생략합니다.", gameBoardId);
+            log.info("게임판 {} 구독자가 없어 {} 브로드캐스트를 생략합니다.", gameBoardId, type);
             return;
         }
 
@@ -40,14 +60,14 @@ public class GameBoardBroadcaster {
                     subscriber.memberId(),
                     subscriber.sessionId(),
                     GameRealtimeProtocol.DOMAIN,
-                    GameRealtimeProtocol.TYPE_BOARD_UPDATED,
-                    boardData);
+                    type,
+                    data);
             if (result.deliveredToAnySession()) {
                 deliveredCount++;
             }
         }
 
-        log.info("게임판 브로드캐스트 완료 - gameBoardId: {}, 구독 세션: {}개, 전달: {}개",
-                gameBoardId, subscribers.size(), deliveredCount);
+        log.info("게임판 {} 브로드캐스트 완료 - gameBoardId: {}, 구독 세션: {}개, 전달: {}개",
+                type, gameBoardId, subscribers.size(), deliveredCount);
     }
 }

--- a/src/main/java/umc/cockple/demo/global/enums/Gender.java
+++ b/src/main/java/umc/cockple/demo/global/enums/Gender.java
@@ -1,5 +1,6 @@
 package umc.cockple.demo.global.enums;
 
+import lombok.Getter;
 import umc.cockple.demo.global.exception.GeneralException;
 import umc.cockple.demo.global.response.code.status.CommonErrorCode;
 
@@ -9,6 +10,7 @@ public enum Gender {
     MALE("남성"),
     FEMALE("여성");
 
+    @Getter
     private final String koreanName;
 
     Gender(String koreanName) {

--- a/src/test/java/umc/cockple/demo/domain/exercise/service/ExerciseGuestCommandServiceTest.java
+++ b/src/test/java/umc/cockple/demo/domain/exercise/service/ExerciseGuestCommandServiceTest.java
@@ -7,12 +7,14 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.test.util.ReflectionTestUtils;
 import umc.cockple.demo.domain.exercise.domain.Exercise;
 import umc.cockple.demo.domain.exercise.domain.Guest;
 import umc.cockple.demo.domain.exercise.exception.ExerciseErrorCode;
 import umc.cockple.demo.domain.exercise.exception.ExerciseException;
 import umc.cockple.demo.domain.game.domain.GameBoardMember;
+import umc.cockple.demo.domain.game.events.GameBoardMembersChangedEvent;
 import umc.cockple.demo.domain.game.repository.GamePlayerRepository;
 import umc.cockple.demo.domain.exercise.repository.GuestRepository;
 import umc.cockple.demo.domain.exercise.repository.MemberExerciseRepository;
@@ -58,6 +60,7 @@ class ExerciseGuestCommandServiceTest {
     @Mock private GuestReader guestReader;
     @Mock private MemberLookupService memberLookupService;
     @Mock private GamePlayerRepository gamePlayerRepository;
+    @Mock private ApplicationEventPublisher eventPublisher;
 
     private ExerciseGuestCommandService exerciseGuestCommandService;
 
@@ -74,6 +77,7 @@ class ExerciseGuestCommandServiceTest {
                 exerciseReader,
                 guestReader,
                 memberLookupService,
+                eventPublisher,
                 exerciseValidator,
                 new ExerciseGameAssignmentValidator(gamePlayerRepository));
 
@@ -129,6 +133,9 @@ class ExerciseGuestCommandServiceTest {
                         assertThat(gameBoardMember.getLevel()).isEqualTo(command.level());
                         assertThat(gameBoardMember.getAgeGroup()).isNull();
                     });
+            then(eventPublisher).should().publishEvent(
+                    GameBoardMembersChangedEvent.membersOnly(
+                            exercise.getGameBoard().getId(), command.inviterId()));
         }
 
         @Test
@@ -230,6 +237,9 @@ class ExerciseGuestCommandServiceTest {
             assertThat(result.currentParticipants()).isNotNull();
             then(guestRepository).should().delete(guest);
             assertThat(exercise.getGameBoard().getGameBoardMembers()).isEmpty();
+            then(eventPublisher).should().publishEvent(
+                    GameBoardMembersChangedEvent.membersOnly(
+                            exercise.getGameBoard().getId(), manager.getId()));
         }
 
         @Test

--- a/src/test/java/umc/cockple/demo/domain/exercise/service/ExerciseParticipationCommandServiceTest.java
+++ b/src/test/java/umc/cockple/demo/domain/exercise/service/ExerciseParticipationCommandServiceTest.java
@@ -34,6 +34,7 @@ import umc.cockple.demo.domain.exercise.domain.MemberExercise;
 import umc.cockple.demo.domain.member.exception.MemberErrorCode;
 import umc.cockple.demo.domain.member.exception.MemberException;
 import umc.cockple.demo.domain.exercise.repository.MemberExerciseRepository;
+import umc.cockple.demo.domain.game.events.GameBoardMembersChangedEvent;
 import umc.cockple.demo.domain.member.repository.MemberPartyRepository;
 import umc.cockple.demo.domain.member.service.query.lookup.MemberLookupService;
 import umc.cockple.demo.domain.member.service.query.lookup.MemberPartyLookupService;
@@ -56,6 +57,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.atLeastOnce;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("ExerciseParticipationCommandService")
@@ -158,6 +160,9 @@ class ExerciseParticipationCommandServiceTest {
                             assertThat(gameBoardMember.getGender()).isEqualTo(participant.getGender());
                             assertThat(gameBoardMember.getLevel()).isEqualTo(participant.getLevel());
                         });
+                then(eventPublisher).should().publishEvent(
+                        GameBoardMembersChangedEvent.membersOnly(
+                                exercise.getGameBoard().getId(), participant.getId()));
             }
 
             @Test
@@ -699,6 +704,9 @@ class ExerciseParticipationCommandServiceTest {
 
             // then: 게스트 취소는 참석 변경 알림 대상이 아니므로 이벤트 미발행
             then(eventPublisher).should(never()).publishEvent(any(ExerciseAttendanceChangedEvent.class));
+            then(eventPublisher).should().publishEvent(
+                    GameBoardMembersChangedEvent.membersOnly(
+                            exercise.getGameBoard().getId(), manager.getId()));
         }
 
         private void addPartyMember(Member member, Role role) {
@@ -708,10 +716,13 @@ class ExerciseParticipationCommandServiceTest {
         }
 
         private ExerciseAttendanceChangedEvent captureAttendanceEvent() {
-            ArgumentCaptor<ExerciseAttendanceChangedEvent> captor =
-                    ArgumentCaptor.forClass(ExerciseAttendanceChangedEvent.class);
-            then(eventPublisher).should().publishEvent(captor.capture());
-            return captor.getValue();
+            ArgumentCaptor<Object> captor = ArgumentCaptor.forClass(Object.class);
+            then(eventPublisher).should(atLeastOnce()).publishEvent(captor.capture());
+            return captor.getAllValues().stream()
+                    .filter(ExerciseAttendanceChangedEvent.class::isInstance)
+                    .map(ExerciseAttendanceChangedEvent.class::cast)
+                    .findFirst()
+                    .orElseThrow();
         }
     }
 

--- a/src/test/java/umc/cockple/demo/domain/game/domain/GameBoardMemberTest.java
+++ b/src/test/java/umc/cockple/demo/domain/game/domain/GameBoardMemberTest.java
@@ -65,6 +65,32 @@ class GameBoardMemberTest {
     }
 
     @Test
+    @DisplayName("명단 표시 정보를 수정하고 연령대를 제거할 수 있다")
+    void updateInfo_changesEditableSnapshotFields() {
+        GameBoardMember gameBoardMember = GameBoardMember.create(
+                "수정 전", Gender.MALE, Level.D, AgeGroup.THIRTIES);
+
+        gameBoardMember.updateInfo("수정 후", Gender.FEMALE, Level.B, null);
+
+        assertThat(gameBoardMember.getName()).isEqualTo("수정 후");
+        assertThat(gameBoardMember.getGender()).isEqualTo(Gender.FEMALE);
+        assertThat(gameBoardMember.getLevel()).isEqualTo(Level.B);
+        assertThat(gameBoardMember.getAgeGroup()).isNull();
+    }
+
+    @Test
+    @DisplayName("참여 상태를 변경하며 같은 값 요청은 멱등적으로 처리한다")
+    void changeParticipation_updatesIdempotently() {
+        GameBoardMember gameBoardMember = GameBoardMember.create(
+                "선수", Gender.MALE, Level.D, AgeGroup.TWENTIES);
+
+        gameBoardMember.changeParticipation(false);
+        gameBoardMember.changeParticipation(false);
+
+        assertThat(gameBoardMember.getParticipating()).isFalse();
+    }
+
+    @Test
     @DisplayName("회원과 게스트 원본을 동시에 연결할 수 없다")
     void validateSourceReference_rejectsMemberAndGuestTogether() {
         GameBoardMember gameBoardMember = GameBoardMember.builder()

--- a/src/test/java/umc/cockple/demo/domain/game/enums/AgeGroupTest.java
+++ b/src/test/java/umc/cockple/demo/domain/game/enums/AgeGroupTest.java
@@ -6,6 +6,7 @@ import umc.cockple.demo.domain.game.exception.GameErrorCode;
 import umc.cockple.demo.domain.game.exception.GameException;
 
 import java.time.LocalDate;
+import java.util.Arrays;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -52,7 +53,9 @@ class AgeGroupTest {
     @Test
     @DisplayName("한글 연령대 문자열을 enum으로 변환한다")
     void fromKorean_convertsKoreanName() {
-        assertThat(AgeGroup.fromKorean(" 30대 ")).isEqualTo(AgeGroup.THIRTIES);
+        assertThat(Arrays.stream(AgeGroup.values())
+                .map(ageGroup -> AgeGroup.fromKorean(" " + ageGroup.getKoreanName() + " ")))
+                .containsExactly(AgeGroup.values());
     }
 
     @Test

--- a/src/test/java/umc/cockple/demo/domain/game/exception/GameErrorCodeTest.java
+++ b/src/test/java/umc/cockple/demo/domain/game/exception/GameErrorCodeTest.java
@@ -1,0 +1,19 @@
+package umc.cockple.demo.domain.game.exception;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("GameErrorCode")
+class GameErrorCodeTest {
+
+    @Test
+    @DisplayName("게임 도메인 오류 코드는 서로 고유하다")
+    void errorCodes_areUnique() {
+        assertThat(Arrays.stream(GameErrorCode.values()).map(GameErrorCode::getCode))
+                .doesNotHaveDuplicates();
+    }
+}

--- a/src/test/java/umc/cockple/demo/domain/game/integration/GameBoardMemberCreateIntegrationTest.java
+++ b/src/test/java/umc/cockple/demo/domain/game/integration/GameBoardMemberCreateIntegrationTest.java
@@ -130,7 +130,8 @@ class GameBoardMemberCreateIntegrationTest extends IntegrationTestBase {
         List<String> invalidRequests = List.of(
                 "{\"name\":\"   \",\"gender\":\"남성\",\"level\":\"D조\"}",
                 "{\"name\":\"선수\",\"level\":\"D조\"}",
-                "{\"name\":\"선수\",\"gender\":\"남성\"}");
+                "{\"name\":\"선수\",\"gender\":\"남성\"}",
+                "{\"name\":\"" + "가".repeat(256) + "\",\"gender\":\"남성\",\"level\":\"D조\"}");
 
         for (String request : invalidRequests) {
             mockMvc.perform(post("/api/game-boards/{gameBoardId}/gameBoardMembers", exercise.getGameBoard().getId())

--- a/src/test/java/umc/cockple/demo/domain/game/integration/GameBoardMemberCreateIntegrationTest.java
+++ b/src/test/java/umc/cockple/demo/domain/game/integration/GameBoardMemberCreateIntegrationTest.java
@@ -1,0 +1,182 @@
+package umc.cockple.demo.domain.game.integration;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+import umc.cockple.demo.domain.exercise.domain.Exercise;
+import umc.cockple.demo.domain.exercise.repository.ExerciseRepository;
+import umc.cockple.demo.domain.game.domain.GameBoardMember;
+import umc.cockple.demo.domain.game.exception.GameErrorCode;
+import umc.cockple.demo.domain.game.repository.GameBoardMemberRepository;
+import umc.cockple.demo.domain.member.domain.Member;
+import umc.cockple.demo.domain.member.repository.MemberRepository;
+import umc.cockple.demo.domain.party.domain.Party;
+import umc.cockple.demo.domain.party.domain.PartyAddr;
+import umc.cockple.demo.domain.party.repository.PartyAddrRepository;
+import umc.cockple.demo.domain.party.repository.PartyRepository;
+import umc.cockple.demo.global.enums.Gender;
+import umc.cockple.demo.global.enums.Level;
+import umc.cockple.demo.support.IntegrationTestBase;
+import umc.cockple.demo.support.SecurityContextHelper;
+import umc.cockple.demo.support.fixture.ExerciseFixture;
+import umc.cockple.demo.support.fixture.MemberFixture;
+import umc.cockple.demo.support.fixture.PartyFixture;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@Transactional
+@DisplayName("게임판 명단 추가 통합 테스트")
+class GameBoardMemberCreateIntegrationTest extends IntegrationTestBase {
+
+    @Autowired private MockMvc mockMvc;
+    @Autowired private MemberRepository memberRepository;
+    @Autowired private PartyAddrRepository partyAddrRepository;
+    @Autowired private PartyRepository partyRepository;
+    @Autowired private ExerciseRepository exerciseRepository;
+    @Autowired private GameBoardMemberRepository gameBoardMemberRepository;
+
+    private Member gameHost;
+    private Member otherMember;
+    private Exercise exercise;
+
+    @BeforeEach
+    void setUp() {
+        gameHost = memberRepository.save(MemberFixture.createMemberWithName(
+                "게임 진행자", "진행자", Gender.FEMALE, Level.A, 72001L));
+        otherMember = memberRepository.save(MemberFixture.createMemberWithName(
+                "일반 회원", "일반", Gender.MALE, Level.B, 72002L));
+
+        PartyAddr partyAddr = partyAddrRepository.save(
+                PartyFixture.createPartyAddr("서울특별시", "강남구"));
+        Party party = partyRepository.save(
+                PartyFixture.createParty("명단 추가 테스트 모임", gameHost.getId(), partyAddr));
+        exercise = exerciseRepository.save(
+                ExerciseFixture.createExerciseWithAddr(party, LocalDate.of(2099, 12, 31)));
+    }
+
+    @AfterEach
+    void clearAuthentication() {
+        SecurityContextHelper.clearAuthentication();
+    }
+
+    @Test
+    @DisplayName("게임 진행자가 한글 입력으로 수동 명단을 생성한다")
+    void createMember_createsManualMemberWithDefaults() throws Exception {
+        authenticate(gameHost);
+        String request = """
+                {
+                  "name": "  김세익  ",
+                  "gender": "남성",
+                  "level": "D조",
+                  "ageGroup": "30대"
+                }
+                """;
+
+        mockMvc.perform(post("/api/game-boards/{gameBoardId}/gameBoardMembers", exercise.getGameBoard().getId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(request))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.gameBoardMemberId").isNumber());
+
+        List<GameBoardMember> members = gameBoardMemberRepository.findAll();
+        assertThat(members).singleElement().satisfies(member -> {
+            assertThat(member.getGameBoard().getId()).isEqualTo(exercise.getGameBoard().getId());
+            assertThat(member.getMember()).isNull();
+            assertThat(member.getGuest()).isNull();
+            assertThat(member.getName()).isEqualTo("김세익");
+            assertThat(member.getGender()).isEqualTo(Gender.MALE);
+            assertThat(member.getLevel()).isEqualTo(Level.D);
+            assertThat(member.getAgeGroup().getKoreanName()).isEqualTo("30대");
+            assertThat(member.getShuttlecockSubmitted()).isFalse();
+            assertThat(member.getParticipating()).isTrue();
+            assertThat(member.getGameCount()).isZero();
+        });
+    }
+
+    @Test
+    @DisplayName("ageGroup을 생략하면 연령대 없이 명단을 생성한다")
+    void createMember_allowsMissingAgeGroup() throws Exception {
+        authenticate(gameHost);
+        String request = """
+                {"name":"선수","gender":"여성","level":"A조"}
+                """;
+
+        mockMvc.perform(post("/api/game-boards/{gameBoardId}/gameBoardMembers", exercise.getGameBoard().getId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(request))
+                .andExpect(status().isOk());
+
+        assertThat(gameBoardMemberRepository.findAll())
+                .singleElement()
+                .extracting(GameBoardMember::getAgeGroup)
+                .isNull();
+    }
+
+    @Test
+    @DisplayName("필수 입력값이 없거나 공백이면 400을 반환한다")
+    void createMember_rejectsMissingRequiredFields() throws Exception {
+        authenticate(gameHost);
+        List<String> invalidRequests = List.of(
+                "{\"name\":\"   \",\"gender\":\"남성\",\"level\":\"D조\"}",
+                "{\"name\":\"선수\",\"level\":\"D조\"}",
+                "{\"name\":\"선수\",\"gender\":\"남성\"}");
+
+        for (String request : invalidRequests) {
+            mockMvc.perform(post("/api/game-boards/{gameBoardId}/gameBoardMembers", exercise.getGameBoard().getId())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(request))
+                    .andExpect(status().isBadRequest());
+        }
+        assertThat(gameBoardMemberRepository.count()).isZero();
+    }
+
+    @Test
+    @DisplayName("정의되지 않은 성별, 급수, 연령대는 400을 반환한다")
+    void createMember_rejectsInvalidKoreanValues() throws Exception {
+        authenticate(gameHost);
+        List<String> invalidRequests = List.of(
+                "{\"name\":\"선수\",\"gender\":\"기타\",\"level\":\"D조\"}",
+                "{\"name\":\"선수\",\"gender\":\"남성\",\"level\":\"프로\"}",
+                "{\"name\":\"선수\",\"gender\":\"남성\",\"level\":\"D조\",\"ageGroup\":\"80대\"}");
+
+        for (String request : invalidRequests) {
+            mockMvc.perform(post("/api/game-boards/{gameBoardId}/gameBoardMembers", exercise.getGameBoard().getId())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(request))
+                    .andExpect(status().isBadRequest());
+        }
+        assertThat(gameBoardMemberRepository.count()).isZero();
+    }
+
+    @Test
+    @DisplayName("게임 진행자가 아닌 사용자는 명단을 생성할 수 없다")
+    void createMember_deniesNonGameHost() throws Exception {
+        authenticate(otherMember);
+        String request = """
+                {"name":"선수","gender":"남성","level":"D조","ageGroup":"30대"}
+                """;
+
+        mockMvc.perform(post("/api/game-boards/{gameBoardId}/gameBoardMembers", exercise.getGameBoard().getId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(request))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code").value(GameErrorCode.GAME_BOARD_ACCESS_DENIED.getCode()));
+
+        assertThat(gameBoardMemberRepository.count()).isZero();
+    }
+
+    private void authenticate(Member member) {
+        SecurityContextHelper.setAuthentication(member.getId(), member.getNickname());
+    }
+}

--- a/src/test/java/umc/cockple/demo/domain/game/integration/GameBoardMemberParticipationIntegrationTest.java
+++ b/src/test/java/umc/cockple/demo/domain/game/integration/GameBoardMemberParticipationIntegrationTest.java
@@ -1,0 +1,230 @@
+package umc.cockple.demo.domain.game.integration;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+import umc.cockple.demo.domain.exercise.domain.Exercise;
+import umc.cockple.demo.domain.exercise.repository.ExerciseRepository;
+import umc.cockple.demo.domain.game.domain.Game;
+import umc.cockple.demo.domain.game.domain.GameBoardMember;
+import umc.cockple.demo.domain.game.domain.GamePlayer;
+import umc.cockple.demo.domain.game.enums.GameStatus;
+import umc.cockple.demo.domain.game.exception.GameErrorCode;
+import umc.cockple.demo.domain.game.repository.GameBoardMemberRepository;
+import umc.cockple.demo.domain.game.repository.GameRepository;
+import umc.cockple.demo.domain.member.domain.Member;
+import umc.cockple.demo.domain.member.repository.MemberRepository;
+import umc.cockple.demo.domain.party.domain.Party;
+import umc.cockple.demo.domain.party.domain.PartyAddr;
+import umc.cockple.demo.domain.party.repository.PartyAddrRepository;
+import umc.cockple.demo.domain.party.repository.PartyRepository;
+import umc.cockple.demo.global.enums.Gender;
+import umc.cockple.demo.global.enums.Level;
+import umc.cockple.demo.support.IntegrationTestBase;
+import umc.cockple.demo.support.SecurityContextHelper;
+import umc.cockple.demo.support.fixture.ExerciseFixture;
+import umc.cockple.demo.support.fixture.MemberFixture;
+import umc.cockple.demo.support.fixture.PartyFixture;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@Transactional
+@DisplayName("게임판 명단 참여 상태 변경 통합 테스트")
+class GameBoardMemberParticipationIntegrationTest extends IntegrationTestBase {
+
+    @Autowired private MockMvc mockMvc;
+    @Autowired private MemberRepository memberRepository;
+    @Autowired private PartyAddrRepository partyAddrRepository;
+    @Autowired private PartyRepository partyRepository;
+    @Autowired private ExerciseRepository exerciseRepository;
+    @Autowired private GameBoardMemberRepository gameBoardMemberRepository;
+    @Autowired private GameRepository gameRepository;
+
+    private Member gameHost;
+    private Member otherMember;
+    private Party party;
+    private Exercise exercise;
+    private GameBoardMember idleParticipatingMember;
+    private GameBoardMember idleInactiveMember;
+    private GameBoardMember waitingMember;
+    private GameBoardMember playingMember;
+    private GameBoardMember completedMember;
+
+    @BeforeEach
+    void setUp() {
+        gameHost = memberRepository.save(MemberFixture.createMemberWithName(
+                "게임 진행자", "진행자", Gender.FEMALE, Level.A, 74001L));
+        otherMember = memberRepository.save(MemberFixture.createMemberWithName(
+                "일반 회원", "일반", Gender.MALE, Level.B, 74002L));
+
+        PartyAddr partyAddr = partyAddrRepository.save(
+                PartyFixture.createPartyAddr("서울특별시", "강남구"));
+        party = partyRepository.save(
+                PartyFixture.createParty("참여 상태 테스트 모임", gameHost.getId(), partyAddr));
+        exercise = exerciseRepository.save(
+                ExerciseFixture.createExerciseWithAddr(party, LocalDate.of(2099, 12, 31)));
+
+        idleParticipatingMember = saveMember("참여 선수", true);
+        idleInactiveMember = saveMember("불참 선수", false);
+        waitingMember = saveMember("대기 선수", true);
+        playingMember = saveMember("진행 선수", true);
+        completedMember = saveMember("완료 선수", true);
+        saveGame(GameStatus.WAITING, waitingMember);
+        saveGame(GameStatus.PLAYING, playingMember);
+        saveGame(GameStatus.COMPLETED, completedMember);
+    }
+
+    @AfterEach
+    void clearAuthentication() {
+        SecurityContextHelper.clearAuthentication();
+    }
+
+    @Test
+    @DisplayName("활성 게임에 없는 선수는 참여와 불참 상태를 변경할 수 있다")
+    void changeParticipation_updatesBothDirections() throws Exception {
+        authenticate(gameHost);
+
+        changeParticipation(idleParticipatingMember, false)
+                .andExpect(status().isOk());
+        assertThat(idleParticipatingMember.getParticipating()).isFalse();
+
+        changeParticipation(idleParticipatingMember, true)
+                .andExpect(status().isOk());
+        assertThat(idleParticipatingMember.getParticipating()).isTrue();
+
+        changeParticipation(completedMember, false)
+                .andExpect(status().isOk());
+        assertThat(completedMember.getParticipating()).isFalse();
+    }
+
+    @Test
+    @DisplayName("현재 값과 같은 참여 상태 요청은 성공한다")
+    void changeParticipation_sameValueSucceeds() throws Exception {
+        authenticate(gameHost);
+
+        changeParticipation(idleInactiveMember, false)
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data").doesNotExist());
+
+        assertThat(idleInactiveMember.getParticipating()).isFalse();
+    }
+
+    @Test
+    @DisplayName("WAITING 게임 선수는 참여 해제할 수 없다")
+    void changeParticipation_rejectsWaitingMemberDeactivation() throws Exception {
+        authenticate(gameHost);
+
+        changeParticipation(waitingMember, false)
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code")
+                        .value(GameErrorCode.ACTIVE_GAME_MEMBER_CANNOT_BE_INACTIVE.getCode()));
+
+        assertThat(waitingMember.getParticipating()).isTrue();
+    }
+
+    @Test
+    @DisplayName("PLAYING 게임 선수는 참여 해제할 수 없다")
+    void changeParticipation_rejectsPlayingMemberDeactivation() throws Exception {
+        authenticate(gameHost);
+
+        changeParticipation(playingMember, false)
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code")
+                        .value(GameErrorCode.ACTIVE_GAME_MEMBER_CANNOT_BE_INACTIVE.getCode()));
+
+        assertThat(playingMember.getParticipating()).isTrue();
+    }
+
+    @Test
+    @DisplayName("다른 게임판 소속 명단의 참여 상태는 변경할 수 없다")
+    void changeParticipation_rejectsMemberFromOtherGameBoard() throws Exception {
+        Exercise otherExercise = exerciseRepository.save(
+                ExerciseFixture.createExerciseWithAddr(party, LocalDate.of(2099, 12, 30)));
+        GameBoardMember otherBoardMember = gameBoardMemberRepository.save(GameBoardMember.builder()
+                .gameBoard(otherExercise.getGameBoard())
+                .name("다른 선수")
+                .gender(Gender.MALE)
+                .level(Level.C)
+                .shuttlecockSubmitted(false)
+                .participating(true)
+                .gameCount(0)
+                .build());
+        authenticate(gameHost);
+
+        mockMvc.perform(patch("/api/game-boards/{gameBoardId}/gameBoardMembers/{gameBoardMemberId}/participation",
+                        exercise.getGameBoard().getId(), otherBoardMember.getId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"participating\":false}"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value(GameErrorCode.GAME_BOARD_MEMBER_NOT_FOUND.getCode()));
+    }
+
+    @Test
+    @DisplayName("게임 진행자가 아니면 참여 상태를 변경할 수 없다")
+    void changeParticipation_deniesNonGameHost() throws Exception {
+        authenticate(otherMember);
+
+        changeParticipation(idleParticipatingMember, false)
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code").value(GameErrorCode.GAME_BOARD_ACCESS_DENIED.getCode()));
+
+        assertThat(idleParticipatingMember.getParticipating()).isTrue();
+    }
+
+    @Test
+    @DisplayName("participating이 없으면 400을 반환한다")
+    void changeParticipation_requiresParticipatingValue() throws Exception {
+        authenticate(gameHost);
+
+        mockMvc.perform(patch("/api/game-boards/{gameBoardId}/gameBoardMembers/{gameBoardMemberId}/participation",
+                        exercise.getGameBoard().getId(), idleParticipatingMember.getId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    private ResultActions changeParticipation(
+            GameBoardMember member, boolean participating) throws Exception {
+        return mockMvc.perform(patch("/api/game-boards/{gameBoardId}/gameBoardMembers/{gameBoardMemberId}/participation",
+                        exercise.getGameBoard().getId(), member.getId())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"participating\":" + participating + "}"));
+    }
+
+    private GameBoardMember saveMember(String name, boolean participating) {
+        return gameBoardMemberRepository.save(GameBoardMember.builder()
+                .gameBoard(exercise.getGameBoard())
+                .name(name)
+                .gender(Gender.MALE)
+                .level(Level.D)
+                .shuttlecockSubmitted(false)
+                .participating(participating)
+                .gameCount(0)
+                .build());
+    }
+
+    private void saveGame(GameStatus status, GameBoardMember member) {
+        Game game = Game.builder()
+                .gameBoard(exercise.getGameBoard())
+                .status(status)
+                .waitingOrder(status == GameStatus.WAITING ? 1 : null)
+                .build();
+        game.addPlayer(GamePlayer.create(member, 0));
+        gameRepository.save(game);
+    }
+
+    private void authenticate(Member member) {
+        SecurityContextHelper.setAuthentication(member.getId(), member.getNickname());
+    }
+}

--- a/src/test/java/umc/cockple/demo/domain/game/integration/GameBoardMemberParticipationIntegrationTest.java
+++ b/src/test/java/umc/cockple/demo/domain/game/integration/GameBoardMemberParticipationIntegrationTest.java
@@ -16,8 +16,11 @@ import umc.cockple.demo.domain.game.domain.GameBoardMember;
 import umc.cockple.demo.domain.game.domain.GamePlayer;
 import umc.cockple.demo.domain.game.enums.GameStatus;
 import umc.cockple.demo.domain.game.exception.GameErrorCode;
+import umc.cockple.demo.domain.game.exception.GameException;
 import umc.cockple.demo.domain.game.repository.GameBoardMemberRepository;
 import umc.cockple.demo.domain.game.repository.GameRepository;
+import umc.cockple.demo.domain.game.service.command.GameCommandService;
+import umc.cockple.demo.domain.game.service.command.model.GameCreateCommand;
 import umc.cockple.demo.domain.member.domain.Member;
 import umc.cockple.demo.domain.member.repository.MemberRepository;
 import umc.cockple.demo.domain.party.domain.Party;
@@ -33,8 +36,10 @@ import umc.cockple.demo.support.fixture.MemberFixture;
 import umc.cockple.demo.support.fixture.PartyFixture;
 
 import java.time.LocalDate;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -50,6 +55,7 @@ class GameBoardMemberParticipationIntegrationTest extends IntegrationTestBase {
     @Autowired private ExerciseRepository exerciseRepository;
     @Autowired private GameBoardMemberRepository gameBoardMemberRepository;
     @Autowired private GameRepository gameRepository;
+    @Autowired private GameCommandService gameCommandService;
 
     private Member gameHost;
     private Member otherMember;
@@ -118,6 +124,17 @@ class GameBoardMemberParticipationIntegrationTest extends IntegrationTestBase {
                 .andExpect(jsonPath("$.data").doesNotExist());
 
         assertThat(idleInactiveMember.getParticipating()).isFalse();
+    }
+
+    @Test
+    @DisplayName("불참 상태의 선수는 새 대기 게임에 추가할 수 없다")
+    void createGame_rejectsInactiveMember() {
+        assertThatThrownBy(() -> gameCommandService.createGame(
+                gameHost.getId(),
+                new GameCreateCommand(
+                        exercise.getGameBoard().getId(), List.of(idleInactiveMember.getId()))))
+                .isInstanceOfSatisfying(GameException.class, exception ->
+                        assertThat(exception.getCode()).isEqualTo(GameErrorCode.INACTIVE_GAME_PLAYER));
     }
 
     @Test

--- a/src/test/java/umc/cockple/demo/domain/game/integration/GameBoardMemberQueryIntegrationTest.java
+++ b/src/test/java/umc/cockple/demo/domain/game/integration/GameBoardMemberQueryIntegrationTest.java
@@ -101,7 +101,7 @@ class GameBoardMemberQueryIntegrationTest extends IntegrationTestBase {
                 .andExpect(jsonPath("$.data.gameBoardMembers[0].ageGroup").value("20대"))
                 .andExpect(jsonPath("$.data.gameBoardMembers[2].ageGroup").value(nullValue()))
                 .andExpect(jsonPath("$.data.gameBoardMembers[0].level").value("A조"))
-                .andExpect(jsonPath("$.data.gameBoardMembers[0].gender").doesNotExist());
+                .andExpect(jsonPath("$.data.gameBoardMembers[0].gender").value("여성"));
     }
 
     @Test

--- a/src/test/java/umc/cockple/demo/domain/game/integration/GameBoardMemberQueryIntegrationTest.java
+++ b/src/test/java/umc/cockple/demo/domain/game/integration/GameBoardMemberQueryIntegrationTest.java
@@ -1,0 +1,202 @@
+package umc.cockple.demo.domain.game.integration;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+import umc.cockple.demo.domain.game.domain.Game;
+import umc.cockple.demo.domain.game.domain.GameBoard;
+import umc.cockple.demo.domain.game.domain.GameBoardMember;
+import umc.cockple.demo.domain.game.domain.GamePlayer;
+import umc.cockple.demo.domain.game.enums.AgeGroup;
+import umc.cockple.demo.domain.game.enums.GameStatus;
+import umc.cockple.demo.domain.game.repository.GameBoardMemberRepository;
+import umc.cockple.demo.domain.game.repository.GameBoardRepository;
+import umc.cockple.demo.domain.game.repository.GameRepository;
+import umc.cockple.demo.domain.member.domain.Member;
+import umc.cockple.demo.domain.member.domain.ProfileImg;
+import umc.cockple.demo.domain.member.repository.MemberRepository;
+import umc.cockple.demo.global.enums.Gender;
+import umc.cockple.demo.global.enums.Level;
+import umc.cockple.demo.support.IntegrationTestBase;
+import umc.cockple.demo.support.SecurityContextHelper;
+import umc.cockple.demo.support.fixture.MemberFixture;
+
+import java.time.LocalDateTime;
+
+import static org.hamcrest.Matchers.nullValue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@Transactional
+@DisplayName("게임판 명단 조회 통합 테스트")
+class GameBoardMemberQueryIntegrationTest extends IntegrationTestBase {
+
+    @Autowired private MockMvc mockMvc;
+    @Autowired private GameBoardRepository gameBoardRepository;
+    @Autowired private GameBoardMemberRepository gameBoardMemberRepository;
+    @Autowired private GameRepository gameRepository;
+    @Autowired private MemberRepository memberRepository;
+
+    private GameBoard gameBoard;
+    private GameBoardMember playingMember;
+    private GameBoardMember waitingMember;
+    private GameBoardMember completedMember;
+    private GameBoardMember idleMember;
+
+    @BeforeEach
+    void setUp() {
+        gameBoard = gameBoardRepository.save(GameBoard.create());
+
+        Member profileMember = MemberFixture.createMemberWithName(
+                "프로필 선수", "프로필 닉네임", Gender.FEMALE, Level.A, 71001L);
+        profileMember.updateProfileImg(ProfileImg.builder().imgKey("profiles/game-player.jpg").build());
+        profileMember = memberRepository.save(profileMember);
+
+        playingMember = saveMember(profileMember, "가 선수", Gender.FEMALE, Level.A,
+                AgeGroup.TWENTIES, true, true, 3);
+        waitingMember = saveMember(null, "나 선수", Gender.MALE, Level.B,
+                AgeGroup.THIRTIES, false, true, 1);
+        completedMember = saveMember(null, "다 선수", Gender.MALE, Level.A,
+                null, true, false, 2);
+        idleMember = saveMember(null, "라 선수", Gender.FEMALE, Level.C,
+                AgeGroup.FORTIES, false, true, 0);
+
+        saveGame(GameStatus.PLAYING, playingMember);
+        saveGame(GameStatus.WAITING, waitingMember);
+        saveGame(GameStatus.COMPLETED, completedMember);
+    }
+
+    @AfterEach
+    void clearAuthentication() {
+        SecurityContextHelper.clearAuthentication();
+    }
+
+    @Test
+    @DisplayName("필터 없이 전체 명단을 ID 오름차순과 게임 상태, 프로필 정보로 조회한다")
+    void getMembers_returnsAllMembersInIdOrder() throws Exception {
+        authenticate();
+
+        mockMvc.perform(get("/api/game-boards/{gameBoardId}/gameBoardMembers", gameBoard.getId()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.totalCount").value(4))
+                .andExpect(jsonPath("$.data.gameBoardMembers.length()").value(4))
+                .andExpect(jsonPath("$.data.gameBoardMembers[0].gameBoardMemberId").value(playingMember.getId()))
+                .andExpect(jsonPath("$.data.gameBoardMembers[1].gameBoardMemberId").value(waitingMember.getId()))
+                .andExpect(jsonPath("$.data.gameBoardMembers[2].gameBoardMemberId").value(completedMember.getId()))
+                .andExpect(jsonPath("$.data.gameBoardMembers[3].gameBoardMemberId").value(idleMember.getId()))
+                .andExpect(jsonPath("$.data.gameBoardMembers[0].inGame").value(true))
+                .andExpect(jsonPath("$.data.gameBoardMembers[0].waiting").value(false))
+                .andExpect(jsonPath("$.data.gameBoardMembers[1].inGame").value(false))
+                .andExpect(jsonPath("$.data.gameBoardMembers[1].waiting").value(true))
+                .andExpect(jsonPath("$.data.gameBoardMembers[2].inGame").value(false))
+                .andExpect(jsonPath("$.data.gameBoardMembers[2].waiting").value(false))
+                .andExpect(jsonPath("$.data.gameBoardMembers[0].profileImageUrl")
+                        .value("https://storage.googleapis.com/test-bucket/profiles/game-player.jpg"))
+                .andExpect(jsonPath("$.data.gameBoardMembers[1].profileImageUrl").value(nullValue()))
+                .andExpect(jsonPath("$.data.gameBoardMembers[0].ageGroup").value("20대"))
+                .andExpect(jsonPath("$.data.gameBoardMembers[2].ageGroup").value(nullValue()))
+                .andExpect(jsonPath("$.data.gameBoardMembers[0].level").value("A조"))
+                .andExpect(jsonPath("$.data.gameBoardMembers[0].gender").doesNotExist());
+    }
+
+    @Test
+    @DisplayName("단일 급수 필터를 적용해도 totalCount는 전체 명단 수를 반환한다")
+    void getMembers_filtersSingleLevelWithoutChangingTotalCount() throws Exception {
+        authenticate();
+
+        mockMvc.perform(get("/api/game-boards/{gameBoardId}/gameBoardMembers", gameBoard.getId())
+                        .param("level", "B조"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.totalCount").value(4))
+                .andExpect(jsonPath("$.data.gameBoardMembers.length()").value(1))
+                .andExpect(jsonPath("$.data.gameBoardMembers[0].gameBoardMemberId").value(waitingMember.getId()));
+    }
+
+    @Test
+    @DisplayName("복수 급수 필터는 OR 조건으로 적용한다")
+    void getMembers_filtersMultipleLevelsWithOrCondition() throws Exception {
+        authenticate();
+
+        mockMvc.perform(get("/api/game-boards/{gameBoardId}/gameBoardMembers", gameBoard.getId())
+                        .param("level", "A조", "B조"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.gameBoardMembers.length()").value(3))
+                .andExpect(jsonPath("$.data.gameBoardMembers[0].gameBoardMemberId").value(playingMember.getId()))
+                .andExpect(jsonPath("$.data.gameBoardMembers[1].gameBoardMemberId").value(waitingMember.getId()))
+                .andExpect(jsonPath("$.data.gameBoardMembers[2].gameBoardMemberId").value(completedMember.getId()));
+    }
+
+    @Test
+    @DisplayName("급수, 성별, 셔틀콕 필터는 AND 조건으로 적용한다")
+    void getMembers_combinesDifferentFiltersWithAndCondition() throws Exception {
+        authenticate();
+
+        mockMvc.perform(get("/api/game-boards/{gameBoardId}/gameBoardMembers", gameBoard.getId())
+                        .param("level", "A조")
+                        .param("gender", "남성")
+                        .param("shuttlecockSubmitted", "true"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.totalCount").value(4))
+                .andExpect(jsonPath("$.data.gameBoardMembers.length()").value(1))
+                .andExpect(jsonPath("$.data.gameBoardMembers[0].gameBoardMemberId").value(completedMember.getId()));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 게임판은 404를 반환한다")
+    void getMembers_returnsNotFoundForMissingGameBoard() throws Exception {
+        authenticate();
+
+        mockMvc.perform(get("/api/game-boards/{gameBoardId}/gameBoardMembers", 999999L))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("미인증 사용자는 명단을 조회할 수 없다")
+    void getMembers_requiresAuthentication() throws Exception {
+        mockMvc.perform(get("/api/game-boards/{gameBoardId}/gameBoardMembers", gameBoard.getId()))
+                .andExpect(status().isUnauthorized());
+    }
+
+    private GameBoardMember saveMember(
+            Member member,
+            String name,
+            Gender gender,
+            Level level,
+            AgeGroup ageGroup,
+            boolean shuttlecockSubmitted,
+            boolean participating,
+            int gameCount) {
+        return gameBoardMemberRepository.save(GameBoardMember.builder()
+                .gameBoard(gameBoard)
+                .member(member)
+                .name(name)
+                .gender(gender)
+                .level(level)
+                .ageGroup(ageGroup)
+                .shuttlecockSubmitted(shuttlecockSubmitted)
+                .participating(participating)
+                .gameCount(gameCount)
+                .build());
+    }
+
+    private void saveGame(GameStatus status, GameBoardMember member) {
+        Game game = Game.builder()
+                .gameBoard(gameBoard)
+                .status(status)
+                .waitingOrder(status == GameStatus.WAITING ? 1 : null)
+                .startedAt(status == GameStatus.PLAYING ? LocalDateTime.now() : null)
+                .completedAt(status == GameStatus.COMPLETED ? LocalDateTime.now() : null)
+                .build();
+        game.addPlayer(GamePlayer.create(member, 0));
+        gameRepository.save(game);
+    }
+
+    private void authenticate() {
+        SecurityContextHelper.setAuthentication(999L, "명단 조회자");
+    }
+}

--- a/src/test/java/umc/cockple/demo/domain/game/integration/GameBoardMemberQueryIntegrationTest.java
+++ b/src/test/java/umc/cockple/demo/domain/game/integration/GameBoardMemberQueryIntegrationTest.java
@@ -7,24 +7,33 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
+import umc.cockple.demo.domain.exercise.domain.Exercise;
+import umc.cockple.demo.domain.exercise.repository.ExerciseRepository;
 import umc.cockple.demo.domain.game.domain.Game;
 import umc.cockple.demo.domain.game.domain.GameBoard;
 import umc.cockple.demo.domain.game.domain.GameBoardMember;
 import umc.cockple.demo.domain.game.domain.GamePlayer;
 import umc.cockple.demo.domain.game.enums.AgeGroup;
 import umc.cockple.demo.domain.game.enums.GameStatus;
+import umc.cockple.demo.domain.game.exception.GameErrorCode;
 import umc.cockple.demo.domain.game.repository.GameBoardMemberRepository;
-import umc.cockple.demo.domain.game.repository.GameBoardRepository;
 import umc.cockple.demo.domain.game.repository.GameRepository;
 import umc.cockple.demo.domain.member.domain.Member;
 import umc.cockple.demo.domain.member.domain.ProfileImg;
 import umc.cockple.demo.domain.member.repository.MemberRepository;
+import umc.cockple.demo.domain.party.domain.Party;
+import umc.cockple.demo.domain.party.domain.PartyAddr;
+import umc.cockple.demo.domain.party.repository.PartyAddrRepository;
+import umc.cockple.demo.domain.party.repository.PartyRepository;
 import umc.cockple.demo.global.enums.Gender;
 import umc.cockple.demo.global.enums.Level;
 import umc.cockple.demo.support.IntegrationTestBase;
 import umc.cockple.demo.support.SecurityContextHelper;
+import umc.cockple.demo.support.fixture.ExerciseFixture;
 import umc.cockple.demo.support.fixture.MemberFixture;
+import umc.cockple.demo.support.fixture.PartyFixture;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 import static org.hamcrest.Matchers.nullValue;
@@ -37,12 +46,17 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 class GameBoardMemberQueryIntegrationTest extends IntegrationTestBase {
 
     @Autowired private MockMvc mockMvc;
-    @Autowired private GameBoardRepository gameBoardRepository;
     @Autowired private GameBoardMemberRepository gameBoardMemberRepository;
     @Autowired private GameRepository gameRepository;
     @Autowired private MemberRepository memberRepository;
+    @Autowired private PartyAddrRepository partyAddrRepository;
+    @Autowired private PartyRepository partyRepository;
+    @Autowired private ExerciseRepository exerciseRepository;
 
     private GameBoard gameBoard;
+    private Member participant;
+    private Member gameHost;
+    private Member nonParticipant;
     private GameBoardMember playingMember;
     private GameBoardMember waitingMember;
     private GameBoardMember completedMember;
@@ -50,14 +64,24 @@ class GameBoardMemberQueryIntegrationTest extends IntegrationTestBase {
 
     @BeforeEach
     void setUp() {
-        gameBoard = gameBoardRepository.save(GameBoard.create());
-
-        Member profileMember = MemberFixture.createMemberWithName(
+        participant = MemberFixture.createMemberWithName(
                 "프로필 선수", "프로필 닉네임", Gender.FEMALE, Level.A, 71001L);
-        profileMember.updateProfileImg(ProfileImg.builder().imgKey("profiles/game-player.jpg").build());
-        profileMember = memberRepository.save(profileMember);
+        participant.updateProfileImg(ProfileImg.builder().imgKey("profiles/game-player.jpg").build());
+        participant = memberRepository.save(participant);
+        gameHost = memberRepository.save(MemberFixture.createMemberWithName(
+                "게임 진행자", "진행자 닉네임", Gender.FEMALE, Level.A, 71003L));
+        nonParticipant = memberRepository.save(MemberFixture.createMemberWithName(
+                "비참가 회원", "비참가 닉네임", Gender.MALE, Level.B, 71002L));
 
-        playingMember = saveMember(profileMember, "가 선수", Gender.FEMALE, Level.A,
+        PartyAddr partyAddr = partyAddrRepository.save(
+                PartyFixture.createPartyAddr("서울특별시", "명단조회구"));
+        Party party = partyRepository.save(
+                PartyFixture.createParty("명단 조회 테스트 모임", gameHost.getId(), partyAddr));
+        Exercise exercise = exerciseRepository.save(
+                ExerciseFixture.createExerciseWithAddr(party, LocalDate.of(2099, 12, 31)));
+        gameBoard = exercise.getGameBoard();
+
+        playingMember = saveMember(participant, "가 선수", Gender.FEMALE, Level.A,
                 AgeGroup.TWENTIES, true, true, 3);
         waitingMember = saveMember(null, "나 선수", Gender.MALE, Level.B,
                 AgeGroup.THIRTIES, false, true, 1);
@@ -156,6 +180,26 @@ class GameBoardMemberQueryIntegrationTest extends IntegrationTestBase {
     }
 
     @Test
+    @DisplayName("운동에 참여하지 않은 게임 진행자도 명단을 조회할 수 있다")
+    void getMembers_allowsGameHost() throws Exception {
+        SecurityContextHelper.setAuthentication(gameHost.getId(), gameHost.getMemberName());
+
+        mockMvc.perform(get("/api/game-boards/{gameBoardId}/gameBoardMembers", gameBoard.getId()))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("운동 참가자와 게임 진행자가 아닌 회원은 명단을 조회할 수 없다")
+    void getMembers_forbidsUnauthorizedMember() throws Exception {
+        SecurityContextHelper.setAuthentication(nonParticipant.getId(), nonParticipant.getMemberName());
+
+        mockMvc.perform(get("/api/game-boards/{gameBoardId}/gameBoardMembers", gameBoard.getId()))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code")
+                        .value(GameErrorCode.GAME_BOARD_VIEW_ACCESS_DENIED.getCode()));
+    }
+
+    @Test
     @DisplayName("미인증 사용자는 명단을 조회할 수 없다")
     void getMembers_requiresAuthentication() throws Exception {
         mockMvc.perform(get("/api/game-boards/{gameBoardId}/gameBoardMembers", gameBoard.getId()))
@@ -197,6 +241,6 @@ class GameBoardMemberQueryIntegrationTest extends IntegrationTestBase {
     }
 
     private void authenticate() {
-        SecurityContextHelper.setAuthentication(999L, "명단 조회자");
+        SecurityContextHelper.setAuthentication(participant.getId(), participant.getMemberName());
     }
 }

--- a/src/test/java/umc/cockple/demo/domain/game/integration/GameBoardMemberUpdateIntegrationTest.java
+++ b/src/test/java/umc/cockple/demo/domain/game/integration/GameBoardMemberUpdateIntegrationTest.java
@@ -1,0 +1,187 @@
+package umc.cockple.demo.domain.game.integration;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+import umc.cockple.demo.domain.exercise.domain.Exercise;
+import umc.cockple.demo.domain.exercise.repository.ExerciseRepository;
+import umc.cockple.demo.domain.game.domain.Game;
+import umc.cockple.demo.domain.game.domain.GameBoardMember;
+import umc.cockple.demo.domain.game.domain.GamePlayer;
+import umc.cockple.demo.domain.game.enums.AgeGroup;
+import umc.cockple.demo.domain.game.enums.GameStatus;
+import umc.cockple.demo.domain.game.exception.GameErrorCode;
+import umc.cockple.demo.domain.game.repository.GameBoardMemberRepository;
+import umc.cockple.demo.domain.game.repository.GameRepository;
+import umc.cockple.demo.domain.member.domain.Member;
+import umc.cockple.demo.domain.member.repository.MemberRepository;
+import umc.cockple.demo.domain.party.domain.Party;
+import umc.cockple.demo.domain.party.domain.PartyAddr;
+import umc.cockple.demo.domain.party.repository.PartyAddrRepository;
+import umc.cockple.demo.domain.party.repository.PartyRepository;
+import umc.cockple.demo.global.enums.Gender;
+import umc.cockple.demo.global.enums.Level;
+import umc.cockple.demo.support.IntegrationTestBase;
+import umc.cockple.demo.support.SecurityContextHelper;
+import umc.cockple.demo.support.fixture.ExerciseFixture;
+import umc.cockple.demo.support.fixture.MemberFixture;
+import umc.cockple.demo.support.fixture.PartyFixture;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@Transactional
+@DisplayName("게임판 명단 정보 수정 통합 테스트")
+class GameBoardMemberUpdateIntegrationTest extends IntegrationTestBase {
+
+    @Autowired private MockMvc mockMvc;
+    @Autowired private MemberRepository memberRepository;
+    @Autowired private PartyAddrRepository partyAddrRepository;
+    @Autowired private PartyRepository partyRepository;
+    @Autowired private ExerciseRepository exerciseRepository;
+    @Autowired private GameBoardMemberRepository gameBoardMemberRepository;
+    @Autowired private GameRepository gameRepository;
+
+    private Member gameHost;
+    private Member otherMember;
+    private Party party;
+    private Exercise exercise;
+    private GameBoardMember gameBoardMember;
+
+    @BeforeEach
+    void setUp() {
+        gameHost = memberRepository.save(MemberFixture.createMemberWithName(
+                "게임 진행자", "진행자", Gender.FEMALE, Level.A, 73001L));
+        otherMember = memberRepository.save(MemberFixture.createMemberWithName(
+                "일반 회원", "일반", Gender.MALE, Level.B, 73002L));
+
+        PartyAddr partyAddr = partyAddrRepository.save(
+                PartyFixture.createPartyAddr("서울특별시", "강남구"));
+        party = partyRepository.save(
+                PartyFixture.createParty("명단 수정 테스트 모임", gameHost.getId(), partyAddr));
+        exercise = exerciseRepository.save(
+                ExerciseFixture.createExerciseWithAddr(party, LocalDate.of(2099, 12, 31)));
+
+        gameBoardMember = gameBoardMemberRepository.save(GameBoardMember.builder()
+                .gameBoard(exercise.getGameBoard())
+                .name("수정 전")
+                .gender(Gender.MALE)
+                .level(Level.D)
+                .ageGroup(AgeGroup.THIRTIES)
+                .shuttlecockSubmitted(false)
+                .participating(true)
+                .gameCount(0)
+                .build());
+
+        Game waitingGame = Game.builder()
+                .gameBoard(exercise.getGameBoard())
+                .status(GameStatus.WAITING)
+                .waitingOrder(1)
+                .build();
+        waitingGame.addPlayer(GamePlayer.create(gameBoardMember, 0));
+        gameRepository.save(waitingGame);
+    }
+
+    @AfterEach
+    void clearAuthentication() {
+        SecurityContextHelper.clearAuthentication();
+    }
+
+    @Test
+    @DisplayName("대기 게임 선수도 정보를 수정하고 보드 조회에 즉시 반영한다")
+    void updateMember_updatesActivePlayerAndBoardView() throws Exception {
+        authenticate(gameHost);
+        String request = """
+                {"name":"  수정 후  ","gender":"여성","level":"A조"}
+                """;
+
+        mockMvc.perform(patch("/api/game-boards/{gameBoardId}/gameBoardMembers/{gameBoardMemberId}",
+                        exercise.getGameBoard().getId(), gameBoardMember.getId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(request))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data").doesNotExist());
+
+        GameBoardMember updated = gameBoardMemberRepository.findById(gameBoardMember.getId()).orElseThrow();
+        assertThat(updated.getName()).isEqualTo("수정 후");
+        assertThat(updated.getGender()).isEqualTo(Gender.FEMALE);
+        assertThat(updated.getLevel()).isEqualTo(Level.A);
+        assertThat(updated.getAgeGroup()).isNull();
+
+        mockMvc.perform(get("/api/game-boards/{gameBoardId}", exercise.getGameBoard().getId()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.waitings[0].players[0].name").value("수정 후"))
+                .andExpect(jsonPath("$.data.waitings[0].players[0].level").value("A조"));
+    }
+
+    @Test
+    @DisplayName("다른 게임판 소속 명단은 수정할 수 없다")
+    void updateMember_rejectsMemberFromOtherGameBoard() throws Exception {
+        Exercise otherExercise = exerciseRepository.save(
+                ExerciseFixture.createExerciseWithAddr(party, LocalDate.of(2099, 12, 30)));
+        GameBoardMember otherBoardMember = gameBoardMemberRepository.save(GameBoardMember.builder()
+                .gameBoard(otherExercise.getGameBoard())
+                .name("다른 선수")
+                .gender(Gender.MALE)
+                .level(Level.C)
+                .shuttlecockSubmitted(false)
+                .participating(true)
+                .gameCount(0)
+                .build());
+        authenticate(gameHost);
+
+        mockMvc.perform(patch("/api/game-boards/{gameBoardId}/gameBoardMembers/{gameBoardMemberId}",
+                        exercise.getGameBoard().getId(), otherBoardMember.getId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(validRequest()))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value(GameErrorCode.GAME_BOARD_MEMBER_NOT_FOUND.getCode()));
+    }
+
+    @Test
+    @DisplayName("게임 진행자가 아니면 명단 정보를 수정할 수 없다")
+    void updateMember_deniesNonGameHost() throws Exception {
+        authenticate(otherMember);
+
+        mockMvc.perform(patch("/api/game-boards/{gameBoardId}/gameBoardMembers/{gameBoardMemberId}",
+                        exercise.getGameBoard().getId(), gameBoardMember.getId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(validRequest()))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code").value(GameErrorCode.GAME_BOARD_ACCESS_DENIED.getCode()));
+
+        assertThat(gameBoardMember.getName()).isEqualTo("수정 전");
+    }
+
+    @Test
+    @DisplayName("필수값이 비어 있거나 정의되지 않은 한글값이면 400을 반환한다")
+    void updateMember_rejectsInvalidInput() throws Exception {
+        authenticate(gameHost);
+
+        mockMvc.perform(patch("/api/game-boards/{gameBoardId}/gameBoardMembers/{gameBoardMemberId}",
+                        exercise.getGameBoard().getId(), gameBoardMember.getId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"name\":\"   \",\"gender\":\"기타\",\"level\":\"프로\"}"))
+                .andExpect(status().isBadRequest());
+
+        assertThat(gameBoardMember.getName()).isEqualTo("수정 전");
+    }
+
+    private String validRequest() {
+        return "{\"name\":\"수정 후\",\"gender\":\"여성\",\"level\":\"A조\",\"ageGroup\":\"20대\"}";
+    }
+
+    private void authenticate(Member member) {
+        SecurityContextHelper.setAuthentication(member.getId(), member.getNickname());
+    }
+}

--- a/src/test/java/umc/cockple/demo/domain/game/integration/GameBoardMemberUpdateIntegrationTest.java
+++ b/src/test/java/umc/cockple/demo/domain/game/integration/GameBoardMemberUpdateIntegrationTest.java
@@ -33,6 +33,7 @@ import umc.cockple.demo.support.fixture.MemberFixture;
 import umc.cockple.demo.support.fixture.PartyFixture;
 
 import java.time.LocalDate;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -168,11 +169,17 @@ class GameBoardMemberUpdateIntegrationTest extends IntegrationTestBase {
     void updateMember_rejectsInvalidInput() throws Exception {
         authenticate(gameHost);
 
-        mockMvc.perform(patch("/api/game-boards/{gameBoardId}/gameBoardMembers/{gameBoardMemberId}",
-                        exercise.getGameBoard().getId(), gameBoardMember.getId())
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"name\":\"   \",\"gender\":\"기타\",\"level\":\"프로\"}"))
-                .andExpect(status().isBadRequest());
+        List<String> invalidRequests = List.of(
+                "{\"name\":\"   \",\"gender\":\"기타\",\"level\":\"프로\"}",
+                "{\"name\":\"" + "가".repeat(256) + "\",\"gender\":\"여성\",\"level\":\"A조\"}");
+
+        for (String request : invalidRequests) {
+            mockMvc.perform(patch("/api/game-boards/{gameBoardId}/gameBoardMembers/{gameBoardMemberId}",
+                            exercise.getGameBoard().getId(), gameBoardMember.getId())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(request))
+                    .andExpect(status().isBadRequest());
+        }
 
         assertThat(gameBoardMember.getName()).isEqualTo("수정 전");
     }

--- a/src/test/java/umc/cockple/demo/domain/game/integration/GameParticipationAssignmentConcurrencyIntegrationTest.java
+++ b/src/test/java/umc/cockple/demo/domain/game/integration/GameParticipationAssignmentConcurrencyIntegrationTest.java
@@ -1,0 +1,219 @@
+package umc.cockple.demo.domain.game.integration;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+import umc.cockple.demo.domain.exercise.domain.Exercise;
+import umc.cockple.demo.domain.exercise.repository.ExerciseRepository;
+import umc.cockple.demo.domain.game.domain.Game;
+import umc.cockple.demo.domain.game.domain.GameBoard;
+import umc.cockple.demo.domain.game.domain.GameBoardMember;
+import umc.cockple.demo.domain.game.domain.GamePlayer;
+import umc.cockple.demo.domain.game.enums.GameStatus;
+import umc.cockple.demo.domain.game.exception.GameErrorCode;
+import umc.cockple.demo.domain.game.exception.GameException;
+import umc.cockple.demo.domain.game.repository.GameBoardMemberRepository;
+import umc.cockple.demo.domain.game.repository.GameBoardRepository;
+import umc.cockple.demo.domain.game.repository.GameRepository;
+import umc.cockple.demo.domain.game.service.command.GameBoardMemberCommandService;
+import umc.cockple.demo.domain.game.service.command.GameCommandService;
+import umc.cockple.demo.domain.game.service.command.model.GameBoardMemberParticipationCommand;
+import umc.cockple.demo.domain.game.service.command.model.GameCreateCommand;
+import umc.cockple.demo.domain.member.domain.Member;
+import umc.cockple.demo.domain.member.repository.MemberRepository;
+import umc.cockple.demo.domain.party.domain.Party;
+import umc.cockple.demo.domain.party.domain.PartyAddr;
+import umc.cockple.demo.domain.party.repository.PartyAddrRepository;
+import umc.cockple.demo.domain.party.repository.PartyRepository;
+import umc.cockple.demo.global.enums.Gender;
+import umc.cockple.demo.global.enums.Level;
+import umc.cockple.demo.support.IntegrationTestBase;
+import umc.cockple.demo.support.fixture.ExerciseFixture;
+import umc.cockple.demo.support.fixture.MemberFixture;
+import umc.cockple.demo.support.fixture.PartyFixture;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("게임판 참여 상태-게임 배정 동시성 통합 테스트")
+class GameParticipationAssignmentConcurrencyIntegrationTest extends IntegrationTestBase {
+
+    @Autowired private PlatformTransactionManager transactionManager;
+    @Autowired private GameBoardRepository gameBoardRepository;
+    @Autowired private GameBoardMemberRepository gameBoardMemberRepository;
+    @Autowired private GameRepository gameRepository;
+    @Autowired private GameCommandService gameCommandService;
+    @Autowired private GameBoardMemberCommandService gameBoardMemberCommandService;
+    @Autowired private ExerciseRepository exerciseRepository;
+    @Autowired private MemberRepository memberRepository;
+    @Autowired private PartyRepository partyRepository;
+    @Autowired private PartyAddrRepository partyAddrRepository;
+
+    private TransactionTemplate transactionTemplate;
+    private Long gameHostId;
+    private Long gameBoardId;
+    private Long gameBoardMemberId;
+
+    @BeforeEach
+    void setUp() {
+        transactionTemplate = new TransactionTemplate(transactionManager);
+
+        Member gameHost = memberRepository.save(MemberFixture.createMemberWithName(
+                "게임 진행자", "진행자", Gender.FEMALE, Level.A, 75001L));
+        PartyAddr partyAddr = partyAddrRepository.save(
+                PartyFixture.createPartyAddr("서울특별시", "강남구"));
+        Party party = partyRepository.save(
+                PartyFixture.createParty("게임 배정 동시성 테스트", gameHost.getId(), partyAddr));
+        Exercise exercise = exerciseRepository.save(
+                ExerciseFixture.createExerciseWithAddr(party, LocalDate.of(2099, 12, 31)));
+        GameBoardMember gameBoardMember = gameBoardMemberRepository.save(GameBoardMember.builder()
+                .gameBoard(exercise.getGameBoard())
+                .name("동시성 선수")
+                .gender(Gender.MALE)
+                .level(Level.D)
+                .shuttlecockSubmitted(false)
+                .participating(true)
+                .gameCount(0)
+                .build());
+
+        gameHostId = gameHost.getId();
+        gameBoardId = exercise.getGameBoard().getId();
+        gameBoardMemberId = gameBoardMember.getId();
+    }
+
+    @AfterEach
+    void tearDown() {
+        gameRepository.deleteAll();
+        gameBoardMemberRepository.deleteAll();
+        exerciseRepository.deleteAll();
+        partyRepository.deleteAll();
+        partyAddrRepository.deleteAll();
+        memberRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("참여 해제가 게임판을 먼저 잠그면 게임 생성은 대기한 뒤 불참 선수 오류로 실패한다")
+    void gameCreationWaitsForDeactivationAndRejectsInactiveMember() throws Exception {
+        CountDownLatch deactivationLocked = new CountDownLatch(1);
+        CountDownLatch allowDeactivationCommit = new CountDownLatch(1);
+        CountDownLatch creationAttempted = new CountDownLatch(1);
+        CountDownLatch creationFinished = new CountDownLatch(1);
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+
+        try {
+            Future<?> deactivationFuture = executor.submit(() ->
+                    transactionTemplate.executeWithoutResult(status -> {
+                        gameBoardRepository.findByIdForUpdate(gameBoardId).orElseThrow();
+                        GameBoardMember member = gameBoardMemberRepository.findById(gameBoardMemberId).orElseThrow();
+                        member.changeParticipation(false);
+                        deactivationLocked.countDown();
+                        await(allowDeactivationCommit);
+                    }));
+
+            assertThat(deactivationLocked.await(5, TimeUnit.SECONDS)).isTrue();
+
+            Future<String> creationFuture = executor.submit(() -> {
+                creationAttempted.countDown();
+                try {
+                    gameCommandService.createGame(
+                            gameHostId, new GameCreateCommand(gameBoardId, List.of(gameBoardMemberId)));
+                    return null;
+                } catch (GameException exception) {
+                    return exception.getErrorReason().getCode();
+                } finally {
+                    creationFinished.countDown();
+                }
+            });
+
+            assertThat(creationAttempted.await(5, TimeUnit.SECONDS)).isTrue();
+            assertThat(creationFinished.await(300, TimeUnit.MILLISECONDS)).isFalse();
+
+            allowDeactivationCommit.countDown();
+            deactivationFuture.get(5, TimeUnit.SECONDS);
+            assertThat(creationFuture.get(5, TimeUnit.SECONDS))
+                    .isEqualTo(GameErrorCode.INACTIVE_GAME_PLAYER.getCode());
+        } finally {
+            allowDeactivationCommit.countDown();
+            executor.shutdownNow();
+        }
+
+        assertThat(gameRepository.countByGameBoardIdAndStatus(gameBoardId, GameStatus.WAITING)).isZero();
+        assertThat(gameBoardMemberRepository.findById(gameBoardMemberId).orElseThrow().getParticipating()).isFalse();
+    }
+
+    @Test
+    @DisplayName("게임 배정이 게임판을 먼저 잠그면 참여 해제는 대기한 뒤 활성 게임 오류로 실패한다")
+    void deactivationWaitsForAssignmentAndRejectsActiveMember() throws Exception {
+        CountDownLatch assignmentLocked = new CountDownLatch(1);
+        CountDownLatch allowAssignmentCommit = new CountDownLatch(1);
+        CountDownLatch deactivationAttempted = new CountDownLatch(1);
+        CountDownLatch deactivationFinished = new CountDownLatch(1);
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+
+        try {
+            Future<?> assignmentFuture = executor.submit(() ->
+                    transactionTemplate.executeWithoutResult(status -> {
+                        GameBoard gameBoard = gameBoardRepository.findByIdForUpdate(gameBoardId).orElseThrow();
+                        GameBoardMember member = gameBoardMemberRepository.findById(gameBoardMemberId).orElseThrow();
+                        Game waitingGame = Game.createWaiting(gameBoard, 1);
+                        waitingGame.addPlayer(GamePlayer.create(member, 0));
+                        gameRepository.saveAndFlush(waitingGame);
+                        assignmentLocked.countDown();
+                        await(allowAssignmentCommit);
+                    }));
+
+            assertThat(assignmentLocked.await(5, TimeUnit.SECONDS)).isTrue();
+
+            Future<String> deactivationFuture = executor.submit(() -> {
+                deactivationAttempted.countDown();
+                try {
+                    gameBoardMemberCommandService.changeParticipation(
+                            gameHostId,
+                            new GameBoardMemberParticipationCommand(
+                                    gameBoardId, gameBoardMemberId, false));
+                    return null;
+                } catch (GameException exception) {
+                    return exception.getErrorReason().getCode();
+                } finally {
+                    deactivationFinished.countDown();
+                }
+            });
+
+            assertThat(deactivationAttempted.await(5, TimeUnit.SECONDS)).isTrue();
+            assertThat(deactivationFinished.await(300, TimeUnit.MILLISECONDS)).isFalse();
+
+            allowAssignmentCommit.countDown();
+            assignmentFuture.get(5, TimeUnit.SECONDS);
+            assertThat(deactivationFuture.get(5, TimeUnit.SECONDS))
+                    .isEqualTo(GameErrorCode.ACTIVE_GAME_MEMBER_CANNOT_BE_INACTIVE.getCode());
+        } finally {
+            allowAssignmentCommit.countDown();
+            executor.shutdownNow();
+        }
+
+        assertThat(gameBoardMemberRepository.findById(gameBoardMemberId).orElseThrow().getParticipating()).isTrue();
+        assertThat(gameRepository.countByGameBoardIdAndStatus(gameBoardId, GameStatus.WAITING)).isEqualTo(1L);
+    }
+
+    private void await(CountDownLatch latch) {
+        try {
+            if (!latch.await(5, TimeUnit.SECONDS)) {
+                throw new AssertionError("동시성 테스트 대기 시간이 초과되었습니다.");
+            }
+        } catch (InterruptedException exception) {
+            Thread.currentThread().interrupt();
+            throw new AssertionError("동시성 테스트 대기 중 인터럽트가 발생했습니다.", exception);
+        }
+    }
+}

--- a/src/test/java/umc/cockple/demo/domain/game/service/command/GameBoardMemberCommandServiceTest.java
+++ b/src/test/java/umc/cockple/demo/domain/game/service/command/GameBoardMemberCommandServiceTest.java
@@ -87,7 +87,7 @@ class GameBoardMemberCommandServiceTest {
         assertThat(createdMember.getParticipating()).isTrue();
         assertThat(createdMember.getGameCount()).isZero();
         then(eventPublisher).should()
-                .publishEvent(new GameBoardMembersChangedEvent(GAME_BOARD_ID, MEMBER_ID));
+                .publishEvent(GameBoardMembersChangedEvent.membersAndBoard(GAME_BOARD_ID, MEMBER_ID));
     }
 
     @Test
@@ -122,7 +122,7 @@ class GameBoardMemberCommandServiceTest {
         assertThat(gameBoardMember.getLevel()).isEqualTo(Level.A);
         assertThat(gameBoardMember.getAgeGroup()).isNull();
         then(eventPublisher).should()
-                .publishEvent(new GameBoardMembersChangedEvent(GAME_BOARD_ID, MEMBER_ID));
+                .publishEvent(GameBoardMembersChangedEvent.membersAndBoard(GAME_BOARD_ID, MEMBER_ID));
     }
 
     @Test
@@ -141,8 +141,9 @@ class GameBoardMemberCommandServiceTest {
         gameBoardMemberCommandService.changeParticipation(MEMBER_ID, participationCommand);
 
         assertThat(gameBoardMember.getParticipating()).isFalse();
+        then(gameBoardReader).should().readForUpdate(GAME_BOARD_ID);
         then(eventPublisher).should()
-                .publishEvent(new GameBoardMembersChangedEvent(GAME_BOARD_ID, MEMBER_ID));
+                .publishEvent(GameBoardMembersChangedEvent.membersAndBoard(GAME_BOARD_ID, MEMBER_ID));
     }
 
     @Test

--- a/src/test/java/umc/cockple/demo/domain/game/service/command/GameBoardMemberCommandServiceTest.java
+++ b/src/test/java/umc/cockple/demo/domain/game/service/command/GameBoardMemberCommandServiceTest.java
@@ -17,6 +17,8 @@ import umc.cockple.demo.domain.game.exception.GameErrorCode;
 import umc.cockple.demo.domain.game.exception.GameException;
 import umc.cockple.demo.domain.game.repository.GameBoardMemberRepository;
 import umc.cockple.demo.domain.game.service.command.model.GameBoardMemberCreateCommand;
+import umc.cockple.demo.domain.game.service.command.model.GameBoardMemberUpdateCommand;
+import umc.cockple.demo.domain.game.service.support.reader.GameBoardMemberReader;
 import umc.cockple.demo.domain.game.service.support.reader.GameBoardReader;
 import umc.cockple.demo.domain.game.service.support.validator.GameBoardAccessValidator;
 import umc.cockple.demo.global.enums.Gender;
@@ -41,6 +43,7 @@ class GameBoardMemberCommandServiceTest {
 
     @InjectMocks private GameBoardMemberCommandService gameBoardMemberCommandService;
     @Mock private GameBoardReader gameBoardReader;
+    @Mock private GameBoardMemberReader gameBoardMemberReader;
     @Mock private GameBoardAccessValidator gameBoardAccessValidator;
     @Mock private GameBoardMemberRepository gameBoardMemberRepository;
     @Mock private ApplicationEventPublisher eventPublisher;
@@ -95,5 +98,26 @@ class GameBoardMemberCommandServiceTest {
         then(gameBoardReader).should(never()).read(any());
         then(gameBoardMemberRepository).should(never()).save(any());
         then(eventPublisher).should(never()).publishEvent(any());
+    }
+
+    @Test
+    @DisplayName("게임 진행자가 명단 정보를 수정하고 연령대를 제거한 뒤 변경 이벤트를 발행한다")
+    void updateMember_updatesInfoAndPublishesEvent() {
+        GameBoardMember gameBoardMember = GameBoardMember.create(
+                "수정 전", Gender.MALE, Level.D, AgeGroup.THIRTIES);
+        GameBoardMemberUpdateCommand updateCommand = new GameBoardMemberUpdateCommand(
+                GAME_BOARD_ID, GAME_BOARD_MEMBER_ID, "수정 후", Gender.FEMALE, Level.A, null);
+        given(gameBoardMemberReader.read(GAME_BOARD_ID, GAME_BOARD_MEMBER_ID))
+                .willReturn(gameBoardMember);
+
+        gameBoardMemberCommandService.updateMember(MEMBER_ID, updateCommand);
+
+        then(gameBoardAccessValidator).should().validateGameHost(GAME_BOARD_ID, MEMBER_ID);
+        assertThat(gameBoardMember.getName()).isEqualTo("수정 후");
+        assertThat(gameBoardMember.getGender()).isEqualTo(Gender.FEMALE);
+        assertThat(gameBoardMember.getLevel()).isEqualTo(Level.A);
+        assertThat(gameBoardMember.getAgeGroup()).isNull();
+        then(eventPublisher).should()
+                .publishEvent(new GameBoardMembersChangedEvent(GAME_BOARD_ID, MEMBER_ID));
     }
 }

--- a/src/test/java/umc/cockple/demo/domain/game/service/command/GameBoardMemberCommandServiceTest.java
+++ b/src/test/java/umc/cockple/demo/domain/game/service/command/GameBoardMemberCommandServiceTest.java
@@ -147,6 +147,24 @@ class GameBoardMemberCommandServiceTest {
     }
 
     @Test
+    @DisplayName("게임 진행자가 아니면 게임판 락을 획득하지 않는다")
+    void changeParticipation_deniesNonGameHostBeforeLock() {
+        GameBoardMemberParticipationCommand participationCommand =
+                new GameBoardMemberParticipationCommand(GAME_BOARD_ID, GAME_BOARD_MEMBER_ID, false);
+        willThrow(new GameException(GameErrorCode.GAME_BOARD_ACCESS_DENIED))
+                .given(gameBoardAccessValidator).validateGameHost(GAME_BOARD_ID, MEMBER_ID);
+
+        assertThatThrownBy(() -> gameBoardMemberCommandService.changeParticipation(
+                MEMBER_ID, participationCommand))
+                .isInstanceOfSatisfying(GameException.class, exception ->
+                        assertThat(exception.getCode()).isEqualTo(GameErrorCode.GAME_BOARD_ACCESS_DENIED));
+
+        then(gameBoardReader).should(never()).readForUpdate(any());
+        then(gameBoardMemberReader).shouldHaveNoInteractions();
+        then(eventPublisher).shouldHaveNoInteractions();
+    }
+
+    @Test
     @DisplayName("활성 게임 선수는 참여 해제할 수 없다")
     void changeParticipation_rejectsActiveMemberDeactivation() {
         GameBoardMember gameBoardMember = GameBoardMember.create(

--- a/src/test/java/umc/cockple/demo/domain/game/service/command/GameBoardMemberCommandServiceTest.java
+++ b/src/test/java/umc/cockple/demo/domain/game/service/command/GameBoardMemberCommandServiceTest.java
@@ -1,0 +1,99 @@
+package umc.cockple.demo.domain.game.service.command;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+import umc.cockple.demo.domain.game.domain.GameBoard;
+import umc.cockple.demo.domain.game.domain.GameBoardMember;
+import umc.cockple.demo.domain.game.enums.AgeGroup;
+import umc.cockple.demo.domain.game.events.GameBoardMembersChangedEvent;
+import umc.cockple.demo.domain.game.exception.GameErrorCode;
+import umc.cockple.demo.domain.game.exception.GameException;
+import umc.cockple.demo.domain.game.repository.GameBoardMemberRepository;
+import umc.cockple.demo.domain.game.service.command.model.GameBoardMemberCreateCommand;
+import umc.cockple.demo.domain.game.service.support.reader.GameBoardReader;
+import umc.cockple.demo.domain.game.service.support.validator.GameBoardAccessValidator;
+import umc.cockple.demo.global.enums.Gender;
+import umc.cockple.demo.global.enums.Level;
+import umc.cockple.demo.support.fixture.GameFixture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.never;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("GameBoardMemberCommandService")
+class GameBoardMemberCommandServiceTest {
+
+    private static final Long MEMBER_ID = 1L;
+    private static final Long GAME_BOARD_ID = 2L;
+    private static final Long GAME_BOARD_MEMBER_ID = 3L;
+
+    @InjectMocks private GameBoardMemberCommandService gameBoardMemberCommandService;
+    @Mock private GameBoardReader gameBoardReader;
+    @Mock private GameBoardAccessValidator gameBoardAccessValidator;
+    @Mock private GameBoardMemberRepository gameBoardMemberRepository;
+    @Mock private ApplicationEventPublisher eventPublisher;
+
+    private GameBoard gameBoard;
+    private GameBoardMemberCreateCommand command;
+
+    @BeforeEach
+    void setUp() {
+        gameBoard = GameFixture.gameBoard(GAME_BOARD_ID);
+        command = new GameBoardMemberCreateCommand(
+                GAME_BOARD_ID, "김선수", Gender.MALE, Level.D, AgeGroup.THIRTIES);
+    }
+
+    @Test
+    @DisplayName("게임 진행자가 수동 명단을 기본값과 함께 생성하고 변경 이벤트를 발행한다")
+    void createMember_createsManualMemberAndPublishesEvent() {
+        GameBoardMember savedMember = GameBoardMember.builder().id(GAME_BOARD_MEMBER_ID).build();
+        given(gameBoardReader.read(GAME_BOARD_ID)).willReturn(gameBoard);
+        given(gameBoardMemberRepository.save(any(GameBoardMember.class))).willReturn(savedMember);
+        ArgumentCaptor<GameBoardMember> memberCaptor = ArgumentCaptor.forClass(GameBoardMember.class);
+
+        Long result = gameBoardMemberCommandService.createMember(MEMBER_ID, command);
+
+        assertThat(result).isEqualTo(GAME_BOARD_MEMBER_ID);
+        then(gameBoardAccessValidator).should().validateGameHost(GAME_BOARD_ID, MEMBER_ID);
+        then(gameBoardMemberRepository).should().save(memberCaptor.capture());
+        GameBoardMember createdMember = memberCaptor.getValue();
+        assertThat(createdMember.getGameBoard()).isSameAs(gameBoard);
+        assertThat(createdMember.getMember()).isNull();
+        assertThat(createdMember.getGuest()).isNull();
+        assertThat(createdMember.getName()).isEqualTo("김선수");
+        assertThat(createdMember.getGender()).isEqualTo(Gender.MALE);
+        assertThat(createdMember.getLevel()).isEqualTo(Level.D);
+        assertThat(createdMember.getAgeGroup()).isEqualTo(AgeGroup.THIRTIES);
+        assertThat(createdMember.getShuttlecockSubmitted()).isFalse();
+        assertThat(createdMember.getParticipating()).isTrue();
+        assertThat(createdMember.getGameCount()).isZero();
+        then(eventPublisher).should()
+                .publishEvent(new GameBoardMembersChangedEvent(GAME_BOARD_ID, MEMBER_ID));
+    }
+
+    @Test
+    @DisplayName("게임 진행자가 아니면 명단을 생성하거나 이벤트를 발행하지 않는다")
+    void createMember_deniesNonGameHost() {
+        willThrow(new GameException(GameErrorCode.GAME_BOARD_ACCESS_DENIED))
+                .given(gameBoardAccessValidator).validateGameHost(GAME_BOARD_ID, MEMBER_ID);
+
+        assertThatThrownBy(() -> gameBoardMemberCommandService.createMember(MEMBER_ID, command))
+                .isInstanceOfSatisfying(GameException.class, exception ->
+                        assertThat(exception.getCode()).isEqualTo(GameErrorCode.GAME_BOARD_ACCESS_DENIED));
+        then(gameBoardReader).should(never()).read(any());
+        then(gameBoardMemberRepository).should(never()).save(any());
+        then(eventPublisher).should(never()).publishEvent(any());
+    }
+}

--- a/src/test/java/umc/cockple/demo/domain/game/service/command/GameBoardMemberCommandServiceTest.java
+++ b/src/test/java/umc/cockple/demo/domain/game/service/command/GameBoardMemberCommandServiceTest.java
@@ -147,8 +147,8 @@ class GameBoardMemberCommandServiceTest {
     }
 
     @Test
-    @DisplayName("게임 진행자가 아니면 게임판 락을 획득하지 않는다")
-    void changeParticipation_deniesNonGameHostBeforeLock() {
+    @DisplayName("게임판 락 획득 후 게임 진행자가 아니면 명단을 조회하지 않는다")
+    void changeParticipation_deniesNonGameHostAfterLock() {
         GameBoardMemberParticipationCommand participationCommand =
                 new GameBoardMemberParticipationCommand(GAME_BOARD_ID, GAME_BOARD_MEMBER_ID, false);
         willThrow(new GameException(GameErrorCode.GAME_BOARD_ACCESS_DENIED))
@@ -159,7 +159,7 @@ class GameBoardMemberCommandServiceTest {
                 .isInstanceOfSatisfying(GameException.class, exception ->
                         assertThat(exception.getCode()).isEqualTo(GameErrorCode.GAME_BOARD_ACCESS_DENIED));
 
-        then(gameBoardReader).should(never()).readForUpdate(any());
+        then(gameBoardReader).should().readForUpdate(GAME_BOARD_ID);
         then(gameBoardMemberReader).shouldHaveNoInteractions();
         then(eventPublisher).shouldHaveNoInteractions();
     }

--- a/src/test/java/umc/cockple/demo/domain/game/service/command/GameBoardMemberCommandServiceTest.java
+++ b/src/test/java/umc/cockple/demo/domain/game/service/command/GameBoardMemberCommandServiceTest.java
@@ -17,9 +17,11 @@ import umc.cockple.demo.domain.game.exception.GameErrorCode;
 import umc.cockple.demo.domain.game.exception.GameException;
 import umc.cockple.demo.domain.game.repository.GameBoardMemberRepository;
 import umc.cockple.demo.domain.game.service.command.model.GameBoardMemberCreateCommand;
+import umc.cockple.demo.domain.game.service.command.model.GameBoardMemberParticipationCommand;
 import umc.cockple.demo.domain.game.service.command.model.GameBoardMemberUpdateCommand;
 import umc.cockple.demo.domain.game.service.support.reader.GameBoardMemberReader;
 import umc.cockple.demo.domain.game.service.support.reader.GameBoardReader;
+import umc.cockple.demo.domain.game.service.support.reader.GameReader;
 import umc.cockple.demo.domain.game.service.support.validator.GameBoardAccessValidator;
 import umc.cockple.demo.global.enums.Gender;
 import umc.cockple.demo.global.enums.Level;
@@ -28,6 +30,7 @@ import umc.cockple.demo.support.fixture.GameFixture;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.BDDMockito.willThrow;
@@ -44,6 +47,7 @@ class GameBoardMemberCommandServiceTest {
     @InjectMocks private GameBoardMemberCommandService gameBoardMemberCommandService;
     @Mock private GameBoardReader gameBoardReader;
     @Mock private GameBoardMemberReader gameBoardMemberReader;
+    @Mock private GameReader gameReader;
     @Mock private GameBoardAccessValidator gameBoardAccessValidator;
     @Mock private GameBoardMemberRepository gameBoardMemberRepository;
     @Mock private ApplicationEventPublisher eventPublisher;
@@ -119,5 +123,63 @@ class GameBoardMemberCommandServiceTest {
         assertThat(gameBoardMember.getAgeGroup()).isNull();
         then(eventPublisher).should()
                 .publishEvent(new GameBoardMembersChangedEvent(GAME_BOARD_ID, MEMBER_ID));
+    }
+
+    @Test
+    @DisplayName("활성 게임에 포함되지 않은 선수를 참여 해제하고 이벤트를 발행한다")
+    void changeParticipation_deactivatesIdleMemberAndPublishesEvent() {
+        GameBoardMember gameBoardMember = GameBoardMember.create(
+                "선수", Gender.MALE, Level.D, AgeGroup.THIRTIES);
+        GameBoardMemberParticipationCommand participationCommand =
+                new GameBoardMemberParticipationCommand(GAME_BOARD_ID, GAME_BOARD_MEMBER_ID, false);
+        given(gameBoardMemberReader.read(GAME_BOARD_ID, GAME_BOARD_MEMBER_ID))
+                .willReturn(gameBoardMember);
+        given(gameReader.existsByGameBoardMemberAndStatuses(
+                eq(GAME_BOARD_MEMBER_ID), any()))
+                .willReturn(false);
+
+        gameBoardMemberCommandService.changeParticipation(MEMBER_ID, participationCommand);
+
+        assertThat(gameBoardMember.getParticipating()).isFalse();
+        then(eventPublisher).should()
+                .publishEvent(new GameBoardMembersChangedEvent(GAME_BOARD_ID, MEMBER_ID));
+    }
+
+    @Test
+    @DisplayName("활성 게임 선수는 참여 해제할 수 없다")
+    void changeParticipation_rejectsActiveMemberDeactivation() {
+        GameBoardMember gameBoardMember = GameBoardMember.create(
+                "선수", Gender.MALE, Level.D, AgeGroup.THIRTIES);
+        GameBoardMemberParticipationCommand participationCommand =
+                new GameBoardMemberParticipationCommand(GAME_BOARD_ID, GAME_BOARD_MEMBER_ID, false);
+        given(gameBoardMemberReader.read(GAME_BOARD_ID, GAME_BOARD_MEMBER_ID))
+                .willReturn(gameBoardMember);
+        given(gameReader.existsByGameBoardMemberAndStatuses(
+                eq(GAME_BOARD_MEMBER_ID), any()))
+                .willReturn(true);
+
+        assertThatThrownBy(() -> gameBoardMemberCommandService.changeParticipation(MEMBER_ID, participationCommand))
+                .isInstanceOfSatisfying(GameException.class, exception ->
+                        assertThat(exception.getCode())
+                                .isEqualTo(GameErrorCode.ACTIVE_GAME_MEMBER_CANNOT_BE_INACTIVE));
+        assertThat(gameBoardMember.getParticipating()).isTrue();
+        then(eventPublisher).should(never()).publishEvent(any());
+    }
+
+    @Test
+    @DisplayName("현재 값과 같은 참여 상태 요청은 조회와 이벤트 없이 성공한다")
+    void changeParticipation_sameValueIsIdempotent() {
+        GameBoardMember gameBoardMember = GameBoardMember.create(
+                "선수", Gender.MALE, Level.D, AgeGroup.THIRTIES);
+        GameBoardMemberParticipationCommand participationCommand =
+                new GameBoardMemberParticipationCommand(GAME_BOARD_ID, GAME_BOARD_MEMBER_ID, true);
+        given(gameBoardMemberReader.read(GAME_BOARD_ID, GAME_BOARD_MEMBER_ID))
+                .willReturn(gameBoardMember);
+
+        gameBoardMemberCommandService.changeParticipation(MEMBER_ID, participationCommand);
+
+        assertThat(gameBoardMember.getParticipating()).isTrue();
+        then(gameReader).shouldHaveNoInteractions();
+        then(eventPublisher).should(never()).publishEvent(any());
     }
 }

--- a/src/test/java/umc/cockple/demo/domain/game/service/command/GameCommandServiceTest.java
+++ b/src/test/java/umc/cockple/demo/domain/game/service/command/GameCommandServiceTest.java
@@ -9,12 +9,14 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 import umc.cockple.demo.domain.game.domain.Court;
 import umc.cockple.demo.domain.game.domain.Game;
 import umc.cockple.demo.domain.game.domain.GameBoard;
 import umc.cockple.demo.domain.game.domain.GameBoardMember;
 import umc.cockple.demo.domain.game.domain.GamePlayer;
 import umc.cockple.demo.domain.game.enums.GameStatus;
+import umc.cockple.demo.domain.game.events.GameBoardMembersChangedEvent;
 import umc.cockple.demo.domain.game.exception.GameErrorCode;
 import umc.cockple.demo.domain.game.exception.GameException;
 import umc.cockple.demo.domain.game.repository.CourtRepository;
@@ -50,6 +52,7 @@ class GameCommandServiceTest {
     @Mock private GameRepository gameRepository;
     @Mock private CourtRepository courtRepository;
     @Mock private GameBoardMemberRepository gameBoardMemberRepository;
+    @Mock private ApplicationEventPublisher eventPublisher;
 
     @InjectMocks private GameCommandService gameCommandService;
 
@@ -91,6 +94,8 @@ class GameCommandServiceTest {
             assertThat(waiting.getCourt()).isEqualTo(court);
             assertThat(waiting.getStartedAt()).isNotNull();
             assertThat(waiting.getWaitingOrder()).isNull();
+            then(eventPublisher).should()
+                    .publishEvent(GameBoardMembersChangedEvent.membersOnly(BOARD_ID, MEMBER_ID));
         }
 
         @Test
@@ -195,7 +200,7 @@ class GameCommandServiceTest {
             // given - 이미 대기 게임이 2개 있으므로 새 게임의 waitingOrder는 3
             GameBoardMember m7 = GameFixture.member(7L, board, "선수7", Level.A);
             GameBoardMember m8 = GameFixture.member(8L, board, "선수8", Level.B);
-            given(gameBoardReader.read(BOARD_ID)).willReturn(board);
+            given(gameBoardReader.readForUpdate(BOARD_ID)).willReturn(board);
             given(gameBoardMemberRepository.findByGameBoardIdAndIdIn(BOARD_ID, List.of(8L, 7L)))
                     .willReturn(List.of(m7, m8));
             given(gameRepository.countByGameBoardIdAndStatus(BOARD_ID, GameStatus.WAITING)).willReturn(2L);
@@ -213,13 +218,15 @@ class GameCommandServiceTest {
             assertThat(saved.getPlayers())
                     .extracting(p -> p.getGameBoardMember().getId(), GamePlayer::getPlayerOrder)
                     .containsExactly(tuple(8L, 0), tuple(7L, 1));
+            then(eventPublisher).should()
+                    .publishEvent(GameBoardMembersChangedEvent.membersOnly(BOARD_ID, MEMBER_ID));
         }
 
         @Test
         @DisplayName("명단에 없는 멤버가 포함되면 GAME_BOARD_MEMBER_NOT_FOUND 예외")
         void createGame_memberNotOnBoard() {
             GameBoardMember m7 = GameFixture.member(7L, board, "선수7", Level.A);
-            given(gameBoardReader.read(BOARD_ID)).willReturn(board);
+            given(gameBoardReader.readForUpdate(BOARD_ID)).willReturn(board);
             given(gameBoardMemberRepository.findByGameBoardIdAndIdIn(BOARD_ID, List.of(7L, 999L)))
                     .willReturn(List.of(m7)); // 999는 조회되지 않음
 
@@ -227,6 +234,24 @@ class GameCommandServiceTest {
                     .isInstanceOf(GameException.class)
                     .extracting(e -> ((GameException) e).getCode())
                     .isEqualTo(GameErrorCode.GAME_BOARD_MEMBER_NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("불참 상태의 선수가 포함되면 INACTIVE_GAME_PLAYER 예외")
+        void createGame_inactivePlayer() {
+            GameBoardMember inactiveMember = GameFixture.member(7L, board, "불참 선수", Level.A);
+            inactiveMember.changeParticipation(false);
+            given(gameBoardReader.readForUpdate(BOARD_ID)).willReturn(board);
+            given(gameBoardMemberRepository.findByGameBoardIdAndIdIn(BOARD_ID, List.of(7L)))
+                    .willReturn(List.of(inactiveMember));
+
+            assertThatThrownBy(() -> gameCommandService.createGame(
+                    MEMBER_ID, new GameCreateCommand(BOARD_ID, List.of(7L))))
+                    .isInstanceOf(GameException.class)
+                    .extracting(e -> ((GameException) e).getCode())
+                    .isEqualTo(GameErrorCode.INACTIVE_GAME_PLAYER);
+            then(gameRepository).should(never()).save(any());
+            then(eventPublisher).should(never()).publishEvent(any());
         }
 
         @Test
@@ -281,6 +306,8 @@ class GameCommandServiceTest {
             assertThat(result.gameId()).isEqualTo(GAME_ID);
             then(gameRepository).should().delete(waiting);
             assertThat(remaining.getWaitingOrder()).isEqualTo(1);
+            then(eventPublisher).should()
+                    .publishEvent(GameBoardMembersChangedEvent.membersOnly(BOARD_ID, MEMBER_ID));
         }
 
         @Test
@@ -392,9 +419,14 @@ class GameCommandServiceTest {
             assertThat(otherWaiting.getWaitingOrder()).isEqualTo(2);
             assertThat(m1.getGameCount()).isZero();
             assertThat(m2.getGameCount()).isZero();
+            assertThat(playing.getPlayers())
+                    .extracting(p -> p.getGameBoardMember().getId(), GamePlayer::getPlayerOrder)
+                    .containsExactly(tuple(7L, 0), tuple(8L, 1));
 
             // 새 게임을 만들지 않는다 (같은 게임을 재사용)
             then(gameRepository).should(never()).save(any(Game.class));
+            then(eventPublisher).should()
+                    .publishEvent(GameBoardMembersChangedEvent.membersOnly(BOARD_ID, MEMBER_ID));
         }
 
         @Test

--- a/src/test/java/umc/cockple/demo/domain/game/service/command/GameCommandServiceTest.java
+++ b/src/test/java/umc/cockple/demo/domain/game/service/command/GameCommandServiceTest.java
@@ -483,6 +483,8 @@ class GameCommandServiceTest {
             assertThat(playing.getStartedAt()).isEqualTo(startedAt);
             assertThat(m1.getGameCount()).isEqualTo(1);
             assertThat(m2.getGameCount()).isEqualTo(1);
+            then(eventPublisher).should()
+                    .publishEvent(GameBoardMembersChangedEvent.membersOnly(BOARD_ID, MEMBER_ID));
         }
 
         @Test

--- a/src/test/java/umc/cockple/demo/domain/game/service/listener/GameBoardMembersChangedEventFlowTest.java
+++ b/src/test/java/umc/cockple/demo/domain/game/service/listener/GameBoardMembersChangedEventFlowTest.java
@@ -64,7 +64,7 @@ class GameBoardMembersChangedEventFlowTest extends IntegrationTestBase {
         GameBoardResult board = new GameBoardResult(0, List.of(), List.of());
         boardDto = new GameBoardDTO.Response(0, List.of(), List.of());
 
-        given(gameBoardMemberQueryService.getMembers(anyLong(), eq(NO_FILTERS))).willReturn(members);
+        given(gameBoardMemberQueryService.getMembersSnapshot(anyLong(), eq(NO_FILTERS))).willReturn(members);
         given(gameBoardMemberMapper.toResponse(members)).willReturn(membersDto);
         given(gameBoardQueryService.getBoard(eq(ACTOR_MEMBER_ID), anyLong())).willReturn(board);
         given(gameBoardMapper.toResponse(board)).willReturn(boardDto);
@@ -98,7 +98,7 @@ class GameBoardMembersChangedEventFlowTest extends IntegrationTestBase {
         });
 
         then(gameBoardMemberQueryService).should(after(700).never())
-                .getMembers(anyLong(), eq(NO_FILTERS));
+                .getMembersSnapshot(anyLong(), eq(NO_FILTERS));
         then(gameBoardBroadcaster).should(never())
                 .broadcastMembersUpdate(anyLong(), eq(membersDto), isNull());
         then(gameBoardBroadcaster).should(never())

--- a/src/test/java/umc/cockple/demo/domain/game/service/listener/GameBoardMembersChangedEventFlowTest.java
+++ b/src/test/java/umc/cockple/demo/domain/game/service/listener/GameBoardMembersChangedEventFlowTest.java
@@ -1,0 +1,128 @@
+package umc.cockple.demo.domain.game.service.listener;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.support.TransactionTemplate;
+import umc.cockple.demo.domain.game.domain.GameBoard;
+import umc.cockple.demo.domain.game.events.GameBoardMembersChangedEvent;
+import umc.cockple.demo.domain.game.presentation.dto.GameBoardDTO;
+import umc.cockple.demo.domain.game.presentation.dto.GameBoardMemberDTO;
+import umc.cockple.demo.domain.game.presentation.mapper.GameBoardMapper;
+import umc.cockple.demo.domain.game.presentation.mapper.GameBoardMemberMapper;
+import umc.cockple.demo.domain.game.repository.GameBoardRepository;
+import umc.cockple.demo.domain.game.service.query.GameBoardMemberQueryService;
+import umc.cockple.demo.domain.game.service.query.GameBoardQueryService;
+import umc.cockple.demo.domain.game.service.query.model.GameBoardMemberSearchQuery;
+import umc.cockple.demo.domain.game.service.query.result.GameBoardMemberResult;
+import umc.cockple.demo.domain.game.service.query.result.GameBoardResult;
+import umc.cockple.demo.domain.game.service.websocket.broadcast.GameBoardBroadcaster;
+import umc.cockple.demo.support.IntegrationTestBase;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.after;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.timeout;
+
+@DisplayName("게임판 명단 변경 after-commit 실시간 동기화")
+class GameBoardMembersChangedEventFlowTest extends IntegrationTestBase {
+
+    private static final Long GAME_BOARD_ID = 100L;
+    private static final Long ACTOR_MEMBER_ID = 200L;
+    private static final GameBoardMemberSearchQuery NO_FILTERS =
+            new GameBoardMemberSearchQuery(List.of(), null, null);
+
+    @Autowired private ApplicationEventPublisher eventPublisher;
+    @Autowired private TransactionTemplate transactionTemplate;
+    @Autowired private GameBoardRepository gameBoardRepository;
+
+    @MockitoBean private GameBoardMemberQueryService gameBoardMemberQueryService;
+    @MockitoBean private GameBoardMemberMapper gameBoardMemberMapper;
+    @MockitoBean private GameBoardQueryService gameBoardQueryService;
+    @MockitoBean private GameBoardMapper gameBoardMapper;
+    @MockitoBean private GameBoardBroadcaster gameBoardBroadcaster;
+
+    private GameBoardMemberDTO.Response membersDto;
+    private GameBoardDTO.Response boardDto;
+
+    @BeforeEach
+    void setUp() {
+        GameBoardMemberResult members = new GameBoardMemberResult(0, List.of());
+        membersDto = new GameBoardMemberDTO.Response(0, List.of());
+        GameBoardResult board = new GameBoardResult(0, List.of(), List.of());
+        boardDto = new GameBoardDTO.Response(0, List.of(), List.of());
+
+        given(gameBoardMemberQueryService.getMembers(anyLong(), eq(NO_FILTERS))).willReturn(members);
+        given(gameBoardMemberMapper.toResponse(members)).willReturn(membersDto);
+        given(gameBoardQueryService.getBoard(eq(ACTOR_MEMBER_ID), anyLong())).willReturn(board);
+        given(gameBoardMapper.toResponse(board)).willReturn(boardDto);
+    }
+
+    @AfterEach
+    void tearDown() {
+        gameBoardRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("트랜잭션이 커밋되면 두 snapshot을 전파한다")
+    void committedEvent_broadcastsMembersAndBoard() {
+        transactionTemplate.executeWithoutResult(status ->
+                eventPublisher.publishEvent(
+                        new GameBoardMembersChangedEvent(GAME_BOARD_ID, ACTOR_MEMBER_ID)));
+
+        then(gameBoardBroadcaster).should(timeout(3000))
+                .broadcastMembersUpdate(GAME_BOARD_ID, membersDto, null);
+        then(gameBoardBroadcaster).should(timeout(3000))
+                .broadcastBoardUpdate(GAME_BOARD_ID, boardDto, null);
+    }
+
+    @Test
+    @DisplayName("트랜잭션이 롤백되면 snapshot을 조회하거나 전파하지 않는다")
+    void rolledBackEvent_doesNotBroadcast() {
+        transactionTemplate.executeWithoutResult(status -> {
+            eventPublisher.publishEvent(
+                    new GameBoardMembersChangedEvent(GAME_BOARD_ID, ACTOR_MEMBER_ID));
+            status.setRollbackOnly();
+        });
+
+        then(gameBoardMemberQueryService).should(after(700).never())
+                .getMembers(anyLong(), eq(NO_FILTERS));
+        then(gameBoardBroadcaster).should(never())
+                .broadcastMembersUpdate(anyLong(), eq(membersDto), isNull());
+        then(gameBoardBroadcaster).should(never())
+                .broadcastBoardUpdate(anyLong(), eq(boardDto), isNull());
+    }
+
+    @Test
+    @DisplayName("WebSocket 전파가 실패해도 명단 변경 트랜잭션은 커밋되고 다른 snapshot 전파를 시도한다")
+    void broadcastFailure_doesNotRollbackCommittedChange() {
+        willThrow(new RuntimeException("명단 전파 실패"))
+                .given(gameBoardBroadcaster)
+                .broadcastMembersUpdate(anyLong(), eq(membersDto), isNull());
+
+        Long savedGameBoardId = transactionTemplate.execute(status -> {
+            GameBoard saved = gameBoardRepository.save(GameBoard.create());
+            eventPublisher.publishEvent(
+                    new GameBoardMembersChangedEvent(saved.getId(), ACTOR_MEMBER_ID));
+            return saved.getId();
+        });
+
+        then(gameBoardBroadcaster).should(timeout(3000))
+                .broadcastMembersUpdate(savedGameBoardId, membersDto, null);
+        then(gameBoardBroadcaster).should(timeout(3000))
+                .broadcastBoardUpdate(savedGameBoardId, boardDto, null);
+        assertThat(gameBoardRepository.existsById(savedGameBoardId)).isTrue();
+    }
+}

--- a/src/test/java/umc/cockple/demo/domain/game/service/listener/GameBoardMembersChangedEventFlowTest.java
+++ b/src/test/java/umc/cockple/demo/domain/game/service/listener/GameBoardMembersChangedEventFlowTest.java
@@ -80,7 +80,7 @@ class GameBoardMembersChangedEventFlowTest extends IntegrationTestBase {
     void committedEvent_broadcastsMembersAndBoard() {
         transactionTemplate.executeWithoutResult(status ->
                 eventPublisher.publishEvent(
-                        new GameBoardMembersChangedEvent(GAME_BOARD_ID, ACTOR_MEMBER_ID)));
+                        GameBoardMembersChangedEvent.membersAndBoard(GAME_BOARD_ID, ACTOR_MEMBER_ID)));
 
         then(gameBoardBroadcaster).should(timeout(3000))
                 .broadcastMembersUpdate(GAME_BOARD_ID, membersDto, null);
@@ -93,7 +93,7 @@ class GameBoardMembersChangedEventFlowTest extends IntegrationTestBase {
     void rolledBackEvent_doesNotBroadcast() {
         transactionTemplate.executeWithoutResult(status -> {
             eventPublisher.publishEvent(
-                    new GameBoardMembersChangedEvent(GAME_BOARD_ID, ACTOR_MEMBER_ID));
+                    GameBoardMembersChangedEvent.membersAndBoard(GAME_BOARD_ID, ACTOR_MEMBER_ID));
             status.setRollbackOnly();
         });
 
@@ -115,7 +115,7 @@ class GameBoardMembersChangedEventFlowTest extends IntegrationTestBase {
         Long savedGameBoardId = transactionTemplate.execute(status -> {
             GameBoard saved = gameBoardRepository.save(GameBoard.create());
             eventPublisher.publishEvent(
-                    new GameBoardMembersChangedEvent(saved.getId(), ACTOR_MEMBER_ID));
+                    GameBoardMembersChangedEvent.membersAndBoard(saved.getId(), ACTOR_MEMBER_ID));
             return saved.getId();
         });
 

--- a/src/test/java/umc/cockple/demo/domain/game/service/listener/GameBoardMembersChangedEventListenerTest.java
+++ b/src/test/java/umc/cockple/demo/domain/game/service/listener/GameBoardMembersChangedEventListenerTest.java
@@ -1,0 +1,85 @@
+package umc.cockple.demo.domain.game.service.listener;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import umc.cockple.demo.domain.game.events.GameBoardMembersChangedEvent;
+import umc.cockple.demo.domain.game.presentation.dto.GameBoardDTO;
+import umc.cockple.demo.domain.game.presentation.dto.GameBoardMemberDTO;
+import umc.cockple.demo.domain.game.presentation.mapper.GameBoardMapper;
+import umc.cockple.demo.domain.game.presentation.mapper.GameBoardMemberMapper;
+import umc.cockple.demo.domain.game.service.query.GameBoardMemberQueryService;
+import umc.cockple.demo.domain.game.service.query.GameBoardQueryService;
+import umc.cockple.demo.domain.game.service.query.model.GameBoardMemberSearchQuery;
+import umc.cockple.demo.domain.game.service.query.result.GameBoardMemberResult;
+import umc.cockple.demo.domain.game.service.query.result.GameBoardResult;
+import umc.cockple.demo.domain.game.service.websocket.broadcast.GameBoardBroadcaster;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willThrow;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("GameBoardMembersChangedEventListener")
+class GameBoardMembersChangedEventListenerTest {
+
+    private static final Long GAME_BOARD_ID = 1L;
+    private static final Long ACTOR_MEMBER_ID = 2L;
+    private static final GameBoardMemberSearchQuery NO_FILTERS =
+            new GameBoardMemberSearchQuery(List.of(), null, null);
+
+    @InjectMocks private GameBoardMembersChangedEventListener listener;
+    @Mock private GameBoardMemberQueryService gameBoardMemberQueryService;
+    @Mock private GameBoardMemberMapper gameBoardMemberMapper;
+    @Mock private GameBoardQueryService gameBoardQueryService;
+    @Mock private GameBoardMapper gameBoardMapper;
+    @Mock private GameBoardBroadcaster gameBoardBroadcaster;
+
+    private GameBoardMembersChangedEvent event;
+    private GameBoardMemberDTO.Response membersDto;
+    private GameBoardDTO.Response boardDto;
+
+    @BeforeEach
+    void setUp() {
+        event = new GameBoardMembersChangedEvent(GAME_BOARD_ID, ACTOR_MEMBER_ID);
+        GameBoardMemberResult members = new GameBoardMemberResult(0, List.of());
+        membersDto = new GameBoardMemberDTO.Response(0, List.of());
+        GameBoardResult board = new GameBoardResult(0, List.of(), List.of());
+        boardDto = new GameBoardDTO.Response(0, List.of(), List.of());
+
+        given(gameBoardMemberQueryService.getMembers(GAME_BOARD_ID, NO_FILTERS)).willReturn(members);
+        given(gameBoardMemberMapper.toResponse(members)).willReturn(membersDto);
+        given(gameBoardQueryService.getBoard(ACTOR_MEMBER_ID, GAME_BOARD_ID)).willReturn(board);
+        given(gameBoardMapper.toResponse(board)).willReturn(boardDto);
+    }
+
+    @Test
+    @DisplayName("필터 없는 최신 명단과 게임판 snapshot을 전체 구독 세션에 전파한다")
+    void handleMembersChanged_broadcastsMembersAndBoardSnapshots() {
+        listener.handleMembersChanged(event);
+
+        then(gameBoardBroadcaster).should()
+                .broadcastMembersUpdate(GAME_BOARD_ID, membersDto, null);
+        then(gameBoardBroadcaster).should()
+                .broadcastBoardUpdate(GAME_BOARD_ID, boardDto, null);
+    }
+
+    @Test
+    @DisplayName("명단 snapshot 전파가 실패해도 게임판 snapshot 전파를 계속한다")
+    void handleMembersChanged_continuesBoardBroadcastAfterMembersFailure() {
+        willThrow(new RuntimeException("명단 전파 실패"))
+                .given(gameBoardBroadcaster).broadcastMembersUpdate(GAME_BOARD_ID, membersDto, null);
+
+        assertThatCode(() -> listener.handleMembersChanged(event)).doesNotThrowAnyException();
+
+        then(gameBoardBroadcaster).should()
+                .broadcastBoardUpdate(GAME_BOARD_ID, boardDto, null);
+    }
+}

--- a/src/test/java/umc/cockple/demo/domain/game/service/listener/GameBoardMembersChangedEventListenerTest.java
+++ b/src/test/java/umc/cockple/demo/domain/game/service/listener/GameBoardMembersChangedEventListenerTest.java
@@ -25,6 +25,8 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("GameBoardMembersChangedEventListener")
@@ -48,7 +50,7 @@ class GameBoardMembersChangedEventListenerTest {
 
     @BeforeEach
     void setUp() {
-        event = new GameBoardMembersChangedEvent(GAME_BOARD_ID, ACTOR_MEMBER_ID);
+        event = GameBoardMembersChangedEvent.membersAndBoard(GAME_BOARD_ID, ACTOR_MEMBER_ID);
         GameBoardMemberResult members = new GameBoardMemberResult(0, List.of());
         membersDto = new GameBoardMemberDTO.Response(0, List.of());
         GameBoardResult board = new GameBoardResult(0, List.of(), List.of());
@@ -56,8 +58,8 @@ class GameBoardMembersChangedEventListenerTest {
 
         given(gameBoardMemberQueryService.getMembers(GAME_BOARD_ID, NO_FILTERS)).willReturn(members);
         given(gameBoardMemberMapper.toResponse(members)).willReturn(membersDto);
-        given(gameBoardQueryService.getBoard(ACTOR_MEMBER_ID, GAME_BOARD_ID)).willReturn(board);
-        given(gameBoardMapper.toResponse(board)).willReturn(boardDto);
+        lenient().when(gameBoardQueryService.getBoard(ACTOR_MEMBER_ID, GAME_BOARD_ID)).thenReturn(board);
+        lenient().when(gameBoardMapper.toResponse(board)).thenReturn(boardDto);
     }
 
     @Test
@@ -80,6 +82,20 @@ class GameBoardMembersChangedEventListenerTest {
         assertThatCode(() -> listener.handleMembersChanged(event)).doesNotThrowAnyException();
 
         then(gameBoardBroadcaster).should()
+                .broadcastBoardUpdate(GAME_BOARD_ID, boardDto, null);
+    }
+
+    @Test
+    @DisplayName("게임/운동 상태 변경은 명단 snapshot만 전파한다")
+    void handleMembersChanged_membersOnlySkipsBoardSnapshot() {
+        event = GameBoardMembersChangedEvent.membersOnly(GAME_BOARD_ID, ACTOR_MEMBER_ID);
+
+        listener.handleMembersChanged(event);
+
+        then(gameBoardBroadcaster).should()
+                .broadcastMembersUpdate(GAME_BOARD_ID, membersDto, null);
+        then(gameBoardQueryService).shouldHaveNoInteractions();
+        then(gameBoardBroadcaster).should(never())
                 .broadcastBoardUpdate(GAME_BOARD_ID, boardDto, null);
     }
 }

--- a/src/test/java/umc/cockple/demo/domain/game/service/listener/GameBoardMembersChangedEventListenerTest.java
+++ b/src/test/java/umc/cockple/demo/domain/game/service/listener/GameBoardMembersChangedEventListenerTest.java
@@ -56,7 +56,7 @@ class GameBoardMembersChangedEventListenerTest {
         GameBoardResult board = new GameBoardResult(0, List.of(), List.of());
         boardDto = new GameBoardDTO.Response(0, List.of(), List.of());
 
-        given(gameBoardMemberQueryService.getMembers(GAME_BOARD_ID, NO_FILTERS)).willReturn(members);
+        given(gameBoardMemberQueryService.getMembersSnapshot(GAME_BOARD_ID, NO_FILTERS)).willReturn(members);
         given(gameBoardMemberMapper.toResponse(members)).willReturn(membersDto);
         lenient().when(gameBoardQueryService.getBoard(ACTOR_MEMBER_ID, GAME_BOARD_ID)).thenReturn(board);
         lenient().when(gameBoardMapper.toResponse(board)).thenReturn(boardDto);

--- a/src/test/java/umc/cockple/demo/domain/game/service/query/GameBoardMemberQueryServiceTest.java
+++ b/src/test/java/umc/cockple/demo/domain/game/service/query/GameBoardMemberQueryServiceTest.java
@@ -1,0 +1,98 @@
+package umc.cockple.demo.domain.game.service.query;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import umc.cockple.demo.domain.file.service.ImageUrlResolver;
+import umc.cockple.demo.domain.game.domain.GameBoard;
+import umc.cockple.demo.domain.game.enums.GameStatus;
+import umc.cockple.demo.domain.game.exception.GameErrorCode;
+import umc.cockple.demo.domain.game.exception.GameException;
+import umc.cockple.demo.domain.game.service.query.model.GameBoardMemberSearchQuery;
+import umc.cockple.demo.domain.game.service.query.result.GameBoardMemberResult;
+import umc.cockple.demo.domain.game.service.support.reader.GameBoardMemberReader;
+import umc.cockple.demo.domain.game.service.support.reader.GameBoardReader;
+import umc.cockple.demo.domain.game.service.support.reader.GameReader;
+import umc.cockple.demo.domain.game.service.support.validator.GameBoardAccessValidator;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("게임판 명단 조회 서비스")
+class GameBoardMemberQueryServiceTest {
+
+    private static final Long MEMBER_ID = 1L;
+    private static final Long GAME_BOARD_ID = 2L;
+    private static final GameBoardMemberSearchQuery NO_FILTERS =
+            new GameBoardMemberSearchQuery(List.of(), null, null);
+
+    @InjectMocks private GameBoardMemberQueryService gameBoardMemberQueryService;
+    @Mock private GameBoardReader gameBoardReader;
+    @Mock private GameBoardMemberReader gameBoardMemberReader;
+    @Mock private GameReader gameReader;
+    @Mock private GameBoardAccessValidator gameBoardAccessValidator;
+    @Mock private ImageUrlResolver imageUrlResolver;
+
+    @Test
+    @DisplayName("운동 참가자 검증 후 명단을 조회한다")
+    void getMembers_validatesParticipantBeforeQuery() {
+        given(gameBoardReader.read(GAME_BOARD_ID)).willReturn(GameBoard.create());
+        given(gameBoardMemberReader.countByGameBoard(GAME_BOARD_ID)).willReturn(0L);
+        given(gameBoardMemberReader.readAllByFilters(GAME_BOARD_ID, List.of(), null, null))
+                .willReturn(List.of());
+        given(gameReader.readAllByGameBoardAndStatuses(
+                GAME_BOARD_ID, List.of(GameStatus.PLAYING, GameStatus.WAITING)))
+                .willReturn(List.of());
+
+        GameBoardMemberResult result = gameBoardMemberQueryService.getMembers(
+                MEMBER_ID, GAME_BOARD_ID, NO_FILTERS);
+
+        assertThat(result.totalCount()).isZero();
+        assertThat(result.gameBoardMembers()).isEmpty();
+        then(gameBoardAccessValidator).should().validateViewer(GAME_BOARD_ID, MEMBER_ID);
+    }
+
+    @Test
+    @DisplayName("조회 권한이 없는 회원은 명단 데이터를 조회하지 않는다")
+    void getMembers_rejectsUnauthorizedMemberBeforeQuery() {
+        given(gameBoardReader.read(GAME_BOARD_ID)).willReturn(GameBoard.create());
+        willThrow(new GameException(GameErrorCode.GAME_BOARD_VIEW_ACCESS_DENIED))
+                .given(gameBoardAccessValidator).validateViewer(GAME_BOARD_ID, MEMBER_ID);
+
+        assertThatThrownBy(() -> gameBoardMemberQueryService.getMembers(
+                MEMBER_ID, GAME_BOARD_ID, NO_FILTERS))
+                .isInstanceOfSatisfying(GameException.class, exception ->
+                        assertThat(exception.getCode())
+                                .isEqualTo(GameErrorCode.GAME_BOARD_VIEW_ACCESS_DENIED));
+
+        verifyNoInteractions(gameBoardMemberReader, gameReader, imageUrlResolver);
+    }
+
+    @Test
+    @DisplayName("내부 이벤트 스냅샷은 요청자 권한 검증 없이 명단을 조회한다")
+    void getMembersSnapshot_loadsWithoutViewerValidation() {
+        given(gameBoardReader.read(GAME_BOARD_ID)).willReturn(GameBoard.create());
+        given(gameBoardMemberReader.countByGameBoard(GAME_BOARD_ID)).willReturn(0L);
+        given(gameBoardMemberReader.readAllByFilters(GAME_BOARD_ID, List.of(), null, null))
+                .willReturn(List.of());
+        given(gameReader.readAllByGameBoardAndStatuses(
+                GAME_BOARD_ID, List.of(GameStatus.PLAYING, GameStatus.WAITING)))
+                .willReturn(List.of());
+
+        GameBoardMemberResult result = gameBoardMemberQueryService.getMembersSnapshot(
+                GAME_BOARD_ID, NO_FILTERS);
+
+        assertThat(result.gameBoardMembers()).isEmpty();
+        then(gameBoardAccessValidator).shouldHaveNoInteractions();
+    }
+}

--- a/src/test/java/umc/cockple/demo/domain/game/service/support/reader/GameBoardMemberReaderTest.java
+++ b/src/test/java/umc/cockple/demo/domain/game/service/support/reader/GameBoardMemberReaderTest.java
@@ -1,0 +1,51 @@
+package umc.cockple.demo.domain.game.service.support.reader;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import umc.cockple.demo.domain.game.domain.GameBoardMember;
+import umc.cockple.demo.domain.game.exception.GameErrorCode;
+import umc.cockple.demo.domain.game.exception.GameException;
+import umc.cockple.demo.domain.game.repository.GameBoardMemberRepository;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("GameBoardMemberReader")
+class GameBoardMemberReaderTest {
+
+    private static final Long GAME_BOARD_ID = 1L;
+    private static final Long GAME_BOARD_MEMBER_ID = 2L;
+
+    @InjectMocks private GameBoardMemberReader gameBoardMemberReader;
+    @Mock private GameBoardMemberRepository gameBoardMemberRepository;
+    @Mock private GameBoardMember gameBoardMember;
+
+    @Test
+    @DisplayName("게임판과 명단 ID가 모두 일치하면 명단을 반환한다")
+    void read_returnsMemberBelongingToGameBoard() {
+        given(gameBoardMemberRepository.findByIdAndGameBoardId(GAME_BOARD_MEMBER_ID, GAME_BOARD_ID))
+                .willReturn(Optional.of(gameBoardMember));
+
+        assertThat(gameBoardMemberReader.read(GAME_BOARD_ID, GAME_BOARD_MEMBER_ID))
+                .isSameAs(gameBoardMember);
+    }
+
+    @Test
+    @DisplayName("해당 게임판에 명단 ID가 없으면 GAME_BOARD_MEMBER_NOT_FOUND 예외를 던진다")
+    void read_throwsWhenMemberDoesNotBelongToGameBoard() {
+        given(gameBoardMemberRepository.findByIdAndGameBoardId(GAME_BOARD_MEMBER_ID, GAME_BOARD_ID))
+                .willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> gameBoardMemberReader.read(GAME_BOARD_ID, GAME_BOARD_MEMBER_ID))
+                .isInstanceOfSatisfying(GameException.class, exception ->
+                        assertThat(exception.getCode()).isEqualTo(GameErrorCode.GAME_BOARD_MEMBER_NOT_FOUND));
+    }
+}

--- a/src/test/java/umc/cockple/demo/domain/game/service/support/reader/GameBoardMemberReaderTest.java
+++ b/src/test/java/umc/cockple/demo/domain/game/service/support/reader/GameBoardMemberReaderTest.java
@@ -10,12 +10,16 @@ import umc.cockple.demo.domain.game.domain.GameBoardMember;
 import umc.cockple.demo.domain.game.exception.GameErrorCode;
 import umc.cockple.demo.domain.game.exception.GameException;
 import umc.cockple.demo.domain.game.repository.GameBoardMemberRepository;
+import umc.cockple.demo.global.enums.Gender;
+import umc.cockple.demo.global.enums.Level;
 
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("GameBoardMemberReader")
@@ -47,5 +51,26 @@ class GameBoardMemberReaderTest {
         assertThatThrownBy(() -> gameBoardMemberReader.read(GAME_BOARD_ID, GAME_BOARD_MEMBER_ID))
                 .isInstanceOfSatisfying(GameException.class, exception ->
                         assertThat(exception.getCode()).isEqualTo(GameErrorCode.GAME_BOARD_MEMBER_NOT_FOUND));
+    }
+
+    @Test
+    @DisplayName("게임판 전체 명단 수를 repository에서 조회한다")
+    void countByGameBoard_delegatesToRepository() {
+        given(gameBoardMemberRepository.countByGameBoardId(GAME_BOARD_ID)).willReturn(3L);
+
+        assertThat(gameBoardMemberReader.countByGameBoard(GAME_BOARD_ID)).isEqualTo(3L);
+    }
+
+    @Test
+    @DisplayName("게임판 명단 필터 조건을 repository에 전달한다")
+    void readAllByFilters_delegatesToRepository() {
+        List<Level> levels = List.of(Level.A, Level.B);
+        given(gameBoardMemberRepository.findAllByFilters(GAME_BOARD_ID, levels, Gender.MALE, true))
+                .willReturn(List.of(gameBoardMember));
+
+        assertThat(gameBoardMemberReader.readAllByFilters(GAME_BOARD_ID, levels, Gender.MALE, true))
+                .containsExactly(gameBoardMember);
+        then(gameBoardMemberRepository).should()
+                .findAllByFilters(GAME_BOARD_ID, levels, Gender.MALE, true);
     }
 }

--- a/src/test/java/umc/cockple/demo/domain/game/service/support/reader/GameReaderTest.java
+++ b/src/test/java/umc/cockple/demo/domain/game/service/support/reader/GameReaderTest.java
@@ -1,0 +1,38 @@
+package umc.cockple.demo.domain.game.service.support.reader;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import umc.cockple.demo.domain.game.domain.Game;
+import umc.cockple.demo.domain.game.enums.GameStatus;
+import umc.cockple.demo.domain.game.repository.GameRepository;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("GameReader")
+class GameReaderTest {
+
+    private static final Long GAME_BOARD_ID = 1L;
+
+    @InjectMocks private GameReader gameReader;
+    @Mock private GameRepository gameRepository;
+    @Mock private Game game;
+
+    @Test
+    @DisplayName("게임판과 상태 조건으로 플레이어를 포함한 게임을 조회한다")
+    void readAllByGameBoardAndStatuses_delegatesToRepository() {
+        List<GameStatus> statuses = List.of(GameStatus.PLAYING, GameStatus.WAITING);
+        given(gameRepository.findByGameBoardIdAndStatusInWithPlayers(GAME_BOARD_ID, statuses))
+                .willReturn(List.of(game));
+
+        assertThat(gameReader.readAllByGameBoardAndStatuses(GAME_BOARD_ID, statuses))
+                .containsExactly(game);
+    }
+}

--- a/src/test/java/umc/cockple/demo/domain/game/service/support/reader/GameReaderTest.java
+++ b/src/test/java/umc/cockple/demo/domain/game/service/support/reader/GameReaderTest.java
@@ -14,6 +14,7 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("GameReader")
@@ -34,5 +35,18 @@ class GameReaderTest {
 
         assertThat(gameReader.readAllByGameBoardAndStatuses(GAME_BOARD_ID, statuses))
                 .containsExactly(game);
+    }
+
+    @Test
+    @DisplayName("명단이 주어진 상태의 게임에 포함됐는지 조회한다")
+    void existsByGameBoardMemberAndStatuses_delegatesToRepository() {
+        Long gameBoardMemberId = 2L;
+        List<GameStatus> statuses = List.of(GameStatus.PLAYING, GameStatus.WAITING);
+        given(gameRepository.existsByGameBoardMemberIdAndStatusIn(gameBoardMemberId, statuses))
+                .willReturn(true);
+
+        assertThat(gameReader.existsByGameBoardMemberAndStatuses(gameBoardMemberId, statuses)).isTrue();
+        then(gameRepository).should()
+                .existsByGameBoardMemberIdAndStatusIn(gameBoardMemberId, statuses);
     }
 }

--- a/src/test/java/umc/cockple/demo/domain/game/service/support/validator/GameBoardAccessValidatorTest.java
+++ b/src/test/java/umc/cockple/demo/domain/game/service/support/validator/GameBoardAccessValidatorTest.java
@@ -1,0 +1,67 @@
+package umc.cockple.demo.domain.game.service.support.validator;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import umc.cockple.demo.domain.exercise.domain.Exercise;
+import umc.cockple.demo.domain.exercise.repository.ExerciseRepository;
+import umc.cockple.demo.domain.game.exception.GameErrorCode;
+import umc.cockple.demo.domain.game.exception.GameException;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("GameBoardAccessValidator")
+class GameBoardAccessValidatorTest {
+
+    private static final Long GAME_BOARD_ID = 1L;
+    private static final Long GAME_HOST_ID = 2L;
+
+    @InjectMocks private GameBoardAccessValidator gameBoardAccessValidator;
+    @Mock private ExerciseRepository exerciseRepository;
+
+    private Exercise exercise;
+
+    @BeforeEach
+    void setUp() {
+        exercise = Exercise.builder().gameHostId(GAME_HOST_ID).build();
+    }
+
+    @Test
+    @DisplayName("연결된 운동의 게임 진행자는 게임판을 관리할 수 있다")
+    void validateGameHost_allowsExerciseGameHost() {
+        given(exerciseRepository.findByGameBoardId(GAME_BOARD_ID)).willReturn(Optional.of(exercise));
+
+        assertThatCode(() -> gameBoardAccessValidator.validateGameHost(GAME_BOARD_ID, GAME_HOST_ID))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("게임 진행자가 아니면 GAME_BOARD_ACCESS_DENIED 예외를 던진다")
+    void validateGameHost_deniesOtherMember() {
+        given(exerciseRepository.findByGameBoardId(GAME_BOARD_ID)).willReturn(Optional.of(exercise));
+
+        assertThatThrownBy(() -> gameBoardAccessValidator.validateGameHost(GAME_BOARD_ID, 999L))
+                .isInstanceOfSatisfying(GameException.class, exception ->
+                        assertThat(exception.getCode()).isEqualTo(GameErrorCode.GAME_BOARD_ACCESS_DENIED));
+    }
+
+    @Test
+    @DisplayName("운동과 연결된 게임판이 없으면 GAME_BOARD_NOT_FOUND 예외를 던진다")
+    void validateGameHost_throwsWhenGameBoardDoesNotExist() {
+        given(exerciseRepository.findByGameBoardId(GAME_BOARD_ID)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> gameBoardAccessValidator.validateGameHost(GAME_BOARD_ID, GAME_HOST_ID))
+                .isInstanceOfSatisfying(GameException.class, exception ->
+                        assertThat(exception.getCode()).isEqualTo(GameErrorCode.GAME_BOARD_NOT_FOUND));
+    }
+}

--- a/src/test/java/umc/cockple/demo/domain/game/service/support/validator/GameBoardAccessValidatorTest.java
+++ b/src/test/java/umc/cockple/demo/domain/game/service/support/validator/GameBoardAccessValidatorTest.java
@@ -11,6 +11,7 @@ import umc.cockple.demo.domain.exercise.domain.Exercise;
 import umc.cockple.demo.domain.exercise.repository.ExerciseRepository;
 import umc.cockple.demo.domain.game.exception.GameErrorCode;
 import umc.cockple.demo.domain.game.exception.GameException;
+import umc.cockple.demo.domain.game.repository.GameBoardMemberRepository;
 
 import java.util.Optional;
 
@@ -28,6 +29,7 @@ class GameBoardAccessValidatorTest {
 
     @InjectMocks private GameBoardAccessValidator gameBoardAccessValidator;
     @Mock private ExerciseRepository exerciseRepository;
+    @Mock private GameBoardMemberRepository gameBoardMemberRepository;
 
     private Exercise exercise;
 
@@ -63,5 +65,42 @@ class GameBoardAccessValidatorTest {
         assertThatThrownBy(() -> gameBoardAccessValidator.validateGameHost(GAME_BOARD_ID, GAME_HOST_ID))
                 .isInstanceOfSatisfying(GameException.class, exception ->
                         assertThat(exception.getCode()).isEqualTo(GameErrorCode.GAME_BOARD_NOT_FOUND));
+    }
+
+    @Test
+    @DisplayName("게임판 명단에 연결된 회원은 운동 참가자로 조회 권한이 있다")
+    void validateViewer_allowsExerciseParticipant() {
+        given(gameBoardMemberRepository.existsByGameBoardIdAndMemberId(GAME_BOARD_ID, GAME_HOST_ID))
+                .willReturn(true);
+
+        assertThatCode(() -> gameBoardAccessValidator.validateViewer(GAME_BOARD_ID, GAME_HOST_ID))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("운동 참가자가 아니어도 게임 진행자는 조회 권한이 있다")
+    void validateViewer_allowsGameHost() {
+        given(gameBoardMemberRepository.existsByGameBoardIdAndMemberId(GAME_BOARD_ID, GAME_HOST_ID))
+                .willReturn(false);
+        given(exerciseRepository.findByGameBoardId(GAME_BOARD_ID)).willReturn(Optional.of(exercise));
+
+        assertThatCode(() -> gameBoardAccessValidator.validateViewer(GAME_BOARD_ID, GAME_HOST_ID))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("운동 참가자와 게임 진행자가 아니면 GAME_BOARD_VIEW_ACCESS_DENIED 예외를 던진다")
+    void validateViewer_deniesUnauthorizedMember() {
+        Long unauthorizedMemberId = 999L;
+        given(gameBoardMemberRepository.existsByGameBoardIdAndMemberId(
+                GAME_BOARD_ID, unauthorizedMemberId))
+                .willReturn(false);
+        given(exerciseRepository.findByGameBoardId(GAME_BOARD_ID)).willReturn(Optional.of(exercise));
+
+        assertThatThrownBy(() -> gameBoardAccessValidator.validateViewer(
+                GAME_BOARD_ID, unauthorizedMemberId))
+                .isInstanceOfSatisfying(GameException.class, exception ->
+                        assertThat(exception.getCode())
+                                .isEqualTo(GameErrorCode.GAME_BOARD_VIEW_ACCESS_DENIED));
     }
 }

--- a/src/test/java/umc/cockple/demo/domain/game/service/websocket/broadcast/GameBoardBroadcasterTest.java
+++ b/src/test/java/umc/cockple/demo/domain/game/service/websocket/broadcast/GameBoardBroadcasterTest.java
@@ -31,6 +31,7 @@ class GameBoardBroadcasterTest {
 
     private static final Long BOARD_ID = 1L;
     private static final Object BOARD_DATA = new Object();
+    private static final Object MEMBERS_DATA = new Object();
 
     @Test
     @DisplayName("변경을 일으킨 세션은 제외하고, 나머지 구독 세션 각각에 세션 단위로 발행한다")
@@ -82,5 +83,24 @@ class GameBoardBroadcasterTest {
                 eq(10L), eq("session-1"), any(), any(), eq(BOARD_DATA));
         then(realtimeMessagePublisher).should().publishToSession(
                 eq(20L), eq("session-2"), any(), any(), eq(BOARD_DATA));
+    }
+
+    @Test
+    @DisplayName("REST 명단 변경은 요청자를 포함한 모든 구독 세션에 MEMBERS_UPDATED를 발행한다")
+    void membersUpdateBroadcastsToAllSessions() {
+        GameBoardSubscriber s1 = new GameBoardSubscriber(10L, "session-1");
+        GameBoardSubscriber s2 = new GameBoardSubscriber(20L, "session-2");
+        given(subscriptionStore.getSubscribers(BOARD_ID)).willReturn(Set.of(s1, s2));
+        given(realtimeMessagePublisher.publishToSession(any(), any(), any(), any(), any()))
+                .willReturn(new RealtimePublishResult(1, 1));
+
+        gameBoardBroadcaster.broadcastMembersUpdate(BOARD_ID, MEMBERS_DATA, null);
+
+        then(realtimeMessagePublisher).should().publishToSession(
+                eq(10L), eq("session-1"), eq(GameRealtimeProtocol.DOMAIN),
+                eq(GameRealtimeProtocol.TYPE_MEMBERS_UPDATED), eq(MEMBERS_DATA));
+        then(realtimeMessagePublisher).should().publishToSession(
+                eq(20L), eq("session-2"), eq(GameRealtimeProtocol.DOMAIN),
+                eq(GameRealtimeProtocol.TYPE_MEMBERS_UPDATED), eq(MEMBERS_DATA));
     }
 }


### PR DESCRIPTION
## ❤️ 기능 설명

게임판 명단을 조회·추가·수정하고 참여 상태를 관리하는 REST API를 구현했습니다.
명단 변경은 REST 트랜잭션 커밋 이후 WebSocket으로 최신 명단/게임판 snapshot을 전파합니다.

### 주요 변경사항

1. 게임판 명단 관리 API
- `GET /api/game-boards/{gameBoardId}/gameBoardMembers`
- `POST /api/game-boards/{gameBoardId}/gameBoardMembers`
- `PATCH /api/game-boards/{gameBoardId}/gameBoardMembers/{gameBoardMemberId}`
- `PATCH /api/game-boards/{gameBoardId}/gameBoardMembers/{gameBoardMemberId}/participation`
- 급수·성별·셔틀콕 제출 여부 필터와 필터 무관 `totalCount` 제공
- PLAYING/WAITING 상태, 게임 횟수, 프로필 이미지, 한글 성별·급수·연령대 반환

2. 권한 및 입력 검증
- 조회는 인증 사용자에게 허용
- 추가·수정은 연결된 운동의 `gameHostId` 사용자만 허용
- URL의 게임판과 명단 소속을 함께 검증
- 이름·한글 성별·급수·연령대 및 이름 최대 255자 검증

3. 참여 상태와 게임 배정 불변식
- PLAYING/WAITING 선수의 참여 해제 차단
- 불참 선수의 새 대기 게임 생성 차단
- 게임 생성과 참여 해제를 게임판 pessimistic lock으로 직렬화
- 두 커밋 순서에 대한 MySQL 동시성 테스트 추가

4. REST/WebSocket 동기화
- REST 명단 변경 후 `AFTER_COMMIT`에서 `MEMBERS_UPDATED` 전파
- 이름·급수처럼 보드에도 영향을 주는 명단 변경은 `BOARD_UPDATED`도 함께 전파
- 게임 생성·시작·삭제·재대기와 운동 회원/게스트 참가 변경도 명단 projection 갱신 이벤트 발행
- 롤백 시 미전파, 일부 전파 실패가 다른 snapshot이나 커밋 결과에 영향을 주지 않도록 격리

5. 조회 및 테스트
- QueryDSL fetch join으로 회원 프로필 N+1 방지
- 명단 CRUD, 필터, 권한, 이벤트, 롤백, 동시성 단위·통합 테스트 추가

<br>

## 연결된 issue

close #718

<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 이 PR은 #725(`feature/#714`) 위에 쌓인 stacked Draft PR입니다. #725 squash merge 후 `develop`로 rebase/retarget할 예정입니다.
- [ ] 현재 배포는 단일 앱 인스턴스입니다. Redis 전역 구독자와 JVM 로컬 WebSocket 세션 간 멀티 인스턴스 라우팅은 후속 개선이 필요합니다.
- [ ] 비동기 snapshot에는 아직 board revision/순서 보장이 없어, 멀티 인스턴스·고빈도 변경 환경의 ordering은 후속 개선 대상입니다.

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
