### PR TITLE
[feature/#730] 운동 생성/상세 조회 응답에 gameBoardId 추가

### DIFF
--- a/src/main/java/umc/cockple/demo/domain/exercise/presentation/controller/api/ExerciseLifecycleApi.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/presentation/controller/api/ExerciseLifecycleApi.java
@@ -24,7 +24,8 @@ public interface ExerciseLifecycleApi {
 
     @PostMapping("/parties/{partyId}/exercises")
     @Operation(summary = "운동 생성",
-            description = "모임 내에서 새로운 운동을 생성합니다. 모임장과 부모임장만 생성 가능합니다.")
+            description = "모임 내에서 새로운 운동을 생성합니다. 모임장과 부모임장만 생성 가능합니다. "
+                    + "응답의 gameBoardId는 함께 생성된 게임판 ID로, 게임판 API 호출 시 사용합니다.")
     @ApiResponse(responseCode = "201", description = "운동 생성 성공")
     @ApiResponse(responseCode = "400", description = "입력값 오류")
     @ApiResponse(responseCode = "403", description = "권한 없음")
@@ -57,7 +58,8 @@ public interface ExerciseLifecycleApi {
 
     @GetMapping("/exercises/{exerciseId}")
     @Operation(summary = "운동 상세 조회",
-            description = "운동의 상세 정보를 조회합니다. 권한, 멤버 여부, 게스트 여부에 따라 반환되는 값이 달라집니다.")
+            description = "운동의 상세 정보를 조회합니다. 권한, 멤버 여부, 게스트 여부에 따라 반환되는 값이 달라집니다. "
+                    + "응답의 gameBoardId는 해당 운동의 게임판 ID로, 게임판 API 호출 시 사용합니다.")
     @ApiResponse(responseCode = "200", description = "운동 상세 조회 성공")
     @ApiResponse(responseCode = "404", description = "존재하지 않는 운동")
     ResponseEntity<BaseResponse<ExerciseDetailDTO.Response>> getExerciseDetail(

--- a/src/main/java/umc/cockple/demo/domain/exercise/presentation/dto/lifecycle/ExerciseCreateDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/presentation/dto/lifecycle/ExerciseCreateDTO.java
@@ -85,6 +85,7 @@ public class ExerciseCreateDTO {
     @Builder
     public record Response(
             Long exerciseId,
+            Long gameBoardId,
             LocalDateTime createdAt
     ) {
     }

--- a/src/main/java/umc/cockple/demo/domain/exercise/presentation/dto/lifecycle/ExerciseDetailDTO.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/presentation/dto/lifecycle/ExerciseDetailDTO.java
@@ -10,6 +10,7 @@ public class ExerciseDetailDTO {
     @Builder
     public record Response(
             Boolean isManager,
+            Long gameBoardId,
             ExerciseInfo info,
             ParticipantGroup participants,
             WaitingGroup waiting

--- a/src/main/java/umc/cockple/demo/domain/exercise/presentation/mapper/command/ExerciseLifecycleCommandMapper.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/presentation/mapper/command/ExerciseLifecycleCommandMapper.java
@@ -64,6 +64,7 @@ public class ExerciseLifecycleCommandMapper {
     public ExerciseCreateDTO.Response toCreateResponse(ExerciseCreateResult result) {
         return ExerciseCreateDTO.Response.builder()
                 .exerciseId(result.exerciseId())
+                .gameBoardId(result.gameBoardId())
                 .createdAt(result.createdAt())
                 .build();
     }

--- a/src/main/java/umc/cockple/demo/domain/exercise/presentation/mapper/query/ExerciseLifecycleQueryMapper.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/presentation/mapper/query/ExerciseLifecycleQueryMapper.java
@@ -18,6 +18,7 @@ public class ExerciseLifecycleQueryMapper {
     public ExerciseDetailDTO.Response toDetailResponse(ExerciseDetailResult result) {
         return ExerciseDetailDTO.Response.builder()
                 .isManager(result.isManager())
+                .gameBoardId(result.gameBoardId())
                 .info(toExerciseInfo(result.info()))
                 .participants(toParticipantGroup(result.participants()))
                 .waiting(toWaitingGroup(result.waiting()))

--- a/src/main/java/umc/cockple/demo/domain/exercise/service/command/ExerciseLifecycleCommandService.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/service/command/ExerciseLifecycleCommandService.java
@@ -58,7 +58,8 @@ public class ExerciseLifecycleCommandService {
 
         log.info("운동 생성 완료 - 운동ID: {}", savedExercise.getId());
 
-        return new ExerciseCreateResult(savedExercise.getId(), savedExercise.getCreatedAt());
+        return new ExerciseCreateResult(
+                savedExercise.getId(), savedExercise.getGameBoard().getId(), savedExercise.getCreatedAt());
     }
 
     public ExerciseDeleteResult deleteExercise(Long exerciseId, Long memberId) {

--- a/src/main/java/umc/cockple/demo/domain/exercise/service/command/result/ExerciseCreateResult.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/service/command/result/ExerciseCreateResult.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 
 public record ExerciseCreateResult(
         Long exerciseId,
+        Long gameBoardId,
         LocalDateTime createdAt
 ) {
 }

--- a/src/main/java/umc/cockple/demo/domain/exercise/service/query/ExerciseLifecycleQueryService.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/service/query/ExerciseLifecycleQueryService.java
@@ -58,7 +58,8 @@ public class ExerciseLifecycleQueryService {
                 createParticipantGroup(groups.participants(), exercise.getMaxCapacity());
         ExerciseDetailResult.WaitingGroup waitingGroup = createWaitingGroup(groups.waiting());
 
-        return new ExerciseDetailResult(isManager, exerciseInfo, participantGroup, waitingGroup);
+        return new ExerciseDetailResult(
+                isManager, exercise.getGameBoard().getId(), exerciseInfo, participantGroup, waitingGroup);
     }
 
     public ExerciseEditDetailResult getExerciseForEdit(Long exerciseId, Long memberId) {

--- a/src/main/java/umc/cockple/demo/domain/exercise/service/query/result/ExerciseDetailResult.java
+++ b/src/main/java/umc/cockple/demo/domain/exercise/service/query/result/ExerciseDetailResult.java
@@ -10,6 +10,7 @@ import java.util.List;
 
 public record ExerciseDetailResult(
         boolean isManager,
+        Long gameBoardId,
         ExerciseInfo info,
         ParticipantGroup participants,
         WaitingGroup waiting

--- a/src/test/java/umc/cockple/demo/domain/exercise/service/ExerciseLifecycleCommandServiceTest.java
+++ b/src/test/java/umc/cockple/demo/domain/exercise/service/ExerciseLifecycleCommandServiceTest.java
@@ -134,6 +134,7 @@ class ExerciseLifecycleCommandServiceTest {
                         .outsideGuestAccept(false)
                         .build();
                 ReflectionTestUtils.setField(savedExercise, "id", 100L);
+                ReflectionTestUtils.setField(savedExercise.getGameBoard(), "id", 500L);
 
                 given(exerciseRepository.save(any(Exercise.class))).willReturn(savedExercise);
 
@@ -143,6 +144,7 @@ class ExerciseLifecycleCommandServiceTest {
 
                 // then
                 assertThat(result.exerciseId()).isEqualTo(100L);
+                assertThat(result.gameBoardId()).isEqualTo(500L);
                 ArgumentCaptor<Exercise> exerciseCaptor = ArgumentCaptor.forClass(Exercise.class);
                 then(exerciseRepository).should().save(exerciseCaptor.capture());
                 assertThat(exerciseCaptor.getValue().getGameBoard()).isNotNull();

--- a/src/test/java/umc/cockple/demo/domain/exercise/service/ExerciseLifecycleQueryServiceTest.java
+++ b/src/test/java/umc/cockple/demo/domain/exercise/service/ExerciseLifecycleQueryServiceTest.java
@@ -96,6 +96,7 @@ class ExerciseLifecycleQueryServiceTest {
 
         exercise = ExerciseFixture.createExercise(party, LocalDate.now().minusDays(1));
         ReflectionTestUtils.setField(exercise, "id", 100L);
+        ReflectionTestUtils.setField(exercise.getGameBoard(), "id", 300L);
 
         ReflectionTestUtils.setField(exercise, "exerciseAddr", ExerciseFixture.createExerciseAddr());
     }
@@ -151,6 +152,7 @@ class ExerciseLifecycleQueryServiceTest {
 
                 // then
                 assertThat(response.isManager()).isTrue();
+                assertThat(response.gameBoardId()).isEqualTo(300L);
             }
 
             @Test


### PR DESCRIPTION
## ❤️ 기능 설명
게임판 ID를 알 수 있는 API가 부재하여, 운동 생성 및 운동 상세조회 API에 게임판ID를 필드로 추가합니다.


<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #730 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [ ] 이슈넘버를 적었는가?
