### PR TITLE
[fix/#728] 게임판 명단 조회 권한 검증 제거

### DIFF
--- a/src/main/java/umc/cockple/demo/domain/game/exception/GameErrorCode.java
+++ b/src/main/java/umc/cockple/demo/domain/game/exception/GameErrorCode.java
@@ -17,7 +17,6 @@ public enum GameErrorCode implements BaseErrorCode {
     GAME_BOARD_MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "GAME205", "게임판 명단에 없는 멤버가 포함되어 있습니다."),
 
     GAME_BOARD_ACCESS_DENIED(HttpStatus.FORBIDDEN, "GAME301", "게임판을 관리할 권한이 없습니다."),
-    GAME_BOARD_VIEW_ACCESS_DENIED(HttpStatus.FORBIDDEN, "GAME302", "해당 운동 참가자 또는 게임 진행자만 게임판 명단을 조회할 수 있습니다."),
 
     GAME_BOARD_ID_REQUIRED(HttpStatus.BAD_REQUEST, "GAME401", "게임판 ID가 필요합니다."),
     INVALID_REALTIME_PAYLOAD(HttpStatus.BAD_REQUEST, "GAME402", "게임 요청 형식이 올바르지 않습니다."),

--- a/src/main/java/umc/cockple/demo/domain/game/presentation/controller/GameBoardMemberController.java
+++ b/src/main/java/umc/cockple/demo/domain/game/presentation/controller/GameBoardMemberController.java
@@ -71,12 +71,11 @@ public class GameBoardMemberController implements GameBoardMemberApi {
     @Override
     public ResponseEntity<BaseResponse<GameBoardMemberDTO.Response>> getMembers(
             Long gameBoardId, List<String> levels, String gender, Boolean shuttlecockSubmitted) {
-        Long memberId = SecurityUtil.getCurrentMemberId();
         GameBoardMemberSearchQuery searchQuery = gameBoardMemberMapper.toSearchQuery(
                 levels, gender, shuttlecockSubmitted);
 
         GameBoardMemberResult result = gameBoardMemberQueryService.getMembers(
-                memberId, gameBoardId, searchQuery);
+                gameBoardId, searchQuery);
 
         return BaseResponse.of(CommonSuccessCode.OK, gameBoardMemberMapper.toResponse(result));
     }

--- a/src/main/java/umc/cockple/demo/domain/game/presentation/controller/api/GameBoardMemberApi.java
+++ b/src/main/java/umc/cockple/demo/domain/game/presentation/controller/api/GameBoardMemberApi.java
@@ -83,11 +83,9 @@ public interface GameBoardMemberApi {
             - 서로 다른 종류의 필터는 AND 조건입니다.
             - `totalCount`는 필터와 무관한 전체 명단 수입니다.
             - 명단의 `gender`, `level`, `ageGroup`은 한글 표시값으로 반환합니다.
-            - 해당 운동에 참여 중인 회원 또는 게임 진행자만 조회할 수 있습니다.
             """)
     @ApiResponse(responseCode = "200", description = "조회 성공")
     @ApiResponse(responseCode = "401", description = "인증 필요")
-    @ApiResponse(responseCode = "403", description = "운동 참가자 또는 게임 진행자가 아닌 회원")
     @ApiResponse(responseCode = "404", description = "게임판을 찾을 수 없음")
     ResponseEntity<BaseResponse<GameBoardMemberDTO.Response>> getMembers(
             @PathVariable Long gameBoardId,

--- a/src/main/java/umc/cockple/demo/domain/game/repository/GameBoardMemberRepository.java
+++ b/src/main/java/umc/cockple/demo/domain/game/repository/GameBoardMemberRepository.java
@@ -20,8 +20,6 @@ public interface GameBoardMemberRepository extends JpaRepository<GameBoardMember
 
     long countByGameBoardId(Long gameBoardId);
 
-    boolean existsByGameBoardIdAndMemberId(Long gameBoardId, Long memberId);
-
     @Modifying(flushAutomatically = true)
     @Query(value = """
             DELETE game_board_member

--- a/src/main/java/umc/cockple/demo/domain/game/service/listener/GameBoardMembersChangedEventListener.java
+++ b/src/main/java/umc/cockple/demo/domain/game/service/listener/GameBoardMembersChangedEventListener.java
@@ -40,7 +40,7 @@ public class GameBoardMembersChangedEventListener {
     public void handleMembersChanged(GameBoardMembersChangedEvent event) {
         GameBoardMemberDTO.Response membersDto;
         try {
-            GameBoardMemberResult members = gameBoardMemberQueryService.getMembersSnapshot(
+            GameBoardMemberResult members = gameBoardMemberQueryService.getMembers(
                     event.gameBoardId(), NO_FILTERS);
             membersDto = gameBoardMemberMapper.toResponse(members);
         } catch (Exception e) {

--- a/src/main/java/umc/cockple/demo/domain/game/service/query/GameBoardMemberQueryService.java
+++ b/src/main/java/umc/cockple/demo/domain/game/service/query/GameBoardMemberQueryService.java
@@ -13,7 +13,6 @@ import umc.cockple.demo.domain.game.service.query.result.GameBoardMemberResult;
 import umc.cockple.demo.domain.game.service.support.reader.GameBoardMemberReader;
 import umc.cockple.demo.domain.game.service.support.reader.GameBoardReader;
 import umc.cockple.demo.domain.game.service.support.reader.GameReader;
-import umc.cockple.demo.domain.game.service.support.validator.GameBoardAccessValidator;
 import umc.cockple.demo.domain.member.domain.Member;
 import umc.cockple.demo.domain.member.domain.ProfileImg;
 
@@ -32,18 +31,9 @@ public class GameBoardMemberQueryService {
     private final GameBoardReader gameBoardReader;
     private final GameBoardMemberReader gameBoardMemberReader;
     private final GameReader gameReader;
-    private final GameBoardAccessValidator gameBoardAccessValidator;
     private final ImageUrlResolver imageUrlResolver;
 
     public GameBoardMemberResult getMembers(
-            Long memberId, Long gameBoardId, GameBoardMemberSearchQuery searchQuery) {
-        gameBoardReader.read(gameBoardId);
-        gameBoardAccessValidator.validateViewer(gameBoardId, memberId);
-
-        return loadMembers(gameBoardId, searchQuery);
-    }
-
-    public GameBoardMemberResult getMembersSnapshot(
             Long gameBoardId, GameBoardMemberSearchQuery searchQuery) {
         gameBoardReader.read(gameBoardId);
 

--- a/src/main/java/umc/cockple/demo/domain/game/service/support/validator/GameBoardAccessValidator.java
+++ b/src/main/java/umc/cockple/demo/domain/game/service/support/validator/GameBoardAccessValidator.java
@@ -7,7 +7,6 @@ import umc.cockple.demo.domain.exercise.domain.Exercise;
 import umc.cockple.demo.domain.exercise.repository.ExerciseRepository;
 import umc.cockple.demo.domain.game.exception.GameErrorCode;
 import umc.cockple.demo.domain.game.exception.GameException;
-import umc.cockple.demo.domain.game.repository.GameBoardMemberRepository;
 
 import java.util.Objects;
 
@@ -17,7 +16,6 @@ import java.util.Objects;
 public class GameBoardAccessValidator {
 
     private final ExerciseRepository exerciseRepository;
-    private final GameBoardMemberRepository gameBoardMemberRepository;
 
     public void validateGameHost(Long gameBoardId, Long memberId) {
         Exercise exercise = exerciseRepository.findByGameBoardId(gameBoardId)
@@ -25,18 +23,6 @@ public class GameBoardAccessValidator {
 
         if (!Objects.equals(exercise.getGameHostId(), memberId)) {
             throw new GameException(GameErrorCode.GAME_BOARD_ACCESS_DENIED);
-        }
-    }
-
-    public void validateViewer(Long gameBoardId, Long memberId) {
-        if (gameBoardMemberRepository.existsByGameBoardIdAndMemberId(gameBoardId, memberId)) {
-            return;
-        }
-
-        Exercise exercise = exerciseRepository.findByGameBoardId(gameBoardId)
-                .orElseThrow(() -> new GameException(GameErrorCode.GAME_BOARD_NOT_FOUND));
-        if (!Objects.equals(exercise.getGameHostId(), memberId)) {
-            throw new GameException(GameErrorCode.GAME_BOARD_VIEW_ACCESS_DENIED);
         }
     }
 }

--- a/src/test/java/umc/cockple/demo/domain/game/integration/GameBoardMemberQueryIntegrationTest.java
+++ b/src/test/java/umc/cockple/demo/domain/game/integration/GameBoardMemberQueryIntegrationTest.java
@@ -15,7 +15,6 @@ import umc.cockple.demo.domain.game.domain.GameBoardMember;
 import umc.cockple.demo.domain.game.domain.GamePlayer;
 import umc.cockple.demo.domain.game.enums.AgeGroup;
 import umc.cockple.demo.domain.game.enums.GameStatus;
-import umc.cockple.demo.domain.game.exception.GameErrorCode;
 import umc.cockple.demo.domain.game.repository.GameBoardMemberRepository;
 import umc.cockple.demo.domain.game.repository.GameRepository;
 import umc.cockple.demo.domain.member.domain.Member;
@@ -189,14 +188,13 @@ class GameBoardMemberQueryIntegrationTest extends IntegrationTestBase {
     }
 
     @Test
-    @DisplayName("운동 참가자와 게임 진행자가 아닌 회원은 명단을 조회할 수 없다")
-    void getMembers_forbidsUnauthorizedMember() throws Exception {
+    @DisplayName("운동 참가자와 게임 진행자가 아닌 인증 회원도 명단을 조회할 수 있다")
+    void getMembers_allowsNonParticipant() throws Exception {
         SecurityContextHelper.setAuthentication(nonParticipant.getId(), nonParticipant.getMemberName());
 
         mockMvc.perform(get("/api/game-boards/{gameBoardId}/gameBoardMembers", gameBoard.getId()))
-                .andExpect(status().isForbidden())
-                .andExpect(jsonPath("$.code")
-                        .value(GameErrorCode.GAME_BOARD_VIEW_ACCESS_DENIED.getCode()));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.totalCount").value(4));
     }
 
     @Test

--- a/src/test/java/umc/cockple/demo/domain/game/service/listener/GameBoardMembersChangedEventFlowTest.java
+++ b/src/test/java/umc/cockple/demo/domain/game/service/listener/GameBoardMembersChangedEventFlowTest.java
@@ -64,7 +64,7 @@ class GameBoardMembersChangedEventFlowTest extends IntegrationTestBase {
         GameBoardResult board = new GameBoardResult(0, List.of(), List.of());
         boardDto = new GameBoardDTO.Response(0, List.of(), List.of());
 
-        given(gameBoardMemberQueryService.getMembersSnapshot(anyLong(), eq(NO_FILTERS))).willReturn(members);
+        given(gameBoardMemberQueryService.getMembers(anyLong(), eq(NO_FILTERS))).willReturn(members);
         given(gameBoardMemberMapper.toResponse(members)).willReturn(membersDto);
         given(gameBoardQueryService.getBoard(eq(ACTOR_MEMBER_ID), anyLong())).willReturn(board);
         given(gameBoardMapper.toResponse(board)).willReturn(boardDto);
@@ -98,7 +98,7 @@ class GameBoardMembersChangedEventFlowTest extends IntegrationTestBase {
         });
 
         then(gameBoardMemberQueryService).should(after(700).never())
-                .getMembersSnapshot(anyLong(), eq(NO_FILTERS));
+                .getMembers(anyLong(), eq(NO_FILTERS));
         then(gameBoardBroadcaster).should(never())
                 .broadcastMembersUpdate(anyLong(), eq(membersDto), isNull());
         then(gameBoardBroadcaster).should(never())

--- a/src/test/java/umc/cockple/demo/domain/game/service/listener/GameBoardMembersChangedEventListenerTest.java
+++ b/src/test/java/umc/cockple/demo/domain/game/service/listener/GameBoardMembersChangedEventListenerTest.java
@@ -56,7 +56,7 @@ class GameBoardMembersChangedEventListenerTest {
         GameBoardResult board = new GameBoardResult(0, List.of(), List.of());
         boardDto = new GameBoardDTO.Response(0, List.of(), List.of());
 
-        given(gameBoardMemberQueryService.getMembersSnapshot(GAME_BOARD_ID, NO_FILTERS)).willReturn(members);
+        given(gameBoardMemberQueryService.getMembers(GAME_BOARD_ID, NO_FILTERS)).willReturn(members);
         given(gameBoardMemberMapper.toResponse(members)).willReturn(membersDto);
         lenient().when(gameBoardQueryService.getBoard(ACTOR_MEMBER_ID, GAME_BOARD_ID)).thenReturn(board);
         lenient().when(gameBoardMapper.toResponse(board)).thenReturn(boardDto);

--- a/src/test/java/umc/cockple/demo/domain/game/service/query/GameBoardMemberQueryServiceTest.java
+++ b/src/test/java/umc/cockple/demo/domain/game/service/query/GameBoardMemberQueryServiceTest.java
@@ -16,14 +16,12 @@ import umc.cockple.demo.domain.game.service.query.result.GameBoardMemberResult;
 import umc.cockple.demo.domain.game.service.support.reader.GameBoardMemberReader;
 import umc.cockple.demo.domain.game.service.support.reader.GameBoardReader;
 import umc.cockple.demo.domain.game.service.support.reader.GameReader;
-import umc.cockple.demo.domain.game.service.support.validator.GameBoardAccessValidator;
 
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.then;
 import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.verifyNoInteractions;
 
@@ -31,7 +29,6 @@ import static org.mockito.Mockito.verifyNoInteractions;
 @DisplayName("게임판 명단 조회 서비스")
 class GameBoardMemberQueryServiceTest {
 
-    private static final Long MEMBER_ID = 1L;
     private static final Long GAME_BOARD_ID = 2L;
     private static final GameBoardMemberSearchQuery NO_FILTERS =
             new GameBoardMemberSearchQuery(List.of(), null, null);
@@ -40,12 +37,11 @@ class GameBoardMemberQueryServiceTest {
     @Mock private GameBoardReader gameBoardReader;
     @Mock private GameBoardMemberReader gameBoardMemberReader;
     @Mock private GameReader gameReader;
-    @Mock private GameBoardAccessValidator gameBoardAccessValidator;
     @Mock private ImageUrlResolver imageUrlResolver;
 
     @Test
-    @DisplayName("운동 참가자 검증 후 명단을 조회한다")
-    void getMembers_validatesParticipantBeforeQuery() {
+    @DisplayName("요청자 권한 검증 없이 명단을 조회한다")
+    void getMembers_loadsWithoutViewerValidation() {
         given(gameBoardReader.read(GAME_BOARD_ID)).willReturn(GameBoard.create());
         given(gameBoardMemberReader.countByGameBoard(GAME_BOARD_ID)).willReturn(0L);
         given(gameBoardMemberReader.readAllByFilters(GAME_BOARD_ID, List.of(), null, null))
@@ -55,44 +51,22 @@ class GameBoardMemberQueryServiceTest {
                 .willReturn(List.of());
 
         GameBoardMemberResult result = gameBoardMemberQueryService.getMembers(
-                MEMBER_ID, GAME_BOARD_ID, NO_FILTERS);
+                GAME_BOARD_ID, NO_FILTERS);
 
         assertThat(result.totalCount()).isZero();
         assertThat(result.gameBoardMembers()).isEmpty();
-        then(gameBoardAccessValidator).should().validateViewer(GAME_BOARD_ID, MEMBER_ID);
     }
 
     @Test
-    @DisplayName("조회 권한이 없는 회원은 명단 데이터를 조회하지 않는다")
-    void getMembers_rejectsUnauthorizedMemberBeforeQuery() {
-        given(gameBoardReader.read(GAME_BOARD_ID)).willReturn(GameBoard.create());
-        willThrow(new GameException(GameErrorCode.GAME_BOARD_VIEW_ACCESS_DENIED))
-                .given(gameBoardAccessValidator).validateViewer(GAME_BOARD_ID, MEMBER_ID);
+    @DisplayName("존재하지 않는 게임판은 명단을 조회하지 않는다")
+    void getMembers_rejectsMissingGameBoardBeforeQuery() {
+        willThrow(new GameException(GameErrorCode.GAME_BOARD_NOT_FOUND))
+                .given(gameBoardReader).read(GAME_BOARD_ID);
 
-        assertThatThrownBy(() -> gameBoardMemberQueryService.getMembers(
-                MEMBER_ID, GAME_BOARD_ID, NO_FILTERS))
+        assertThatThrownBy(() -> gameBoardMemberQueryService.getMembers(GAME_BOARD_ID, NO_FILTERS))
                 .isInstanceOfSatisfying(GameException.class, exception ->
-                        assertThat(exception.getCode())
-                                .isEqualTo(GameErrorCode.GAME_BOARD_VIEW_ACCESS_DENIED));
+                        assertThat(exception.getCode()).isEqualTo(GameErrorCode.GAME_BOARD_NOT_FOUND));
 
         verifyNoInteractions(gameBoardMemberReader, gameReader, imageUrlResolver);
-    }
-
-    @Test
-    @DisplayName("내부 이벤트 스냅샷은 요청자 권한 검증 없이 명단을 조회한다")
-    void getMembersSnapshot_loadsWithoutViewerValidation() {
-        given(gameBoardReader.read(GAME_BOARD_ID)).willReturn(GameBoard.create());
-        given(gameBoardMemberReader.countByGameBoard(GAME_BOARD_ID)).willReturn(0L);
-        given(gameBoardMemberReader.readAllByFilters(GAME_BOARD_ID, List.of(), null, null))
-                .willReturn(List.of());
-        given(gameReader.readAllByGameBoardAndStatuses(
-                GAME_BOARD_ID, List.of(GameStatus.PLAYING, GameStatus.WAITING)))
-                .willReturn(List.of());
-
-        GameBoardMemberResult result = gameBoardMemberQueryService.getMembersSnapshot(
-                GAME_BOARD_ID, NO_FILTERS);
-
-        assertThat(result.gameBoardMembers()).isEmpty();
-        then(gameBoardAccessValidator).shouldHaveNoInteractions();
     }
 }

--- a/src/test/java/umc/cockple/demo/domain/game/service/support/validator/GameBoardAccessValidatorTest.java
+++ b/src/test/java/umc/cockple/demo/domain/game/service/support/validator/GameBoardAccessValidatorTest.java
@@ -11,7 +11,6 @@ import umc.cockple.demo.domain.exercise.domain.Exercise;
 import umc.cockple.demo.domain.exercise.repository.ExerciseRepository;
 import umc.cockple.demo.domain.game.exception.GameErrorCode;
 import umc.cockple.demo.domain.game.exception.GameException;
-import umc.cockple.demo.domain.game.repository.GameBoardMemberRepository;
 
 import java.util.Optional;
 
@@ -29,7 +28,6 @@ class GameBoardAccessValidatorTest {
 
     @InjectMocks private GameBoardAccessValidator gameBoardAccessValidator;
     @Mock private ExerciseRepository exerciseRepository;
-    @Mock private GameBoardMemberRepository gameBoardMemberRepository;
 
     private Exercise exercise;
 
@@ -65,42 +63,5 @@ class GameBoardAccessValidatorTest {
         assertThatThrownBy(() -> gameBoardAccessValidator.validateGameHost(GAME_BOARD_ID, GAME_HOST_ID))
                 .isInstanceOfSatisfying(GameException.class, exception ->
                         assertThat(exception.getCode()).isEqualTo(GameErrorCode.GAME_BOARD_NOT_FOUND));
-    }
-
-    @Test
-    @DisplayName("게임판 명단에 연결된 회원은 운동 참가자로 조회 권한이 있다")
-    void validateViewer_allowsExerciseParticipant() {
-        given(gameBoardMemberRepository.existsByGameBoardIdAndMemberId(GAME_BOARD_ID, GAME_HOST_ID))
-                .willReturn(true);
-
-        assertThatCode(() -> gameBoardAccessValidator.validateViewer(GAME_BOARD_ID, GAME_HOST_ID))
-                .doesNotThrowAnyException();
-    }
-
-    @Test
-    @DisplayName("운동 참가자가 아니어도 게임 진행자는 조회 권한이 있다")
-    void validateViewer_allowsGameHost() {
-        given(gameBoardMemberRepository.existsByGameBoardIdAndMemberId(GAME_BOARD_ID, GAME_HOST_ID))
-                .willReturn(false);
-        given(exerciseRepository.findByGameBoardId(GAME_BOARD_ID)).willReturn(Optional.of(exercise));
-
-        assertThatCode(() -> gameBoardAccessValidator.validateViewer(GAME_BOARD_ID, GAME_HOST_ID))
-                .doesNotThrowAnyException();
-    }
-
-    @Test
-    @DisplayName("운동 참가자와 게임 진행자가 아니면 GAME_BOARD_VIEW_ACCESS_DENIED 예외를 던진다")
-    void validateViewer_deniesUnauthorizedMember() {
-        Long unauthorizedMemberId = 999L;
-        given(gameBoardMemberRepository.existsByGameBoardIdAndMemberId(
-                GAME_BOARD_ID, unauthorizedMemberId))
-                .willReturn(false);
-        given(exerciseRepository.findByGameBoardId(GAME_BOARD_ID)).willReturn(Optional.of(exercise));
-
-        assertThatThrownBy(() -> gameBoardAccessValidator.validateViewer(
-                GAME_BOARD_ID, unauthorizedMemberId))
-                .isInstanceOfSatisfying(GameException.class, exception ->
-                        assertThat(exception.getCode())
-                                .isEqualTo(GameErrorCode.GAME_BOARD_VIEW_ACCESS_DENIED));
     }
 }


### PR DESCRIPTION
## ❤️ 기능 설명

게임판 명단 조회 API의 참가자·게임 진행자 권한 검증을 제거했습니다.

- 인증 회원은 운동 참여 여부와 관계없이 명단 조회 가능
- 별도 `getMembersSnapshot` 경로를 `getMembers`로 통합
- 사용하지 않는 조회 권한 검증 코드와 오류 코드 정리

## 연결된 issue

close #728

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 미인증 요청은 기존과 동일하게 `401`을 반환합니다.

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?

## 테스트

- 관련 단위 테스트 통과
- 명단 조회 및 이벤트 흐름 대상 통합 테스트 통과
- 전체 테스트는 CI에서 확인합니다.
